### PR TITLE
fix(client): detect Amp extension clients via amp.mcpServers key

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -217,7 +217,11 @@ type clientAppConfig struct {
 	SettingsFile                  string
 	PlatformPrefix                map[Platform][]string
 	MCPServersPathPrefix          string
-	Extension                     Extension
+	// InstallSettingsKey, when set, requires this JSON key in the client's
+	// settings file for IsClientInstalled to return true. Used for extension
+	// clients that share a host editor's config directory (e.g. Amp in VS Code).
+	InstallSettingsKey string
+	Extension          Extension
 	SupportedTransportTypesMap    map[types.TransportType]string // stdio mapped to streamable-http (SSE deprecated)
 	IsTransportTypeFieldSupported bool
 	// MCPServersUrlLabelMap maps transport type to URL field name (e.g., "url", "serverUrl", "httpUrl")
@@ -599,6 +603,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		Description:          "VS Code Sourcegraph Amp extension",
 		SettingsFile:         "settings.json",
 		MCPServersPathPrefix: "/amp.mcpServers",
+		InstallSettingsKey:   "amp.mcpServers",
 		RelPath:              []string{"Code", "User"},
 		PlatformPrefix: map[Platform][]string{
 			PlatformLinux:   {".config"},
@@ -623,6 +628,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		Description:          "VS Code Insiders Sourcegraph Amp extension",
 		SettingsFile:         "settings.json",
 		MCPServersPathPrefix: "/amp.mcpServers",
+		InstallSettingsKey:   "amp.mcpServers",
 		RelPath:              []string{"Code - Insiders", "User"},
 		PlatformPrefix: map[Platform][]string{
 			PlatformLinux:   {".config"},
@@ -647,6 +653,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		Description:          "Cursor Sourcegraph Amp extension",
 		SettingsFile:         "settings.json",
 		MCPServersPathPrefix: "/amp.mcpServers",
+		InstallSettingsKey:   "amp.mcpServers",
 		RelPath:              []string{"Cursor", "User"},
 		PlatformPrefix: map[Platform][]string{
 			PlatformLinux:   {".config"},
@@ -671,6 +678,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		Description:          "Windsurf Sourcegraph Amp extension",
 		SettingsFile:         "settings.json",
 		MCPServersPathPrefix: "/amp.mcpServers",
+		InstallSettingsKey:   "amp.mcpServers",
 		RelPath:              []string{"Windsurf", "User"},
 		PlatformPrefix: map[Platform][]string{
 			PlatformLinux:   {".config"},

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -212,16 +212,16 @@ type clientAppConfig struct {
 	Deprecated bool
 	// DeprecationMessage is the full warning text shown to users (on stderr)
 	// when they touch a deprecated client. Only set when Deprecated is true.
-	DeprecationMessage            string
-	RelPath                       []string
-	SettingsFile                  string
-	PlatformPrefix                map[Platform][]string
-	MCPServersPathPrefix          string
+	DeprecationMessage   string
+	RelPath              []string
+	SettingsFile         string
+	PlatformPrefix       map[Platform][]string
+	MCPServersPathPrefix string
 	// InstallSettingsKey, when set, requires this JSON key in the client's
 	// settings file for IsClientInstalled to return true. Used for extension
 	// clients that share a host editor's config directory (e.g. Amp in VS Code).
-	InstallSettingsKey string
-	Extension          Extension
+	InstallSettingsKey            string
+	Extension                     Extension
 	SupportedTransportTypesMap    map[types.TransportType]string // stdio mapped to streamable-http (SSE deprecated)
 	IsTransportTypeFieldSupported bool
 	// MCPServersUrlLabelMap maps transport type to URL field name (e.g., "url", "serverUrl", "httpUrl")

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -12,8 +12,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/tidwall/gjson"
 	"github.com/tailscale/hujson"
+	"github.com/tidwall/gjson"
 
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/groups"
@@ -114,7 +114,7 @@ func (cm *ClientManager) IsClientInstalled(clientType ClientApp) bool {
 }
 
 func settingsFileHasKey(path, key string) bool {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is constructed from trusted home-dir client config locations
 	if err != nil {
 		return false
 	}

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -10,6 +10,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tailscale/hujson"
 
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/groups"
@@ -84,10 +88,20 @@ type ClientAppStatus struct {
 // IsClientInstalled reports whether the given client appears to be installed on
 // the current system. Detection is based on the presence of the client's
 // configuration directory (or settings file when no relative path is defined).
+// When InstallSettingsKey is set, the settings file must also contain that key.
 func (cm *ClientManager) IsClientInstalled(clientType ClientApp) bool {
 	cfg := cm.lookupClientAppConfig(clientType)
 	if cfg == nil || cfg.LLMGatewayOnly {
 		return false
+	}
+	if cfg.InstallSettingsKey != "" {
+		settingsPath := buildConfigFilePath(
+			cfg.SettingsFile,
+			cfg.RelPath,
+			cfg.PlatformPrefix,
+			[]string{cm.homeDir},
+		)
+		return settingsFileHasKey(settingsPath, cfg.InstallSettingsKey)
 	}
 	var pathToCheck string
 	if len(cfg.RelPath) == 0 {
@@ -97,6 +111,23 @@ func (cm *ClientManager) IsClientInstalled(clientType ClientApp) bool {
 	}
 	_, err := os.Stat(pathToCheck)
 	return err == nil
+}
+
+func settingsFileHasKey(path, key string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	parsed, err := hujson.Parse(data)
+	if err != nil {
+		return false
+	}
+	parsed.Standardize()
+	return gjson.GetBytes(parsed.Pack(), gjsonEscapePath(key)).Exists()
+}
+
+func gjsonEscapePath(path string) string {
+	return strings.ReplaceAll(path, ".", `\.`)
 }
 
 // GetClientStatus returns the status of all supported MCP clients using this manager's dependencies

--- a/pkg/client/discovery_test.go
+++ b/pkg/client/discovery_test.go
@@ -260,6 +260,49 @@ func TestIsClientInstalled(t *testing.T) {
 	}
 }
 
+func TestIsClientInstalled_AmpExtensionRequiresSettingsKey(t *testing.T) {
+	t.Parallel()
+
+	ampCursorCfg := clientAppConfig{
+		ClientType:           AmpCursor,
+		SettingsFile:         "settings.json",
+		RelPath:              []string{"Cursor", "User"},
+		PlatformPrefix:       map[Platform][]string{PlatformLinux: {".config"}},
+		InstallSettingsKey:   "amp.mcpServers",
+		MCPServersPathPrefix: "/amp.mcpServers",
+		Extension:            JSON,
+	}
+
+	t.Run("host editor present without amp key", func(t *testing.T) {
+		t.Parallel()
+		tempHome := t.TempDir()
+		cursorUserDir := filepath.Join(tempHome, ".config", "Cursor", "User")
+		require.NoError(t, os.MkdirAll(cursorUserDir, 0700))
+		settingsPath := filepath.Join(cursorUserDir, "settings.json")
+		require.NoError(t, os.WriteFile(settingsPath, []byte(`{"editor.fontSize": 14}`), 0600))
+		manager := NewTestClientManager(tempHome, nil, []clientAppConfig{ampCursorCfg}, nil)
+		assert.False(t, manager.IsClientInstalled(AmpCursor))
+	})
+
+	t.Run("host editor present with amp key", func(t *testing.T) {
+		t.Parallel()
+		tempHome := t.TempDir()
+		cursorUserDir := filepath.Join(tempHome, ".config", "Cursor", "User")
+		require.NoError(t, os.MkdirAll(cursorUserDir, 0700))
+		settingsPath := filepath.Join(cursorUserDir, "settings.json")
+		require.NoError(t, os.WriteFile(settingsPath, []byte(`{"amp.mcpServers": {}}`), 0600))
+		manager := NewTestClientManager(tempHome, nil, []clientAppConfig{ampCursorCfg}, nil)
+		assert.True(t, manager.IsClientInstalled(AmpCursor))
+	})
+
+	t.Run("host editor directory absent", func(t *testing.T) {
+		t.Parallel()
+		emptyHome := t.TempDir()
+		manager := NewTestClientManager(emptyHome, nil, []clientAppConfig{ampCursorCfg}, nil)
+		assert.False(t, manager.IsClientInstalled(AmpCursor))
+	})
+}
+
 func TestGetClientStatus_WithGroups(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fix false-positive "installed" status for Amp editor extensions (`amp-vscode`, `amp-cursor`, `amp-windsurf`, `amp-vscode-insider`) in `thv client status`.

## Motivation

These Amp clients share the host editor's config directory (`Code/User`, `Cursor/User`, `Windsurf/User`). Checking only for directory presence reports Amp as installed whenever VS Code, Cursor, or Windsurf is installed, even without the Amp extension.

Fixes #2174

## Changes

- Add optional `InstallSettingsKey` to `clientAppConfig`
- Set `InstallSettingsKey: "amp.mcpServers"` for Amp extension clients (not `amp-cli`, which has its own directory)
- Update `IsClientInstalled` to require the settings key when configured, using `hujson` + `gjson` with dot escaping for dotted JSON keys
- Add regression tests for Amp-on-Cursor detection

## Tests

```bash
go test ./pkg/client/... -count=1
```

All tests pass.

## Notes

- `amp-cli` is unchanged (dedicated `~/.config/amp` directory)
- Uses the same JSONC parsing path as other client config readers
- A stale `amp.mcpServers: null` key after uninstall could still report installed; acceptable edge case per maintainer guidance