### PR TITLE
fix(vmcp): allow JSON-RPC client responses through authz middleware

### DIFF
--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -175,6 +175,14 @@ func Middleware(a authorizers.Authorizer, next http.Handler, passThroughTools ma
 			return
 		}
 
+		// JSON-RPC responses (client replies to server-initiated requests) are not
+		// subject to MCP method authorization. Downstream transport handlers
+		// accept them with 202 per the streamable HTTP spec.
+		if !parsedRequest.IsRequest {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Check if we should skip authorization after parsing the message
 		if shouldSkipSubsequentAuthorization(parsedRequest.Method) {
 			next.ServeHTTP(w, r)

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -1522,7 +1522,7 @@ func TestMiddleware_AllowsJSONRPCClientResponse(t *testing.T) {
 
 	denyAll := &stubAuthorizer{allowed: false}
 	handlerCalled := false
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		handlerCalled = true
 		w.WriteHeader(http.StatusAccepted)
 	})
@@ -1544,7 +1544,7 @@ func TestMiddleware_RejectsMalformedJSONRPCBody(t *testing.T) {
 	t.Parallel()
 
 	denyAll := &stubAuthorizer{allowed: false}
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("next handler should not be called for malformed JSON-RPC")
 	})
 

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -1544,7 +1544,7 @@ func TestMiddleware_RejectsMalformedJSONRPCBody(t *testing.T) {
 	t.Parallel()
 
 	denyAll := &stubAuthorizer{allowed: false}
-	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Fatal("next handler should not be called for malformed JSON-RPC")
 	})
 

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -1516,3 +1516,46 @@ func TestHandleToolsCall(t *testing.T) {
 		})
 	}
 }
+
+func TestMiddleware_AllowsJSONRPCClientResponse(t *testing.T) {
+	t.Parallel()
+
+	denyAll := &stubAuthorizer{allowed: false}
+	handlerCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	chain := mcpparser.ParsingMiddleware(Middleware(denyAll, next, nil))
+
+	body := `{"jsonrpc":"2.0","id":1,"result":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	chain.ServeHTTP(rr, req)
+
+	assert.True(t, handlerCalled, "client JSON-RPC response should bypass authorization")
+	assert.Equal(t, http.StatusAccepted, rr.Code)
+}
+
+func TestMiddleware_RejectsMalformedJSONRPCBody(t *testing.T) {
+	t.Parallel()
+
+	denyAll := &stubAuthorizer{allowed: false}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called for malformed JSON-RPC")
+	})
+
+	chain := mcpparser.ParsingMiddleware(Middleware(denyAll, next, nil))
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewBufferString(`{"invalid json`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	chain.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Invalid or malformed MCP request")
+}

--- a/pkg/mcp/parser.go
+++ b/pkg/mcp/parser.go
@@ -152,7 +152,20 @@ func parseMCPRequest(bodyBytes []byte) *ParsedMCPRequest {
 	// Handle only request messages (both calls with ID and notifications without ID)
 	req, ok := msg.(*jsonrpc2.Request)
 	if !ok {
-		// Response or error messages are not parsed here
+		// JSON-RPC responses (client replies to server-initiated requests) are
+		// not MCP requests and must bypass authorization, but we still record
+		// them in context so downstream middleware can distinguish them from
+		// malformed bodies.
+		if resp, ok := msg.(*jsonrpc2.Response); ok {
+			var id interface{}
+			if resp.ID.IsValid() {
+				id = resp.ID.Raw()
+			}
+			return &ParsedMCPRequest{
+				ID:        id,
+				IsRequest: false,
+			}
+		}
 		return nil
 	}
 

--- a/pkg/mcp/parser_test.go
+++ b/pkg/mcp/parser_test.go
@@ -1239,14 +1239,6 @@ func TestParseMCPRequestWithInvalidJSON(t *testing.T) {
 			name: "invalid JSON",
 			body: "not json",
 		},
-		{
-			name: "JSON-RPC response instead of request",
-			body: `{"jsonrpc":"2.0","id":1,"result":{"success":true}}`,
-		},
-		{
-			name: "JSON-RPC error instead of request",
-			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"error"}}`,
-		},
 	}
 
 	for _, tt := range tests {
@@ -1254,6 +1246,37 @@ func TestParseMCPRequestWithInvalidJSON(t *testing.T) {
 			t.Parallel()
 			result := parseMCPRequest([]byte(tt.body))
 			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestParseMCPRequestClientResponse(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		id   interface{}
+	}{
+		{
+			name: "JSON-RPC success response",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"success":true}}`,
+			id:   int64(1),
+		},
+		{
+			name: "JSON-RPC error response",
+			body: `{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"error"}}`,
+			id:   int64(1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := parseMCPRequest([]byte(tt.body))
+			require.NotNil(t, result)
+			assert.False(t, result.IsRequest)
+			assert.Equal(t, tt.id, result.ID)
+			assert.Empty(t, result.Method)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

When MCP clients POST JSON-RPC responses to server-initiated requests on the streamable HTTP backchannel (e.g. replying to server pings), vMCP returned `400 Invalid or malformed MCP request` instead of `202 Accepted`. This caused clients like VS Code and Cursor to tear down sessions every ~30s.

## Motivation

Per the MCP streamable HTTP spec, the server must return **202 Accepted** for accepted JSON-RPC responses/notifications. The authz middleware rejected these messages because the MCP parser only recognized JSON-RPC **requests**, leaving `GetParsedMCPRequest()` nil for valid client responses.

Fixes #5009

## Changes

- `pkg/mcp/parser.go`: parse JSON-RPC responses into context with `IsRequest: false`
- `pkg/authz/middleware.go`: bypass method authorization for non-request messages
- Add regression tests in `pkg/mcp/parser_test.go` and `pkg/authz/middleware_test.go`

## Tests

```bash
go test ./pkg/mcp/... ./pkg/authz/... -run 'TestParseMCPRequest|TestMiddleware_AllowsJSONRPC|TestMiddleware_RejectsMalformed'
```

All targeted tests pass.

## Notes

- Connection authentication is unchanged; only method-level authorization is skipped for responses (which carry no MCP method).
- Webhook validating/mutating middleware may need a follow-up guard (`Method == ""`) if webhook-enabled streamable-http deployments observe ping-reply regressions; left out of this PR to keep the diff focused on the reported 400 path.
