### PR TITLE
docs(vmcp): document core transport split

### DIFF
--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -16,13 +16,17 @@ vMCP solves the problem of **MCP server sprawl**. As organizations deploy more s
 
 ## Architecture
 
-The vmcp package follows Domain-Driven Design principles with clear separation into bounded contexts:
+The vmcp package follows Domain-Driven Design principles with clear separation into bounded contexts. The current public API also separates the vMCP domain object from the HTTP/MCP transport:
+
+- `pkg/vmcp/core.New` builds the identity-parameterized `core.VMCP` domain object. The core aggregates backend capabilities, routes calls, applies admission checks, executes composite workflows, and owns backend health.
+- `pkg/vmcp/server.Serve` wraps an existing `core.VMCP` in the transport layer. The server owns the mcp-go server, session hooks, middleware, status routes, metrics routes, and lifecycle.
+- `pkg/vmcp/server.New` remains the stable composition root used by existing callers. It derives the core and transport configs, calls `core.New`, then calls `Serve`.
 
 ```mermaid
 graph TB
     subgraph "Virtual MCP Server"
         Server[Server<br/>HTTP + MCP Protocol]
-        Discovery[Discovery Manager]
+        Core[core.VMCP<br/>Domain API]
         Router[Router]
         BackendClient[Backend Client]
         Health[Health Monitor]
@@ -47,10 +51,10 @@ graph TB
 
     Client[MCP Client] --> Server
     Server --> InAuth
-    InAuth --> Discovery
-    Discovery --> Aggregator
+    InAuth --> Core
+    Core --> Aggregator
     Aggregator --> Conflict
-    Discovery --> Router
+    Core --> Router
     Router --> OutAuth
     OutAuth --> BackendClient
     BackendClient --> B1
@@ -63,6 +67,7 @@ graph TB
     Health --> B4
 
     style Server fill:#90caf9
+    style Core fill:#90caf9
     style Aggregator fill:#81c784
     style Router fill:#fff59d
 ```

--- a/docs/arch/vmcp-library.md
+++ b/docs/arch/vmcp-library.md
@@ -14,6 +14,7 @@ Downstream consumers like `brood-box` need predictability across ToolHive releas
 
 ```go
 import (
+    vmcpcore "github.com/stacklok/toolhive/pkg/vmcp/core"
     vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
     "github.com/stacklok/toolhive/pkg/vmcp/server"
     "github.com/stacklok/toolhive/pkg/vmcp/aggregator"
@@ -21,18 +22,39 @@ import (
 )
 ```
 
-The `pkg/vmcp/` root package (`github.com/stacklok/toolhive/pkg/vmcp`) contains only shared domain types (`types.go`, `errors.go`) and is always safe to import.
+The `pkg/vmcp/` root package (`github.com/stacklok/toolhive/pkg/vmcp`) contains only shared domain types (`types.go`, `errors.go`) and is always safe to import. Embedders that need the split public API import `pkg/vmcp/core` for the domain object and `pkg/vmcp/server` for the HTTP/MCP transport.
 
 ### Reference Implementation: brood-box
 
 [`github.com/stacklok/brood-box`](https://github.com/stacklok/brood-box) embeds `pkg/vmcp/` under `internal/infra/mcp/`. It demonstrates the recommended pattern:
 
 1. Load a `vmcpconfig.Config` from YAML or programmatically.
-2. Instantiate a `discovery.Manager`, `vmcp.BackendRegistry`, router, and backend client.
-3. Build a `server.Server` via `server.New(ctx, cfg, router, backendClient, discoveryMgr, backendRegistry, workflowDefs)`.
+2. Instantiate an aggregator, router, backend client, backend registry, session factory, and any workflow definitions.
+3. Use `server.New(ctx, cfg, rt, backendClient, backendRegistry, workflowDefs)` when you want the stable composition root to assemble `core.New(...)` and `server.Serve(...)` for you.
 4. Call `server.Start(ctx)` and `server.Stop(ctx)` for lifecycle management.
 
 This is the same path used by `pkg/vmcp/cli/serve.go` in the `thv vmcp serve` command; the library has no CLI-specific coupling.
+
+### New/Serve Split
+
+The public API now separates the vMCP domain object from the transport:
+
+```go
+coreVMCP, err := vmcpcore.New(coreCfg)
+srv, err := server.Serve(ctx, coreVMCP, serverCfg)
+```
+
+`core.New` builds the identity-parameterized `core.VMCP` domain object. It owns capability aggregation, routing, composite workflows, admission checks, and backend health. Its methods use `pkg/vmcp` domain types and an explicit `*auth.Identity`; no `mcp-go` types cross this boundary.
+
+`server.Serve` wraps an already-constructed `core.VMCP` with the MCP/HTTP transport. It owns the mcp-go server, session hooks, session storage, handler construction, lifecycle wiring, status reporting, metrics routes, and optional embedded auth-server routes.
+
+`server.New` remains the stable convenience path for existing embedders. It derives the core and transport configs, calls `core.New(...)`, optionally wraps the core with configured decorators, then calls `server.Serve(...)`. It is retained, not deprecated.
+
+### Decorator Extension Model
+
+Extension at the domain layer is done by wrapping an inner `core.VMCP`. A decorator should hold only `inner core.VMCP`, filter `List*` results, and refuse matching `CallTool`, `ReadResource`, or `GetPrompt` operations before delegating. This makes decorators subtract-only: they can hide or deny capabilities, but they cannot widen backend reachability because they have no backend access except through `inner`.
+
+When extending the transport instead, use `(*server.Server).Handler(ctx)` as the supported outermost-wrapping seam. An embedder can mount the fully composed vMCP handler in its own mux, apply its own middleware outside ToolHive's internal chain, and serve sibling routes without reordering vMCP authentication, parsing, telemetry, or session handling.
 
 ## `pkg/vmcp/` Stability Table
 
@@ -40,11 +62,12 @@ The table below maps every sub-package to its stability level per RFC THV-0059. 
 
 | Package | Stability | Notes |
 |---------|-----------|-------|
-| `pkg/vmcp` (root) | Stable | Shared domain types (`BackendTarget`, `Tool`, etc.) and errors; public API |
+| `pkg/vmcp` (root) | Stable | Shared domain types (`BackendTarget`, `Tool`, etc.) and errors; safe for public import |
 | `pkg/vmcp/config` | Stable | Config structs and YAML loader; `Config`, `BackendConfig`, `OptimizerConfig` |
+| `pkg/vmcp/core` | Stable | Identity-explicit domain API; `VMCP`, `Config`, `New` |
 | `pkg/vmcp/aggregator` | Stable | Backend discovery and capability merge; `Aggregator` interface |
 | `pkg/vmcp/router` | Stable | Request routing and tool name translation; `Router` interface |
-| `pkg/vmcp/server` | Stable | Server constructor and lifecycle; `New`, `Start`, `Stop` |
+| `pkg/vmcp/server` | Stable | Transport constructor and lifecycle; `Serve`, stable wrapper `New`, `Handler`, `Start`, `Stop` |
 | `pkg/vmcp/session` | Stable | Session factory and per-session routing table |
 | `pkg/vmcp/auth` | Stable | Incoming/outgoing auth interfaces; `IncomingAuthenticator`, `OutgoingAuthRegistry` |
 | `pkg/vmcp/client` | Stable | Backend HTTP client; used for all backend MCP calls |

--- a/pkg/vmcp/doc.go
+++ b/pkg/vmcp/doc.go
@@ -15,6 +15,12 @@
 //	pkg/vmcp/
 //	├── types.go              // Shared domain types (BackendTarget, Tool, etc.)
 //	├── errors.go             // Domain errors
+//	├── core/                 // Identity-explicit vMCP domain object
+//	│   ├── core.go           // VMCP interface + Config
+//	│   └── core_vmcp.go      // core.New composition
+//	├── server/               // HTTP + MCP protocol transport
+//	│   ├── serve.go          // server.Serve transport entry point
+//	│   └── server.go         // Stable server.New wrapper + Handler/Start/Stop
 //	├── router/               // Request routing
 //	│   └── router.go         // Router interface + routing strategies
 //	├── aggregator/           // Capability aggregation
@@ -29,6 +35,10 @@
 //	    └── cache.go          // Cache interface + implementations
 //
 // # Core Concepts
+//
+// **Core/Transport Split**: pkg/vmcp/core owns the identity-explicit VMCP
+// domain object. pkg/vmcp/server owns the MCP/HTTP transport that serves that
+// domain object to clients.
 //
 // **Routing**: Forward MCP protocol requests (tools, resources, prompts) to
 // appropriate backend workloads. Supports session affinity and load balancing.
@@ -51,6 +61,22 @@
 // (memory, Redis).
 //
 // # Key Interfaces
+//
+// VMCP (pkg/vmcp/core):
+//
+//	type VMCP interface {
+//		ListTools(ctx context.Context, identity *auth.Identity) ([]vmcp.Tool, error)
+//		CallTool(ctx context.Context, identity *auth.Identity, name string, args, meta map[string]any) (*vmcp.ToolCallResult, error)
+//		ListResources(ctx context.Context, identity *auth.Identity) ([]vmcp.Resource, error)
+//		ReadResource(ctx context.Context, identity *auth.Identity, uri string) (*vmcp.ResourceReadResult, error)
+//		ListPrompts(ctx context.Context, identity *auth.Identity) ([]vmcp.Prompt, error)
+//		GetPrompt(ctx context.Context, identity *auth.Identity, name string, args map[string]any) (*vmcp.PromptGetResult, error)
+//		// Lookup* helpers, BackendHealth, and Close omitted.
+//	}
+//
+// The VMCP contract is the domain boundary: identity is always an explicit
+// parameter and is never read from context, and the interface uses root
+// pkg/vmcp domain types rather than mcp-go protocol types.
 //
 // Router (pkg/vmcp/router):
 //
@@ -92,61 +118,58 @@
 //		RegisterStrategy(name string, strategy Strategy) error
 //	}
 //
+// # Extension Model
+//
+// Domain-layer extension is done with decorators around an inner core.VMCP. A
+// decorator filters List* output and refuses matching CallTool, ReadResource, or
+// GetPrompt operations before delegating to inner. Because it only holds the
+// inner VMCP, it can subtract reachability but cannot widen access to backends.
+//
+// Transport-layer extension is done by calling (*server.Server).Handler(ctx),
+// mounting the fully composed handler in an embedder-owned mux, and applying
+// outer middleware there. This preserves ToolHive's internal middleware order.
+//
 // # Design Principles
 //
 //  1. Platform Independence: Core domain logic works for both CLI and Kubernetes
 //  2. Interface Segregation: Small, focused interfaces for better testability
 //  3. Dependency Inversion: Depend on abstractions, not concrete implementations
 //  4. Modularity: Each bounded context can be developed and tested independently
-//  5. Extensibility: Plugin architecture for auth strategies, routing strategies, etc.
+//  5. Extensibility: Decorators for domain behavior; outer handler wrapping for transport behavior.
 //  6. Type Safety: Shared types at package root avoid circular dependencies
 //
 // # Usage Example
 //
 //	import (
-//		"github.com/stacklok/toolhive/pkg/vmcp"
-//		"github.com/stacklok/toolhive/pkg/vmcp/router"
-//		"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
-//		"github.com/stacklok/toolhive/pkg/vmcp/auth"
+//		vmcpcore "github.com/stacklok/toolhive/pkg/vmcp/core"
+//		"github.com/stacklok/toolhive/pkg/vmcp/server"
 //	)
 //
-//	// Load configuration
-//	cfg, err := loadConfig("vmcp-config.yaml")
+//	// Build the domain object from already-created collaborators.
+//	coreVMCP, err := vmcpcore.New(coreCfg)
 //	if err != nil {
 //		return err
 //	}
 //
-//	// Create components
-//	agg := createAggregator(cfg)
-//	rtr := createRouter(cfg)
-//	inAuth := createIncomingAuth(cfg)
-//	outAuth := createOutgoingAuth(cfg)
+//	// Wrap the domain object in the transport.
+//	srv, err := server.Serve(ctx, coreVMCP, serverCfg)
+//	if err != nil {
+//		return err
+//	}
 //
-//	// Discover and aggregate backends
-//	backends, err := agg.DiscoverBackends(ctx)
-//	capabilities, err := agg.AggregateCapabilities(ctx, backends)
+//	// Let ToolHive own the listener.
+//	if err := srv.Start(ctx); err != nil {
+//		return err
+//	}
+//	defer srv.Stop(ctx)
 //
-//	// With lazy discovery, capabilities are stored in request context
-//	// by the discovery middleware, not in the router
-//
-//	// Handle incoming requests
-//	http.Handle("/tools/call", inAuth.Middleware()(
-//		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-//			// Authenticate request
-//			identity, err := inAuth.Authenticate(ctx, r)
-//
-//			// Route to backend (router gets capabilities from context)
-//			target, err := rtr.RouteTool(ctx, toolName)
-//
-//			// Authenticate to backend (resolve strategy and call it)
-//			backendReq := createBackendRequest(...)
-//			strategy, err := outAuth.GetStrategy(target.AuthConfig.Type)
-//			err = strategy.Authenticate(ctx, backendReq, target.AuthConfig)
-//
-//			// Forward request and return response
-//			// ...
-//		}),
-//	))
+//	// Or, instead of Start, mount the fully composed handler in an
+//	// embedder-owned mux and serve sibling routes around it.
+//	handler, err := srv.Handler(ctx)
+//	if err != nil {
+//		return err
+//	}
+//	rootMux.Handle("/", handler)
 //
 // # Related Documentation
 //


### PR DESCRIPTION
## Summary
- Document the current vMCP core/transport split in the architecture overview and embedding guide.
- Refresh the embedding guidance and stability table for `pkg/vmcp/core`, `server.Serve`, and the stable `server.New` wrapper.
- Update the root `pkg/vmcp` package docs to describe `core.VMCP`, subtract-only decorators, and the supported outer handler wrapping pattern.

## Test plan
- `git diff --check`
- Not run: `gofmt`, `go test ./pkg/vmcp/...`, and `task docs` because `gofmt`, `go`, and `task` are not available in my local PATH.

Closes #5446.
