### PR TITLE
fix(auth): treat typed-nil Identity in context as absent

### DIFF
--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -36,7 +36,9 @@ func WithIdentity(ctx context.Context, identity *Identity) context.Context {
 }
 
 // IdentityFromContext retrieves an Identity from the context.
-// Returns the identity and true if present, nil and false otherwise.
+// Returns the identity and true if a non-nil identity is present, nil and false otherwise.
+// A typed-nil *Identity stored directly in the context (bypassing WithIdentity) is
+// treated as absent so callers can safely gate on the boolean without nil checks.
 //
 // This function is typically called by authorization middleware or handlers that need
 // to check who the authenticated user is.
@@ -50,7 +52,7 @@ func WithIdentity(ctx context.Context, identity *Identity) context.Context {
 //	log.Printf("Request from user: %s", identity.Subject)
 func IdentityFromContext(ctx context.Context) (*Identity, bool) {
 	identity, ok := ctx.Value(IdentityContextKey{}).(*Identity)
-	return identity, ok
+	return identity, ok && identity != nil
 }
 
 // PlatformUserContextKey is the key used to store the platform's canonical user

--- a/pkg/auth/context_test.go
+++ b/pkg/auth/context_test.go
@@ -91,9 +91,9 @@ func TestIdentityContext_ExplicitNilValue(t *testing.T) {
 	// Explicitly store nil Identity pointer in context (edge case)
 	ctx = context.WithValue(ctx, IdentityContextKey{}, (*Identity)(nil))
 
-	// Retrieval should detect the nil pointer
+	// Typed-nil pointers must read as absent so fallback identity injection can proceed.
 	identity, ok := IdentityFromContext(ctx)
-	assert.True(t, ok, "expected value to be present")
+	assert.False(t, ok, "typed-nil identity should not be treated as present")
 	assert.Nil(t, identity, "expected nil identity")
 }
 


### PR DESCRIPTION
## Summary

Fixes #5337.

`IdentityFromContext` could return `(nil, true)` when a typed-nil `*Identity` was stored in context via direct `context.WithValue` (bypassing `WithIdentity`). In Go, the type assertion succeeds on a typed-nil interface value even though the pointer is nil.

That caused two problems:
1. vMCP fallback identity injection (`!hasIdentity && fallback != nil`) was skipped, leaving downstream requests unauthenticated.
2. Callers gating only on `ok` could nil-dereference (webhooks, ratelimit, auth strategies).

## Motivation

vMCP roundtrippers and other auth paths gate fallback injection on `!hasIdentity`. A typed-nil `*Identity` incorrectly satisfied `hasIdentity == true`, suppressing fallback and allowing nil to flow into upstream auth strategies.

## Changes

- Return `ok && identity != nil` from `IdentityFromContext`, aligning retrieval with `WithIdentity` (which never stores nil).
- Update `TestIdentityContext_ExplicitNilValue` to assert the defensive behavior.
- Document the typed-nil edge case in the function comment.

## Tests

- [x] `go test ./pkg/auth/... -run TestIdentityContext`
- [x] `go test ./pkg/vmcp/session/internal/backend/...`

## Notes

- Normal paths using `WithIdentity` are unchanged.
- Only the unsupported typed-nil bypass path changes from `(nil, true)` to `(nil, false)`.
- Callers with redundant `identity != nil` checks remain correct.