### PR TITLE
Surface upstream ID tokens through auth middleware

### DIFF
--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -7,6 +7,8 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
+
+	upstreamtoken "github.com/stacklok/toolhive/pkg/auth/upstreamtoken"
 )
 
 // PrincipalInfo contains the non-sensitive identity fields safe for external consumption.
@@ -85,11 +87,39 @@ type Identity struct {
 	// is active and the JWT contains a token session ID (tsid claim).
 	// Redacted in MarshalJSON() to prevent token leakage.
 	//
+	// State semantics:
+	//   - nil            — no tsid claim was present on the incoming JWT
+	//                      (middleware did not attempt to load credentials).
+	//   - empty map      — tsid claim was valid but no providers had a stored
+	//                      access token for the session.
+	//   - populated map  — keys are upstream provider names; values are the
+	//                      stored access token strings.
+	//
 	// MUST NOT be mutated after the Identity is placed in the publicly-reachable
 	// request context. It MAY be mutated while the Identity is reachable only via
 	// a load-scoped ctx, provided the loader does not share that ctx with
 	// concurrent code. See TokenValidator.Middleware for the canonical pattern.
 	UpstreamTokens map[string]string
+
+	// UpstreamIDTokens maps upstream provider names to their ID tokens.
+	// This is populated by the auth middleware when an embedded auth server
+	// is active and the JWT contains a token session ID (tsid claim).
+	// Each value is the rotated ID token when a refresh produced one
+	// (OIDC Core 1.0 §12.2), otherwise the original JWT captured at the initial
+	// OIDC login; it is not independently validated for freshness.
+	//
+	// State semantics:
+	//   - nil            — no tsid claim was present on the incoming JWT
+	//                      (middleware did not attempt to load credentials).
+	//   - empty map      — tsid claim was valid but no providers had an
+	//                      ID token stored for the session.
+	//   - populated map  — keys are upstream provider names; values are the
+	//                      stored ID token JWTs (may be expired; callers MUST
+	//                      validate the `exp` claim before use).
+	//
+	// Redacted in MarshalJSON() to prevent token leakage.
+	// MUST NOT be mutated after the Identity is placed in the request context.
+	UpstreamIDTokens map[string]string
 }
 
 // String returns a string representation of the Identity with sensitive fields redacted.
@@ -111,21 +141,34 @@ func (i *Identity) MarshalJSON() ([]byte, error) {
 
 	// Create a safe representation with lowercase field names and redacted token
 	type SafeIdentity struct {
-		Subject        string            `json:"subject"`
-		PlatformUserID string            `json:"platformUserId,omitempty"`
-		Name           string            `json:"name"`
-		Email          string            `json:"email"`
-		Groups         []string          `json:"groups"`
-		Claims         map[string]any    `json:"claims"`
-		Token          string            `json:"token"`
-		TokenType      string            `json:"tokenType"`
-		Metadata       map[string]string `json:"metadata"`
-		UpstreamTokens map[string]string `json:"upstreamTokens,omitempty"`
+		Subject          string            `json:"subject"`
+		PlatformUserID   string            `json:"platformUserId,omitempty"`
+		Name             string            `json:"name"`
+		Email            string            `json:"email"`
+		Groups           []string          `json:"groups"`
+		Claims           map[string]any    `json:"claims"`
+		Token            string            `json:"token"`
+		TokenType        string            `json:"tokenType"`
+		Metadata         map[string]string `json:"metadata"`
+		UpstreamTokens   map[string]string `json:"upstreamTokens,omitempty"`
+		UpstreamIDTokens map[string]string `json:"upstreamIDTokens,omitempty"`
 	}
+
+	const redacted = "REDACTED"
 
 	token := i.Token
 	if token != "" {
-		token = "REDACTED"
+		token = redacted
+	}
+
+	claims := i.Claims
+	if _, hasTsid := claims[upstreamtoken.TokenSessionIDClaimKey]; hasTsid {
+		claims = make(map[string]any, len(i.Claims))
+		for k, v := range i.Claims {
+			if k != upstreamtoken.TokenSessionIDClaimKey {
+				claims[k] = v
+			}
+		}
 	}
 
 	// Redact upstream tokens: preserve keys, replace non-empty values
@@ -136,24 +179,38 @@ func (i *Identity) MarshalJSON() ([]byte, error) {
 		redactedUpstreamTokens = make(map[string]string, len(i.UpstreamTokens))
 		for k, v := range i.UpstreamTokens {
 			if v != "" {
-				redactedUpstreamTokens[k] = "REDACTED"
+				redactedUpstreamTokens[k] = redacted
 			} else {
 				redactedUpstreamTokens[k] = ""
 			}
 		}
 	}
 
+	// Redact upstream ID tokens with the same pattern as access tokens.
+	var redactedUpstreamIDTokens map[string]string
+	if len(i.UpstreamIDTokens) > 0 {
+		redactedUpstreamIDTokens = make(map[string]string, len(i.UpstreamIDTokens))
+		for k, v := range i.UpstreamIDTokens {
+			if v != "" {
+				redactedUpstreamIDTokens[k] = redacted
+			} else {
+				redactedUpstreamIDTokens[k] = ""
+			}
+		}
+	}
+
 	return json.Marshal(&SafeIdentity{
-		Subject:        i.Subject,
-		PlatformUserID: i.PlatformUserID,
-		Name:           i.Name,
-		Email:          i.Email,
-		Groups:         i.Groups,
-		Claims:         i.Claims,
-		Token:          token,
-		TokenType:      i.TokenType,
-		Metadata:       i.Metadata,
-		UpstreamTokens: redactedUpstreamTokens,
+		Subject:          i.Subject,
+		PlatformUserID:   i.PlatformUserID,
+		Name:             i.Name,
+		Email:            i.Email,
+		Groups:           i.Groups,
+		Claims:           claims,
+		Token:            token,
+		TokenType:        i.TokenType,
+		Metadata:         i.Metadata,
+		UpstreamTokens:   redactedUpstreamTokens,
+		UpstreamIDTokens: redactedUpstreamIDTokens,
 	})
 }
 

--- a/pkg/auth/identity_test.go
+++ b/pkg/auth/identity_test.go
@@ -389,6 +389,153 @@ func TestIdentity_MarshalJSON(t *testing.T) {
 				assert.NotContains(t, string(data), "gho_secret123")
 			},
 		},
+		{
+			name: "redacts_upstream_id_tokens",
+			identity: &Identity{
+				PrincipalInfo: PrincipalInfo{Subject: "user123"},
+				UpstreamIDTokens: map[string]string{
+					"github":    "eyJhbGciOiJSUzI1NiJ9.github-id-token",
+					"atlassian": "eyJhbGciOiJSUzI1NiJ9.atlassian-id-token",
+				},
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, data []byte) {
+				t.Helper()
+
+				var result map[string]any
+				err := json.Unmarshal(data, &result)
+				require.NoError(t, err)
+
+				tokens, ok := result["upstreamIDTokens"].(map[string]any)
+				require.True(t, ok, "upstreamIDTokens should be a map")
+				assert.Equal(t, "REDACTED", tokens["github"])
+				assert.Equal(t, "REDACTED", tokens["atlassian"])
+				assert.NotContains(t, string(data), "eyJhbGciOiJSUzI1NiJ9")
+			},
+		},
+		{
+			name: "empty_upstream_id_tokens_omitted",
+			identity: &Identity{
+				PrincipalInfo:    PrincipalInfo{Subject: "user123"},
+				UpstreamIDTokens: map[string]string{},
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, data []byte) {
+				t.Helper()
+
+				var result map[string]any
+				err := json.Unmarshal(data, &result)
+				require.NoError(t, err)
+
+				_, exists := result["upstreamIDTokens"]
+				assert.False(t, exists, "empty upstreamIDTokens should be omitted")
+			},
+		},
+		{
+			name: "nil_upstream_id_tokens_omitted",
+			identity: &Identity{
+				PrincipalInfo:    PrincipalInfo{Subject: "user123"},
+				UpstreamIDTokens: nil,
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, data []byte) {
+				t.Helper()
+
+				var result map[string]any
+				err := json.Unmarshal(data, &result)
+				require.NoError(t, err)
+
+				_, exists := result["upstreamIDTokens"]
+				assert.False(t, exists, "nil upstreamIDTokens should be omitted")
+			},
+		},
+		{
+			name: "upstream_id_tokens_round_trip_preserves_keys_redacts_values",
+			identity: &Identity{
+				PrincipalInfo: PrincipalInfo{Subject: "user123"},
+				UpstreamIDTokens: map[string]string{
+					"github":    "eyJhbGciOiJSUzI1NiJ9.github-id-token",
+					"atlassian": "eyJhbGciOiJSUzI1NiJ9.atlassian-id-token",
+				},
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, data []byte) {
+				t.Helper()
+
+				// Unmarshal into the same SafeIdentity shape that MarshalJSON produces
+				// so we can verify the round-trip preserves the key set and the
+				// redaction replaces every non-empty value with "REDACTED".
+				var roundTrip struct {
+					Subject          string            `json:"subject"`
+					UpstreamIDTokens map[string]string `json:"upstreamIDTokens,omitempty"`
+				}
+				require.NoError(t, json.Unmarshal(data, &roundTrip))
+
+				assert.Equal(t, "user123", roundTrip.Subject)
+				assert.Equal(t, map[string]string{
+					"github":    "REDACTED",
+					"atlassian": "REDACTED",
+				}, roundTrip.UpstreamIDTokens,
+					"round-trip must preserve all provider keys with redacted values")
+				assert.NotContains(t, string(data), "eyJhbGciOiJSUzI1NiJ9",
+					"raw ID token material must not appear in marshaled output")
+			},
+		},
+		{
+			name: "strips_tsid_claim_from_serialized_claims",
+			identity: &Identity{
+				PrincipalInfo: PrincipalInfo{
+					Subject: "user123",
+					Claims: map[string]any{
+						"tsid":   "session-xyz",
+						"sub":    "user123",
+						"org_id": "org456",
+					},
+				},
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, data []byte) {
+				t.Helper()
+
+				var result map[string]any
+				require.NoError(t, json.Unmarshal(data, &result))
+
+				claims, ok := result["claims"].(map[string]any)
+				require.True(t, ok, "claims should be a map")
+				_, hasTsid := claims["tsid"]
+				assert.False(t, hasTsid, "tsid must be stripped from serialized claims")
+				assert.NotContains(t, string(data), "session-xyz",
+					"tsid value must not appear anywhere in marshaled output")
+				// Guard: co-resident claims must be preserved
+				assert.Equal(t, "user123", claims["sub"], "sub claim must be preserved")
+				assert.Equal(t, "org456", claims["org_id"], "org_id claim must be preserved")
+			},
+		},
+		{
+			name: "marshals_claims_without_tsid_unchanged",
+			identity: &Identity{
+				PrincipalInfo: PrincipalInfo{
+					Subject: "user123",
+					Claims: map[string]any{
+						"sub":    "user123",
+						"org_id": "org456",
+					},
+				},
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, data []byte) {
+				t.Helper()
+
+				var result map[string]any
+				require.NoError(t, json.Unmarshal(data, &result))
+
+				claims, ok := result["claims"].(map[string]any)
+				require.True(t, ok, "claims should be a map")
+				assert.Equal(t, "user123", claims["sub"], "sub must pass through verbatim")
+				assert.Equal(t, "org456", claims["org_id"], "org_id must pass through verbatim")
+				assert.Len(t, claims, 2, "no claims should be added or dropped when tsid is absent")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -553,9 +553,9 @@ func WithEnvReader(reader env.Reader) TokenValidatorOption {
 
 // WithUpstreamTokenReader configures the token validator to enrich Identity
 // with upstream provider tokens. When set, the Middleware extracts the token
-// session ID (tsid) from JWT claims, loads all upstream tokens into
-// Identity.UpstreamTokens, and then places the enriched Identity in the
-// request context.
+// session ID (tsid) from JWT claims and loads all upstream tokens into
+// Identity.UpstreamTokens (access tokens) and Identity.UpstreamIDTokens
+// (ID tokens) before placing the Identity in the request context.
 func WithUpstreamTokenReader(reader upstreamtoken.TokenReader) TokenValidatorOption {
 	return func(o *tokenValidatorOptions) {
 		o.upstreamTokenReader = reader
@@ -1167,23 +1167,28 @@ func writeOAuthError(w http.ResponseWriter, errorCode, description string) {
 }
 
 // loadUpstreamTokens extracts the token session ID from claims and loads
-// all upstream provider tokens for that session. Returns (nil, nil, nil) if no
-// tsid claim exists. Returns a non-nil error when a tsid claim is present
-// but token loading fails due to an infrastructure error (storage unavailable).
-// A non-nil failed slice means one or more providers' tokens could not be
-// refreshed; the caller should return HTTP 401 to trigger re-authentication.
-func (v *TokenValidator) loadUpstreamTokens(ctx context.Context, claims jwt.MapClaims) (map[string]string, []string, error) {
+// all upstream provider credentials (access + ID tokens) for that session.
+// Returns (nil, nil, nil) if no tsid claim exists. Returns a non-nil error
+// when a tsid claim is present but token loading fails due to an infrastructure
+// error (storage unavailable). A non-empty failed slice means one or more
+// providers' tokens could not be refreshed; the caller should return HTTP 401
+// to trigger re-authentication.
+func (v *TokenValidator) loadUpstreamTokens(
+	ctx context.Context, claims jwt.MapClaims,
+) (map[string]upstreamtoken.UpstreamCredential, []string, error) {
 	tsid, ok := claims[upstreamtoken.TokenSessionIDClaimKey].(string)
 	if !ok || tsid == "" {
 		return nil, nil, nil
 	}
 
-	tokens, failed, err := v.upstreamTokenReader.GetAllValidTokens(ctx, tsid)
+	creds, failed, err := v.upstreamTokenReader.GetAllUpstreamCredentials(ctx, tsid)
 	if err != nil {
-		return nil, nil, fmt.Errorf("load upstream tokens for session %s: %w", tsid, err)
+		// Log tsid at DEBUG only — it is credential-adjacent and must not
+		// leak into WARN-level logs or returned error strings.
+		slog.DebugContext(ctx, "load upstream credentials failed", "tsid", tsid, "error", err)
+		return nil, nil, fmt.Errorf("load upstream credentials: %w", err)
 	}
-
-	return tokens, failed, nil
+	return creds, failed, nil
 }
 
 // Middleware creates an HTTP middleware that validates JWT tokens and creates Identity.
@@ -1225,7 +1230,7 @@ func (v *TokenValidator) Middleware(next http.Handler) http.Handler {
 		// never mutated afterwards (see the UpstreamTokens doc comment in identity.go).
 		if v.upstreamTokenReader != nil {
 			loadCtx := WithIdentity(r.Context(), identity)
-			tokens, failed, loadErr := v.loadUpstreamTokens(loadCtx, claims)
+			creds, failed, loadErr := v.loadUpstreamTokens(loadCtx, claims)
 			if loadErr != nil {
 				slog.WarnContext(loadCtx, "upstream token storage unavailable",
 					"error", loadErr,
@@ -1233,7 +1238,6 @@ func (v *TokenValidator) Middleware(next http.Handler) http.Handler {
 				http.Error(w, "authentication service temporarily unavailable", http.StatusServiceUnavailable)
 				return
 			}
-			identity.UpstreamTokens = tokens
 			// Conservative policy: any provider refresh failure rejects the entire
 			// request. In vMCP multi-provider sessions this may block requests that
 			// could partially succeed if only some backends need the failing provider.
@@ -1247,6 +1251,31 @@ func (v *TokenValidator) Middleware(next http.Handler) http.Handler {
 				writeOAuthError(w, OAuthErrInvalidToken,
 					"upstream token is no longer valid; re-authentication required")
 				return
+			}
+			// Project the per-provider credential bundle onto the two
+			// consumer-facing Identity fields.
+			//
+			// Non-nil empty maps are preserved when a tsid claim was present
+			// so consumers can distinguish "enrichment attempted, nothing
+			// stored" from "enrichment never ran" (nil).
+			if creds != nil {
+				accessTokens := make(map[string]string, len(creds))
+				idTokens := make(map[string]string, len(creds))
+				for provider, cred := range creds {
+					// Omit providers with no usable access token (mirrors the ID-token
+					// filter below); a provider may carry an ID token but no access token.
+					if cred.AccessToken != "" {
+						accessTokens[provider] = cred.AccessToken
+					}
+					// Omit providers whose upstream login did not yield an
+					// ID token so consumers see the same map shape as before
+					// (keyed only on providers with a usable ID token).
+					if cred.IDToken != "" {
+						idTokens[provider] = cred.IDToken
+					}
+				}
+				identity.UpstreamTokens = accessTokens
+				identity.UpstreamIDTokens = idTokens
 			}
 		}
 

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -2231,21 +2231,27 @@ func TestMiddleware_RFC6750JSONErrorResponse(t *testing.T) {
 func TestLoadUpstreamTokens(t *testing.T) {
 	t.Parallel()
 
-	t.Run("loads tokens when tsid present", func(t *testing.T) {
+	t.Run("loads credentials when tsid present", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
-		reader.EXPECT().GetAllValidTokens(gomock.Any(), "session-abc").
-			Return(map[string]string{"github": "gh-token", "atlassian": "atl-token"}, []string(nil), nil)
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-abc").
+			Return(map[string]upstreamtoken.UpstreamCredential{
+				"github":    {AccessToken: "gh-token", IDToken: "gh-id-token"},
+				"atlassian": {AccessToken: "atl-token"},
+			}, []string(nil), nil)
 
 		v := &TokenValidator{upstreamTokenReader: reader}
-		result, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
+		creds, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
 			"sub":                                "user123",
 			upstreamtoken.TokenSessionIDClaimKey: "session-abc",
 		})
 		require.NoError(t, err)
 		require.Nil(t, failed)
-		require.Equal(t, map[string]string{"github": "gh-token", "atlassian": "atl-token"}, result)
+		require.Equal(t, map[string]upstreamtoken.UpstreamCredential{
+			"github":    {AccessToken: "gh-token", IDToken: "gh-id-token"},
+			"atlassian": {AccessToken: "atl-token"},
+		}, creds)
 	})
 
 	t.Run("returns nil when no tsid claim", func(t *testing.T) {
@@ -2255,9 +2261,9 @@ func TestLoadUpstreamTokens(t *testing.T) {
 		// No EXPECT — reader should not be called
 
 		v := &TokenValidator{upstreamTokenReader: reader}
-		result, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{"sub": "user123"})
+		creds, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{"sub": "user123"})
 		require.NoError(t, err)
-		require.Nil(t, result)
+		require.Nil(t, creds)
 		require.Nil(t, failed)
 	})
 
@@ -2267,12 +2273,12 @@ func TestLoadUpstreamTokens(t *testing.T) {
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
 
 		v := &TokenValidator{upstreamTokenReader: reader}
-		result, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
+		creds, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
 			"sub":                                "user123",
 			upstreamtoken.TokenSessionIDClaimKey: "",
 		})
 		require.NoError(t, err)
-		require.Nil(t, result)
+		require.Nil(t, creds)
 		require.Nil(t, failed)
 	})
 
@@ -2282,12 +2288,12 @@ func TestLoadUpstreamTokens(t *testing.T) {
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
 
 		v := &TokenValidator{upstreamTokenReader: reader}
-		result, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
+		creds, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
 			"sub":                                "user123",
 			upstreamtoken.TokenSessionIDClaimKey: 12345,
 		})
 		require.NoError(t, err)
-		require.Nil(t, result)
+		require.Nil(t, creds)
 		require.Nil(t, failed)
 	})
 
@@ -2295,16 +2301,16 @@ func TestLoadUpstreamTokens(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
-		reader.EXPECT().GetAllValidTokens(gomock.Any(), "session-abc").
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-abc").
 			Return(nil, nil, errors.New("storage unavailable"))
 
 		v := &TokenValidator{upstreamTokenReader: reader}
-		result, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
+		creds, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
 			"sub":                                "user123",
 			upstreamtoken.TokenSessionIDClaimKey: "session-abc",
 		})
 		require.Error(t, err)
-		require.Nil(t, result)
+		require.Nil(t, creds)
 		require.Nil(t, failed)
 	})
 
@@ -2312,16 +2318,16 @@ func TestLoadUpstreamTokens(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
-		reader.EXPECT().GetAllValidTokens(gomock.Any(), "session-abc").
-			Return(map[string]string{}, []string{"github"}, nil)
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-abc").
+			Return(map[string]upstreamtoken.UpstreamCredential{}, []string{"github"}, nil)
 
 		v := &TokenValidator{upstreamTokenReader: reader}
-		result, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
+		creds, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
 			"sub":                                "user123",
 			upstreamtoken.TokenSessionIDClaimKey: "session-abc",
 		})
 		require.NoError(t, err)
-		require.Equal(t, map[string]string{}, result)
+		require.Equal(t, map[string]upstreamtoken.UpstreamCredential{}, creds)
 		require.Equal(t, []string{"github"}, failed)
 	})
 
@@ -2329,16 +2335,16 @@ func TestLoadUpstreamTokens(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
-		reader.EXPECT().GetAllValidTokens(gomock.Any(), "session-abc").
-			Return(map[string]string{}, []string(nil), nil)
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-abc").
+			Return(map[string]upstreamtoken.UpstreamCredential{}, []string(nil), nil)
 
 		v := &TokenValidator{upstreamTokenReader: reader}
-		result, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
+		creds, failed, err := v.loadUpstreamTokens(context.Background(), jwt.MapClaims{
 			"sub":                                "user123",
 			upstreamtoken.TokenSessionIDClaimKey: "session-abc",
 		})
 		require.NoError(t, err)
-		require.Equal(t, map[string]string{}, result)
+		require.Equal(t, map[string]upstreamtoken.UpstreamCredential{}, creds)
 		require.Nil(t, failed)
 	})
 }
@@ -2408,8 +2414,10 @@ func TestMiddleware_UpstreamTokenEnrichment(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
-		reader.EXPECT().GetAllValidTokens(gomock.Any(), "session-xyz").
-			Return(map[string]string{"github": "gh-tok"}, []string(nil), nil)
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-xyz").
+			Return(map[string]upstreamtoken.UpstreamCredential{
+				"github": {AccessToken: "gh-tok", IDToken: "gh-id-tok"},
+			}, []string(nil), nil)
 		v := makeValidator(t, WithUpstreamTokenReader(reader))
 
 		var captured *Identity
@@ -2424,6 +2432,83 @@ func TestMiddleware_UpstreamTokenEnrichment(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rr.Code)
 		require.Equal(t, map[string]string{"github": "gh-tok"}, captured.UpstreamTokens)
+		require.Equal(t, map[string]string{"github": "gh-id-tok"}, captured.UpstreamIDTokens)
+	})
+
+	t.Run("all access tokens with no ID tokens yields non-nil empty UpstreamIDTokens", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
+		// Reader returns providers that have valid access tokens but no ID tokens.
+		// The service layer preserves the empty IDToken field (see
+		// TestInProcessService_GetAllUpstreamCredentials); the projection that
+		// drops providers whose IDToken is empty happens in Middleware.
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-xyz").
+			Return(map[string]upstreamtoken.UpstreamCredential{
+				"github":    {AccessToken: "gh-tok", IDToken: ""},
+				"atlassian": {AccessToken: "atl-tok", IDToken: ""},
+			}, []string(nil), nil)
+		v := makeValidator(t, WithUpstreamTokenReader(reader))
+
+		var captured *Identity
+		handler := v.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			captured, _ = IdentityFromContext(r.Context())
+		}))
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer "+signToken(claimsWithTsid))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		// Access tokens map contains every provider.
+		require.Equal(t, map[string]string{
+			"github":    "gh-tok",
+			"atlassian": "atl-tok",
+		}, captured.UpstreamTokens)
+		// UpstreamIDTokens must be non-nil (tsid was present, enrichment ran)
+		// but empty (no provider had a usable ID token). Consumers rely on
+		// nil vs. empty-map to distinguish "enrichment never ran" from
+		// "enrichment ran, no ID tokens stored".
+		require.NotNil(t, captured.UpstreamIDTokens,
+			"UpstreamIDTokens must be non-nil when tsid was present and enrichment ran")
+		require.Empty(t, captured.UpstreamIDTokens,
+			"UpstreamIDTokens must be empty when no provider has an ID token")
+	})
+
+	t.Run("mixed providers: only those with ID tokens appear in UpstreamIDTokens", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
+		// github has an ID token; atlassian has only an access token. The
+		// projection in Middleware must key UpstreamTokens on both providers
+		// but UpstreamIDTokens only on github.
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-xyz").
+			Return(map[string]upstreamtoken.UpstreamCredential{
+				"github":    {AccessToken: "gh-tok", IDToken: "gh-id-tok"},
+				"atlassian": {AccessToken: "atl-tok", IDToken: ""},
+			}, []string(nil), nil)
+		v := makeValidator(t, WithUpstreamTokenReader(reader))
+
+		var captured *Identity
+		handler := v.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			captured, _ = IdentityFromContext(r.Context())
+		}))
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer "+signToken(claimsWithTsid))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Equal(t, map[string]string{
+			"github":    "gh-tok",
+			"atlassian": "atl-tok",
+		}, captured.UpstreamTokens)
+		require.Equal(t, map[string]string{
+			"github": "gh-id-tok",
+		}, captured.UpstreamIDTokens,
+			"only providers with a non-empty ID token must appear in UpstreamIDTokens")
 	})
 
 	t.Run("places identity in context before loading upstream tokens", func(t *testing.T) {
@@ -2439,11 +2524,11 @@ func TestMiddleware_UpstreamTokenEnrichment(t *testing.T) {
 		var loadCtxHadIdentity bool
 		var loadCtxCanonicalUser string
 		var loadCtxHadCanonicalUser bool
-		reader.EXPECT().GetAllValidTokens(gomock.Any(), "session-xyz").
-			DoAndReturn(func(ctx context.Context, _ string) (map[string]string, []string, error) {
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-xyz").
+			DoAndReturn(func(ctx context.Context, _ string) (map[string]upstreamtoken.UpstreamCredential, []string, error) {
 				loadCtxIdentity, loadCtxHadIdentity = IdentityFromContext(ctx)
 				loadCtxCanonicalUser, loadCtxHadCanonicalUser = CanonicalUserFromContext(ctx)
-				return map[string]string{"github": "gh-tok"}, nil, nil
+				return map[string]upstreamtoken.UpstreamCredential{"github": {AccessToken: "gh-tok"}}, nil, nil
 			})
 		v := makeValidator(t, WithUpstreamTokenReader(reader))
 		handler := v.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
@@ -2469,7 +2554,7 @@ func TestMiddleware_UpstreamTokenEnrichment(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
-		reader.EXPECT().GetAllValidTokens(gomock.Any(), "session-xyz").
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-xyz").
 			Return(nil, nil, errors.New("redis down"))
 		v := makeValidator(t, WithUpstreamTokenReader(reader))
 
@@ -2491,8 +2576,8 @@ func TestMiddleware_UpstreamTokenEnrichment(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
-		reader.EXPECT().GetAllValidTokens(gomock.Any(), "session-xyz").
-			Return(map[string]string{}, []string{"github"}, nil)
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-xyz").
+			Return(map[string]upstreamtoken.UpstreamCredential{}, []string{"github"}, nil)
 		v := makeValidator(t, WithUpstreamTokenReader(reader))
 
 		nextCalled := false
@@ -2516,8 +2601,8 @@ func TestMiddleware_UpstreamTokenEnrichment(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
 		// atlassian succeeded, github failed — the middleware must still reject the request
-		reader.EXPECT().GetAllValidTokens(gomock.Any(), "session-xyz").
-			Return(map[string]string{"atlassian": "atl-tok"}, []string{"github"}, nil)
+		reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-xyz").
+			Return(map[string]upstreamtoken.UpstreamCredential{"atlassian": {AccessToken: "atl-tok"}}, []string{"github"}, nil)
 		v := makeValidator(t, WithUpstreamTokenReader(reader))
 
 		nextCalled := false
@@ -2558,6 +2643,8 @@ func TestMiddleware_UpstreamTokenEnrichment(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rr.Code)
 		require.Nil(t, captured.UpstreamTokens)
+		require.Nil(t, captured.UpstreamIDTokens,
+			"UpstreamIDTokens must stay nil when enrichment never ran (no tsid)")
 	})
 
 	t.Run("no enrichment when reader is nil", func(t *testing.T) {
@@ -2576,6 +2663,8 @@ func TestMiddleware_UpstreamTokenEnrichment(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rr.Code)
 		require.Nil(t, captured.UpstreamTokens)
+		require.Nil(t, captured.UpstreamIDTokens,
+			"UpstreamIDTokens must stay nil when no reader is configured")
 	})
 }
 

--- a/pkg/auth/upstreamtoken/mocks/mock_token_reader.go
+++ b/pkg/auth/upstreamtoken/mocks/mock_token_reader.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	upstreamtoken "github.com/stacklok/toolhive/pkg/auth/upstreamtoken"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,18 +41,18 @@ func (m *MockTokenReader) EXPECT() *MockTokenReaderMockRecorder {
 	return m.recorder
 }
 
-// GetAllValidTokens mocks base method.
-func (m *MockTokenReader) GetAllValidTokens(ctx context.Context, sessionID string) (map[string]string, []string, error) {
+// GetAllUpstreamCredentials mocks base method.
+func (m *MockTokenReader) GetAllUpstreamCredentials(ctx context.Context, sessionID string) (map[string]upstreamtoken.UpstreamCredential, []string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllValidTokens", ctx, sessionID)
-	ret0, _ := ret[0].(map[string]string)
+	ret := m.ctrl.Call(m, "GetAllUpstreamCredentials", ctx, sessionID)
+	ret0, _ := ret[0].(map[string]upstreamtoken.UpstreamCredential)
 	ret1, _ := ret[1].([]string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetAllValidTokens indicates an expected call of GetAllValidTokens.
-func (mr *MockTokenReaderMockRecorder) GetAllValidTokens(ctx, sessionID any) *gomock.Call {
+// GetAllUpstreamCredentials indicates an expected call of GetAllUpstreamCredentials.
+func (mr *MockTokenReaderMockRecorder) GetAllUpstreamCredentials(ctx, sessionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllValidTokens", reflect.TypeOf((*MockTokenReader)(nil).GetAllValidTokens), ctx, sessionID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUpstreamCredentials", reflect.TypeOf((*MockTokenReader)(nil).GetAllUpstreamCredentials), ctx, sessionID)
 }

--- a/pkg/auth/upstreamtoken/service.go
+++ b/pkg/auth/upstreamtoken/service.go
@@ -71,23 +71,33 @@ func (s *InProcessService) GetValidTokens(ctx context.Context, sessionID, provid
 		return s.refreshOrFail(ctx, sessionID, providerName, tokens)
 	}
 
-	return &UpstreamCredential{AccessToken: tokens.AccessToken}, nil
+	return &UpstreamCredential{AccessToken: tokens.AccessToken, IDToken: tokens.IDToken}, nil
 }
 
-// GetAllValidTokens returns access tokens for all upstream providers in a session.
-// Expired tokens are refreshed transparently; if refresh fails, the provider name
-// is included in the returned failed slice so the caller can return HTTP 401.
-func (s *InProcessService) GetAllValidTokens(ctx context.Context, sessionID string) (map[string]string, []string, error) {
+// GetAllUpstreamCredentials returns access tokens and ID tokens for all upstream
+// providers in a session in a single storage round-trip. Expired access tokens
+// are refreshed transparently; providers whose access token cannot be refreshed
+// are included in the returned failed slice so downstream middleware can return
+// a clean 401 for the access-token use case. The IDToken on a returned entry is
+// the rotated ID token when a refresh produced one (OIDC Core 1.0 §12.2),
+// otherwise the original JWT captured at the initial OIDC login; it is not
+// independently validated for freshness and may be empty if the upstream login
+// never yielded one. Callers MUST check its exp claim before use.
+//
+// Returns an empty map and nil failed slice (not error) for unknown sessions.
+func (s *InProcessService) GetAllUpstreamCredentials(
+	ctx context.Context, sessionID string,
+) (map[string]UpstreamCredential, []string, error) {
 	allTokens, err := s.storage.GetAllUpstreamTokens(ctx, sessionID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("bulk read upstream tokens: %w", err)
 	}
 
 	if len(allTokens) == 0 {
-		return map[string]string{}, nil, nil
+		return map[string]UpstreamCredential{}, nil, nil
 	}
 
-	result := make(map[string]string, len(allTokens))
+	result := make(map[string]UpstreamCredential, len(allTokens))
 	var failed []string
 	// TODO(auth): Refresh providers in parallel using errgroup to avoid
 	// worst-case latency of N refreshes when multiple providers need refresh.
@@ -98,7 +108,10 @@ func (s *InProcessService) GetAllValidTokens(ctx context.Context, sessionID stri
 
 		// If token is not expired, use it directly.
 		if tokens.ExpiresAt.IsZero() || !tokens.IsExpired(time.Now()) {
-			result[providerName] = tokens.AccessToken
+			result[providerName] = UpstreamCredential{
+				AccessToken: tokens.AccessToken,
+				IDToken:     tokens.IDToken,
+			}
 			continue
 		}
 
@@ -113,9 +126,14 @@ func (s *InProcessService) GetAllValidTokens(ctx context.Context, sessionID stri
 			failed = append(failed, providerName)
 			continue
 		}
-		result[providerName] = refreshed.AccessToken
+		// refreshOrFail carries through the rotated ID token when the provider
+		// issued one, otherwise the original login ID token (see its doc).
+		result[providerName] = *refreshed
 	}
 
+	// TODO(auth): the "check exp" contract on UpstreamCredential.IDToken is
+	// documented but not enforced here. Enforcement belongs at the RFC 8693
+	// token-exchange consumer when it receives the credential.
 	return result, failed, nil
 }
 
@@ -154,5 +172,15 @@ func (s *InProcessService) refreshOrFail(
 		return nil, ErrRefreshFailed
 	}
 
-	return &UpstreamCredential{AccessToken: refreshed.AccessToken}, nil
+	// Prefer the ID token from the refresh response when the provider rotated
+	// it (OIDC Core 1.0 §12.2 permits — but does not require — a new id_token on
+	// refresh). Fall back to the original login ID token when the refresh response
+	// omitted one. The primary carry-forward into storage is in
+	// upstreamTokenRefresher.refreshAndStore; this fallback is defense-in-depth
+	// so the caller never sees an empty subject token.
+	idToken := refreshed.IDToken
+	if idToken == "" {
+		idToken = expired.IDToken
+	}
+	return &UpstreamCredential{AccessToken: refreshed.AccessToken, IDToken: idToken}, nil
 }

--- a/pkg/auth/upstreamtoken/service_test.go
+++ b/pkg/auth/upstreamtoken/service_test.go
@@ -24,6 +24,7 @@ func TestInProcessService_GetValidTokens(t *testing.T) {
 		ProviderID:      "github",
 		AccessToken:     "valid-access-token",
 		RefreshToken:    "refresh-token",
+		IDToken:         "valid-id-token",
 		ExpiresAt:       time.Now().Add(1 * time.Hour),
 		UserID:          "user-1",
 		UpstreamSubject: "sub-1",
@@ -34,6 +35,7 @@ func TestInProcessService_GetValidTokens(t *testing.T) {
 		ProviderID:      "github",
 		AccessToken:     "expired-access-token",
 		RefreshToken:    "refresh-token",
+		IDToken:         "login-id-token",
 		ExpiresAt:       time.Now().Add(-1 * time.Hour),
 		UserID:          "user-1",
 		UpstreamSubject: "sub-1",
@@ -66,6 +68,7 @@ func TestInProcessService_GetValidTokens(t *testing.T) {
 		setupStorage   func(*storagemocks.MockUpstreamTokenStorage)
 		setupRefresher func(*storagemocks.MockUpstreamTokenRefresher)
 		wantToken      string
+		wantIDToken    string
 		wantErr        error
 		wantAnyErr     bool // expect an error but not a specific sentinel
 	}{
@@ -78,8 +81,11 @@ func TestInProcessService_GetValidTokens(t *testing.T) {
 			},
 			setupRefresher: func(_ *storagemocks.MockUpstreamTokenRefresher) {},
 			wantToken:      "valid-access-token",
+			wantIDToken:    "valid-id-token",
 		},
 		{
+			// The refresh response omits id_token (refreshedTokens has none), so
+			// the original login ID token must be carried through (OIDC §12.2).
 			name:      "expired tokens refreshed via storage ErrExpired",
 			sessionID: "session-2",
 			setupStorage: func(s *storagemocks.MockUpstreamTokenStorage) {
@@ -90,7 +96,8 @@ func TestInProcessService_GetValidTokens(t *testing.T) {
 				r.EXPECT().RefreshAndStore(gomock.Any(), "session-2", expiredTokens).
 					Return(refreshedTokens, nil)
 			},
-			wantToken: "new-access-token",
+			wantToken:   "new-access-token",
+			wantIDToken: "login-id-token",
 		},
 		{
 			name:      "expired tokens refreshed via IsExpired check",
@@ -104,7 +111,8 @@ func TestInProcessService_GetValidTokens(t *testing.T) {
 				r.EXPECT().RefreshAndStore(gomock.Any(), "session-3", expiredTokens).
 					Return(refreshedTokens, nil)
 			},
-			wantToken: "new-access-token",
+			wantToken:   "new-access-token",
+			wantIDToken: "login-id-token",
 		},
 		{
 			name:      "session not found",
@@ -202,6 +210,7 @@ func TestInProcessService_GetValidTokens(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, cred)
 			assert.Equal(t, tt.wantToken, cred.AccessToken)
+			assert.Equal(t, tt.wantIDToken, cred.IDToken)
 		})
 	}
 }
@@ -234,23 +243,26 @@ func TestInProcessService_NilRefresher(t *testing.T) {
 	assert.Nil(t, cred)
 }
 
-func TestInProcessService_GetAllValidTokens(t *testing.T) {
+func TestInProcessService_GetAllUpstreamCredentials(t *testing.T) {
 	t.Parallel()
 
 	freshTokens := &storage.UpstreamTokens{
 		ProviderID:  "github",
 		AccessToken: "github-access-token",
+		IDToken:     "github-id-token",
 		ExpiresAt:   time.Now().Add(1 * time.Hour),
 	}
 	freshTokens2 := &storage.UpstreamTokens{
 		ProviderID:  "atlassian",
 		AccessToken: "atlassian-access-token",
+		IDToken:     "atlassian-id-token",
 		ExpiresAt:   time.Now().Add(1 * time.Hour),
 	}
 	expiredTokens := &storage.UpstreamTokens{
 		ProviderID:   "github",
 		AccessToken:  "expired-github-token",
 		RefreshToken: "github-refresh-token",
+		IDToken:      "github-id-token",
 		ExpiresAt:    time.Now().Add(-1 * time.Hour),
 	}
 	expiredTokensAtlassian := &storage.UpstreamTokens{
@@ -264,18 +276,24 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 		AccessToken: "new-github-token",
 		ExpiresAt:   time.Now().Add(1 * time.Hour),
 	}
+	refreshedTokensWithID := &storage.UpstreamTokens{
+		ProviderID:  "github",
+		AccessToken: "new-github-token",
+		IDToken:     "rotated-github-id-token",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	}
 
 	tests := []struct {
 		name           string
 		sessionID      string
 		setupStorage   func(*storagemocks.MockUpstreamTokenStorage)
 		setupRefresher func(*storagemocks.MockUpstreamTokenRefresher)
-		wantResult     map[string]string
+		wantResult     map[string]UpstreamCredential
 		wantFailed     []string
 		wantErr        bool
 	}{
 		{
-			name:      "all fresh tokens returned directly",
+			name:      "all fresh tokens returned directly with IDs",
 			sessionID: "session-1",
 			setupStorage: func(s *storagemocks.MockUpstreamTokenStorage) {
 				s.EXPECT().GetAllUpstreamTokens(gomock.Any(), "session-1").
@@ -285,13 +303,13 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 					}, nil)
 			},
 			setupRefresher: func(_ *storagemocks.MockUpstreamTokenRefresher) {},
-			wantResult: map[string]string{
-				"github":    "github-access-token",
-				"atlassian": "atlassian-access-token",
+			wantResult: map[string]UpstreamCredential{
+				"github":    {AccessToken: "github-access-token", IDToken: "github-id-token"},
+				"atlassian": {AccessToken: "atlassian-access-token", IDToken: "atlassian-id-token"},
 			},
 		},
 		{
-			name:      "mixed fresh and expired with successful refresh",
+			name:      "mixed fresh and expired with successful refresh carries ID token through",
 			sessionID: "session-2",
 			setupStorage: func(s *storagemocks.MockUpstreamTokenStorage) {
 				s.EXPECT().GetAllUpstreamTokens(gomock.Any(), "session-2").
@@ -304,9 +322,28 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 				r.EXPECT().RefreshAndStore(gomock.Any(), "session-2", expiredTokens).
 					Return(refreshedTokens, nil)
 			},
-			wantResult: map[string]string{
-				"atlassian": "atlassian-access-token",
-				"github":    "new-github-token",
+			wantResult: map[string]UpstreamCredential{
+				"atlassian": {AccessToken: "atlassian-access-token", IDToken: "atlassian-id-token"},
+				"github":    {AccessToken: "new-github-token", IDToken: "github-id-token"},
+			},
+		},
+		{
+			// When the refresh response rotates the id_token (OIDC §12.2), the
+			// refreshed ID token must be preferred over the original login one.
+			name:      "expired refresh that rotates id_token prefers refreshed ID token",
+			sessionID: "session-11",
+			setupStorage: func(s *storagemocks.MockUpstreamTokenStorage) {
+				s.EXPECT().GetAllUpstreamTokens(gomock.Any(), "session-11").
+					Return(map[string]*storage.UpstreamTokens{
+						"github": expiredTokens,
+					}, nil)
+			},
+			setupRefresher: func(r *storagemocks.MockUpstreamTokenRefresher) {
+				r.EXPECT().RefreshAndStore(gomock.Any(), "session-11", expiredTokens).
+					Return(refreshedTokensWithID, nil)
+			},
+			wantResult: map[string]UpstreamCredential{
+				"github": {AccessToken: "new-github-token", IDToken: "rotated-github-id-token"},
 			},
 		},
 		{
@@ -322,7 +359,7 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 				r.EXPECT().RefreshAndStore(gomock.Any(), "session-3", expiredTokens).
 					Return(nil, errors.New("upstream IDP unavailable"))
 			},
-			wantResult: map[string]string{},
+			wantResult: map[string]UpstreamCredential{},
 			wantFailed: []string{"github"},
 		},
 		{
@@ -341,7 +378,7 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 				r.EXPECT().RefreshAndStore(gomock.Any(), "session-3b", expiredTokensAtlassian).
 					Return(nil, errors.New("atlassian IDP unavailable"))
 			},
-			wantResult: map[string]string{},
+			wantResult: map[string]UpstreamCredential{},
 			wantFailed: []string{"github", "atlassian"},
 		},
 		{
@@ -352,7 +389,7 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 					Return(map[string]*storage.UpstreamTokens{}, nil)
 			},
 			setupRefresher: func(_ *storagemocks.MockUpstreamTokenRefresher) {},
-			wantResult:     map[string]string{},
+			wantResult:     map[string]UpstreamCredential{},
 		},
 		{
 			name:      "storage error propagated",
@@ -375,8 +412,8 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 					}, nil)
 			},
 			setupRefresher: func(_ *storagemocks.MockUpstreamTokenRefresher) {},
-			wantResult: map[string]string{
-				"github": "github-access-token",
+			wantResult: map[string]UpstreamCredential{
+				"github": {AccessToken: "github-access-token", IDToken: "github-id-token"},
 			},
 		},
 		{
@@ -388,13 +425,14 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 						"github": {
 							ProviderID:   "github",
 							AccessToken:  "expired-no-refresh",
+							IDToken:      "github-id-token",
 							ExpiresAt:    time.Now().Add(-1 * time.Hour),
 							RefreshToken: "",
 						},
 					}, nil)
 			},
 			setupRefresher: func(_ *storagemocks.MockUpstreamTokenRefresher) {},
-			wantResult:     map[string]string{},
+			wantResult:     map[string]UpstreamCredential{},
 			wantFailed:     []string{"github"},
 		},
 		{
@@ -406,13 +444,64 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 						"github": {
 							ProviderID:  "github",
 							AccessToken: "no-expiry-token",
+							IDToken:     "github-id-token",
 							ExpiresAt:   time.Time{},
 						},
 					}, nil)
 			},
 			setupRefresher: func(_ *storagemocks.MockUpstreamTokenRefresher) {},
-			wantResult: map[string]string{
-				"github": "no-expiry-token",
+			wantResult: map[string]UpstreamCredential{
+				"github": {AccessToken: "no-expiry-token", IDToken: "github-id-token"},
+			},
+		},
+		{
+			name:      "missing ID token carried through as empty string",
+			sessionID: "session-9",
+			setupStorage: func(s *storagemocks.MockUpstreamTokenStorage) {
+				s.EXPECT().GetAllUpstreamTokens(gomock.Any(), "session-9").
+					Return(map[string]*storage.UpstreamTokens{
+						"github": {
+							ProviderID:  "github",
+							AccessToken: "no-id-token",
+							IDToken:     "",
+							ExpiresAt:   time.Now().Add(1 * time.Hour),
+						},
+					}, nil)
+			},
+			setupRefresher: func(_ *storagemocks.MockUpstreamTokenRefresher) {},
+			wantResult: map[string]UpstreamCredential{
+				"github": {AccessToken: "no-id-token", IDToken: ""},
+			},
+		},
+		{
+			// All providers have valid access tokens but none have ID tokens.
+			// GetAllUpstreamCredentials MUST still return every provider with an
+			// empty IDToken field — the decision to project empty ID tokens out
+			// of Identity.UpstreamIDTokens is made in the middleware layer
+			// (pkg/auth/token.go), not here.
+			name:      "all access tokens present with all empty ID tokens returns every provider",
+			sessionID: "session-10",
+			setupStorage: func(s *storagemocks.MockUpstreamTokenStorage) {
+				s.EXPECT().GetAllUpstreamTokens(gomock.Any(), "session-10").
+					Return(map[string]*storage.UpstreamTokens{
+						"github": {
+							ProviderID:  "github",
+							AccessToken: "gh-access",
+							IDToken:     "",
+							ExpiresAt:   time.Now().Add(1 * time.Hour),
+						},
+						"atlassian": {
+							ProviderID:  "atlassian",
+							AccessToken: "atl-access",
+							IDToken:     "",
+							ExpiresAt:   time.Now().Add(1 * time.Hour),
+						},
+					}, nil)
+			},
+			setupRefresher: func(_ *storagemocks.MockUpstreamTokenRefresher) {},
+			wantResult: map[string]UpstreamCredential{
+				"github":    {AccessToken: "gh-access", IDToken: ""},
+				"atlassian": {AccessToken: "atl-access", IDToken: ""},
 			},
 		},
 	}
@@ -431,7 +520,7 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 
 			svc := NewInProcessService(mockStorage, mockRefresher)
 
-			result, failed, err := svc.GetAllValidTokens(context.Background(), tt.sessionID)
+			result, failed, err := svc.GetAllUpstreamCredentials(context.Background(), tt.sessionID)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -446,9 +535,10 @@ func TestInProcessService_GetAllValidTokens(t *testing.T) {
 	}
 }
 
-// TestInProcessService_GetAllValidTokens_NilRefresher verifies that when the
-// refresher is nil, expired tokens in the bulk path are omitted (not panicking).
-func TestInProcessService_GetAllValidTokens_NilRefresher(t *testing.T) {
+// TestInProcessService_GetAllUpstreamCredentials_NilRefresher verifies that
+// when the refresher is nil, expired tokens in the bulk path are omitted
+// (not panicking).
+func TestInProcessService_GetAllUpstreamCredentials_NilRefresher(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
@@ -461,15 +551,16 @@ func TestInProcessService_GetAllValidTokens_NilRefresher(t *testing.T) {
 				ProviderID:   "github",
 				AccessToken:  "expired-token",
 				RefreshToken: "has-refresh",
+				IDToken:      "github-id-token",
 				ExpiresAt:    time.Now().Add(-1 * time.Hour),
 			},
 		}, nil)
 
 	svc := NewInProcessService(mockStorage, nil)
 
-	result, failed, err := svc.GetAllValidTokens(context.Background(), "session-1")
+	result, failed, err := svc.GetAllUpstreamCredentials(context.Background(), "session-1")
 
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{}, result)
+	assert.Equal(t, map[string]UpstreamCredential{}, result)
 	assert.Equal(t, []string{"github"}, failed)
 }

--- a/pkg/auth/upstreamtoken/types.go
+++ b/pkg/auth/upstreamtoken/types.go
@@ -15,26 +15,55 @@ import "context"
 // which defines "sid" for different purposes (RFC 7519, OIDC Session Management).
 const TokenSessionIDClaimKey = "tsid"
 
-// UpstreamCredential is the opaque result of GetValidTokens.
-// The caller only needs the access token to inject into upstream requests.
+// UpstreamCredential bundles the access token and the ID token for a single
+// upstream provider. Access tokens are refreshed when expired.
+//
+// The IDToken is the rotated ID token when a refresh produced one (OIDC Core
+// 1.0 §12.2 permits but does not require a new id_token on refresh), otherwise
+// the original JWT captured at the initial OIDC login (OIDC Core 1.0 §3.1.3.7).
+// It is not independently validated for freshness.
+//
+// Callers MUST check its `exp` claim before using it (e.g. as the subject_token
+// of an RFC 8693 token exchange), as it may be expired. Note also that the ID
+// token's `aud` is this auth server's client registration with the issuing
+// upstream, not the token-exchange endpoint — whether a target authorization
+// server accepts it as a subject token is governed by that server's policy and
+// is typically limited to the same issuer/audience.
+//
+// IDToken may be empty when the upstream login did not return an id_token
+// (e.g. the provider was not asked for the openid scope). An empty IDToken
+// is a legitimate state, not an error. Note that Identity.UpstreamTokens and
+// Identity.UpstreamIDTokens are projected independently and are NOT guaranteed
+// to share the same key set: a provider with an access token but no ID token
+// appears only in UpstreamTokens.
 type UpstreamCredential struct {
 	AccessToken string
+	IDToken     string
 }
 
-// TokenReader retrieves upstream provider access tokens for a session.
+// TokenReader retrieves upstream provider credentials for a session.
 // This narrow interface decouples the auth middleware from storage internals.
 type TokenReader interface {
-	// GetAllValidTokens returns access tokens for all upstream providers in a session.
-	// Expired tokens are refreshed transparently when possible.
+	// GetAllUpstreamCredentials returns the access tokens (refreshing them if
+	// expired) and ID tokens for every upstream provider associated with the
+	// given session ID. Returns an empty map if the session has no stored
+	// upstream tokens.
 	//
 	// The second return value contains the names of providers whose access tokens
 	// were expired and could not be refreshed (e.g. the refresh token is missing
 	// or the upstream IDP rejected the refresh). Those providers are omitted from
-	// the tokens map. Callers should treat a non-empty failed list as a signal to
+	// the creds map. Callers should treat a non-empty failed list as a signal to
 	// return HTTP 401 + WWW-Authenticate so the client can re-authenticate.
 	//
+	// Each returned IDToken is the rotated ID token when a refresh produced
+	// one (OIDC Core 1.0 §12.2), otherwise the original JWT captured at OIDC
+	// login (OIDC Core 1.0 §3.1.3.7). Callers MUST check each ID token's `exp`
+	// claim before using it for e.g. RFC 8693 subject-token exchange, as it may
+	// be expired.
+	//
 	// Returns an empty map and nil failed slice (not error) for unknown sessions.
-	GetAllValidTokens(ctx context.Context, sessionID string) (tokens map[string]string, failed []string, err error)
+	GetAllUpstreamCredentials(ctx context.Context, sessionID string) (
+		creds map[string]UpstreamCredential, failed []string, err error)
 }
 
 // Service owns the upstream token lifecycle: read, refresh, error handling.
@@ -48,5 +77,9 @@ type Service interface {
 	//   - ErrSessionNotFound if no upstream tokens exist for the session/provider
 	//   - ErrNoRefreshToken if the access token is expired and no refresh token is available
 	//   - ErrRefreshFailed if the refresh attempt fails (e.g., revoked refresh token)
+	//
+	// The returned UpstreamCredential.IDToken may be empty or expired; callers
+	// MUST check its `exp` claim before using it (e.g. as the subject_token of
+	// an RFC 8693 token exchange). See UpstreamCredential for details.
 	GetValidTokens(ctx context.Context, sessionID, providerName string) (*UpstreamCredential, error)
 }

--- a/pkg/authserver/integration_test.go
+++ b/pkg/authserver/integration_test.go
@@ -2206,7 +2206,7 @@ func runChainFlow(
 // TestIntegration_MultiUpstreamChain_MixedExpiryOrderings exercises the two-leg
 // authorization chain with one upstream returning expires_in and the other
 // omitting it. Both orderings must succeed and both providers' tokens must be
-// retrievable via GetAllValidTokens.
+// retrievable via GetAllUpstreamCredentials.
 //
 // This pins the chain handler's per-leg storage write and the
 // convertOAuth2Token zero-Expiry path through the full HTTP flow, in both
@@ -2290,17 +2290,17 @@ func TestIntegration_MultiUpstreamChain_MixedExpiryOrderings(t *testing.T) {
 					"provider-2 (expiring) must carry a non-zero ExpiresAt")
 			}
 
-			// GetAllValidTokens must return both providers' access tokens.
+			// GetAllUpstreamCredentials must return both providers' credentials.
 			// Before the Lua TTL fix, the non-expiring provider's index could
 			// be evicted prematurely depending on chain ordering, so this
 			// would have returned an empty or incomplete map for one
 			// ordering.
 			svc := upstreamtoken.NewInProcessService(stor, ts.authServer.UpstreamTokenRefresher())
-			all, _, err := svc.GetAllValidTokens(ctx, tsid)
+			all, _, err := svc.GetAllUpstreamCredentials(ctx, tsid)
 			require.NoError(t, err)
-			require.Len(t, all, 2, "GetAllValidTokens must return both providers regardless of expiry ordering")
-			assert.NotEmpty(t, all["provider-1"], "provider-1 access token must be present")
-			assert.NotEmpty(t, all["provider-2"], "provider-2 access token must be present")
+			require.Len(t, all, 2, "GetAllUpstreamCredentials must return both providers regardless of expiry ordering")
+			assert.NotEmpty(t, all["provider-1"].AccessToken, "provider-1 access token must be present")
+			assert.NotEmpty(t, all["provider-2"].AccessToken, "provider-2 access token must be present")
 		})
 	}
 }
@@ -2499,11 +2499,11 @@ func TestIntegration_MultiUpstreamChain_MixedExpiryOrderings_Redis(t *testing.T)
 			// (commit 1b3bc81e2), the integration flow always produces ttlMs > 0 and
 			// the buggy Lua branch is unreachable from a real auth chain. The Lua
 			// invariant is exercised at unit level by pkg/authserver/storage/redis_test.go.
-			tokensMap, _, err := svc.GetAllValidTokens(ctx, tsid)
+			tokensMap, _, err := svc.GetAllUpstreamCredentials(ctx, tsid)
 			require.NoError(t, err)
-			require.Len(t, tokensMap, 2, "GetAllValidTokens must return both providers after chain")
-			assert.NotEmpty(t, tokensMap["provider-1"], "provider-1 access token must be present")
-			assert.NotEmpty(t, tokensMap["provider-2"], "provider-2 access token must be present")
+			require.Len(t, tokensMap, 2, "GetAllUpstreamCredentials must return both providers after chain")
+			assert.NotEmpty(t, tokensMap["provider-1"].AccessToken, "provider-1 access token must be present")
+			assert.NotEmpty(t, tokensMap["provider-2"].AccessToken, "provider-2 access token must be present")
 		})
 	}
 }

--- a/pkg/authserver/refresher.go
+++ b/pkg/authserver/refresher.go
@@ -148,6 +148,16 @@ func (r *upstreamTokenRefresher) refreshAndStore(
 		updated.RefreshToken = expired.RefreshToken
 	}
 
+	// OIDC Core 1.0 §12.2 permits but does not require a new id_token on refresh.
+	// When the provider omits one, keep the ID token captured at the initial login
+	// so it is not erased from storage. StoreUpstreamTokens replaces the whole row,
+	// so without this the persisted IDToken would be overwritten with "" and the
+	// original login ID token would be lost for the remainder of the session.
+	// Mirrors the RefreshToken carry-forward above.
+	if updated.IDToken == "" {
+		updated.IDToken = expired.IDToken
+	}
+
 	if err := r.storeWithRetry(ctx, sessionID, expired.ProviderID, updated); err != nil {
 		if !rotated {
 			// The old refresh token is still valid in storage; the caller can

--- a/pkg/authserver/refresher_test.go
+++ b/pkg/authserver/refresher_test.go
@@ -336,6 +336,41 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 				assert.Equal(t, "new-refresh", result.RefreshToken)
 			},
 		},
+		{
+			// Regression: when the provider omits id_token on a refresh (common — e.g. Google),
+			// the refresher must carry the original login ID token forward into storage rather
+			// than overwriting the persisted row with an empty string. StoreUpstreamTokens
+			// replaces the whole row, so without the carry-forward the login ID token is
+			// permanently lost after the first refresh cycle.
+			name:      "provider omits id_token on refresh - keeps login ID token",
+			sessionID: "session-9",
+			expired:   baseExpired,
+			setupProvider: func(_ *testing.T, p *upstreammocks.MockOAuth2Provider) {
+				p.EXPECT().RefreshTokens(gomock.Any(), "old-refresh", "upstream-sub-456").
+					Return(&upstream.Tokens{
+						AccessToken:  "new-access",
+						RefreshToken: "new-refresh",
+						IDToken:      "", // provider omitted id_token
+						ExpiresAt:    newExpiry,
+					}, nil)
+			},
+			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
+				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-9", "github", gomock.Any()).
+					DoAndReturn(func(_ context.Context, _, _ string, tokens *storage.UpstreamTokens) error {
+						assert.Equal(t, "old-id-token", tokens.IDToken,
+							"refresher must carry forward the login ID token when provider omits one")
+						return nil
+					})
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, result *storage.UpstreamTokens) {
+				t.Helper()
+				assert.Equal(t, "new-access", result.AccessToken)
+				assert.Equal(t, "new-refresh", result.RefreshToken)
+				assert.Equal(t, "old-id-token", result.IDToken,
+					"returned tokens must carry the login ID token when provider omits one")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/authserver/server/handlers/handler.go
+++ b/pkg/authserver/server/handlers/handler.go
@@ -147,7 +147,7 @@ func (h *Handler) WellKnownRoutes(r chi.Router) {
 // A leg is satisfied when it has a stored token that is live (or asserts no
 // expiry). A present-but-expired token is NOT treated as satisfied by presence
 // alone: the leg is refreshed transparently (mirroring upstreamtoken
-// InProcessService.GetAllValidTokens) and only counts as satisfied if the refresh
+// InProcessService.GetAllUpstreamCredentials) and only counts as satisfied if the refresh
 // succeeds. If refresh is impossible or fails, the leg is reported as missing so
 // the user is re-prompted up front, rather than the stale token surfacing as a
 // runtime auth error later at MCP-request token-swap time.
@@ -179,7 +179,7 @@ func (h *Handler) nextMissingUpstream(ctx context.Context, sessionID string) (st
 // succeeded) and false when the user must be re-prompted: no refresher configured,
 // no refresh token on the row, or the refresh itself failed (expired/revoked
 // refresh token, provider error). Mirrors the refresh-then-classify behavior in
-// upstreamtoken.InProcessService.GetAllValidTokens.
+// upstreamtoken.InProcessService.GetAllUpstreamCredentials.
 func (h *Handler) refreshExpiredLeg(
 	ctx context.Context,
 	sessionID, providerName string,

--- a/pkg/vmcp/auth/factory/incoming_upstream_test.go
+++ b/pkg/vmcp/auth/factory/incoming_upstream_test.go
@@ -86,8 +86,9 @@ func signJWT(t *testing.T, privateKey *rsa.PrivateKey, claims jwt.MapClaims) str
 
 // TestNewOIDCAuthMiddleware_UpstreamTokenReaderWiring verifies the full wiring:
 // newOIDCAuthMiddleware forwards the TokenReader through to the TokenValidator,
-// and a request with a JWT containing a "tsid" claim triggers GetAllValidTokens
-// on the reader, populating Identity.UpstreamTokens.
+// and a request with a JWT containing a "tsid" claim triggers
+// GetAllUpstreamCredentials on the reader, populating both Identity.UpstreamTokens
+// and Identity.UpstreamIDTokens.
 func TestNewOIDCAuthMiddleware_UpstreamTokenReaderWiring(t *testing.T) {
 	t.Parallel()
 
@@ -110,8 +111,10 @@ func TestNewOIDCAuthMiddleware_UpstreamTokenReaderWiring(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
 		reader.EXPECT().
-			GetAllValidTokens(gomock.Any(), "session-abc").
-			Return(map[string]string{"google": "gcp-access-token"}, []string(nil), nil)
+			GetAllUpstreamCredentials(gomock.Any(), "session-abc").
+			Return(map[string]upstreamtoken.UpstreamCredential{
+				"google": {AccessToken: "gcp-access-token", IDToken: "gcp-id-token"},
+			}, []string(nil), nil)
 
 		authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, reader, nil)
 		require.NoError(t, err, "middleware creation should succeed with non-nil reader")
@@ -140,6 +143,8 @@ func TestNewOIDCAuthMiddleware_UpstreamTokenReaderWiring(t *testing.T) {
 		require.NotNil(t, capturedIdentity, "identity should be present in context")
 		assert.Equal(t, map[string]string{"google": "gcp-access-token"}, capturedIdentity.UpstreamTokens,
 			"upstream tokens should be populated from the reader")
+		assert.Equal(t, map[string]string{"google": "gcp-id-token"}, capturedIdentity.UpstreamIDTokens,
+			"upstream ID tokens should be populated from the reader")
 	})
 
 	t.Run("upstream tokens nil when reader is nil", func(t *testing.T) {
@@ -172,6 +177,8 @@ func TestNewOIDCAuthMiddleware_UpstreamTokenReaderWiring(t *testing.T) {
 		require.NotNil(t, capturedIdentity, "identity should be present in context")
 		assert.Nil(t, capturedIdentity.UpstreamTokens,
 			"upstream tokens should be nil when no reader is configured")
+		assert.Nil(t, capturedIdentity.UpstreamIDTokens,
+			"upstream ID tokens should be nil when no reader is configured")
 	})
 
 	t.Run("reader not called when tsid claim absent", func(t *testing.T) {

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -265,7 +265,7 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 // overridden. The per-request identity placed on the request context by
 // auth.TokenValidator.Middleware carries the freshest upstream tokens (the
 // middleware refreshes them transparently on every incoming request via
-// upstreamtoken.InProcessService.GetAllValidTokens). Overriding it with a
+// upstreamtoken.InProcessService.GetAllUpstreamCredentials). Overriding it with a
 // snapshot captured at session-init time would silently re-inject stale
 // upstream access tokens on every backend call, forcing users to re-auth
 // once the captured access token expired (see issue #5323).

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -541,8 +541,8 @@ func (s *Server) Handler(_ context.Context) (http.Handler, error) {
 	//   rate-limit → audit → MCP-parsing → telemetry → handler
 	//
 	// Upstream token refresh failures are detected inside AuthMiddleware itself:
-	// when GetAllValidTokens cannot refresh an expired token it populates
-	// Identity.FailedUpstreamProviders and the middleware short-circuits with
+	// GetAllUpstreamCredentials returns a non-empty failed-provider slice when
+	// any upstream refresh fails, and the middleware short-circuits with
 	// HTTP 401 + WWW-Authenticate before the request reaches any inner layer.
 	//
 	// The legacy HTTP authz, annotation-enrichment, and discovery layers have all been

--- a/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
@@ -93,7 +93,7 @@ func TestHTTPSession_PerRequestIdentity_DrivesUpstreamAuthHeader(t *testing.T) {
 	// simulates what auth.TokenValidator.Middleware does on every
 	// authenticated incoming request: the identity it places on the
 	// context carries upstream tokens that were transparently refreshed
-	// by upstreamtoken.InProcessService.GetAllValidTokens.
+	// by upstreamtoken.InProcessService.GetAllUpstreamCredentials.
 	freshIdentity := &auth.Identity{
 		PrincipalInfo:  auth.PrincipalInfo{Subject: "user-1"},
 		UpstreamTokens: map[string]string{providerName: freshToken},


### PR DESCRIPTION
## Summary

Auth strategies need access to OIDC ID tokens from upstream providers (GitHub, Atlassian, etc.) to use them as RFC 8693 subject tokens in token exchange flows. Previously only access tokens were surfaced through the middleware; ID tokens captured at login were stored but unreachable.

- Consolidate `TokenReader` to a single `GetAllUpstreamCredentials` bulk method returning `map[string]UpstreamCredential` (each carrying both `AccessToken` and `IDToken`), replacing the separate per-token-type methods and avoiding double reads from the same storage backend
- Add `UpstreamIDTokens map[string]string` to `Identity`, populated by auth middleware alongside the existing `UpstreamTokens` map
- Redact `UpstreamIDTokens` in `MarshalJSON` (same pattern as access tokens); also strip the `tsid` claim from the serialized `claims` map to avoid leaking session IDs
- Carry the login ID token forward on a non-rotating refresh: when an upstream omits `id_token` on refresh (common — e.g. Google), the refresher preserves the ID token captured at login instead of erasing it from storage. A rotated `id_token` (OIDC Core 1.0 §12.2) is preferred when the provider returns one.
- ID tokens are not independently re-validated for freshness — callers MUST validate the `exp` claim before using an ID token as an RFC 8693 subject token

Fixes #5679

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Added a regression test in `pkg/authserver/refresher_test.go` asserting the login ID token is carried forward into storage when the provider omits `id_token` on refresh, plus `MarshalJSON` tests pinning the `tsid`-strip and ID-token redaction invariants.

## Does this introduce a user-facing change?

No — `UpstreamIDTokens` is an internal field on `Identity` used by auth strategy code. It is redacted in any JSON serialization, so it does not appear in API responses.

## Special notes for reviewers

- **ID token refresh handling** follows OIDC Core 1.0 §12.2: a refresh response MAY include a new `id_token`. When it does, the rotated token is surfaced and persisted; when it does not, the original login ID token is carried forward so it survives subsequent refreshes. (Previously the persisted ID token was overwritten with an empty value on a non-rotating refresh and permanently lost after the first refresh cycle — see `refreshAndStore` in `pkg/authserver/refresher.go`.)
- The `tsid`-claim stripping in `MarshalJSON` and the error-path `tsid` redaction are intentional defense-in-depth hardening bundled with this change: `tsid` indexes a session's upstream credentials, so it is kept out of serialized `Identity` JSON and out of error strings (demoted to DEBUG logs).
- The documented "MUST check `exp`" contract on `UpstreamIDTokens` is not yet enforced in code (no production consumer reads the field today); a `TODO(auth)` marks the eventual RFC 8693 exchange consumer as the enforcement point.

Generated with [Claude Code](https://claude.com/claude-code)
