### PR TITLE
Unify token-endpoint URL validation, fix insecure-mode gap

### DIFF
--- a/pkg/oauthproto/jwtbearer/doc.go
+++ b/pkg/oauthproto/jwtbearer/doc.go
@@ -3,5 +3,6 @@
 
 // Package jwtbearer provides an OAuth 2.0 JWT Bearer Grant (RFC 7523) implementation.
 // It exchanges a JWT assertion (such as an ID-JAG) for an access token at a target
-// authorization server.
+// authorization server. It also exposes ValidateTokenURL, a shared token-endpoint
+// URL validator reused by other OAuth token-exchange strategies in this repo.
 package jwtbearer

--- a/pkg/oauthproto/jwtbearer/grant.go
+++ b/pkg/oauthproto/jwtbearer/grant.go
@@ -55,6 +55,38 @@ type Config struct {
 	InsecureAllowHTTP bool
 }
 
+// ValidateTokenURL checks that a token endpoint URL is syntactically valid: an
+// http or https scheme, a host, no fragment, and no embedded credentials. The
+// http(s)-only scheme check is enforced unconditionally, even when
+// insecureAllowHTTP is true — insecureAllowHTTP only relaxes the HTTPS
+// requirement (permitting plain HTTP on any host, not just localhost), it does
+// not permit other schemes such as ftp://. label prefixes every error message
+// (e.g. "TokenURL", "IDPTokenURL") so call sites can identify which field
+// failed. Shared by jwtbearer.Config.Validate and the vMCP XAA strategy
+// (pkg/vmcp/auth/strategies), which both validate OAuth token endpoints.
+func ValidateTokenURL(label, endpoint string, insecureAllowHTTP bool) error {
+	if err := networking.ValidateEndpointURLWithInsecure(endpoint, insecureAllowHTTP); err != nil {
+		return fmt.Errorf("%s: %w", label, err)
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("%s is not a valid URL: %w", label, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s must use http or https scheme", label)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%s must include a host", label)
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("%s must not contain a fragment", label)
+	}
+	if u.User != nil {
+		return fmt.Errorf("%s must not contain embedded credentials", label)
+	}
+	return nil
+}
+
 // Validate checks that the Config contains all required fields.
 func (c *Config) Validate() error {
 	if c.TokenURL == "" {
@@ -65,27 +97,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("AssertionProvider is required")
 	}
 
-	// Validate TokenURL: must be https (or http on localhost) per RFC 6749 Section 3.2
-	// and RFC 7523 Section 7. Reuses the repo-wide endpoint validator for scheme,
-	// and adds host and fragment checks that it does not perform.
-	if err := networking.ValidateEndpointURLWithInsecure(c.TokenURL, c.InsecureAllowHTTP); err != nil {
-		return fmt.Errorf("TokenURL: %w", err)
-	}
-	u, err := url.Parse(c.TokenURL)
-	if err != nil {
-		return fmt.Errorf("TokenURL is not a valid URL: %w", err)
-	}
-	if u.Host == "" {
-		return fmt.Errorf("TokenURL must include a host")
-	}
-	if u.Fragment != "" {
-		return fmt.Errorf("TokenURL must not contain a fragment")
-	}
-	if u.User != nil {
-		return fmt.Errorf("TokenURL must not contain embedded credentials")
-	}
-
-	return nil
+	return ValidateTokenURL("TokenURL", c.TokenURL, c.InsecureAllowHTTP)
 }
 
 // String implements fmt.Stringer for Config, redacting sensitive fields.

--- a/pkg/oauthproto/jwtbearer/grant_test.go
+++ b/pkg/oauthproto/jwtbearer/grant_test.go
@@ -100,6 +100,15 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: "must use HTTPS",
 		},
 		{
+			name: "non-http scheme is rejected even with InsecureAllowHTTP",
+			config: Config{
+				TokenURL:          "ftp://as.example.com/token",
+				InsecureAllowHTTP: true,
+				AssertionProvider: func() (string, error) { return testAssertion, nil },
+			},
+			wantErr: "must use http or https scheme",
+		},
+		{
 			name: "fragment is rejected",
 			config: Config{
 				TokenURL:          "https://as.example.com/token#section",

--- a/pkg/vmcp/auth/strategies/xaa.go
+++ b/pkg/vmcp/auth/strategies/xaa.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/stacklok/toolhive-core/env"
 	"github.com/stacklok/toolhive/pkg/auth"
-	"github.com/stacklok/toolhive/pkg/networking"
 	"github.com/stacklok/toolhive/pkg/oauthproto"
 	"github.com/stacklok/toolhive/pkg/oauthproto/jwtbearer"
 	"github.com/stacklok/toolhive/pkg/oauthproto/tokenexchange"
@@ -315,39 +314,6 @@ func (*XAAStrategy) performStepB(
 	return token.AccessToken, nil
 }
 
-// validateTokenURL checks that a configured token endpoint is a syntactically
-// valid HTTPS (or localhost HTTP) URL with a host and no fragment. Mirrors the
-// validator in pkg/oauthproto/jwtbearer.Config.Validate.
-func validateTokenURL(label, endpoint string) error {
-	return validateTokenURLWithInsecure(label, endpoint, false)
-}
-
-// validateTokenURLWithInsecure is like validateTokenURL but allows plain HTTP
-// when allowInsecureHTTP is true. Used for the TargetTokenURL when
-// InsecureTargetTokenURL is set.
-func validateTokenURLWithInsecure(label, endpoint string, allowInsecureHTTP bool) error {
-	if err := networking.ValidateEndpointURLWithInsecure(endpoint, allowInsecureHTTP); err != nil {
-		return fmt.Errorf("%s: %w", label, err)
-	}
-	u, err := url.Parse(endpoint)
-	if err != nil {
-		return fmt.Errorf("%s is not a valid URL: %w", label, err)
-	}
-	if u.Scheme != "https" && u.Scheme != "http" {
-		return fmt.Errorf("%s must use http or https scheme", label)
-	}
-	if u.Host == "" {
-		return fmt.Errorf("%s must include a host", label)
-	}
-	if u.Fragment != "" {
-		return fmt.Errorf("%s must not contain a fragment", label)
-	}
-	if u.User != nil {
-		return fmt.Errorf("%s must not contain embedded credentials", label)
-	}
-	return nil
-}
-
 // resolveClientSecret resolves a client secret from either a direct value or an
 // environment variable. If both are provided, the direct value takes precedence.
 // Returns an error if a secret source requires a client ID but none is provided,
@@ -415,10 +381,10 @@ func (s *XAAStrategy) parseXAAConfig(strategy *authtypes.BackendAuthStrategy) (*
 
 	// Token endpoint URL shape: must be https (or http on localhost), have a
 	// host, and not carry a fragment. Applied to both IdP and target endpoints.
-	if err := validateTokenURL("IDPTokenURL", cfg.IDPTokenURL); err != nil {
+	if err := jwtbearer.ValidateTokenURL("IDPTokenURL", cfg.IDPTokenURL, false); err != nil {
 		return nil, err
 	}
-	if err := validateTokenURLWithInsecure("TargetTokenURL", cfg.TargetTokenURL, cfg.InsecureTargetTokenURL); err != nil {
+	if err := jwtbearer.ValidateTokenURL("TargetTokenURL", cfg.TargetTokenURL, cfg.InsecureTargetTokenURL); err != nil {
 		return nil, err
 	}
 

--- a/pkg/vmcp/auth/strategies/xaa_test.go
+++ b/pkg/vmcp/auth/strategies/xaa_test.go
@@ -379,6 +379,16 @@ func TestXAAStrategy_Validate(t *testing.T) {
 			expectError: "embedded credentials",
 		},
 		{
+			name: "InsecureTargetTokenURL=true still rejects non-http scheme in TargetTokenURL",
+			strategy: createXAAStrategy(func(cfg *authtypes.XAAConfig) {
+				cfg.IDPTokenURL = testIDPTokenURL
+				cfg.TargetTokenURL = "ftp://target.example.com/token"
+				cfg.TargetAudience = testTargetAudience
+				cfg.InsecureTargetTokenURL = true
+			}),
+			expectError: "TargetTokenURL must use http or https scheme",
+		},
+		{
 			name: "InsecureTargetTokenURL=true does not relax IDPTokenURL validation",
 			strategy: createXAAStrategy(func(cfg *authtypes.XAAConfig) {
 				cfg.IDPTokenURL = "http://idp.example.com/token"


### PR DESCRIPTION
## Summary

- `pkg/oauthproto/jwtbearer/grant.go`'s `Config.Validate()` relied entirely on `networking.ValidateEndpointURLWithInsecure` for TokenURL scheme checking. That helper skips *all* validation (not just the HTTPS requirement) when `insecureAllowHTTP` is true, so a non-http(s) scheme such as `ftp://` could slip through whenever `InsecureAllowHTTP` was set.
- `pkg/vmcp/auth/strategies/xaa.go` already had its own correct (unconditional) scheme check, duplicated across two private helper functions — so the same logic existed twice, once with the gap and once without.
- This PR extracts the correct validation logic into a single exported `jwtbearer.ValidateTokenURL(label, endpoint string, insecureAllowHTTP bool) error`, used by both `jwtbearer.Config.Validate()` and the XAA strategy's `parseXAAConfig`. This removes the duplication and closes the gap in `jwtbearer.Config.Validate()`.

Closes #5686

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Added a regression test in `grant_test.go` covering a non-http(s) scheme (`ftp://`) with `InsecureAllowHTTP: true`, which previously would have been accepted by `jwtbearer.Config.Validate()`. Added a matching case in `xaa_test.go` exercising the shared function through the XAA strategy's `InsecureTargetTokenURL` path.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

No behavior change for the XAA strategy — it already enforced this scheme check correctly; only `jwtbearer.Config.Validate()` gains stricter validation as a result of sharing the logic.

Generated with [Claude Code](https://claude.com/claude-code)