### PR TITLE
Stop fabricating partial identity in RestoreSession

### DIFF
--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -37,11 +37,11 @@ type PrincipalInfo struct {
 	// bearer will silently mis-key writes.
 	//
 	// Only claimsToIdentity populates this field today. Other Identity
-	// constructors in this repo (local.go, anonymous.go, vmcp session restore)
-	// intentionally leave it unset for now: standalone OSS keys upstream-token
-	// storage on the session, not PlatformUserID, so those paths have no
-	// canonical-user reader to satisfy. Populating them is deferred until a
-	// storage layer that reads PlatformUserID on those paths exists.
+	// constructors in this repo (local.go, anonymous.go) intentionally leave it
+	// unset for now: standalone OSS keys upstream-token storage on the session,
+	// not PlatformUserID, so those paths have no canonical-user reader to
+	// satisfy. Populating them is deferred until a storage layer that reads
+	// PlatformUserID on those paths exists.
 	PlatformUserID string `json:"platform_user_id,omitempty"`
 
 	// Name is the human-readable name (from 'name' claim).
@@ -67,6 +67,21 @@ type PrincipalInfo struct {
 //
 // It embeds PrincipalInfo (the credential-free subset) and adds sensitive fields
 // (Token, TokenType) and internal metadata that must never be externalized.
+//
+// # Field-completeness contract
+//
+// A non-nil *Identity is always COMPLETE: all credential fields that are relevant
+// for its authentication path are populated by the constructor that created it.
+// Anonymous and "no principal known" states are represented by nil, not by a
+// struct with empty credential fields. Code that receives a non-nil *Identity is
+// entitled to assume it is fully initialized for its session-binding semantics.
+//
+// In particular, do NOT construct &Identity{Subject: …} with Token and
+// UpstreamTokens unset as a substitute for nil when no live bearer token is
+// available (e.g. during session restore). Pass nil instead and let downstream
+// consumers read the identity from the per-request context, where
+// TokenValidator.Middleware places a fully-populated identity on every incoming
+// request.
 type Identity struct {
 	PrincipalInfo
 

--- a/pkg/cache/validating_cache.go
+++ b/pkg/cache/validating_cache.go
@@ -6,6 +6,7 @@
 package cache
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -33,8 +34,8 @@ var ErrExpired = errors.New("cache entry expired")
 type ValidatingCache[K comparable, V any] struct {
 	lruCache *lru.Cache[K, V]
 	flight   singleflight.Group
-	load     func(key K) (V, error)
-	check    func(key K, val V) error
+	load     func(ctx context.Context, key K) (V, error)
+	check    func(ctx context.Context, key K, val V) error
 	onEvict  func(K, V)
 	// mu serializes Set against the conditional eviction in getHit.
 	// check() runs outside the lock to avoid holding it during I/O; the lock
@@ -56,8 +57,8 @@ type ValidatingCache[K comparable, V any] struct {
 // onEvict is called after any eviction (LRU or expiry); it may be nil.
 func New[K comparable, V any](
 	capacity int,
-	load func(K) (V, error),
-	check func(K, V) error,
+	load func(context.Context, K) (V, error),
+	check func(context.Context, K, V) error,
 	onEvict func(K, V),
 ) *ValidatingCache[K, V] {
 	if capacity < 1 {
@@ -88,8 +89,8 @@ func New[K comparable, V any](
 // If the entry has definitively expired it is evicted and (zero, false) is
 // returned. Transient check errors leave the entry in place and return the
 // cached value.
-func (c *ValidatingCache[K, V]) getHit(key K, val V) (V, bool) {
-	if err := c.check(key, val); err != nil {
+func (c *ValidatingCache[K, V]) getHit(ctx context.Context, key K, val V) (V, bool) {
+	if err := c.check(ctx, key, val); err != nil {
 		if errors.Is(err, ErrExpired) {
 			// check() ran outside the lock to avoid holding it during I/O.
 			// Re-verify under the lock that the entry hasn't been replaced by a
@@ -121,7 +122,7 @@ func (c *ValidatingCache[K, V]) getHit(key K, val V) (V, bool) {
 // The returned bool is false whenever the value is unavailable — either
 // because load returned an error or because the key does not exist in the
 // backing store. Callers cannot distinguish these two cases.
-func (c *ValidatingCache[K, V]) Get(key K) (V, bool) {
+func (c *ValidatingCache[K, V]) Get(ctx context.Context, key K) (V, bool) {
 	type result struct{ v V }
 	// fmt.Sprint(key) is the singleflight key. For string keys this is
 	// exact. For other types, distinct values with identical string
@@ -130,7 +131,7 @@ func (c *ValidatingCache[K, V]) Get(key K) (V, bool) {
 	raw, err, _ := c.flight.Do(fmt.Sprint(key), func() (any, error) {
 		// Cache hit path: validate liveness.
 		if val, ok := c.lruCache.Get(key); ok {
-			v, alive := c.getHit(key, val)
+			v, alive := c.getHit(ctx, key, val)
 			if alive {
 				return result{v: v}, nil
 			}
@@ -138,7 +139,7 @@ func (c *ValidatingCache[K, V]) Get(key K) (V, bool) {
 		}
 
 		// Cache miss (or expired): load the value and store it.
-		v, loadErr := c.load(key)
+		v, loadErr := c.load(ctx, key)
 		if loadErr != nil {
 			return nil, loadErr
 		}

--- a/pkg/cache/validating_cache.go
+++ b/pkg/cache/validating_cache.go
@@ -114,6 +114,10 @@ func (c *ValidatingCache[K, V]) getHit(ctx context.Context, key K, val V) (V, bo
 // group so at most one operation executes concurrently per key. Concurrent
 // callers for the same key share the result.
 //
+// ctx is forwarded to the load and check callbacks. When concurrent calls for
+// the same key are coalesced by singleflight, only the first caller's context
+// is forwarded; later callers' contexts are not used.
+//
 // On a cache hit the entry's liveness is validated via the check function
 // provided to New: ErrExpired evicts the entry and falls through to load;
 // transient errors return the cached value unchanged. On a cache miss, load

--- a/pkg/cache/validating_cache_test.go
+++ b/pkg/cache/validating_cache_test.go
@@ -4,6 +4,7 @@
 package cache
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -17,15 +18,15 @@ import (
 
 // newStringCache builds a ValidatingCache[string, string] for tests.
 func newStringCache(
-	load func(string) (string, error),
-	check func(string, string) error,
+	load func(context.Context, string) (string, error),
+	check func(context.Context, string, string) error,
 	evict func(string, string),
 ) *ValidatingCache[string, string] {
 	return New(1000, load, check, evict)
 }
 
 // alwaysAliveCheck returns a check function that always reports the entry as alive.
-func alwaysAliveCheck(_ string, _ string) error { return nil }
+func alwaysAliveCheck(_ context.Context, _ string, _ string) error { return nil }
 
 // ---------------------------------------------------------------------------
 // Construction invariants
@@ -34,14 +35,14 @@ func alwaysAliveCheck(_ string, _ string) error { return nil }
 func TestValidatingCache_New_PanicsOnZeroCapacity(t *testing.T) {
 	t.Parallel()
 	assert.Panics(t, func() {
-		New(0, func(_ string) (string, error) { return "", nil }, alwaysAliveCheck, nil)
+		New(0, func(_ context.Context, _ string) (string, error) { return "", nil }, alwaysAliveCheck, nil)
 	})
 }
 
 func TestValidatingCache_New_PanicsOnNegativeCapacity(t *testing.T) {
 	t.Parallel()
 	assert.Panics(t, func() {
-		New(-1, func(_ string) (string, error) { return "", nil }, alwaysAliveCheck, nil)
+		New(-1, func(_ context.Context, _ string) (string, error) { return "", nil }, alwaysAliveCheck, nil)
 	})
 }
 
@@ -55,7 +56,7 @@ func TestValidatingCache_New_PanicsOnNilLoad(t *testing.T) {
 func TestValidatingCache_New_PanicsOnNilCheck(t *testing.T) {
 	t.Parallel()
 	assert.Panics(t, func() {
-		New(1, func(_ string) (string, error) { return "", nil }, nil, nil)
+		New(1, func(_ context.Context, _ string) (string, error) { return "", nil }, nil, nil)
 	})
 }
 
@@ -68,7 +69,7 @@ func TestValidatingCache_CacheMiss_CallsLoad(t *testing.T) {
 
 	loaded := false
 	c := newStringCache(
-		func(key string) (string, error) {
+		func(_ context.Context, key string) (string, error) {
 			loaded = true
 			return "value-" + key, nil
 		},
@@ -76,7 +77,7 @@ func TestValidatingCache_CacheMiss_CallsLoad(t *testing.T) {
 		nil,
 	)
 
-	v, ok := c.Get("k")
+	v, ok := c.Get(t.Context(), "k")
 	require.True(t, ok)
 	assert.Equal(t, "value-k", v)
 	assert.True(t, loaded)
@@ -87,7 +88,7 @@ func TestValidatingCache_CacheMiss_StoresResult(t *testing.T) {
 
 	calls := 0
 	c := newStringCache(
-		func(_ string) (string, error) {
+		func(_ context.Context, _ string) (string, error) {
 			calls++
 			return "v", nil
 		},
@@ -95,8 +96,8 @@ func TestValidatingCache_CacheMiss_StoresResult(t *testing.T) {
 		nil,
 	)
 
-	c.Get("k")
-	c.Get("k")
+	c.Get(t.Context(), "k")
+	c.Get(t.Context(), "k")
 	assert.Equal(t, 1, calls, "load should be called only once after caching")
 }
 
@@ -105,12 +106,12 @@ func TestValidatingCache_CacheMiss_LoadError_ReturnsNotFound(t *testing.T) {
 
 	loadErr := errors.New("not found")
 	c := newStringCache(
-		func(_ string) (string, error) { return "", loadErr },
+		func(_ context.Context, _ string) (string, error) { return "", loadErr },
 		alwaysAliveCheck,
 		nil,
 	)
 
-	v, ok := c.Get("k")
+	v, ok := c.Get(t.Context(), "k")
 	assert.False(t, ok)
 	assert.Empty(t, v)
 }
@@ -123,14 +124,14 @@ func TestValidatingCache_CacheHit_AliveCheck_ReturnsCached(t *testing.T) {
 	t.Parallel()
 
 	c := newStringCache(
-		func(key string) (string, error) { return "loaded-" + key, nil },
+		func(_ context.Context, key string) (string, error) { return "loaded-" + key, nil },
 		alwaysAliveCheck,
 		nil,
 	)
-	c.Get("k") // prime the cache
+	c.Get(t.Context(), "k") // prime the cache
 
 	// Second Get should return cached value without calling load again.
-	v, ok := c.Get("k")
+	v, ok := c.Get(t.Context(), "k")
 	require.True(t, ok)
 	assert.Equal(t, "loaded-k", v)
 }
@@ -141,18 +142,18 @@ func TestValidatingCache_CacheHit_Expired_EvictsAndCallsOnEvict(t *testing.T) {
 	evictedKey := ""
 	evictedVal := ""
 	c := newStringCache(
-		func(_ string) (string, error) { return "v", nil },
-		func(_ string, _ string) error { return ErrExpired },
+		func(_ context.Context, _ string) (string, error) { return "v", nil },
+		func(_ context.Context, _ string, _ string) error { return ErrExpired },
 		func(key, val string) {
 			evictedKey = key
 			evictedVal = val
 		},
 	)
-	c.Get("k") // prime the cache
+	c.Get(t.Context(), "k") // prime the cache
 
 	// With singleflight wrapping the full Get, an expired hit evicts the entry
 	// and falls through to load within the same operation, returning the fresh value.
-	v, ok := c.Get("k")
+	v, ok := c.Get(t.Context(), "k")
 	require.True(t, ok)
 	assert.Equal(t, "v", v)
 	assert.Equal(t, "k", evictedKey)
@@ -165,11 +166,11 @@ func TestValidatingCache_CacheHit_Expired_EntryRemovedFromCache(t *testing.T) {
 	calls := 0
 	expired := false
 	c := newStringCache(
-		func(_ string) (string, error) {
+		func(_ context.Context, _ string) (string, error) {
 			calls++
 			return "v", nil
 		},
-		func(_ string, _ string) error {
+		func(_ context.Context, _ string, _ string) error {
 			if expired {
 				return ErrExpired
 			}
@@ -178,11 +179,11 @@ func TestValidatingCache_CacheHit_Expired_EntryRemovedFromCache(t *testing.T) {
 		nil,
 	)
 
-	c.Get("k") // prime the cache; check returns alive
+	c.Get(t.Context(), "k") // prime the cache; check returns alive
 	expired = true
-	c.Get("k") // check returns ErrExpired → evict
+	c.Get(t.Context(), "k") // check returns ErrExpired → evict
 	expired = false
-	c.Get("k") // cache miss again → load called
+	c.Get(t.Context(), "k") // cache miss again → load called
 
 	assert.Equal(t, 2, calls, "load should be called twice: initial + after eviction")
 }
@@ -191,13 +192,13 @@ func TestValidatingCache_CacheHit_TransientCheckError_ReturnsCached(t *testing.T
 	t.Parallel()
 
 	c := newStringCache(
-		func(_ string) (string, error) { return "v", nil },
-		func(_ string, _ string) error { return errors.New("transient storage error") },
+		func(_ context.Context, _ string) (string, error) { return "v", nil },
+		func(_ context.Context, _ string, _ string) error { return errors.New("transient storage error") },
 		nil,
 	)
-	c.Get("k") // prime the cache
+	c.Get(t.Context(), "k") // prime the cache
 
-	v, ok := c.Get("k")
+	v, ok := c.Get(t.Context(), "k")
 	require.True(t, ok)
 	assert.Equal(t, "v", v, "transient check error should keep cached value")
 }
@@ -210,14 +211,14 @@ func TestValidatingCache_Set_StoresValue(t *testing.T) {
 	t.Parallel()
 
 	c := newStringCache(
-		func(_ string) (string, error) { return "", errors.New("should not call load") },
+		func(_ context.Context, _ string) (string, error) { return "", errors.New("should not call load") },
 		alwaysAliveCheck,
 		nil,
 	)
 
 	c.Set("k", "v")
 
-	v, ok := c.Get("k")
+	v, ok := c.Get(t.Context(), "k")
 	require.True(t, ok)
 	assert.Equal(t, "v", v)
 }
@@ -226,14 +227,14 @@ func TestValidatingCache_Set_UpdatesExisting(t *testing.T) {
 	t.Parallel()
 
 	c := newStringCache(
-		func(_ string) (string, error) { return "loaded", nil },
+		func(_ context.Context, _ string) (string, error) { return "loaded", nil },
 		alwaysAliveCheck,
 		nil,
 	)
-	c.Get("k") // prime with "loaded"
+	c.Get(t.Context(), "k") // prime with "loaded"
 	c.Set("k", "updated")
 
-	v, ok := c.Get("k")
+	v, ok := c.Get(t.Context(), "k")
 	require.True(t, ok)
 	assert.Equal(t, "updated", v)
 }
@@ -250,7 +251,7 @@ func TestValidatingCache_LRU_EvictsLeastRecentlyUsed(t *testing.T) {
 
 	// capacity=2: inserting a third entry evicts the LRU.
 	c := New(2,
-		func(key string) (string, error) { return "val-" + key, nil },
+		func(_ context.Context, key string) (string, error) { return "val-" + key, nil },
 		alwaysAliveCheck,
 		func(key, _ string) {
 			mu.Lock()
@@ -259,18 +260,18 @@ func TestValidatingCache_LRU_EvictsLeastRecentlyUsed(t *testing.T) {
 		},
 	)
 
-	c.Get("a") // a=MRU
-	c.Get("b") // b=MRU, a=LRU
-	c.Get("c") // c=MRU, b, a=LRU → evicts a
+	c.Get(t.Context(), "a") // a=MRU
+	c.Get(t.Context(), "b") // b=MRU, a=LRU
+	c.Get(t.Context(), "c") // c=MRU, b, a=LRU → evicts a
 
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal(t, []string{"a"}, evictedKeys, "LRU entry (a) should be evicted")
 
 	// a is evicted; b and c remain.
-	_, bPresent := c.Get("b")
+	_, bPresent := c.Get(t.Context(), "b")
 	assert.True(t, bPresent)
-	_, cPresent := c.Get("c")
+	_, cPresent := c.Get(t.Context(), "c")
 	assert.True(t, cPresent)
 }
 
@@ -281,7 +282,7 @@ func TestValidatingCache_LRU_GetRefreshesMRUPosition(t *testing.T) {
 	var mu sync.Mutex
 
 	c := New(2,
-		func(key string) (string, error) { return "val-" + key, nil },
+		func(_ context.Context, key string) (string, error) { return "val-" + key, nil },
 		alwaysAliveCheck,
 		func(key, _ string) {
 			mu.Lock()
@@ -290,16 +291,16 @@ func TestValidatingCache_LRU_GetRefreshesMRUPosition(t *testing.T) {
 		},
 	)
 
-	c.Get("a") // a loaded (MRU)
-	c.Get("b") // b loaded (MRU), a=LRU
-	c.Get("a") // a accessed → a becomes MRU, b=LRU
-	c.Get("c") // c loaded → evicts b (LRU), not a
+	c.Get(t.Context(), "a") // a loaded (MRU)
+	c.Get(t.Context(), "b") // b loaded (MRU), a=LRU
+	c.Get(t.Context(), "a") // a accessed → a becomes MRU, b=LRU
+	c.Get(t.Context(), "c") // c loaded → evicts b (LRU), not a
 
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal(t, []string{"b"}, evictedKeys, "b should be evicted (LRU after a was re-accessed)")
 
-	_, aPresent := c.Get("a")
+	_, aPresent := c.Get(t.Context(), "a")
 	assert.True(t, aPresent, "a should still be in cache")
 }
 
@@ -310,7 +311,7 @@ func TestValidatingCache_LRU_SetRefreshesMRUPosition(t *testing.T) {
 	var mu sync.Mutex
 
 	c := New(2,
-		func(key string) (string, error) { return "val-" + key, nil },
+		func(_ context.Context, key string) (string, error) { return "val-" + key, nil },
 		alwaysAliveCheck,
 		func(key, _ string) {
 			mu.Lock()
@@ -319,10 +320,10 @@ func TestValidatingCache_LRU_SetRefreshesMRUPosition(t *testing.T) {
 		},
 	)
 
-	c.Get("a")      // a=MRU
-	c.Get("b")      // b=MRU, a=LRU
-	c.Set("a", "x") // Set refreshes a to MRU; b becomes LRU
-	c.Get("c")      // c loaded → evicts b
+	c.Get(t.Context(), "a") // a=MRU
+	c.Get(t.Context(), "b") // b=MRU, a=LRU
+	c.Set("a", "x")         // Set refreshes a to MRU; b becomes LRU
+	c.Get(t.Context(), "c") // c loaded → evicts b
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -336,7 +337,7 @@ func TestValidatingCache_LRU_CapacityOne(t *testing.T) {
 	var mu sync.Mutex
 
 	c := New(1,
-		func(key string) (string, error) { return "val-" + key, nil },
+		func(_ context.Context, key string) (string, error) { return "val-" + key, nil },
 		alwaysAliveCheck,
 		func(key, _ string) {
 			mu.Lock()
@@ -345,9 +346,9 @@ func TestValidatingCache_LRU_CapacityOne(t *testing.T) {
 		},
 	)
 
-	c.Get("a")
-	c.Get("b") // evicts a
-	c.Get("c") // evicts b
+	c.Get(t.Context(), "a")
+	c.Get(t.Context(), "b") // evicts a
+	c.Get(t.Context(), "c") // evicts b
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -359,7 +360,7 @@ func TestValidatingCache_LRU_LargeCapacityNoEviction(t *testing.T) {
 
 	const n = 100
 	c := New(n+1,
-		func(key string) (string, error) { return "val-" + key, nil },
+		func(_ context.Context, key string) (string, error) { return "val-" + key, nil },
 		alwaysAliveCheck,
 		func(key, _ string) {
 			t.Errorf("unexpected eviction for key %s", key)
@@ -367,7 +368,7 @@ func TestValidatingCache_LRU_LargeCapacityNoEviction(t *testing.T) {
 	)
 
 	for i := range n {
-		c.Get(fmt.Sprintf("k%d", i))
+		c.Get(t.Context(), fmt.Sprintf("k%d", i))
 	}
 	assert.Equal(t, n, c.Len(), "no entries should be evicted when under capacity")
 }
@@ -376,15 +377,15 @@ func TestValidatingCache_LRU_Len(t *testing.T) {
 	t.Parallel()
 
 	c := New(5,
-		func(_ string) (string, error) { return "v", nil },
+		func(_ context.Context, _ string) (string, error) { return "v", nil },
 		alwaysAliveCheck,
 		nil,
 	)
 
 	assert.Equal(t, 0, c.Len())
-	c.Get("a")
+	c.Get(t.Context(), "a")
 	assert.Equal(t, 1, c.Len())
-	c.Get("b")
+	c.Get(t.Context(), "b")
 	assert.Equal(t, 2, c.Len())
 }
 
@@ -407,7 +408,7 @@ func TestValidatingCache_Singleflight_SetBeforeLoadReturns(t *testing.T) {
 	allowReturn := make(chan struct{})
 
 	c := newStringCache(
-		func(_ string) (string, error) {
+		func(_ context.Context, _ string) (string, error) {
 			close(loadReached) // signal: load is now in-flight
 			<-allowReturn      // block until test injects the concurrent Set
 			loadCount.Add(1)
@@ -425,7 +426,7 @@ func TestValidatingCache_Singleflight_SetBeforeLoadReturns(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		result, ok = c.Get("k")
+		result, ok = c.Get(context.Background(), "k")
 	}()
 
 	// Wait until load is definitely executing, then write via Set so that
@@ -468,7 +469,7 @@ func TestValidatingCache_Singleflight_DeduplicatesConcurrentLivenessChecks(t *te
 	var expired atomic.Bool
 
 	c := newStringCache(
-		func(_ string) (string, error) {
+		func(_ context.Context, _ string) (string, error) {
 			// Wait until every goroutine has signalled it is about to call Get.
 			// allStarted.Done() is called before Get(), so this unblocks once
 			// the goroutine scheduler has scheduled all callers — not necessarily
@@ -481,7 +482,7 @@ func TestValidatingCache_Singleflight_DeduplicatesConcurrentLivenessChecks(t *te
 			expired.Store(false) // refresh: late arrivals see a live entry
 			return "reloaded", nil
 		},
-		func(_ string, _ string) error {
+		func(_ context.Context, _ string, _ string) error {
 			if expired.Load() {
 				return ErrExpired
 			}
@@ -492,7 +493,7 @@ func TestValidatingCache_Singleflight_DeduplicatesConcurrentLivenessChecks(t *te
 
 	// Prime the cache with a live entry. allStarted has count 0 here, so
 	// Wait() inside load returns immediately — no deadlock.
-	_, ok := c.Get("k")
+	_, ok := c.Get(t.Context(), "k")
 	require.True(t, ok)
 	assert.Equal(t, int32(1), loadCount.Load())
 
@@ -507,7 +508,7 @@ func TestValidatingCache_Singleflight_DeduplicatesConcurrentLivenessChecks(t *te
 		go func(i int) {
 			defer wg.Done()
 			allStarted.Done() // signal: about to call Get
-			results[i], oks[i] = c.Get("k")
+			results[i], oks[i] = c.Get(context.Background(), "k")
 		}(i)
 	}
 
@@ -550,7 +551,7 @@ func TestValidatingCache_Singleflight_DeduplicatesConcurrentMisses(t *testing.T)
 	allStarted.Add(goroutines)
 
 	c := newStringCache(
-		func(_ string) (string, error) {
+		func(_ context.Context, _ string) (string, error) {
 			// Block until all goroutines have signalled they are about to call
 			// Get. While blocked the cache entry has not been stored, so
 			// every goroutine that reaches the miss path is deduplicated via
@@ -569,7 +570,7 @@ func TestValidatingCache_Singleflight_DeduplicatesConcurrentMisses(t *testing.T)
 		go func(i int) {
 			defer wg.Done()
 			allStarted.Done() // signal: about to call Get
-			results[i], oks[i] = c.Get("k")
+			results[i], oks[i] = c.Get(context.Background(), "k")
 		}(i)
 	}
 

--- a/pkg/vmcp/server/serve_handlers.go
+++ b/pkg/vmcp/server/serve_handlers.go
@@ -188,7 +188,7 @@ func (s *Server) coreToolHandler(sessionID, toolName, backendName string) server
 		}
 
 		caller, _ := auth.IdentityFromContext(ctx)
-		if err := s.enforceSessionBinding(sessionID, caller); err != nil {
+		if err := s.enforceSessionBinding(ctx, sessionID, caller); err != nil {
 			s.terminateOnBindingFailure(sessionID, toolName, err)
 			return mcp.NewToolResultError(fmt.Sprintf("Unauthorized: %v", err)), nil
 		}
@@ -223,7 +223,7 @@ func (s *Server) coreResourceHandler(
 		}
 
 		caller, _ := auth.IdentityFromContext(ctx)
-		if err := s.enforceSessionBinding(sessionID, caller); err != nil {
+		if err := s.enforceSessionBinding(ctx, sessionID, caller); err != nil {
 			s.terminateOnBindingFailure(sessionID, uri, err)
 			return nil, fmt.Errorf("unauthorized: %w", err)
 		}
@@ -251,8 +251,8 @@ func (s *Server) coreResourceHandler(
 // ErrSessionOwnerUnknown. Unlike the legacy GetAdaptedTools handler, which terminates
 // only on ErrUnauthorizedCaller/ErrNilCaller, terminateOnBindingFailure terminates on
 // any rejection here — intentional fail-closed behavior, not a bug.
-func (s *Server) enforceSessionBinding(sessionID string, caller *auth.Identity) error {
-	sess, ok := s.vmcpSessionMgr.GetMultiSession(sessionID)
+func (s *Server) enforceSessionBinding(ctx context.Context, sessionID string, caller *auth.Identity) error {
+	sess, ok := s.vmcpSessionMgr.GetMultiSession(ctx, sessionID)
 	if !ok {
 		return sessiontypes.ErrUnauthorizedCaller
 	}

--- a/pkg/vmcp/server/serve_optimizer.go
+++ b/pkg/vmcp/server/serve_optimizer.go
@@ -127,7 +127,7 @@ func (s *Server) optimizerToolHandler(
 func (s *Server) optimizerFindToolHandler(sessionID string, opt optimizer.Optimizer) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		caller, _ := auth.IdentityFromContext(ctx)
-		if err := s.enforceSessionBinding(sessionID, caller); err != nil {
+		if err := s.enforceSessionBinding(ctx, sessionID, caller); err != nil {
 			s.terminateOnBindingFailure(sessionID, optimizerdec.FindToolName, err)
 			return mcp.NewToolResultError(fmt.Sprintf("Unauthorized: %v", err)), nil
 		}
@@ -179,7 +179,7 @@ func (s *Server) optimizerFindToolHandler(sessionID string, opt optimizer.Optimi
 func (s *Server) optimizerCallToolHandler(sessionID string, opt optimizer.Optimizer) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		caller, _ := auth.IdentityFromContext(ctx)
-		if err := s.enforceSessionBinding(sessionID, caller); err != nil {
+		if err := s.enforceSessionBinding(ctx, sessionID, caller); err != nil {
 			s.terminateOnBindingFailure(sessionID, optimizerdec.CallToolName, err)
 			return mcp.NewToolResultError(fmt.Sprintf("Unauthorized: %v", err)), nil
 		}

--- a/pkg/vmcp/server/serve_optimizer_test.go
+++ b/pkg/vmcp/server/serve_optimizer_test.go
@@ -126,7 +126,7 @@ func registerServeOptimizerSession(t *testing.T, fc *fakeCore) (*Server, string,
 	require.Equal(t, http.StatusOK, initResp.StatusCode)
 	sessionID := initResp.Header.Get("Mcp-Session-Id")
 	require.NotEmpty(t, sessionID)
-	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(sessionID); return ok },
+	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID); return ok },
 		2*time.Second, 10*time.Millisecond, "session should be registered")
 	return srv, sessionID, ts.URL, optFactory
 }
@@ -361,7 +361,7 @@ func TestServeOptimizerEnforcesSessionBinding(t *testing.T) {
 
 			assert.Equal(t, int32(0), fc.callToolCalls.Load(),
 				"a binding failure must reject before any inner core call")
-			require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(sessionID); return !ok },
+			require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID); return !ok },
 				2*time.Second, 10*time.Millisecond, "a binding failure must terminate the session (fail-closed)")
 		})
 	}

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -340,7 +340,7 @@ func TestServeLazyInjectsToolsForRehydratedSession(t *testing.T) {
 
 	// Wait until the session is fully registered in the manager.
 	require.Eventually(t, func() bool {
-		_, ok := srv.vmcpSessionMgr.GetMultiSession(sessionID)
+		_, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID)
 		return ok
 	}, 2*time.Second, 10*time.Millisecond, "session should be registered")
 
@@ -561,15 +561,15 @@ func TestServeEnforcesSessionBinding(t *testing.T) {
 	sessionID := initResp.Header.Get("Mcp-Session-Id")
 	require.NotEmpty(t, sessionID)
 
-	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(sessionID); return ok },
+	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID); return ok },
 		2*time.Second, 10*time.Millisecond, "session should be registered")
 
 	// Anonymous caller (no token) matches the anonymous binding — allowed.
-	require.NoError(t, srv.enforceSessionBinding(sessionID, nil),
+	require.NoError(t, srv.enforceSessionBinding(context.Background(), sessionID, nil),
 		"anonymous caller must be permitted on an anonymous session")
 
 	// A caller presenting a token on an anonymous session is a session-upgrade attack.
-	err = srv.enforceSessionBinding(sessionID, &auth.Identity{Token: "attacker-token"})
+	err = srv.enforceSessionBinding(context.Background(), sessionID, &auth.Identity{Token: "attacker-token"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, sessiontypes.ErrUnauthorizedCaller,
 		"a token presented to an anonymous session must be rejected by the session-layer binding check")
@@ -624,7 +624,7 @@ func registerServeSessionWithRegistry(
 	require.Equal(t, http.StatusOK, initResp.StatusCode)
 	sessionID := initResp.Header.Get("Mcp-Session-Id")
 	require.NotEmpty(t, sessionID)
-	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(sessionID); return ok },
+	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID); return ok },
 		2*time.Second, 10*time.Millisecond, "session should be registered")
 	return srv, sessionID, ts.URL
 }
@@ -705,7 +705,7 @@ func TestServeToolCallTerminatesOnBindingFailure(t *testing.T) {
 	assert.Contains(t, string(body), "Unauthorized")
 	assert.Equal(t, int32(0), fc.callToolCalls.Load(), "core.CallTool must not be reached on a binding failure")
 
-	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(sessionID); return !ok },
+	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID); return !ok },
 		2*time.Second, 10*time.Millisecond, "a binding failure must terminate the session (fail-closed)")
 }
 

--- a/pkg/vmcp/server/session_manager_interface.go
+++ b/pkg/vmcp/server/session_manager_interface.go
@@ -30,7 +30,9 @@ type SessionManager interface {
 	// GetMultiSession retrieves the fully-formed MultiSession for the given session ID.
 	// Returns (nil, false) if the session does not exist or is still a placeholder.
 	// Used to access session-scoped backend tool metadata (e.g. for conflict validation).
-	GetMultiSession(sessionID string) (vmcpsession.MultiSession, bool)
+	// The context is propagated to storage operations using context.WithoutCancel so
+	// caller identity (e.g. *auth.Identity in ctx) reaches the backend restore path.
+	GetMultiSession(ctx context.Context, sessionID string) (vmcpsession.MultiSession, bool)
 
 	// DecorateSession retrieves the MultiSession for sessionID, applies fn to it,
 	// and stores the result back. Used to stack session decorators (composite tools,

--- a/pkg/vmcp/server/session_manager_interface.go
+++ b/pkg/vmcp/server/session_manager_interface.go
@@ -29,9 +29,11 @@ type SessionManager interface {
 
 	// GetMultiSession retrieves the fully-formed MultiSession for the given session ID.
 	// Returns (nil, false) if the session does not exist or is still a placeholder.
-	// Used to access session-scoped backend tool metadata (e.g. for conflict validation).
-	// The context is propagated to storage operations using context.WithoutCancel so
-	// caller identity (e.g. *auth.Identity in ctx) reaches the backend restore path.
+	//
+	// ctx may carry request-scoped values (e.g. *auth.Identity) that implementations
+	// should forward to storage and backend-restore operations. Implementations must
+	// not let caller cancellation abort an in-progress restore that concurrent
+	// waiters depend on.
 	GetMultiSession(ctx context.Context, sessionID string) (vmcpsession.MultiSession, bool)
 
 	// DecorateSession retrieves the MultiSession for sessionID, applies fn to it,

--- a/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
+++ b/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
@@ -185,7 +185,7 @@ func TestHorizontalScaling_CrossPodReconstruction(t *testing.T) {
 	smB := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
 
 	// GetMultiSession triggers cache miss → loadSession → RestoreSession from Redis.
-	sess, ok := smB.GetMultiSession(sessionID)
+	sess, ok := smB.GetMultiSession(t.Context(), sessionID)
 	require.True(t, ok, "pod B must reconstruct the session from Redis on cache miss")
 	require.NotNil(t, sess)
 
@@ -238,7 +238,7 @@ func TestHorizontalScaling_CrossPodHijackPrevention(t *testing.T) {
 
 	// Pod B: restore from Redis.
 	smB := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
-	sess, ok := smB.GetMultiSession(sessionID)
+	sess, ok := smB.GetMultiSession(t.Context(), sessionID)
 	require.True(t, ok, "session must be restorable on pod B")
 	require.NotNil(t, sess)
 
@@ -289,7 +289,7 @@ func TestHorizontalScaling_AllBackendsFailOnRestore(t *testing.T) {
 	// Use a fresh manager: its cache is empty, so GetMultiSession takes the
 	// restore path without needing to explicitly evict the session.
 	smReader := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
-	sess, ok := smReader.GetMultiSession(sessionID)
+	sess, ok := smReader.GetMultiSession(t.Context(), sessionID)
 	require.True(t, ok, "GetMultiSession must return ok=true even when backends are unreachable")
 	require.NotNil(t, sess)
 	assert.Empty(t, sess.Tools(), "routing table must be empty when no backend reconnected")
@@ -319,7 +319,7 @@ func TestHorizontalScaling_BackendExpiry_SkipsExpiredOnRestore(t *testing.T) {
 	sessionID := createSession(t, smA, nil)
 
 	// Verify session A has tools from both backends before expiry.
-	sessA, ok := smA.GetMultiSession(sessionID)
+	sessA, ok := smA.GetMultiSession(t.Context(), sessionID)
 	require.True(t, ok)
 	toolNames := make(map[string]bool)
 	for _, tool := range sessA.Tools() {
@@ -336,7 +336,7 @@ func TestHorizontalScaling_BackendExpiry_SkipsExpiredOnRestore(t *testing.T) {
 	// (backendB is still running — we're testing that RestoreSession filters
 	// it out based on the updated Redis metadata, not because it's unreachable.)
 	smC := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backendA, backendB})
-	sessC, ok := smC.GetMultiSession(sessionID)
+	sessC, ok := smC.GetMultiSession(t.Context(), sessionID)
 	require.True(t, ok, "session must be restorable after NotifyBackendExpired")
 	require.NotNil(t, sessC)
 
@@ -379,11 +379,11 @@ func TestHorizontalScaling_InMemoryOnlyMode(t *testing.T) {
 	sessionID := createSession(t, smA, nil)
 
 	// Pod B must not be able to see pod A's session.
-	_, ok := smB.GetMultiSession(sessionID)
+	_, ok := smB.GetMultiSession(t.Context(), sessionID)
 	assert.False(t, ok, "in-memory-only: pod B must not see pod A's session")
 
 	// Single-pod usage on pod A must still work.
-	sess, ok := smA.GetMultiSession(sessionID)
+	sess, ok := smA.GetMultiSession(t.Context(), sessionID)
 	require.True(t, ok, "pod A must still serve its own session")
 	require.NotNil(t, sess)
 	assert.NotEmpty(t, sess.Tools(), "session on pod A must have tools")

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -625,16 +625,11 @@ func (sm *Manager) updateMetadata(sessionID string, metadata map[string]string) 
 // factory.RestoreSession, enabling cross-pod session recovery when Redis is
 // used as the storage backend.
 //
-// Known limitation: GetMultiSession's signature is fixed by the
-// MultiSessionGetter interface and carries no context. Both the liveness
-// check and the restore path use context.Background() with per-operation
-// timeouts (restoreStorageTimeout / restoreSessionTimeout), so they are
-// bounded independently of any caller deadline. The caller's HTTP request
-// cancellation cannot propagate here.
-// TODO: add context propagation through MultiSessionGetter so the caller's
-// deadline can further bound these operations.
-func (sm *Manager) GetMultiSession(sessionID string) (vmcpsession.MultiSession, bool) {
-	return sm.sessions.Get(sessionID)
+// The context is propagated to storage and restore operations using
+// context.WithoutCancel so caller identity (e.g. *auth.Identity in ctx) reaches
+// the backend Initialize handshake during cross-pod session restore.
+func (sm *Manager) GetMultiSession(ctx context.Context, sessionID string) (vmcpsession.MultiSession, bool) {
+	return sm.sessions.Get(ctx, sessionID)
 }
 
 // checkSession is the liveness check supplied to sessions. It confirms the
@@ -649,8 +644,8 @@ func (sm *Manager) GetMultiSession(sessionID string) (vmcpsession.MultiSession, 
 // replacing the old session and its backend connections. This ensures that a
 // backend-expiry update written by pod A propagates to pod B on the next
 // cache access rather than waiting for natural TTL expiry.
-func (sm *Manager) checkSession(sessionID string, sess vmcpsession.MultiSession) error {
-	checkCtx, cancel := context.WithTimeout(context.Background(), restoreStorageTimeout)
+func (sm *Manager) checkSession(ctx context.Context, sessionID string, sess vmcpsession.MultiSession) error {
+	checkCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), restoreStorageTimeout)
 	defer cancel()
 	metadata, err := sm.storage.Load(checkCtx, sessionID)
 	if errors.Is(err, transportsession.ErrSessionNotFound) {
@@ -686,8 +681,8 @@ func (sm *Manager) checkSession(sessionID string, sess vmcpsession.MultiSession)
 // loadSession is the restore function supplied to sessions. It loads session
 // metadata from storage and calls factory.RestoreSession to reconnect to
 // backends, returning the fully-formed MultiSession on success.
-func (sm *Manager) loadSession(sessionID string) (vmcpsession.MultiSession, error) {
-	loadCtx, loadCancel := context.WithTimeout(context.Background(), restoreStorageTimeout)
+func (sm *Manager) loadSession(ctx context.Context, sessionID string) (vmcpsession.MultiSession, error) {
+	loadCtx, loadCancel := context.WithTimeout(context.WithoutCancel(ctx), restoreStorageTimeout)
 	defer loadCancel()
 	metadata, loadErr := sm.storage.Load(loadCtx, sessionID)
 	if loadErr != nil {
@@ -718,7 +713,7 @@ func (sm *Manager) loadSession(sessionID string) (vmcpsession.MultiSession, erro
 		return nil, transportsession.ErrSessionNotFound
 	}
 
-	restoreCtx, restoreCancel := context.WithTimeout(context.Background(), restoreSessionTimeout)
+	restoreCtx, restoreCancel := context.WithTimeout(context.WithoutCancel(ctx), restoreSessionTimeout)
 	defer restoreCancel()
 	restored, restoreErr := sm.factory.RestoreSession(restoreCtx, sessionID, metadata, sm.listAllBackends(restoreCtx))
 	if restoreErr != nil {
@@ -737,7 +732,7 @@ func (sm *Manager) loadSession(sessionID string) (vmcpsession.MultiSession, erro
 	// that was concurrently deleted (Terminate / TTL expiry). A (false, nil)
 	// result means the key is already gone — treat it as not found so the
 	// cache never serves a session that no longer exists in storage.
-	updateCtx, updateCancel := context.WithTimeout(context.Background(), restoreMetadataWriteTimeout)
+	updateCtx, updateCancel := context.WithTimeout(context.WithoutCancel(ctx), restoreMetadataWriteTimeout)
 	defer updateCancel()
 	updated, updateErr := sm.storage.Update(updateCtx, sessionID, restored.GetMetadata())
 	if updateErr != nil {
@@ -770,7 +765,7 @@ func (sm *Manager) loadSession(sessionID string) (vmcpsession.MultiSession, erro
 // session was deleted; the cache entry will be evicted on the next Get when
 // checkSession detects ErrSessionNotFound.
 func (sm *Manager) DecorateSession(sessionID string, fn func(sessiontypes.MultiSession) sessiontypes.MultiSession) error {
-	sess, ok := sm.GetMultiSession(sessionID)
+	sess, ok := sm.GetMultiSession(context.Background(), sessionID)
 	if !ok {
 		return fmt.Errorf("DecorateSession: session %q not found or not a multi-session", sessionID)
 	}

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -765,6 +765,9 @@ func (sm *Manager) loadSession(ctx context.Context, sessionID string) (vmcpsessi
 // session was deleted; the cache entry will be evicted on the next Get when
 // checkSession detects ErrSessionNotFound.
 func (sm *Manager) DecorateSession(sessionID string, fn func(sessiontypes.MultiSession) sessiontypes.MultiSession) error {
+	// context.Background() is intentional: DecorateSession is called from
+	// OnRegisterSession during session setup, not from a live authenticated
+	// HTTP request, so there is no caller identity to propagate.
 	sess, ok := sm.GetMultiSession(context.Background(), sessionID)
 	if !ok {
 		return fmt.Errorf("DecorateSession: session %q not found or not a multi-session", sessionID)

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -654,7 +654,7 @@ func TestSessionManager_Terminate(t *testing.T) {
 
 		// The next GetMultiSession triggers checkSession: storage returns
 		// ErrSessionNotFound → ErrExpired → onEvict → Close().
-		_, ok := sm.GetMultiSession(sessionID)
+		_, ok := sm.GetMultiSession(t.Context(), sessionID)
 		assert.False(t, ok, "terminated session must not be returned")
 		// gomock verifies Close() was called exactly once via Times(1)
 	})
@@ -816,7 +816,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		registry := newFakeRegistry()
 		sm, _ := newTestSessionManager(t, factory, registry)
 
-		multiSess, ok := sm.GetMultiSession("ghost")
+		multiSess, ok := sm.GetMultiSession(t.Context(), "ghost")
 		assert.False(t, ok)
 		assert.Nil(t, multiSess)
 	})
@@ -834,7 +834,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		require.NotEmpty(t, sessionID)
 
 		// Placeholder has not been upgraded yet.
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		assert.False(t, ok, "placeholder should not satisfy MultiSession type assertion")
 		assert.Nil(t, multiSess)
 	})
@@ -861,7 +861,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		_, err := sm.CreateSession(context.Background(), sessionID)
 		require.NoError(t, err)
 
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		require.True(t, ok)
 		require.NotNil(t, multiSess)
 		assert.Equal(t, sessionID, multiSess.ID())
@@ -889,7 +889,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// loadSession detects absent MetadataKeyIdentityBinding → ErrSessionNotFound.
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		assert.False(t, ok, "placeholder should not be restorable")
 		assert.Nil(t, multiSess)
 	})
@@ -925,7 +925,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// loadSession should call RestoreSession, not treat it as a placeholder.
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		require.True(t, ok, "initialized zero-backend session should be restorable")
 		require.NotNil(t, multiSess)
 		assert.Equal(t, sessionID, multiSess.ID())
@@ -962,7 +962,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		_, err := sm.storage.Create(context.Background(), sessionID, legacyMeta)
 		require.NoError(t, err)
 
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		require.True(t, ok, "legacy record without MetadataKeyBackendIDs must still be restorable")
 		require.NotNil(t, multiSess)
 		assert.Equal(t, sessionID, multiSess.ID())
@@ -1007,7 +1007,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		_, err := sm.storage.Create(context.Background(), sessionID, staleMeta)
 		require.NoError(t, err)
 
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		require.True(t, ok, "session must be restored")
 		require.NotNil(t, multiSess)
 
@@ -1060,7 +1060,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 
 		// GetMultiSession triggers loadSession; the racing delete causes
 		// Update to return (false, nil) → ErrSessionNotFound → (nil, false).
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		assert.False(t, ok, "session deleted before metadata write-back must not be cached")
 		assert.Nil(t, multiSess)
 	})
@@ -1096,7 +1096,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// Write failure must be non-fatal: session is still returned and cached.
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		assert.True(t, ok, "transient Update error must not prevent session from being served")
 		assert.NotNil(t, multiSess)
 		assert.Equal(t, sessionID, multiSess.ID())
@@ -1153,7 +1153,7 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 		require.NoError(t, err)
 
 		// After decoration, GetMultiSession returns the decorated session with both tools.
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		require.True(t, ok)
 		require.Len(t, multiSess.Tools(), 2)
 		assert.Equal(t, "hello", multiSess.Tools()[0].Name)
@@ -1222,7 +1222,7 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 		assert.Contains(t, err.Error(), "was deleted during decoration")
 
 		// The session must not be resurrected.
-		_, ok := sm.GetMultiSession(sessionID)
+		_, ok := sm.GetMultiSession(t.Context(), sessionID)
 		assert.False(t, ok, "terminated session must not be resurrected by DecorateSession")
 	})
 }
@@ -1262,7 +1262,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		_, err := storage.Create(context.Background(), sessionID, map[string]string{})
 		require.NoError(t, err)
 
-		err = sm.checkSession(sessionID, makeEmptySess(t))
+		err = sm.checkSession(t.Context(), sessionID, makeEmptySess(t))
 		assert.NoError(t, err, "alive session must return nil")
 	})
 
@@ -1270,7 +1270,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		t.Parallel()
 		sm, _ := newTestSessionManager(t, makeFactory(t), newFakeRegistry())
 
-		err := sm.checkSession("nonexistent-session", makeEmptySess(t))
+		err := sm.checkSession(t.Context(), "nonexistent-session", makeEmptySess(t))
 		assert.ErrorIs(t, err, cache.ErrExpired, "deleted session must return ErrExpired")
 	})
 
@@ -1286,7 +1286,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = sm.checkSession(sessionID, makeEmptySess(t))
+		err = sm.checkSession(t.Context(), sessionID, makeEmptySess(t))
 		assert.ErrorIs(t, err, cache.ErrExpired, "terminated session must return ErrExpired")
 	})
 
@@ -1314,7 +1314,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		}).AnyTimes()
 		sm.sessions.Set(sessionID, cached)
 
-		err = sm.checkSession(sessionID, cached)
+		err = sm.checkSession(t.Context(), sessionID, cached)
 		assert.ErrorIs(t, err, cache.ErrExpired,
 			"stale backend list must return ErrExpired to trigger cross-pod eviction")
 	})
@@ -1336,7 +1336,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		}).AnyTimes()
 		sm.sessions.Set(sessionID, cached)
 
-		err = sm.checkSession(sessionID, cached)
+		err = sm.checkSession(t.Context(), sessionID, cached)
 		assert.NoError(t, err, "matching backend list must return nil")
 	})
 
@@ -1355,7 +1355,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		cached.EXPECT().GetMetadata().Return(map[string]string{}).AnyTimes()
 		sm.sessions.Set(sessionID, cached)
 
-		err = sm.checkSession(sessionID, cached)
+		err = sm.checkSession(t.Context(), sessionID, cached)
 		assert.NoError(t, err, "matching empty metadata must not cause eviction")
 	})
 
@@ -1388,7 +1388,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		}).AnyTimes()
 		sm.sessions.Set(sessionID, cached)
 
-		err = sm.checkSession(sessionID, cached)
+		err = sm.checkSession(t.Context(), sessionID, cached)
 		assert.NoError(t, err,
 			"differing per-backend session IDs must not evict to avoid cross-pod eviction storms")
 	})
@@ -1713,7 +1713,7 @@ func TestLoadSession_Phase2Marker_UsesIdentityBindingKey(t *testing.T) {
 
 		// loadSession must treat absent MetadataKeyIdentityBinding as a legacy session
 		// and return (nil, false) — not attempting RestoreSession.
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		assert.False(t, ok, "legacy session with only MetadataKeyTokenHash must not be restored")
 		assert.Nil(t, multiSess)
 	})
@@ -1742,7 +1742,7 @@ func TestLoadSession_Phase2Marker_UsesIdentityBindingKey(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		multiSess, ok := sm.GetMultiSession(sessionID)
+		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
 		require.True(t, ok, "session with MetadataKeyIdentityBinding must be restorable")
 		require.NotNil(t, multiSess)
 		assert.Equal(t, sessionID, multiSess.ID())

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -1104,6 +1104,69 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Tests: identity propagation through loadSession (issue #5336 Layer B)
+// ---------------------------------------------------------------------------
+
+// TestGetMultiSession_PropagatesIdentityToRestoreSession verifies that the
+// *auth.Identity present on the context passed to GetMultiSession reaches the
+// RestoreSession call inside loadSession. This pins the context.WithoutCancel
+// propagation contract: reversing that call to context.Background() would
+// cause zero test failures without this test.
+func TestGetMultiSession_PropagatesIdentityToRestoreSession(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	// An identity with a non-empty UpstreamTokens map — the concrete value
+	// any outgoing-auth strategy would need at restore time.
+	wantIdentity := &auth.Identity{
+		PrincipalInfo: auth.PrincipalInfo{
+			Subject: "alice",
+			Claims:  map[string]any{"iss": "https://idp.example", "sub": "alice"},
+		},
+		UpstreamTokens: map[string]string{"provider": "live-upstream-token"},
+	}
+
+	sessionID := "restore-identity-propagation-session"
+	restored := newMockSession(t, ctrl, sessionID, nil)
+
+	// Capture the context RestoreSession receives.
+	var capturedCtx context.Context
+	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
+	factory.EXPECT().
+		RestoreSession(gomock.Any(), sessionID, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ string, _ map[string]string, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			capturedCtx = ctx
+			return restored, nil
+		}).Times(1)
+
+	sm, _ := newTestSessionManager(t, factory, newFakeRegistry())
+
+	// Write fully-initialized metadata directly to storage (bypassing cache)
+	// so GetMultiSession triggers the cache-miss → loadSession → RestoreSession path.
+	_, err := sm.storage.Create(context.Background(), sessionID, map[string]string{
+		sessiontypes.MetadataKeyIdentityBinding: "https://idp.example\x00alice",
+		vmcpsession.MetadataKeyBackendIDs:       "",
+	})
+	require.NoError(t, err)
+
+	// Call GetMultiSession with an identity-bearing context.
+	ctxWithIdentity := auth.WithIdentity(t.Context(), wantIdentity)
+	multiSess, ok := sm.GetMultiSession(ctxWithIdentity, sessionID)
+	require.True(t, ok)
+	require.NotNil(t, multiSess)
+
+	// The identity must have propagated to RestoreSession via context.WithoutCancel.
+	require.NotNil(t, capturedCtx, "RestoreSession must have been called")
+	gotIdentity, hasIdentity := auth.IdentityFromContext(capturedCtx)
+	require.True(t, hasIdentity, "identity must be present on the context RestoreSession received")
+	assert.Equal(t, wantIdentity.Subject, gotIdentity.Subject,
+		"Subject must propagate through loadSession's context.WithoutCancel")
+	assert.Equal(t, "live-upstream-token", gotIdentity.UpstreamTokens["provider"],
+		"UpstreamTokens must propagate — these are the credentials backend Initialize needs")
+}
+
+// ---------------------------------------------------------------------------
 // Tests: DecorateSession
 // ---------------------------------------------------------------------------
 

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -420,10 +420,9 @@ func (f *defaultMultiSessionFactory) RestoreSession(
 	// Filter allBackends to the subset originally connected in this session.
 	filteredBackends := filterBackendsByStoredIDs(allBackends, storedBackendIDs)
 
-	// Reconstruct identity from the stored identity binding so makeBaseSession
-	// can pass it to backend connectors (e.g. for outgoing auth injection).
-	// The original bearer token is not available at restore time — only the
-	// (iss, sub) tuple stored in MetadataKeyIdentityBinding is used.
+	// Validate and read the stored identity binding. This key is written by
+	// BindSession at session-creation time and identifies whether the session
+	// was bound to an authenticated identity or was anonymous.
 	storedBinding, hasBinding := storedMetadata[sessiontypes.MetadataKeyIdentityBinding]
 	if !hasBinding {
 		// Legacy token-hash key present confirms not corrupted — safe to invalidate.
@@ -437,26 +436,17 @@ func (f *defaultMultiSessionFactory) RestoreSession(
 			sessiontypes.MetadataKeyIdentityBinding)
 	}
 
-	// Restore identity from the stored (iss, sub) binding. Token is intentionally
-	// empty — the original bearer token is not persisted. Outgoing-auth strategies
-	// must derive credentials from Claims or a token store keyed by tsid; a
-	// strategy that reads identity.Token will reject the request with an
-	// identity-has-no-token error. The anonymous sentinel (identity == nil) is
-	// handled by the IsUnauthenticated guard below.
-	var identity *auth.Identity
+	// Validate that the stored binding is parsable (or the unauthenticated
+	// sentinel) before proceeding. A malformed value indicates corrupted metadata.
+	// We do NOT construct a partial *auth.Identity here: the original bearer
+	// token is not persisted, so UpstreamTokens cannot be recovered. Fabricating
+	// a struct with empty Token and UpstreamTokens would violate the contract that
+	// a non-nil *auth.Identity is always fully populated (see pkg/auth/identity.go).
+	// Backend connectors receive nil identity; live tool calls already carry a
+	// complete identity on req.Context() from TokenValidator.Middleware. See #5336.
 	if !binding.IsUnauthenticated(storedBinding) {
-		iss, sub, ok := binding.Parse(storedBinding)
-		if !ok {
+		if _, _, ok := binding.Parse(storedBinding); !ok {
 			return nil, fmt.Errorf("RestoreSession: stored identity binding is malformed: %q", storedBinding)
-		}
-		identity = &auth.Identity{
-			PrincipalInfo: auth.PrincipalInfo{
-				Subject: sub,
-				Claims: map[string]any{
-					"iss": iss,
-					"sub": sub,
-				},
-			},
 		}
 	}
 
@@ -470,8 +460,8 @@ func (f *defaultMultiSessionFactory) RestoreSession(
 	}
 
 	// Build the base session (backend connections + routing table) without the
-	// security wrapper. The wrapper is applied separately below.
-	baseSession := f.makeBaseSession(ctx, id, identity, filteredBackends, sessionHints)
+	// security wrapper. Pass nil identity — see comment above.
+	baseSession := f.makeBaseSession(ctx, id, nil, filteredBackends, sessionHints)
 
 	// Restore only the identity-binding key from stored metadata. The other
 	// keys (MetadataKeyBackendIDs, MetadataKeyBackendSessionPrefix.*) are

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -394,9 +394,9 @@ func (f *defaultMultiSessionFactory) makeSession(
 // RestoreSession implements MultiSessionFactory.
 // It reconnects to the backends whose IDs are listed in storedMetadata, rebuilds
 // the routing table, and reapplies the session-binding decorator from the stored
-// identity binding. Because the original bearer token is not available at restore
-// time, identity is reconstructed from the (iss, sub) tuple in
-// MetadataKeyIdentityBinding.
+// identity binding. Because the original bearer token is not persisted, backend
+// connectors receive nil identity; live requests carry a fully-populated identity
+// on req.Context() from TokenValidator.Middleware.
 func (f *defaultMultiSessionFactory) RestoreSession(
 	ctx context.Context,
 	id string,

--- a/pkg/vmcp/session/identity_binding_test.go
+++ b/pkg/vmcp/session/identity_binding_test.go
@@ -162,10 +162,11 @@ func TestRestoreSession_ErrorCases(t *testing.T) {
 	}
 }
 
-// TestRestoreSession_PopulatesBothSubjectFieldAndClaims verifies that after
-// RestoreSession the reconstructed identity's binding is stored and the
-// decorator accepts a matching caller.
-func TestRestoreSession_PopulatesBothSubjectFieldAndClaims(t *testing.T) {
+// TestRestoreSession_PreservesIdentityBindingAndAcceptsMatchingCaller verifies
+// that after RestoreSession the stored identity binding is preserved in session
+// metadata and the security decorator accepts a caller whose identity matches
+// the binding.
+func TestRestoreSession_PreservesIdentityBindingAndAcceptsMatchingCaller(t *testing.T) {
 	t.Parallel()
 
 	factory := newSessionFactoryWithConnector(nilBackendConnector())

--- a/pkg/vmcp/session/identity_binding_test.go
+++ b/pkg/vmcp/session/identity_binding_test.go
@@ -197,12 +197,18 @@ func TestRestoreSession_PopulatesBothSubjectFieldAndClaims(t *testing.T) {
 	}
 }
 
-// TestRestoreSession_ReconstructsIdentityWithEmptyTokenButPopulatedClaims pins
-// the contract that RestoreSession passes a reconstructed identity to the
-// backendConnector whose Token field is intentionally empty (the bearer token is
-// not persisted), but whose Claims["iss"] and Claims["sub"] are populated from
-// the stored identity binding.
-func TestRestoreSession_ReconstructsIdentityWithEmptyTokenButPopulatedClaims(t *testing.T) {
+// TestRestoreSession_PassesNilIdentityToConnector pins the contract that
+// RestoreSession does NOT fabricate a partial *auth.Identity to pass to backend
+// connectors. The original bearer token is not persisted; constructing an
+// identity with empty Token and UpstreamTokens would violate the field-
+// completeness contract on *auth.Identity (see pkg/auth/identity.go) and be a
+// landmine for any future consumer that assumes a non-nil identity is fully
+// populated. See issue #5336.
+//
+// Live tool calls already carry a fully-populated identity on req.Context() from
+// TokenValidator.Middleware; the connector's nil fallback identity means it never
+// injects an incomplete substitute.
+func TestRestoreSession_PassesNilIdentityToConnector(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -210,13 +216,17 @@ func TestRestoreSession_ReconstructsIdentityWithEmptyTokenButPopulatedClaims(t *
 		origSub = "carol"
 	)
 
-	var capturedIdentity *auth.Identity
+	var (
+		connectorCalled  bool
+		capturedIdentity *auth.Identity
+	)
 	capturingConnector := func(
 		_ context.Context,
 		_ *vmcp.BackendTarget,
 		id *auth.Identity,
 		_ string,
 	) (internalbk.Session, *vmcp.CapabilityList, error) {
+		connectorCalled = true
 		capturedIdentity = id
 		return nil, nil, nil
 	}
@@ -237,6 +247,7 @@ func TestRestoreSession_ReconstructsIdentityWithEmptyTokenButPopulatedClaims(t *
 	require.NotEmpty(t, meta[sessiontypes.MetadataKeyIdentityBinding],
 		"factory must write MetadataKeyIdentityBinding to metadata")
 
+	connectorCalled = false
 	capturedIdentity = nil
 
 	// Step 3: restore the session on "Pod B" with a backend present so the
@@ -255,16 +266,12 @@ func TestRestoreSession_ReconstructsIdentityWithEmptyTokenButPopulatedClaims(t *
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = restored.Close() })
 
-	// Step 4: the connector must receive an identity with an empty Token but
-	// populated Claims. Any outgoing-auth strategy that reads identity.Token
-	// will silently produce unauthenticated backend requests after a pod restart.
-	require.NotNil(t, capturedIdentity, "connector must be called with a non-nil identity for an authenticated session")
-	assert.Empty(t, capturedIdentity.Token,
-		"restored identity.Token must be empty — bearer token is not persisted across pod restarts")
-	assert.Equal(t, origIss, capturedIdentity.Claims["iss"],
-		"restored identity.Claims[iss] must match original issuer")
-	assert.Equal(t, origSub, capturedIdentity.Claims["sub"],
-		"restored identity.Claims[sub] must match original subject")
-	assert.Equal(t, origSub, capturedIdentity.Subject,
-		"restored identity.Subject must match original subject")
+	// Step 4: the connector must be called with nil identity. RestoreSession
+	// must not fabricate a partial *auth.Identity when the bearer token is
+	// unavailable — passing nil avoids silently supplying empty credentials to
+	// outgoing-auth strategies (upstreamInject, tokenExchange, aws_sts) that
+	// need UpstreamTokens.
+	require.True(t, connectorCalled, "connector must be invoked when a backend is present")
+	assert.Nil(t, capturedIdentity,
+		"RestoreSession must pass nil identity to the connector — no partial *auth.Identity should be fabricated")
 }

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
@@ -236,10 +236,12 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 		})
 
 		// TODO(#5336): extend this test with a tool call against a backend using
-		// upstreamInject outgoing auth after cross-pod restore. That scenario
-		// requires a live OIDC provider in the test environment and depends on
-		// #5323 + its sibling fix for the identityRoundTripper in
-		// pkg/vmcp/session/internal/backend/mcp_session.go being in place.
+		// upstreamInject outgoing auth after cross-pod restore. The code-side fix
+		// is complete (nil identity from RestoreSession, context propagation through
+		// loadSession, fallback-only identityRoundTripper in both client.go and
+		// mcp_session.go). The only remaining blocker is infrastructure: the E2E
+		// environment needs an OIDC provider that issues tokens with upstreamInject
+		// configured so the Initialize handshake can be authenticated.
 		ginkgo.It("Should allow a session established on pod A to be reconstructed on pod B", func() {
 			ginkgo.By("Getting the two ready pods")
 			var pods []corev1.Pod

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go
@@ -235,6 +235,11 @@ var _ = ginkgo.Describe("VirtualMCPServer Redis-Backed Session Sharing", func() 
 			}, timeout, pollInterval).Should(gomega.BeTrue())
 		})
 
+		// TODO(#5336): extend this test with a tool call against a backend using
+		// upstreamInject outgoing auth after cross-pod restore. That scenario
+		// requires a live OIDC provider in the test environment and depends on
+		// #5323 + its sibling fix for the identityRoundTripper in
+		// pkg/vmcp/session/internal/backend/mcp_session.go being in place.
 		ginkgo.It("Should allow a session established on pod A to be reconstructed on pod B", func() {
 			ginkgo.By("Getting the two ready pods")
 			var pods []corev1.Pod


### PR DESCRIPTION
## Summary

Two related bugs caused authenticated backend calls to fail after cross-pod session restore (Redis + \`replicas > 1\`).

**Bug 1 — partial identity fabrication**: \`RestoreSession\` constructed \`&auth.Identity{Subject, Claims}\` with \`Token\` and \`UpstreamTokens\` always empty, violating the field-completeness invariant on \`*auth.Identity\`. This struct was captured as \`identityRoundTripper.fallbackIdentity\` in every backend connector, so it was a latent landmine for any future consumer that assumes a non-nil identity is fully populated. Fix: pass \`nil\` to \`makeBaseSession\` — live requests carry a fully-populated identity on \`req.Context()\` from \`TokenValidator.Middleware\`, so the fallback is never needed.

**Bug 2 — backend Initialize unauthenticated during restore**: \`loadSession\` (the cache-miss restore path) called \`RestoreSession\` with \`context.Background()\`, discarding the incoming request's identity. Backend MCP \`Initialize\` handshakes during restore therefore ran with no auth headers — backends requiring \`upstreamInject\` / \`tokenExchange\` / \`aws_sts\` on \`Initialize\` silently lost their capabilities from the restored session. Fix: thread \`context.Context\` from \`GetMultiSession\` → \`loadSession\` → \`RestoreSession\`, using \`context.WithoutCancel(ctx)\` to carry values (identity) without propagating the caller's cancellation signal (required because \`singleflight\` coalesces concurrent restores).

Fixes #5336

## Type of change

- [x] Bug fix
- [x] Refactor (context propagation through cache + session manager)

## Test plan

- [x] Unit tests (\`task test\`)
- [x] Linting (\`task lint-fix\`)

## Changes

| File | Change |
|------|--------|
| \`pkg/auth/identity.go\` | Add field-completeness contract to \`Identity\` godoc |
| \`pkg/vmcp/session/factory.go\` | Pass \`nil\` identity to \`makeBaseSession\` in \`RestoreSession\`; validate stored binding without fabricating partial struct |
| \`pkg/vmcp/session/identity_binding_test.go\` | Assert connector receives \`nil\` identity on restore; rename stale test |
| \`pkg/cache/validating_cache.go\` | \`Get\`, \`load\`, and \`check\` accept \`context.Context\`; document singleflight winner-takes-context semantic |
| \`pkg/vmcp/server/session_manager_interface.go\` | \`GetMultiSession(ctx, sessionID)\`; doc describes contract for implementors, not Manager internals |
| \`pkg/vmcp/server/sessionmanager/session_manager.go\` | \`GetMultiSession\`, \`loadSession\`, \`checkSession\` accept context; \`loadSession\` uses \`context.WithoutCancel(ctx)\` for both storage load and \`RestoreSession\`; explain \`context.Background()\` in \`DecorateSession\` |
| \`pkg/vmcp/server/sessionmanager/session_manager_test.go\` | \`TestGetMultiSession_PropagatesIdentityToRestoreSession\` — pins that \`*auth.Identity\` and \`UpstreamTokens\` reach \`RestoreSession\`; fails if \`WithoutCancel\` is reverted to \`Background\` |
| \`pkg/vmcp/server/serve_handlers.go\` | \`enforceSessionBinding\` passes handler \`ctx\` to \`GetMultiSession\` |
| \`pkg/vmcp/server/serve_optimizer.go\` | Same for optimizer tool/find handlers |
| \`test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go\` | Add \`TODO(#5336)\` for upstream-auth E2E (needs OIDC provider in test env) |

## Does this introduce a user-facing change?

No visible change for single-replica deployments (never hit \`RestoreSession\`). For multi-replica Redis deployments with upstream-auth strategies: backend Initialize handshakes during cross-pod restore are now authenticated, so restored sessions correctly reflect all backend capabilities rather than silently dropping backends that require auth on Initialize.

## Special notes for reviewers

- **\`context.WithoutCancel\`**: used in \`loadSession\` and \`checkSession\` to copy the caller's identity without propagating its cancellation. This is necessary because \`ValidatingCache.Get\` deduplicates concurrent requests via \`singleflight\` — if the triggering caller cancels mid-restore, the other coalesced waiters must still receive a result. Independent per-operation timeouts (\`restoreStorageTimeout\` / \`restoreSessionTimeout\`) still apply. The regression guard is \`TestGetMultiSession_PropagatesIdentityToRestoreSession\`.
- **\`DecorateSession\`** calls \`GetMultiSession(context.Background(), sessionID)\` — it's a session-setup operation, not a live authenticated request, so there is no caller identity to propagate. Explained by an inline comment.
- **AC2 (\`MetadataKeyIdentitySubject\`)**: This constant does not exist in the codebase — it references a code pattern from an older iteration of the issue description. The subject is encoded inside \`MetadataKeyIdentityBinding\` (format: \`iss\x00sub\`) and is preserved via \`SetMetadata\` at \`factory.go:471\`. AC2 is satisfied; \`TestRestoreSession_PreservesIdentityBindingAndAcceptsMatchingCaller\` (line 185) confirms the binding round-trips correctly.
- The nil-identity path through \`makeBaseSession\` was already safe: all dereferences of \`identity\` in \`factory.go\`, \`identityRoundTripper.RoundTrip\`, and \`RestoreHijackPrevention\` already guard against nil.

Generated with [Claude Code](https://claude.com/claude-code)