### PR TITLE
fix(streamable): emit event: message in SSE proxy responses

### DIFF
--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -530,7 +530,7 @@ func (p *HTTPProxy) handleSingleRequestSSE(
 			},
 		}
 		if data, mErr := json.Marshal(errObj); mErr == nil {
-			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+			if _, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data); err != nil {
 				slog.Debug("failed to write error message", "error", err)
 				return
 			}
@@ -546,7 +546,7 @@ func (p *HTTPProxy) handleSingleRequestSSE(
 		return
 	}
 	// Write SSE event with the JSON-RPC response and flush
-	if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil { //nolint:gosec // G705: SSE data from MCP protocol
+	if _, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data); err != nil { //nolint:gosec // G705: SSE data from MCP protocol
 		slog.Debug("failed to write response", "error", err)
 		return
 	}

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -546,7 +546,8 @@ func (p *HTTPProxy) handleSingleRequestSSE(
 		return
 	}
 	// Write SSE event with the JSON-RPC response and flush
-	if _, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data); err != nil { //nolint:gosec // G705: SSE data from MCP protocol
+	//nolint:gosec // G705: SSE data from MCP protocol
+	if _, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data); err != nil {
 		slog.Debug("failed to write response", "error", err)
 		return
 	}

--- a/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
@@ -323,6 +323,39 @@ func TestSingleRequestWithStaleSessionIncludesRequestID(t *testing.T) {
 	assert.Contains(t, string(body), `"id":"test-42"`)
 }
 
+// TestSSEResponseIncludesEventMessage verifies that SSE responses emitted by
+// the streamable proxy include an explicit "event: message" line, matching
+// reference MCP server transports and clients such as @ai-sdk/mcp that require it.
+func TestSSEResponseIncludesEventMessage(t *testing.T) {
+	t.Parallel()
+
+	const port = 8110
+	proxy, ctx, cancel := startProxyWithBackend(t, port)
+	defer cancel()
+	defer func() { _ = proxy.Stop(ctx) }()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, StreamableHTTPEndpoint)
+
+	initJSON := `{"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"spec-test","version":"0.0.0"},"capabilities":{}}}`
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(initJSON)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	sseBody := string(body)
+	assert.Contains(t, sseBody, "event: message")
+	assert.Contains(t, sseBody, "data: ")
+}
+
 // pickFreePort returns a TCP port the OS reports as available. There is a small
 // race window before the proxy binds it, but that is the same pattern other
 // streamable tests follow and is acceptable here.


### PR DESCRIPTION
## Summary

Add an explicit `event: message` line to JSON-RPC SSE frames emitted by the streamable-http proxy, matching reference MCP server transports and fixing clients that require named events.

## Motivation

The streamable proxy wrote `data:`-only SSE frames. While valid per the WHATWG SSE spec, this diverges from MCP reference transports and breaks spec-lenient clients such as `@ai-sdk/mcp`, which only dispatch frames where `event === "message"`. Those clients hang on `initialize` against stdio servers fronted by this proxy.

Fixes #5655

## Changes

- Update success and error SSE write paths in `handleSingleRequestSSE` to emit `event: message\ndata: ...\n\n`
- Add `TestSSEResponseIncludesEventMessage` regression test in `streamable_proxy_spec_test.go`

## Tests

- `go test ./pkg/transport/proxy/streamable/... -count=1` — all passed

## Notes

- Backward compatible: clients that already accept bare `data:` frames continue to work
- Batch SSE responses are out of scope (pre-existing behavior returns JSON)