### PR TITLE
Fix stale pre-pulled image tag causing flaky E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           # Pre-pull images used by E2E tests so that workload creation
           # does not pay the image-pull cost inside the 60s API timeout.
-          docker pull ghcr.io/stackloklabs/osv-mcp/server:0.1.0 &
+          docker pull ghcr.io/stackloklabs/osv-mcp/server:0.1.3 &
           docker pull ghcr.io/stackloklabs/gofetch/server:1.0.2 &
           docker pull ghcr.io/stacklok/toolhive/egress-proxy:latest &
           # yardstick is only needed for the vmcp test suite

--- a/test/e2e/api_clients_validation_test.go
+++ b/test/e2e/api_clients_validation_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Clients API Validation", Label("api", "api-clients", "clients"
 					}
 				}
 				return false
-			}, 60*time.Second, 2*time.Second).Should(BeTrue())
+			}, 90*time.Second, 2*time.Second).Should(BeTrue())
 
 			By("Attempting to register with an invalid client type")
 			invalidClientName := fmt.Sprintf("invalid-client-%d", time.Now().UnixNano())
@@ -115,7 +115,7 @@ var _ = Describe("Clients API Validation", Label("api", "api-clients", "clients"
 					}
 				}
 				return false
-			}, 60*time.Second, 2*time.Second).Should(BeTrue())
+			}, 90*time.Second, 2*time.Second).Should(BeTrue())
 
 			By("Attempting bulk register with invalid client types")
 			invalidClientName1 := fmt.Sprintf("invalid-bulk-1-%d", time.Now().UnixNano())

--- a/test/e2e/api_groups_test.go
+++ b/test/e2e/api_groups_test.go
@@ -357,7 +357,7 @@ var _ = Describe("Groups API", Label("api", "api-misc", "groups", "e2e"), func()
 						}
 					}
 					return false
-				}, 60*time.Second, 2*time.Second).Should(BeTrue(),
+				}, 90*time.Second, 2*time.Second).Should(BeTrue(),
 					"Workload should reach running state before deletion")
 
 				By("Deleting the group with workloads")


### PR DESCRIPTION
## Summary

E2E jobs `api-clients` and `api-misc` intermittently failed on CI and passed cleanly on re-run with no code changes (#5690). Root cause: the CI pre-pull step pulls `osv-mcp/server:0.1.0`, but the `"osv"` registry entry these tests actually create workloads from resolves to `0.1.3`. The mismatch meant the pre-pull step never warmed the cache for the tag actually used, forcing a cold pull mid-test that could eat into the tight 60s workload-readiness timeout.

- Bump the pre-pulled tag in `.github/workflows/e2e-tests.yml` from `0.1.0` to `0.1.3` to match the tag actually used.
- Raise the `Eventually` timeout from 60s to 90s in the two affected tests (`api_clients_validation_test.go`, `api_groups_test.go`) as headroom against transient pull/runner slowness, without masking a real bug if one exists.

A third test in the same failed CI run (`mcp-run` / `fetch_mcp_server_test.go`) was investigated but not changed — its image (`gofetch:1.0.2`) was correctly pre-pulled in that run, and dozens of other tests use the same 60s timeout with that image without issue, so it looks like a one-off CI/runner blip rather than a fixable bug.

Fixes #5690

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`)
- [ ] E2E tests (`task test-e2e`) — not run locally (requires container runtime + CI-only image pulls); validated by re-reading the actual CI failure logs from PR #5689's failed run to confirm the root cause and reasoning.

## Special notes for reviewers

The `mcp-run` flake from the same CI run is left unaddressed — it appears to be unrelated, transient CI noise rather than a reproducible bug (see summary above). Happy to dig further if it recurs.