### PR TITLE
Fix DetachedEnvVarValidator rejecting optional secret env vars

### DIFF
--- a/pkg/runner/env.go
+++ b/pkg/runner/env.go
@@ -54,8 +54,6 @@ func (*DetachedEnvVarValidator) Validate(
 				continue
 			} else if envVar.Required {
 				return nil, fmt.Errorf("missing required environment variable: %s", envVar.Name)
-			} else if envVar.Secret {
-				return nil, fmt.Errorf("missing required secret environment variable: %s", envVar.Name)
 			} else if envVar.Default != "" {
 				addAsEnvironmentVariable(envVar, envVar.Default, &suppliedEnvVars)
 			}

--- a/pkg/runner/env_test.go
+++ b/pkg/runner/env_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	registry "github.com/stacklok/toolhive-core/registry/types"
+)
+
+func TestDetachedEnvVarValidator_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		envVars         []*registry.EnvVar
+		suppliedEnvVars map[string]string
+		wantErr         bool
+		wantEnvVars     map[string]string
+	}{
+		{
+			name: "optional secret not provided is silently skipped",
+			envVars: []*registry.EnvVar{
+				{Name: "OCI_TOKEN", Required: false, Secret: true},
+			},
+			suppliedEnvVars: map[string]string{},
+			wantErr:         false,
+			wantEnvVars:     map[string]string{},
+		},
+		{
+			name: "required non-secret not provided returns error",
+			envVars: []*registry.EnvVar{
+				{Name: "REQUIRED_VAR", Required: true, Secret: false},
+			},
+			suppliedEnvVars: map[string]string{},
+			wantErr:         true,
+		},
+		{
+			name: "required secret not provided returns error",
+			envVars: []*registry.EnvVar{
+				{Name: "REQUIRED_SECRET", Required: true, Secret: true},
+			},
+			suppliedEnvVars: map[string]string{},
+			wantErr:         true,
+		},
+		{
+			name: "optional secret with default applies default",
+			envVars: []*registry.EnvVar{
+				{Name: "OPT_TOKEN", Required: false, Secret: true, Default: "default-val"},
+			},
+			suppliedEnvVars: map[string]string{},
+			wantErr:         false,
+			wantEnvVars:     map[string]string{"OPT_TOKEN": "default-val"},
+		},
+		{
+			name: "provided secret passes through unchanged",
+			envVars: []*registry.EnvVar{
+				{Name: "OCI_TOKEN", Required: false, Secret: true},
+			},
+			suppliedEnvVars: map[string]string{"OCI_TOKEN": "my-token"},
+			wantErr:         false,
+			wantEnvVars:     map[string]string{"OCI_TOKEN": "my-token"},
+		},
+		{
+			name:            "nil metadata skips all checks",
+			envVars:         nil,
+			suppliedEnvVars: map[string]string{"EXTRA": "val"},
+			wantErr:         false,
+			wantEnvVars:     map[string]string{"EXTRA": "val"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var metadata *registry.ImageMetadata
+			if tc.envVars != nil {
+				metadata = &registry.ImageMetadata{EnvVars: tc.envVars}
+			}
+
+			runConfig := &RunConfig{Secrets: []string{}}
+			validator := &DetachedEnvVarValidator{}
+
+			got, err := validator.Validate(context.Background(), metadata, runConfig, tc.suppliedEnvVars)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.wantEnvVars != nil {
+				assert.Equal(t, tc.wantEnvVars, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`DetachedEnvVarValidator.Validate` had an `else if envVar.Secret` branch that fired for any unset secret env var regardless of its `Required` flag. This caused workload creation to fail with "missing required secret environment variable" when installing servers like `oci-registry` or `context7` from the registry and leaving their optional secrets blank (`OCI_TOKEN`, `CONTEXT7_API_KEY`).

- Remove the erroneous `else if envVar.Secret` branch so optional secrets with no supplied value and no default are silently skipped, aligning `DetachedEnvVarValidator` with the correct behaviour of `CLIEnvVarValidator`.
- Add `pkg/runner/env_test.go` with table-driven coverage for the fixed path and the surrounding cases.

Fixes #5688

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)

## Does this introduce a user-facing change?

Installing an MCP server from the registry via ToolHive Studio that has optional secret env vars (e.g. `oci-registry`, `context7`) no longer fails with a spurious "missing required secret environment variable" error when those fields are left blank.

Generated with [Claude Code](https://claude.com/claude-code)