### PR TITLE
Make --allow-docker-gateway grant host access, not just unblock it

### DIFF
--- a/pkg/container/docker/squid.go
+++ b/pkg/container/docker/squid.go
@@ -207,6 +207,36 @@ func writeDockerGatewayDenyRules(sb *strings.Builder, gatewayIP string) {
 	)
 }
 
+// writeDockerGatewayAllowRules emits Squid ACL definitions and http_access allow
+// rules that grant access to the Docker gateway addresses. They are written when
+// --allow-docker-gateway is set so the flag alone makes the host reachable — in
+// allowlist mode, suppressing the deny is not enough, since Squid is
+// first-match-wins and only a later allow can let the request through.
+//
+// The allow rules are emitted as standalone http_access lines that reference only
+// the host/IP ACLs, NOT the port ACL. On a single http_access line Squid AND-s
+// the ACLs together, so folding the gateway host into the port-restricted
+// allowed_ports/allowed_dsts rule would block it on the arbitrary ports that
+// host-local services use (5432, 3306, 6379, 8080, …). Gateway access is
+// therefore port-independent — a deliberate relaxation, since reaching the host
+// is already a separate, more-privileged opt-in.
+//
+// Like the deny rules, these MUST precede any later http_access allow/deny so
+// they are reached under Squid's first-match-wins evaluation.
+//
+// See writeDockerGatewayDenyRules for the meaning of gatewayIP and the gateway
+// hostnames.
+func writeDockerGatewayAllowRules(sb *strings.Builder, gatewayIP string) {
+	sb.WriteString(
+		"# Grant Docker gateway access — enabled via --allow-docker-gateway\n" +
+			"acl docker_gateway_hosts dstdomain " +
+			dockerGatewayHostname + " " + dockerAltGatewayHostname + "\n" +
+			"acl docker_gateway_ip dst " + gatewayIP + "\n" +
+			"http_access allow docker_gateway_hosts\n" +
+			"http_access allow docker_gateway_ip\n\n",
+	)
+}
+
 func createTempEgressSquidConf(
 	networkPermissions *permissions.NetworkPermissions,
 	serverHostname string,
@@ -217,10 +247,13 @@ func createTempEgressSquidConf(
 
 	writeCommonConfig(&sb, serverHostname, proxyEgress)
 
-	// Always block Docker gateway addresses unless the caller explicitly opts
-	// in via --allow-docker-gateway. MUST precede any http_access allow —
-	// Squid is first-match-wins.
-	if !allowDockerGateway {
+	// Handle Docker gateway access. MUST precede any http_access allow — Squid
+	// is first-match-wins. When --allow-docker-gateway is set, emit explicit
+	// allow rules so the flag alone grants host access; otherwise block the
+	// gateway addresses.
+	if allowDockerGateway {
+		writeDockerGatewayAllowRules(&sb, gatewayIP)
+	} else {
 		writeDockerGatewayDenyRules(&sb, gatewayIP)
 	}
 

--- a/pkg/container/docker/squid_test.go
+++ b/pkg/container/docker/squid_test.go
@@ -301,6 +301,7 @@ func TestCreateTempEgressSquidConf_DockerGatewayBlocking(t *testing.T) {
 		permissions        *permissions.NetworkPermissions
 		allowDockerGateway bool
 		expectDenyRule     bool
+		expectAllowRule    bool
 		expectAllowAll     bool
 		expectContains     []string // additional substrings that must appear
 	}{
@@ -321,7 +322,7 @@ func TestCreateTempEgressSquidConf_DockerGatewayBlocking(t *testing.T) {
 			expectAllowAll: true,
 		},
 		{
-			name: "allow-docker-gateway opt-in removes deny rules",
+			name: "allow-docker-gateway opt-in emits allow rules instead of deny",
 			permissions: &permissions.NetworkPermissions{
 				Outbound: &permissions.OutboundNetworkPermissions{
 					InsecureAllowAll: true,
@@ -329,6 +330,7 @@ func TestCreateTempEgressSquidConf_DockerGatewayBlocking(t *testing.T) {
 			},
 			allowDockerGateway: true,
 			expectDenyRule:     false,
+			expectAllowRule:    true,
 			expectAllowAll:     true,
 		},
 		{
@@ -342,7 +344,7 @@ func TestCreateTempEgressSquidConf_DockerGatewayBlocking(t *testing.T) {
 			expectAllowAll: false,
 		},
 		{
-			name: "ACL-based outbound with allow-docker-gateway omits deny rules but keeps ACL allow",
+			name: "ACL-based outbound with allow-docker-gateway emits gateway allow rules and keeps ACL allow",
 			permissions: &permissions.NetworkPermissions{
 				Outbound: &permissions.OutboundNetworkPermissions{
 					AllowHost: []string{"example.com"},
@@ -351,6 +353,7 @@ func TestCreateTempEgressSquidConf_DockerGatewayBlocking(t *testing.T) {
 			},
 			allowDockerGateway: true,
 			expectDenyRule:     false,
+			expectAllowRule:    true,
 			expectAllowAll:     false,
 			expectContains: []string{
 				"acl allowed_ports port 443",
@@ -380,9 +383,9 @@ func TestCreateTempEgressSquidConf_DockerGatewayBlocking(t *testing.T) {
 			},
 		},
 		{
-			// With the opt-in the deny is dropped and the ACL allow for
-			// host.docker.internal takes effect.
-			name: "host.docker.internal in allow_host with opt-in is allowed via ACL",
+			// With the opt-in the deny is dropped and the standalone gateway
+			// allow rules grant access — no manual allowlist entry required.
+			name: "host.docker.internal with opt-in is allowed via standalone gateway rules",
 			permissions: &permissions.NetworkPermissions{
 				Outbound: &permissions.OutboundNetworkPermissions{
 					AllowHost: []string{"host.docker.internal"},
@@ -391,6 +394,7 @@ func TestCreateTempEgressSquidConf_DockerGatewayBlocking(t *testing.T) {
 			},
 			allowDockerGateway: true,
 			expectDenyRule:     false,
+			expectAllowRule:    true,
 			expectAllowAll:     false,
 			expectContains: []string{
 				"acl allowed_dsts dstdomain host.docker.internal",
@@ -411,7 +415,13 @@ func TestCreateTempEgressSquidConf_DockerGatewayBlocking(t *testing.T) {
 			require.NoError(t, err)
 			s := string(b)
 
-			if tt.expectDenyRule {
+			// A given config either blocks the gateway (deny rules) or grants it
+			// (allow rules), never both.
+			assert.False(t, tt.expectDenyRule && tt.expectAllowRule,
+				"a config cannot both deny and allow the docker gateway")
+
+			switch {
+			case tt.expectDenyRule:
 				assert.Contains(t, s, "acl docker_gateway_hosts dstdomain host.docker.internal gateway.docker.internal")
 				assert.Contains(t, s, "acl docker_gateway_ip dst 172.17.0.1")
 				assert.Contains(t, s, "http_access deny docker_gateway_hosts")
@@ -424,7 +434,22 @@ func TestCreateTempEgressSquidConf_DockerGatewayBlocking(t *testing.T) {
 					assert.Less(t, denyIdx, firstAllowIdx,
 						"docker gateway deny must appear before any http_access allow")
 				}
-			} else {
+			case tt.expectAllowRule:
+				assert.Contains(t, s, "acl docker_gateway_hosts dstdomain host.docker.internal gateway.docker.internal")
+				assert.Contains(t, s, "acl docker_gateway_ip dst 172.17.0.1")
+				assert.Contains(t, s, "http_access allow docker_gateway_hosts")
+				assert.Contains(t, s, "http_access allow docker_gateway_ip")
+				// The gateway must never be denied when the opt-in is set.
+				assert.NotContains(t, s, "http_access deny docker_gateway_hosts")
+				assert.NotContains(t, s, "http_access deny docker_gateway_ip")
+
+				// The gateway allow must precede the final catch-all deny —
+				// Squid is first-match-wins.
+				assert.Less(t,
+					strings.Index(s, "http_access allow docker_gateway_hosts"),
+					strings.LastIndex(s, "http_access deny all"),
+					"docker gateway allow must appear before the catch-all deny")
+			default:
 				assert.NotContains(t, s, "docker_gateway_hosts")
 				assert.NotContains(t, s, "docker_gateway_ip")
 			}

--- a/test/e2e/network_isolation_test.go
+++ b/test/e2e/network_isolation_test.go
@@ -259,11 +259,11 @@ var _ = Describe("NetworkIsolation", Label("proxy", "network", "isolation", "e2e
 				"the egress proxy must deny the bridge gateway IP without --allow-docker-gateway")
 			retireServer(denyServer)
 
-			By("Confirming --allow-docker-gateway removes the deny so the host is reachable")
+			By("Confirming --allow-docker-gateway grants access so the host is reachable")
 			allowServer := startFetchServer("allow", "", "--allow-docker-gateway")
 			result := fetchThrough(allowServer, target)
 			if result.IsError {
-				// The deny removal is pinned deterministically by the config test
+				// The deny→allow swap is pinned deterministically by the config test
 				// below; whether the bridge gateway actually routes to a host
 				// service is environment-specific — it works on Linux Docker Engine
 				// (where the bridge gateway is the host), but on Docker Desktop the
@@ -276,12 +276,13 @@ var _ = Describe("NetworkIsolation", Label("proxy", "network", "isolation", "e2e
 		})
 
 		// This test pins the egress ACL rules deterministically on a real, deployed
-		// container — both the hostname deny (which the traffic test above cannot
-		// exercise without the host.docker.internal DNS confounder of #5640) and the
-		// direct-IP deny. It complements, rather than duplicates, the unit test for
+		// container — the default hostname and direct-IP deny rules (which the
+		// traffic test above cannot exercise without the host.docker.internal DNS
+		// confounder of #5640), and the allow rules the flag emits in their place.
+		// It complements, rather than duplicates, the unit test for
 		// createTempEgressSquidConf: it proves thv actually generates and mounts the
 		// config into the running egress proxy, alongside the real-traffic assertion above.
-		It("carries both gateway deny rules in the egress config by default and drops them with the flag", func() {
+		It("carries both gateway deny rules by default and replaces them with allow rules under the flag", func() {
 			squidConf := func(serverName string) string {
 				//nolint:gosec // container name is test-controlled
 				out, err := exec.Command("docker", "exec", serverName+"-egress",
@@ -300,12 +301,17 @@ var _ = Describe("NetworkIsolation", Label("proxy", "network", "isolation", "e2e
 				"default config must deny the docker gateway IP (the DNS-bypass path)")
 			retireServer(denyServer)
 
-			By("With --allow-docker-gateway: both deny rules are absent")
+			By("With --allow-docker-gateway: the deny rules are replaced by explicit allow rules")
 			allowConf := squidConf(startFetchServer("cfg-allow", "", "--allow-docker-gateway"))
-			Expect(allowConf).ToNot(ContainSubstring("docker_gateway_hosts"),
+			Expect(allowConf).ToNot(ContainSubstring("http_access deny docker_gateway_hosts"),
 				"--allow-docker-gateway must remove the gateway hostname deny rule")
-			Expect(allowConf).ToNot(ContainSubstring("docker_gateway_ip"),
+			Expect(allowConf).ToNot(ContainSubstring("http_access deny docker_gateway_ip"),
 				"--allow-docker-gateway must remove the gateway IP deny rule")
+			Expect(allowConf).To(ContainSubstring("http_access allow docker_gateway_hosts"),
+				"--allow-docker-gateway must grant access to the gateway hostnames")
+			Expect(allowConf).To(ContainSubstring("dstdomain host.docker.internal gateway.docker.internal"))
+			Expect(allowConf).To(ContainSubstring("http_access allow docker_gateway_ip"),
+				"--allow-docker-gateway must grant access to the gateway IP")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

`--allow-docker-gateway` was meant to make the Docker gateway (`host.docker.internal`, `gateway.docker.internal`, and the bridge gateway IP) reachable from an isolated MCP server. In **allowlist mode** it did not: the flag only *suppressed* the egress proxy's deny rules for the gateway. Because Squid is first-match-wins, removing the deny does nothing on its own — without a later `allow` rule the request falls through to the catch-all `http_access deny all`. Users had to *also* manually add `host.docker.internal` (and an appropriate port) to their allowlist for the flag to have any visible effect.

This makes the flag behave symmetrically in both modes: flag on → host reachable, with no manual allowlist entry required.

What changed:
- Added `writeDockerGatewayAllowRules`, symmetric to the existing `writeDockerGatewayDenyRules`. When `--allow-docker-gateway` is set it emits explicit **standalone** `http_access allow` rules for the gateway host(s) and IP, placed before the final catch-all deny so they win under first-match-wins.
- `createTempEgressSquidConf` now branches: opt-in → emit allow rules; otherwise → emit deny rules (unchanged behavior).

The allow rules reference **only** the host/IP ACLs, not the port ACL. On a single `http_access` line Squid AND-s ACLs together, so folding the gateway into the port-restricted `allowed_ports allowed_dsts` rule would re-block it on the arbitrary ports host-local services use (5432, 3306, 6379, 8080, …). Gateway access is therefore deliberately **port-independent** — reaching the host is already a separate, more-privileged opt-in. This rationale is captured in the function's doc comment.

Closes #5694

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] Unit tests: extended `TestCreateTempEgressSquidConf_DockerGatewayBlocking` with an `expectAllowRule` dimension asserting that, with the opt-in, the standalone gateway `allow` rules are emitted, the gateway is never denied, and the allow precedes the catch-all `http_access deny all`. Existing deny-mode and ordering assertions are unchanged.
- [x] `go test ./pkg/container/docker/` passes with the Taskfile race/ldflags settings.

## Does this introduce a user-facing change?

Yes. `--allow-docker-gateway` now grants access to the Docker gateway in allowlist mode instead of merely unblocking it. Previously the flag had no visible effect in allowlist mode unless the user also added `host.docker.internal` to their allowlist; now the flag alone is sufficient. Behavior in `insecure_allow_all` mode is unchanged.

## Special notes for reviewers

Gateway access is intentionally port-independent (see the design decision in #5694 and the `writeDockerGatewayAllowRules` doc comment). Behavior when the flag is *off* is byte-for-byte unchanged.

Generated with [Claude Code](https://claude.com/claude-code)