### PR TITLE
fix: sort tools deterministically in MergeCapabilities

### DIFF
--- a/pkg/vmcp/aggregator/default_aggregator.go
+++ b/pkg/vmcp/aggregator/default_aggregator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -398,6 +399,11 @@ func (a *defaultAggregator) MergeCapabilities(
 			break
 		}
 	}
+
+	// Sort tools deterministically for consistent embedding-batch ordering
+	sort.Slice(tools, func(i, j int) bool {
+		return tools[i].Name < tools[j].Name
+	})
 
 	// Create final aggregated view
 	aggregated := &AggregatedCapabilities{


### PR DESCRIPTION
Closes #5702

The tool catalog was embedded in non-deterministic order because range-over-map produces random iteration order in Go.

Added `sort.Slice` on the tools slice before returning aggregated capabilities, so the embedding batch order is identical across aggregations (same set of tools → same order).

`go vet` and `go test ./pkg/vmcp/aggregator/...` pass cleanly.