### PR TITLE
Strip client Authorization on upstreamswap custom header

### DIFF
--- a/pkg/auth/upstreamswap/middleware.go
+++ b/pkg/auth/upstreamswap/middleware.go
@@ -129,9 +129,21 @@ func createReplaceInjector() injectionFunc {
 }
 
 // createCustomInjector creates an injection function that adds the token to a custom header.
+//
+// It also strips the client's original Authorization header (the ToolHive-issued
+// JWT) so it is never forwarded to the backend: that token was minted for the
+// proxy, not the upstream, and leaking it is credential passthrough (#5504). The
+// "replace" strategy avoids this implicitly because it overwrites Authorization;
+// the custom strategy must strip it explicitly. When the custom header name is
+// itself Authorization (case-insensitive), the Set above already replaced the JWT
+// with the upstream token, so it must be left in place.
 func createCustomInjector(headerName string) injectionFunc {
+	stripAuthorization := http.CanonicalHeaderKey(headerName) != "Authorization"
 	return func(r *http.Request, token string) {
 		r.Header.Set(headerName, fmt.Sprintf("Bearer %s", token))
+		if stripAuthorization {
+			r.Header.Del("Authorization")
+		}
 	}
 }
 

--- a/pkg/auth/upstreamswap/middleware_test.go
+++ b/pkg/auth/upstreamswap/middleware_test.go
@@ -259,7 +259,78 @@ func TestMiddleware_SuccessfulSwap_CustomHeader(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, "Bearer upstream-access-token", capturedCustomHeader)
-	assert.Equal(t, "Bearer original-token", capturedAuthHeader)
+	// The client's Authorization header must be stripped, not forwarded (#5504).
+	assert.Empty(t, capturedAuthHeader)
+}
+
+// TestMiddleware_CustomStrategy_StripsClientAuthHeader is a regression test for
+// stacklok/toolhive#5504: with header_strategy "custom", the upstream token is
+// injected into a custom header but the client's original Authorization header
+// (the ToolHive-issued JWT) must NOT be forwarded to the backend.
+func TestMiddleware_CustomStrategy_StripsClientAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		HeaderStrategy:   HeaderStrategyCustom,
+		CustomHeaderName: "X-Upstream-Token",
+		ProviderName:     "github",
+	}
+	middleware := createMiddlewareFunc(cfg)
+
+	var capturedCustomHeader string
+	var capturedAuthHeader string
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedCustomHeader = r.Header.Get("X-Upstream-Token")
+		capturedAuthHeader = r.Header.Get("Authorization")
+	})
+
+	handler := middleware(nextHandler)
+	req := requestWithIdentity("upstream-access-token")
+	req.Header.Set("Authorization", "Bearer toolhive-jwt")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "Bearer upstream-access-token", capturedCustomHeader,
+		"upstream token should be injected into the custom header")
+	assert.Empty(t, capturedAuthHeader,
+		"client's ToolHive JWT must be stripped from Authorization, not leaked to the backend")
+}
+
+// TestMiddleware_CustomStrategy_AuthorizationHeaderName covers the edge case
+// where the custom header name is itself "Authorization": the Set already
+// overwrites the client JWT with the upstream token, so the token must survive
+// rather than be stripped. Header names are case-insensitive.
+func TestMiddleware_CustomStrategy_AuthorizationHeaderName(t *testing.T) {
+	t.Parallel()
+
+	for _, headerName := range []string{"Authorization", "authorization"} {
+		t.Run(headerName, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				HeaderStrategy:   HeaderStrategyCustom,
+				CustomHeaderName: headerName,
+				ProviderName:     "github",
+			}
+			middleware := createMiddlewareFunc(cfg)
+
+			var capturedAuthHeader string
+			nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				capturedAuthHeader = r.Header.Get("Authorization")
+			})
+
+			handler := middleware(nextHandler)
+			req := requestWithIdentity("upstream-access-token")
+			req.Header.Set("Authorization", "Bearer toolhive-jwt")
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, "Bearer upstream-access-token", capturedAuthHeader,
+				"upstream token must survive when the custom header is Authorization")
+		})
+	}
 }
 
 func TestMiddleware_Close(t *testing.T) {
@@ -298,7 +369,8 @@ func TestCreateInjectors(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer original")
 		injector(req, "test-token")
 		assert.Equal(t, "Bearer test-token", req.Header.Get("X-Custom-Header"))
-		assert.Equal(t, "Bearer original", req.Header.Get("Authorization"))
+		// The client's Authorization header must be stripped, not forwarded (#5504).
+		assert.Empty(t, req.Header.Get("Authorization"))
 	})
 }
 


### PR DESCRIPTION
## Summary

With `header_strategy: custom`, the upstreamswap auth middleware injected the upstream IdP token into a custom header but **left the client's original `Authorization` header (the ToolHive-issued JWT) in place**, forwarding it to the backend MCP server. That JWT is minted for the proxy, not the upstream — passing it through is credential passthrough of a token the backend was never meant to receive.

- The `replace` strategy avoids this implicitly: it calls `Set("Authorization", ...)`, overwriting the client JWT with the upstream token.
- The `strip-auth` middleware from #4168 (`pkg/transport/middleware/strip_auth.go`) does remove `Authorization`, but it is only wired in on the `DisableUpstreamTokenInjection` path, so it never ran on the upstreamswap custom path.
- **Fix:** the custom injector now strips `Authorization` after setting the custom header, matching `replace`. When the custom header name is itself `Authorization` (case-insensitive, via `http.CanonicalHeaderKey`), the `Set` already replaced the JWT with the upstream token, so the strip is skipped.

Scoped to `Authorization` only (not Cookie/Proxy-Authorization) to mirror the `replace` reference path the issue identifies as non-leaking.

Fixes #5504

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`) — clean for `pkg/auth/upstreamswap/...`

Added a regression test that fails on the buggy code (`Should be empty, but was Bearer toolhive-jwt`) and passes after the fix, plus a case-insensitive edge-case test for a custom header named `Authorization`. Updated two existing tests that had been asserting the leaked-JWT behavior. Verified red→green by stashing the production change and re-running.

```
go test ./pkg/auth/upstreamswap/...   # ok
go build ./...                         # clean
```

## Does this introduce a user-facing change?

Yes. When `header_strategy: custom` is configured, the backend MCP server no longer receives the client's ToolHive-issued JWT in the `Authorization` header. The upstream token is still delivered in the configured custom header. Backends that (incorrectly) relied on the leaked JWT will no longer see it.

## Special notes for reviewers

Flagging this as a **security-hardening fix for auth review** — it closes a credential-passthrough path. Worth scrutinizing: the `Authorization`-as-custom-header edge case (must NOT strip there), and the decision to scope the strip to `Authorization` only to stay consistent with `replace` rather than adopting the broader strip-auth header set (Cookie, Proxy-Authorization).

Generated with [Claude Code](https://claude.com/claude-code)
