### PR TITLE
Unify subject provider defaulting, hard-error xaa

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -61,6 +61,10 @@ const (
 	authContextDefault          = "default"
 	authContextBackendPrefix    = "backend:"
 	authContextDiscoveredPrefix = "discovered:"
+
+	// authReasonAmbiguousSubjectProvider is the condition Reason surfaced when
+	// injectSubjectProviderIfNeeded returns authtypes.ErrAmbiguousSubjectProvider.
+	authReasonAmbiguousSubjectProvider = "AmbiguousSubjectProvider"
 )
 
 // AuthConfigError represents a single auth config conversion failure.
@@ -104,6 +108,16 @@ func authConfigErrorReason(authErr *AuthConfigError) string {
 		return authErr.Reason
 	}
 	return "ConversionFailed"
+}
+
+// subjectProviderErrorReason maps an error returned by injectSubjectProviderIfNeeded
+// to a condition Reason. Falls back to "" so the caller's AuthConfigError.Reason
+// stays empty and authConfigErrorReason applies its default ("ConversionFailed").
+func subjectProviderErrorReason(err error) string {
+	if stderrors.Is(err, authtypes.ErrAmbiguousSubjectProvider) {
+		return authReasonAmbiguousSubjectProvider
+	}
+	return ""
 }
 
 // VirtualMCPServerReconciler reconciles a VirtualMCPServer object
@@ -2399,12 +2413,24 @@ func (r *VirtualMCPServerReconciler) discoverExternalAuthConfigs(
 			continue
 		}
 
-		// Only add if not already overridden in inline config
-		if vmcp.Spec.OutgoingAuth == nil || vmcp.Spec.OutgoingAuth.Backends == nil {
-			outgoing.Backends[workloadInfo.Name] = injectSubjectProviderIfNeeded(strategy, vmcp.Spec.AuthServerConfig)
-		} else if _, exists := vmcp.Spec.OutgoingAuth.Backends[workloadInfo.Name]; !exists {
-			// Only add discovered config if not explicitly overridden
-			outgoing.Backends[workloadInfo.Name] = injectSubjectProviderIfNeeded(strategy, vmcp.Spec.AuthServerConfig)
+		// Only add if not already overridden in inline config.
+		shouldAssign := true
+		if vmcp.Spec.OutgoingAuth != nil && vmcp.Spec.OutgoingAuth.Backends != nil {
+			_, exists := vmcp.Spec.OutgoingAuth.Backends[workloadInfo.Name]
+			shouldAssign = !exists
+		}
+		if shouldAssign {
+			injected, err := injectSubjectProviderIfNeeded(strategy, vmcp.Spec.AuthServerConfig)
+			if err != nil {
+				authErrors = append(authErrors, AuthConfigError{
+					Context:     fmt.Sprintf("%s%s", authContextDiscoveredPrefix, workloadInfo.Name),
+					BackendName: workloadInfo.Name,
+					Error:       fmt.Errorf("failed to inject subject provider name: %w", err),
+					Reason:      subjectProviderErrorReason(err),
+				})
+			} else {
+				outgoing.Backends[workloadInfo.Name] = injected
+			}
 		}
 	}
 
@@ -2483,8 +2509,15 @@ func (r *VirtualMCPServerReconciler) buildOutgoingAuthConfig(
 				Error:       fmt.Errorf("failed to convert default auth config: %w", err),
 				Reason:      mirroredReasonFromError(err),
 			})
+		} else if injected, injectErr := injectSubjectProviderIfNeeded(defaultStrategy, vmcp.Spec.AuthServerConfig); injectErr != nil {
+			allAuthErrors = append(allAuthErrors, AuthConfigError{
+				Context:     authContextDefault,
+				BackendName: "",
+				Error:       fmt.Errorf("failed to inject subject provider name: %w", injectErr),
+				Reason:      subjectProviderErrorReason(injectErr),
+			})
 		} else {
-			outgoing.Default = injectSubjectProviderIfNeeded(defaultStrategy, vmcp.Spec.AuthServerConfig)
+			outgoing.Default = injected
 		}
 	}
 
@@ -2509,8 +2542,15 @@ func (r *VirtualMCPServerReconciler) buildOutgoingAuthConfig(
 					Error:       fmt.Errorf("failed to convert backend auth config: %w", err),
 					Reason:      mirroredReasonFromError(err),
 				})
+			} else if injected, injectErr := injectSubjectProviderIfNeeded(strategy, vmcp.Spec.AuthServerConfig); injectErr != nil {
+				allAuthErrors = append(allAuthErrors, AuthConfigError{
+					Context:     fmt.Sprintf("%s%s", authContextBackendPrefix, backendName),
+					BackendName: backendName,
+					Error:       fmt.Errorf("failed to inject subject provider name: %w", injectErr),
+					Reason:      subjectProviderErrorReason(injectErr),
+				})
 			} else {
-				outgoing.Backends[backendName] = injectSubjectProviderIfNeeded(strategy, vmcp.Spec.AuthServerConfig)
+				outgoing.Backends[backendName] = injected
 			}
 		}
 	}
@@ -2520,59 +2560,30 @@ func (r *VirtualMCPServerReconciler) buildOutgoingAuthConfig(
 
 // injectSubjectProviderIfNeeded auto-populates the upstream provider name on
 // token_exchange, aws_sts, and xaa strategies when the field is empty and an
-// embedded auth server is configured on the VirtualMCPServer.
-// All three strategies use SubjectProviderName for the same concept: which
-// upstream provider's token to pull from Identity.UpstreamTokens. Mirrors
+// embedded auth server is configured on the VirtualMCPServer. All three
+// strategies use SubjectProviderName for the same concept: which upstream
+// provider's token to pull from Identity.UpstreamTokens. Mirrors
 // injectUpstreamProviderIfNeeded in pkg/runner/middleware.go, which does the
 // same for Cedar's PrimaryUpstreamProvider, and InjectSubjectProviderNames in
 // pkg/vmcp/config/defaults.go, which applies the same defaulting at serve time.
-// Returns strategy unchanged when it is nil, not an applicable strategy type,
-// already has the provider name set, or no embedded auth server is configured.
+//
+// Delegates the actual defaulting to authtypes.DefaultSubjectProviderName.
+// Returns strategy unchanged when it is nil or no embedded auth server is
+// configured. Can return authtypes.ErrAmbiguousSubjectProvider when strategy
+// is xaa, SubjectProviderName is empty, and more than one upstream provider
+// is configured.
 func injectSubjectProviderIfNeeded(
 	strategy *authtypes.BackendAuthStrategy,
 	embeddedCfg *mcpv1beta1.EmbeddedAuthServerConfig,
-) *authtypes.BackendAuthStrategy {
+) (*authtypes.BackendAuthStrategy, error) {
 	if strategy == nil || embeddedCfg == nil {
-		return strategy
+		return strategy, nil
 	}
-
-	switch strategy.Type {
-	case authtypes.StrategyTypeTokenExchange:
-		if strategy.TokenExchange == nil || strategy.TokenExchange.SubjectProviderName != "" {
-			return strategy
-		}
-		providerName := resolveFirstUpstreamProvider(embeddedCfg)
-		copied := *strategy
-		teCopied := *strategy.TokenExchange
-		teCopied.SubjectProviderName = providerName
-		copied.TokenExchange = &teCopied
-		return &copied
-
-	case authtypes.StrategyTypeAwsSts:
-		if strategy.AwsSts == nil || strategy.AwsSts.SubjectProviderName != "" {
-			return strategy
-		}
-		providerName := resolveFirstUpstreamProvider(embeddedCfg)
-		copied := *strategy
-		stsCopied := *strategy.AwsSts
-		stsCopied.SubjectProviderName = providerName
-		copied.AwsSts = &stsCopied
-		return &copied
-
-	case authtypes.StrategyTypeXAA:
-		if strategy.XAA == nil || strategy.XAA.SubjectProviderName != "" {
-			return strategy
-		}
-		providerName := resolveFirstUpstreamProvider(embeddedCfg)
-		copied := *strategy
-		xaaCopied := *strategy.XAA
-		xaaCopied.SubjectProviderName = providerName
-		copied.XAA = &xaaCopied
-		return &copied
-
-	default:
-		return strategy
-	}
+	return authtypes.DefaultSubjectProviderName(
+		strategy,
+		resolveFirstUpstreamProvider(embeddedCfg),
+		len(embeddedCfg.UpstreamProviders) > 1,
+	)
 }
 
 // resolveFirstUpstreamProvider returns the resolved name of the first upstream

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -2562,10 +2562,13 @@ func (r *VirtualMCPServerReconciler) buildOutgoingAuthConfig(
 // token_exchange, aws_sts, and xaa strategies when the field is empty and an
 // embedded auth server is configured on the VirtualMCPServer. All three
 // strategies use SubjectProviderName for the same concept: which upstream
-// provider's token to pull from Identity.UpstreamTokens. Mirrors
-// injectUpstreamProviderIfNeeded in pkg/runner/middleware.go, which does the
-// same for Cedar's PrimaryUpstreamProvider, and InjectSubjectProviderNames in
-// pkg/vmcp/config/defaults.go, which applies the same defaulting at serve time.
+// provider's token to pull from Identity.UpstreamTokens.
+//
+// The same first-upstream-name extraction appears in pkg/runner/middleware.go
+// and pkg/vmcp/config/defaults.go, which share the authserver.UpstreamRunConfig
+// type and are candidates for a shared authserver helper (tracked as follow-up
+// work). This function operates on the CRD-specific EmbeddedAuthServerConfig
+// type and is intentionally kept separate.
 //
 // Delegates the actual defaulting to authtypes.DefaultSubjectProviderName.
 // Returns strategy unchanged when it is nil or no embedded auth server is
@@ -2601,15 +2604,25 @@ func resolveFirstUpstreamProvider(embeddedCfg *mcpv1beta1.EmbeddedAuthServerConf
 // Preserves metadata and uses transport types from workload Specs.
 // Logs warnings when backends are skipped due to missing URL or transport information.
 // caBundlePathMap maps backend names to their CA bundle mount paths (populated for MCPServerEntry backends).
+// excludedBackends names backends whose outgoing auth strategy failed to build (see
+// backendsWithFailedAuth); they are dropped from the served set entirely rather than
+// left to fall through to the Default strategy at runtime.
 func convertBackendsToStaticBackends(
 	ctx context.Context,
 	backends []vmcptypes.Backend,
 	transportMap map[string]string,
 	caBundlePathMap map[string]string,
+	excludedBackends map[string]struct{},
 ) []vmcpconfig.StaticBackendConfig {
 	logger := log.FromContext(ctx)
 	static := make([]vmcpconfig.StaticBackendConfig, 0, len(backends))
 	for _, backend := range backends {
+		if _, excluded := excludedBackends[backend.Name]; excluded {
+			logger.V(1).Info("Skipping backend with failed outgoing auth configuration",
+				"backend", backend.Name)
+			continue
+		}
+
 		if backend.BaseURL == "" {
 			logger.V(1).Info("Skipping backend without URL in static mode",
 				"backend", backend.Name)

--- a/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/auth/obo"
-	"github.com/stacklok/toolhive/pkg/authserver"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
@@ -1124,24 +1123,13 @@ func TestGenerateUniqueHeaderInjectionEnvVarName(t *testing.T) {
 	}
 }
 
-// awsStsStrategy returns a minimal aws_sts BackendAuthStrategy for tests.
-func awsStsStrategy(subjectProviderName string) *authtypes.BackendAuthStrategy {
-	return &authtypes.BackendAuthStrategy{
-		Type: authtypes.StrategyTypeAwsSts,
-		AwsSts: &authtypes.AwsStsConfig{
-			Region:              "us-east-1",
-			FallbackRoleArn:     "arn:aws:iam::123456789012:role/test",
-			SubjectProviderName: subjectProviderName,
-		},
-	}
-}
-
-func tokenExchangeStrategy(subjectProviderName string) *authtypes.BackendAuthStrategy {
+// tokenExchangeStrategy returns a minimal token_exchange BackendAuthStrategy
+// with an empty SubjectProviderName, for tests of the defaulting wiring.
+func tokenExchangeStrategy() *authtypes.BackendAuthStrategy {
 	return &authtypes.BackendAuthStrategy{
 		Type: authtypes.StrategyTypeTokenExchange,
 		TokenExchange: &authtypes.TokenExchangeConfig{
-			TokenURL:            "https://oauth.example.com/token",
-			SubjectProviderName: subjectProviderName,
+			TokenURL: "https://oauth.example.com/token",
 		},
 	}
 }
@@ -1172,8 +1160,13 @@ func embeddedAuthServerCfg(upstreamNames ...string) *mcpv1beta1.EmbeddedAuthServ
 	return cfg
 }
 
-// TestInjectSubjectProviderIfNeeded tests the injectSubjectProviderIfNeeded helper.
-// Modelled on TestInjectUpstreamProviderIfNeeded in pkg/runner/middleware_test.go.
+// TestInjectSubjectProviderIfNeeded tests the injectSubjectProviderIfNeeded wrapper.
+// The per-strategy-type defaulting logic (nil-checks, already-set checks, copy
+// semantics, xaa-ambiguity) is exhaustively covered by
+// pkg/vmcp/auth/types.TestDefaultSubjectProviderName; this table covers only what
+// the wrapper itself is responsible for: its own nil-strategy/nil-embeddedCfg
+// guards, and correctly resolving providerName/hasMultipleUpstreams from
+// embeddedCfg via resolveFirstUpstreamProvider before delegating.
 func TestInjectSubjectProviderIfNeeded(t *testing.T) {
 	t.Parallel()
 
@@ -1183,6 +1176,7 @@ func TestInjectSubjectProviderIfNeeded(t *testing.T) {
 		embeddedCfg             *mcpv1beta1.EmbeddedAuthServerConfig
 		wantSubjectProviderName string
 		wantSamePointer         bool
+		wantErr                 error
 	}{
 		{
 			name:            "nil_strategy_returned_unchanged",
@@ -1192,92 +1186,27 @@ func TestInjectSubjectProviderIfNeeded(t *testing.T) {
 		},
 		{
 			name:            "nil_embedded_config_returned_unchanged",
-			strategy:        tokenExchangeStrategy(""),
+			strategy:        tokenExchangeStrategy(),
 			embeddedCfg:     nil,
 			wantSamePointer: true,
 		},
 		{
-			name: "non_token_exchange_strategy_returned_unchanged",
-			strategy: &authtypes.BackendAuthStrategy{
-				Type: authtypes.StrategyTypeHeaderInjection,
-				HeaderInjection: &authtypes.HeaderInjectionConfig{
-					HeaderName:  "Authorization",
-					HeaderValue: "Bearer token",
-				},
-			},
-			embeddedCfg:     embeddedAuthServerCfg("github"),
-			wantSamePointer: true,
-		},
-		{
-			name:                    "already_set_subject_provider_not_overridden",
-			strategy:                tokenExchangeStrategy("explicit-provider"),
-			embeddedCfg:             embeddedAuthServerCfg("github"),
-			wantSamePointer:         true,
-			wantSubjectProviderName: "explicit-provider",
-		},
-		{
 			name:                    "named_upstream_populates_subject_provider",
-			strategy:                tokenExchangeStrategy(""),
+			strategy:                tokenExchangeStrategy(),
 			embeddedCfg:             embeddedAuthServerCfg("github"),
 			wantSubjectProviderName: "github",
-		},
-		{
-			name:                    "unnamed_upstream_falls_back_to_default",
-			strategy:                tokenExchangeStrategy(""),
-			embeddedCfg:             embeddedAuthServerCfg(""),
-			wantSubjectProviderName: authserver.DefaultUpstreamName,
-		},
-		{
-			name:                    "empty_upstream_providers_falls_back_to_default",
-			strategy:                tokenExchangeStrategy(""),
-			embeddedCfg:             embeddedAuthServerCfg(), // no upstreams
-			wantSubjectProviderName: authserver.DefaultUpstreamName,
 		},
 		{
 			name:                    "first_upstream_used_when_multiple_configured",
-			strategy:                tokenExchangeStrategy(""),
+			strategy:                tokenExchangeStrategy(),
 			embeddedCfg:             embeddedAuthServerCfg("first", "second"),
 			wantSubjectProviderName: "first",
 		},
-		// aws_sts strategy cases
 		{
-			name:                    "aws_sts_populates_subject_provider_name",
-			strategy:                awsStsStrategy(""),
-			embeddedCfg:             embeddedAuthServerCfg("github"),
-			wantSubjectProviderName: "github",
-		},
-		{
-			name:                    "aws_sts_already_set_provider_not_overridden",
-			strategy:                awsStsStrategy("explicit-provider"),
-			embeddedCfg:             embeddedAuthServerCfg("github"),
-			wantSamePointer:         true,
-			wantSubjectProviderName: "explicit-provider",
-		},
-		{
-			name:            "aws_sts_nil_AwsSts_config_returned_unchanged",
-			strategy:        &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeAwsSts, AwsSts: nil},
-			embeddedCfg:     embeddedAuthServerCfg("github"),
-			wantSamePointer: true,
-		},
-		// xaa strategy cases
-		{
-			name:                    "xaa_populates_subject_provider_name",
-			strategy:                xaaStrategy(""),
-			embeddedCfg:             embeddedAuthServerCfg("github"),
-			wantSubjectProviderName: "github",
-		},
-		{
-			name:                    "xaa_already_set_provider_not_overridden",
-			strategy:                xaaStrategy("explicit-provider"),
-			embeddedCfg:             embeddedAuthServerCfg("github"),
-			wantSamePointer:         true,
-			wantSubjectProviderName: "explicit-provider",
-		},
-		{
-			name:            "xaa_nil_XAA_config_returned_unchanged",
-			strategy:        &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeXAA, XAA: nil},
-			embeddedCfg:     embeddedAuthServerCfg("github"),
-			wantSamePointer: true,
+			name:        "xaa_ambiguous_multiple_upstreams_returns_error",
+			strategy:    xaaStrategy(""),
+			embeddedCfg: embeddedAuthServerCfg("first", "second"),
+			wantErr:     authtypes.ErrAmbiguousSubjectProvider,
 		},
 	}
 
@@ -1285,50 +1214,27 @@ func TestInjectSubjectProviderIfNeeded(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := injectSubjectProviderIfNeeded(tt.strategy, tt.embeddedCfg)
+			result, err := injectSubjectProviderIfNeeded(tt.strategy, tt.embeddedCfg)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, result)
+				return
+			}
+			require.NoError(t, err)
 
 			if tt.wantSamePointer {
 				assert.Same(t, tt.strategy, result)
-				// When the pointer is unchanged and a provider was set, verify it wasn't mutated.
-				if tt.wantSubjectProviderName != "" && result != nil {
-					switch {
-					case result.TokenExchange != nil:
-						assert.Equal(t, tt.wantSubjectProviderName, result.TokenExchange.SubjectProviderName)
-					case result.AwsSts != nil:
-						assert.Equal(t, tt.wantSubjectProviderName, result.AwsSts.SubjectProviderName)
-					case result.XAA != nil:
-						assert.Equal(t, tt.wantSubjectProviderName, result.XAA.SubjectProviderName)
-					}
-				}
 				return
 			}
 
 			require.NotNil(t, result)
-			switch result.Type {
-			case authtypes.StrategyTypeTokenExchange:
-				require.NotNil(t, result.TokenExchange)
-				assert.Equal(t, tt.wantSubjectProviderName, result.TokenExchange.SubjectProviderName)
-				// Verify the original strategy was not mutated.
-				if tt.strategy != nil && tt.strategy.TokenExchange != nil {
-					assert.Empty(t, tt.strategy.TokenExchange.SubjectProviderName,
-						"original strategy must not be mutated")
-				}
-			case authtypes.StrategyTypeAwsSts:
-				require.NotNil(t, result.AwsSts)
-				assert.Equal(t, tt.wantSubjectProviderName, result.AwsSts.SubjectProviderName)
-				// Verify the original strategy was not mutated.
-				if tt.strategy != nil && tt.strategy.AwsSts != nil {
-					assert.Empty(t, tt.strategy.AwsSts.SubjectProviderName,
-						"original strategy must not be mutated")
-				}
-			case authtypes.StrategyTypeXAA:
-				require.NotNil(t, result.XAA)
-				assert.Equal(t, tt.wantSubjectProviderName, result.XAA.SubjectProviderName)
-				// Verify the original strategy was not mutated.
-				if tt.strategy != nil && tt.strategy.XAA != nil {
-					assert.Empty(t, tt.strategy.XAA.SubjectProviderName,
-						"original strategy must not be mutated")
-				}
+			require.NotNil(t, result.TokenExchange)
+			assert.Equal(t, tt.wantSubjectProviderName, result.TokenExchange.SubjectProviderName)
+			// Verify the original strategy was not mutated.
+			if tt.strategy != nil && tt.strategy.TokenExchange != nil {
+				assert.Empty(t, tt.strategy.TokenExchange.SubjectProviderName,
+					"original strategy must not be mutated")
 			}
 		})
 	}
@@ -1800,6 +1706,137 @@ func TestBuildOutgoingAuthConfig_InlineBackendSubjectProviderInjection(t *testin
 	require.NotNil(t, config.Backends["inline-backend"].TokenExchange)
 	assert.Equal(t, "corporate-idp", config.Backends["inline-backend"].TokenExchange.SubjectProviderName,
 		"inline backend SubjectProviderName should be injected from first upstream")
+}
+
+// TestBuildOutgoingAuthConfig_XAAAmbiguousSubjectProviderError verifies the
+// #5697 hard-error path: an xaa strategy with an empty SubjectProviderName
+// and 2+ configured upstreams must surface a non-fatal AuthConfigError with
+// Reason "AmbiguousSubjectProvider" and must NOT be assigned into the
+// resulting config, for all three call-site shapes in buildOutgoingAuthConfig
+// (Default, inline Backends override, discovered backend). A fourth,
+// unaffected token_exchange backend in the same call must still succeed,
+// proving this is a per-backend condition rather than a whole-function failure.
+func TestBuildOutgoingAuthConfig_XAAAmbiguousSubjectProviderError(t *testing.T) {
+	t.Parallel()
+
+	scheme := testutil.NewScheme(t)
+
+	xaaSpec := func() *mcpv1beta1.XAASpec {
+		return &mcpv1beta1.XAASpec{
+			IDPTokenURL:    "https://idp.example.com/token",
+			TargetTokenURL: "https://target.example.com/token",
+			TargetAudience: "https://target.example.com",
+			// SubjectProviderName intentionally left empty
+		}
+	}
+
+	defaultAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "xaa-default-auth", Namespace: "default"},
+		Spec:       mcpv1beta1.MCPExternalAuthConfigSpec{Type: mcpv1beta1.ExternalAuthTypeXAA, XAA: xaaSpec()},
+	}
+	inlineAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "xaa-inline-auth", Namespace: "default"},
+		Spec:       mcpv1beta1.MCPExternalAuthConfigSpec{Type: mcpv1beta1.ExternalAuthTypeXAA, XAA: xaaSpec()},
+	}
+	discoveredAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "xaa-discovered-auth", Namespace: "default"},
+		Spec:       mcpv1beta1.MCPExternalAuthConfigSpec{Type: mcpv1beta1.ExternalAuthTypeXAA, XAA: xaaSpec()},
+	}
+	// Unaffected backend: token_exchange never hard-errors on ambiguity, so it
+	// must still be defaulted and assigned in the same buildOutgoingAuthConfig call.
+	tokenExchangeAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "te-auth", Namespace: "default"},
+		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+			Type: mcpv1beta1.ExternalAuthTypeTokenExchange,
+			TokenExchange: &mcpv1beta1.TokenExchangeConfig{
+				TokenURL: "https://oauth.example.com/token",
+				// SubjectProviderName intentionally left empty
+			},
+		},
+	}
+
+	discoveredServer := v1beta1test.NewMCPServer("xaa-discovered-backend", "default",
+		v1beta1test.WithExternalAuthConfigRef("xaa-discovered-auth"),
+	)
+	unaffectedServer := v1beta1test.NewMCPServer("token-exchange-backend", "default",
+		v1beta1test.WithExternalAuthConfigRef("te-auth"),
+	)
+
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "discovered",
+			Default: &mcpv1beta1.BackendAuthConfig{
+				Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+				ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+					Name: "xaa-default-auth",
+				},
+			},
+			Backends: map[string]mcpv1beta1.BackendAuthConfig{
+				"xaa-inline-backend": {
+					Type: mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{
+						Name: "xaa-inline-auth",
+					},
+				},
+			},
+		}),
+		// 2 upstreams makes the xaa strategies above ambiguous; token_exchange
+		// is unaffected and defaults to the first one ("first").
+		v1beta1test.WithVMCPAuthServerConfig(embeddedAuthServerCfg("first", "second")),
+	)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			vmcp, discoveredServer, unaffectedServer,
+			defaultAuthConfig, inlineAuthConfig, discoveredAuthConfig, tokenExchangeAuthConfig,
+		).
+		Build()
+
+	r := &VirtualMCPServerReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+	}
+
+	workloadNames := []workloads.TypedWorkload{
+		{Name: "xaa-discovered-backend", Type: workloads.WorkloadTypeMCPServer},
+		{Name: "token-exchange-backend", Type: workloads.WorkloadTypeMCPServer},
+	}
+
+	config, _, allAuthErrors := r.buildOutgoingAuthConfig(context.Background(), vmcp, workloadNames)
+
+	require.NotNil(t, config)
+
+	// All 3 ambiguous xaa call sites produced a non-fatal AuthConfigError...
+	require.Len(t, allAuthErrors, 3)
+	errorsByContext := make(map[string]AuthConfigError, len(allAuthErrors))
+	for _, authErr := range allAuthErrors {
+		errorsByContext[authErr.Context] = authErr
+	}
+	for _, wantContext := range []string{
+		authContextDefault,
+		authContextBackendPrefix + "xaa-inline-backend",
+		authContextDiscoveredPrefix + "xaa-discovered-backend",
+	} {
+		authErr, ok := errorsByContext[wantContext]
+		require.True(t, ok, "expected an AuthConfigError with Context %q", wantContext)
+		assert.Equal(t, authReasonAmbiguousSubjectProvider, authErr.Reason)
+		assert.ErrorIs(t, authErr.Error, authtypes.ErrAmbiguousSubjectProvider)
+	}
+
+	// ...and none of them were assigned into the resulting config.
+	assert.Nil(t, config.Default)
+	assert.NotContains(t, config.Backends, "xaa-inline-backend")
+	assert.NotContains(t, config.Backends, "xaa-discovered-backend")
+
+	// The unaffected token_exchange backend still reconciles successfully in
+	// the same call, proving this is a per-backend condition, not a
+	// whole-function failure.
+	require.Contains(t, config.Backends, "token-exchange-backend")
+	require.NotNil(t, config.Backends["token-exchange-backend"].TokenExchange)
+	assert.Equal(t, "first", config.Backends["token-exchange-backend"].TokenExchange.SubjectProviderName)
 }
 
 // TestGetExternalAuthConfigSecretEnvVars_XAA verifies the XAA arm of

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/groups"
 	vmcptypes "github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
 )
@@ -351,6 +352,41 @@ func extractInlineBackendNames(vmcp *mcpv1beta1.VirtualMCPServer) []string {
 	return names
 }
 
+// backendsWithFailedAuth returns the set of backend names whose outgoing auth strategy
+// failed to build (conversion error, mirrored-invalid source, or subject-provider
+// injection error). These backends must never be served: since ResolveForBackend falls
+// through to Default for any backend absent from OutgoingAuthConfig.Backends, silently
+// omitting a failed backend from that map is not enough to keep it from being routed to
+// with the wrong (Default) identity — it must also be dropped from the served backend set.
+//
+// Default-only errors (empty BackendName) are excluded here: they aren't tied to a
+// specific backend, and a backend that falls through to a nil Default degrades to the
+// explicit "unauthenticated" strategy rather than picking up a different identity.
+//
+// A backend name recorded in authErrors is only added to the exclusion set if it also
+// lacks a successfully-resolved strategy in resolvedBackends. A backend can accumulate an
+// error from one path (e.g. a broken discovered ExternalAuthConfigRef) while still ending
+// up with a valid strategy from another (e.g. an inline override) — discoverExternalAuthConfigs
+// records the discovered-path error before checking whether an inline override makes the
+// discovered result irrelevant. Excluding such a backend would drop a fully routable backend
+// from the served set.
+func backendsWithFailedAuth(
+	authErrors []AuthConfigError,
+	resolvedBackends map[string]*authtypes.BackendAuthStrategy,
+) map[string]struct{} {
+	failed := make(map[string]struct{})
+	for _, authErr := range authErrors {
+		if authErr.BackendName == "" {
+			continue
+		}
+		if resolvedBackends[authErr.BackendName] != nil {
+			continue
+		}
+		failed[authErr.BackendName] = struct{}{}
+	}
+	return failed
+}
+
 // determineValidInlineBackends determines which inline backends have valid auth configs.
 func determineValidInlineBackends(authConfig *vmcpconfig.OutgoingAuthConfig, inlineBackendNames []string) []string {
 	if authConfig == nil || authConfig.Backends == nil {
@@ -397,6 +433,15 @@ func (r *VirtualMCPServerReconciler) processOutgoingAuth(
 	// All errors are non-fatal - the system continues in degraded mode with partial auth config
 	authConfig, backendsWithAuthConfig, allAuthErrors := r.buildOutgoingAuthConfig(ctx, vmcp, typedWorkloads)
 
+	// Backends whose auth strategy failed to build must be excluded from the served
+	// set entirely — see backendsWithFailedAuth for why omission from
+	// authConfig.Backends alone is not sufficient.
+	var resolvedBackends map[string]*authtypes.BackendAuthStrategy
+	if authConfig != nil {
+		resolvedBackends = authConfig.Backends
+	}
+	excludedBackends := backendsWithFailedAuth(allAuthErrors, resolvedBackends)
+
 	// Extract inline backend names and determine valid auth configs
 	inlineBackendNames := extractInlineBackendNames(vmcp)
 	hasValidDefaultAuth := authConfig != nil && authConfig.Default != nil
@@ -437,7 +482,7 @@ func (r *VirtualMCPServerReconciler) processOutgoingAuth(
 			return fmt.Errorf("failed to build CA bundle path map for static mode: %w", err)
 		}
 
-		config.Backends = convertBackendsToStaticBackends(ctx, backends, transportMap, caBundlePathMap)
+		config.Backends = convertBackendsToStaticBackends(ctx, backends, transportMap, caBundlePathMap, excludedBackends)
 
 		// Validate at least one backend exists
 		if len(config.Backends) == 0 {

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
@@ -1727,6 +1727,326 @@ func TestConfigMapContent_StaticModeWithDiscovery(t *testing.T) {
 	t.Log("Static mode ConfigMap contains both auth configs, backend URLs/transports, and metadata")
 }
 
+// TestConfigMapContent_StaticMode_ExcludesBackendWithFailedAuth is a regression test for the
+// fail-open bug where a backend whose outgoing auth strategy failed to build (here, an xaa
+// strategy with an empty SubjectProviderName made ambiguous by 2 configured upstreams) was
+// correctly omitted from config.OutgoingAuth.Backends, but was still embedded in the static
+// config.Backends list served to the vMCP runtime. Since OutgoingAuthConfig.ResolveForBackend
+// falls through to Default for any backend absent from Backends, that backend would have been
+// silently served with the Default (token_exchange) identity instead of being unroutable.
+//
+// This test exercises the full ensureVmcpConfigConfigMap pipeline (not just
+// buildOutgoingAuthConfig in isolation) and asserts the failed backend is absent from BOTH
+// config.OutgoingAuth.Backends and the served config.Backends list, while an unaffected
+// backend relying on the same Default strategy is still served.
+func TestConfigMapContent_StaticMode_ExcludesBackendWithFailedAuth(t *testing.T) {
+	t.Parallel()
+
+	const (
+		issuer   = "https://auth.example.com"
+		audience = "https://api.example.com"
+	)
+
+	ctx := context.Background()
+	testScheme := testutil.NewScheme(t)
+
+	mcpGroup := &mcpv1beta1.MCPGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-group", Namespace: "default"},
+		Status:     mcpv1beta1.MCPGroupStatus{Phase: mcpv1beta1.MCPGroupPhaseReady},
+	}
+
+	// An embedded auth server requires OIDC incoming auth, and the two must agree on
+	// issuer/audience (ValidateAuthServerIntegration) — this is plumbing required to
+	// reach the xaa ambiguity check, not itself under test.
+	oidcConfig := &mcpv1beta1.MCPOIDCConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-oidc", Namespace: "default"},
+		Spec: mcpv1beta1.MCPOIDCConfigSpec{
+			Type:   mcpv1beta1.MCPOIDCConfigTypeInline,
+			Inline: &mcpv1beta1.InlineOIDCSharedConfig{Issuer: issuer},
+		},
+	}
+
+	// b1's override strategy is xaa with an empty SubjectProviderName, which becomes
+	// ambiguous once 2 upstream providers are configured on the embedded auth server below.
+	xaaAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "xaa-auth", Namespace: "default"},
+		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+			Type: mcpv1beta1.ExternalAuthTypeXAA,
+			XAA: &mcpv1beta1.XAASpec{
+				IDPTokenURL:    "https://idp.example.com/token",
+				TargetTokenURL: "https://target.example.com/token",
+				TargetAudience: "https://target.example.com",
+				// SubjectProviderName intentionally left empty.
+			},
+		},
+	}
+
+	// Default strategy is a valid token_exchange config, used by b2.
+	tokenExchangeAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "te-auth", Namespace: "default"},
+		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+			Type: mcpv1beta1.ExternalAuthTypeTokenExchange,
+			TokenExchange: &mcpv1beta1.TokenExchangeConfig{
+				TokenURL: "https://oauth.example.com/token",
+			},
+		},
+	}
+
+	b1 := v1beta1test.NewMCPServer("b1", "default",
+		v1beta1test.WithMCPGroupRef("test-group"),
+		v1beta1test.WithTransport("sse"),
+		v1beta1test.WithStatus(mcpv1beta1.MCPServerStatus{
+			Phase: mcpv1beta1.MCPServerPhaseReady,
+			URL:   "http://b1.default.svc.cluster.local:8080",
+		}),
+	)
+	b2 := v1beta1test.NewMCPServer("b2", "default",
+		v1beta1test.WithMCPGroupRef("test-group"),
+		v1beta1test.WithTransport("sse"),
+		v1beta1test.WithStatus(mcpv1beta1.MCPServerStatus{
+			Phase: mcpv1beta1.MCPServerPhaseReady,
+			URL:   "http://b2.default.svc.cluster.local:8080",
+		}),
+	)
+
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "oidc",
+			OIDCConfigRef: &mcpv1beta1.MCPOIDCConfigReference{
+				Name:        "test-oidc",
+				Audience:    audience,
+				ResourceURL: audience,
+			},
+		}),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "inline",
+			Default: &mcpv1beta1.BackendAuthConfig{
+				Type:                  mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+				ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{Name: "te-auth"},
+			},
+			Backends: map[string]mcpv1beta1.BackendAuthConfig{
+				"b1": {
+					Type:                  mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{Name: "xaa-auth"},
+				},
+			},
+		}),
+		// 2 upstreams makes b1's xaa override ambiguous.
+		v1beta1test.WithVMCPAuthServerConfig(&mcpv1beta1.EmbeddedAuthServerConfig{
+			Issuer: issuer,
+			SigningKeySecretRefs: []mcpv1beta1.SecretKeyRef{
+				{Name: "signing-key-secret", Key: "key.pem"},
+			},
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{
+				{
+					Name: "first",
+					Type: mcpv1beta1.UpstreamProviderTypeOIDC,
+					OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
+						IssuerURL: "https://first-idp.example.com",
+						ClientID:  "first-client-id",
+					},
+				},
+				{
+					Name: "second",
+					Type: mcpv1beta1.UpstreamProviderTypeOIDC,
+					OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
+						IssuerURL: "https://second-idp.example.com",
+						ClientID:  "second-client-id",
+					},
+				},
+			},
+		}),
+	)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(vmcpServer, mcpGroup, b1, b2, xaaAuthConfig, tokenExchangeAuthConfig, oidcConfig).
+		WithStatusSubresource(b1, b2).
+		Build()
+
+	reconciler := &VirtualMCPServerReconciler{
+		Client: fakeClient,
+		Scheme: testScheme,
+	}
+
+	workloadDiscoverer := workloads.NewK8SDiscovererWithClient(fakeClient, vmcpServer.Namespace)
+	workloadNames, err := workloadDiscoverer.ListWorkloadsInGroup(ctx, vmcpServer.ResolveGroupName())
+	require.NoError(t, err)
+	require.Len(t, workloadNames, 2, "should have discovered both backends")
+
+	statusCollector := virtualmcpserverstatus.NewStatusManager(vmcpServer)
+	err = reconciler.ensureVmcpConfigConfigMap(ctx, vmcpServer, workloadNames, nil, statusCollector)
+	require.NoError(t, err, "reconciliation must succeed in degraded mode, not fail outright")
+
+	configMap := &corev1.ConfigMap{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      vmcpConfigMapName("test-vmcp"),
+		Namespace: "default",
+	}, configMap)
+	require.NoError(t, err)
+
+	var config vmcpconfig.Config
+	err = yaml.Unmarshal([]byte(configMap.Data["config.yaml"]), &config)
+	require.NoError(t, err)
+
+	require.NotNil(t, config.OutgoingAuth)
+	require.NotNil(t, config.OutgoingAuth.Default, "Default strategy must still build successfully")
+	assert.Equal(t, "token_exchange", config.OutgoingAuth.Default.Type)
+	assert.NotContains(t, config.OutgoingAuth.Backends, "b1",
+		"b1's ambiguous xaa override must not be assigned")
+
+	// The actual regression: b1 must be excluded from the served/routable backend set
+	// entirely, not merely absent from OutgoingAuth.Backends while still reachable and
+	// falling back to Default at runtime.
+	servedNames := make([]string, 0, len(config.Backends))
+	for _, backend := range config.Backends {
+		servedNames = append(servedNames, backend.Name)
+	}
+	assert.NotContains(t, servedNames, "b1", "b1 must be excluded from the served backend set")
+	assert.Contains(t, servedNames, "b2", "b2 must still be served via the valid Default strategy")
+}
+
+// TestConfigMapContent_StaticMode_KeepsBackendWithValidInlineOverrideDespiteDiscoveredError
+// is a regression test for an over-exclusion bug introduced by the fix for
+// TestConfigMapContent_StaticMode_ExcludesBackendWithFailedAuth: backendsWithFailedAuth
+// excluded a backend from the served set whenever ANY AuthConfigError named it, even if
+// that same backend also had a fully valid, resolved strategy from another source.
+//
+// b1 here has both: a discovered ExternalAuthConfigRef on its own MCPServer spec that
+// mirrors a Valid=False condition (mirroredExternalAuthConfigInvalid), which makes
+// discoverExternalAuthConfigs record an AuthConfigError for "b1" unconditionally, and a
+// valid inline override in vmcp.Spec.OutgoingAuth.Backends["b1"], applied in a separate,
+// unconditional pass that ends up correctly populated in authConfig.Backends.
+// discoverExternalAuthConfigs records the mirrored-invalid error before it even checks
+// whether an inline override exists, so both the error and the valid strategy coexist for
+// the same backend name. b1 must still be served using its valid inline strategy.
+//
+// The Valid=False mirror check is unique to the operator's own discovery path
+// (mirroredExternalAuthConfigInvalid) and is not replicated by the independent backend
+// discovery in pkg/vmcp/workloads (converters.DiscoverAndResolveAuth), so this scenario
+// does not also trip that unrelated fail-closed mechanism.
+func TestConfigMapContent_StaticMode_KeepsBackendWithValidInlineOverrideDespiteDiscoveredError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testScheme := testutil.NewScheme(t)
+
+	mcpGroup := &mcpv1beta1.MCPGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-group", Namespace: "default"},
+		Status:     mcpv1beta1.MCPGroupStatus{Phase: mcpv1beta1.MCPGroupPhaseReady},
+	}
+
+	// The valid inline override strategy for b1.
+	validAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "valid-auth", Namespace: "default"},
+		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+			Type: mcpv1beta1.ExternalAuthTypeTokenExchange,
+			TokenExchange: &mcpv1beta1.TokenExchangeConfig{
+				TokenURL: "https://oauth.example.com/token",
+			},
+		},
+	}
+
+	// b1's own discovered ref exists and is otherwise convertible, but carries a
+	// Valid=False condition (e.g. as set by a validating webhook/controller). This
+	// makes discoverExternalAuthConfigs record an AuthConfigError for "b1" without
+	// affecting the independent, condition-agnostic auth discovery used for backend
+	// listing (converters.DiscoverAndResolveAuth), so b1 remains discoverable.
+	invalidRefAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "invalid-ref-auth", Namespace: "default"},
+		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+			Type: mcpv1beta1.ExternalAuthTypeTokenExchange,
+			TokenExchange: &mcpv1beta1.TokenExchangeConfig{
+				TokenURL: "https://broken.example.com/token",
+			},
+		},
+		Status: mcpv1beta1.MCPExternalAuthConfigStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               mcpv1beta1.ConditionTypeValid,
+					Status:             metav1.ConditionFalse,
+					Reason:             "SomeValidationFailure",
+					Message:            "this config is not valid",
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
+	}
+
+	b1 := v1beta1test.NewMCPServer("b1", "default",
+		v1beta1test.WithMCPGroupRef("test-group"),
+		v1beta1test.WithTransport("sse"),
+		v1beta1test.WithExternalAuthConfigRef("invalid-ref-auth"),
+		v1beta1test.WithStatus(mcpv1beta1.MCPServerStatus{
+			Phase: mcpv1beta1.MCPServerPhaseReady,
+			URL:   "http://b1.default.svc.cluster.local:8080",
+		}),
+	)
+
+	vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+			Source: "inline",
+			Backends: map[string]mcpv1beta1.BackendAuthConfig{
+				"b1": {
+					Type:                  mcpv1beta1.BackendAuthTypeExternalAuthConfigRef,
+					ExternalAuthConfigRef: &mcpv1beta1.ExternalAuthConfigRef{Name: "valid-auth"},
+				},
+			},
+		}),
+	)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(vmcpServer, mcpGroup, b1, validAuthConfig, invalidRefAuthConfig).
+		WithStatusSubresource(b1, invalidRefAuthConfig).
+		Build()
+
+	reconciler := &VirtualMCPServerReconciler{
+		Client: fakeClient,
+		Scheme: testScheme,
+	}
+
+	workloadDiscoverer := workloads.NewK8SDiscovererWithClient(fakeClient, vmcpServer.Namespace)
+	workloadNames, err := workloadDiscoverer.ListWorkloadsInGroup(ctx, vmcpServer.ResolveGroupName())
+	require.NoError(t, err)
+	require.Len(t, workloadNames, 1, "should have discovered b1")
+
+	statusCollector := virtualmcpserverstatus.NewStatusManager(vmcpServer)
+	err = reconciler.ensureVmcpConfigConfigMap(ctx, vmcpServer, workloadNames, nil, statusCollector)
+	require.NoError(t, err, "reconciliation must succeed despite the discovered-path error")
+
+	configMap := &corev1.ConfigMap{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      vmcpConfigMapName("test-vmcp"),
+		Namespace: "default",
+	}, configMap)
+	require.NoError(t, err)
+
+	var config vmcpconfig.Config
+	err = yaml.Unmarshal([]byte(configMap.Data["config.yaml"]), &config)
+	require.NoError(t, err)
+
+	require.NotNil(t, config.OutgoingAuth)
+	b1Strategy, exists := config.OutgoingAuth.Backends["b1"]
+	require.True(t, exists, "b1's valid inline override must still be assigned")
+	require.NotNil(t, b1Strategy)
+	assert.Equal(t, "token_exchange", b1Strategy.Type)
+
+	// The actual regression: b1 must remain in the served/routable backend set because it
+	// has a valid, resolved strategy, even though an AuthConfigError was also recorded for
+	// it via the unrelated broken discovered ref.
+	servedNames := make([]string, 0, len(config.Backends))
+	for _, backend := range config.Backends {
+		servedNames = append(servedNames, backend.Name)
+	}
+	assert.Contains(t, servedNames, "b1", "b1 must not be excluded when it has a valid resolved strategy")
+}
+
 // TestConvertBackendsToStaticBackends_SkipsInvalidBackends tests that backends
 // without URL or transport are skipped with appropriate logging
 func TestConvertBackendsToStaticBackends_SkipsInvalidBackends(t *testing.T) {
@@ -1759,7 +2079,7 @@ func TestConvertBackendsToStaticBackends_SkipsInvalidBackends(t *testing.T) {
 		// "no-transport-backend" intentionally missing
 	}
 
-	result := convertBackendsToStaticBackends(ctx, backends, transportMap, nil)
+	result := convertBackendsToStaticBackends(ctx, backends, transportMap, nil, nil)
 
 	// Should only include the valid backend
 	assert.Len(t, result, 1, "should only include backends with URL and transport")
@@ -1767,6 +2087,35 @@ func TestConvertBackendsToStaticBackends_SkipsInvalidBackends(t *testing.T) {
 	assert.Equal(t, "http://backend1:8080", result[0].URL)
 	assert.Equal(t, "sse", result[0].Transport)
 	assert.Equal(t, "value", result[0].Metadata["key"])
+}
+
+// TestConvertBackendsToStaticBackends_ExcludesFailedAuthBackends verifies that a backend
+// named in excludedBackends is dropped from the served set even though it otherwise has a
+// valid URL and transport. This is the fix for the fail-open bug where a backend whose
+// outgoing auth strategy failed to build (e.g. an ambiguous XAA SubjectProviderName) would
+// still be embedded in the static backend list and silently fall back to the Default auth
+// strategy at runtime.
+func TestConvertBackendsToStaticBackends_ExcludesFailedAuthBackends(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	backends := []vmcp.Backend{
+		{Name: "healthy-backend", BaseURL: "http://backend1:8080", TransportType: "sse"},
+		{Name: "failed-auth-backend", BaseURL: "http://backend2:8080", TransportType: "sse"},
+	}
+	transportMap := map[string]string{
+		"healthy-backend":     "sse",
+		"failed-auth-backend": "sse",
+	}
+	excludedBackends := map[string]struct{}{
+		"failed-auth-backend": {},
+	}
+
+	result := convertBackendsToStaticBackends(ctx, backends, transportMap, nil, excludedBackends)
+
+	require.Len(t, result, 1, "the excluded backend must not be served")
+	assert.Equal(t, "healthy-backend", result[0].Name)
 }
 
 // TestStaticModeTransportConstants verifies that the transport constants match the CRD enum.
@@ -2247,7 +2596,7 @@ func TestConvertBackendsToStaticBackends_WithCABundlePathMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := convertBackendsToStaticBackends(t.Context(), tt.backends, tt.transportMap, tt.caBundlePathMap)
+			result := convertBackendsToStaticBackends(t.Context(), tt.backends, tt.transportMap, tt.caBundlePathMap, nil)
 			assert.Len(t, result, tt.expectedCount)
 
 			if tt.validateBackends != nil {

--- a/pkg/vmcp/auth/types/defaults.go
+++ b/pkg/vmcp/auth/types/defaults.go
@@ -13,11 +13,17 @@ var ErrAmbiguousSubjectProvider = errors.New(
 
 // DefaultSubjectProviderName defaults strategy's SubjectProviderName to
 // providerName for token_exchange, aws_sts, and xaa strategies whose field is
-// empty, returning a copy (the caller's strategy is never mutated in place).
-// For xaa, if hasMultipleUpstreams is true and SubjectProviderName is empty,
-// returns ErrAmbiguousSubjectProvider instead of silently defaulting, since
-// sending the wrong subject token to Step A is a security-relevant mistake
-// specific to xaa. token_exchange and aws_sts always default silently.
+// empty, returning a deep copy with the field defaulted; the caller's
+// strategy is never mutated.
+//
+// All three strategies share the same wrong-subject risk: picking the wrong
+// upstream token via SubjectProviderName is equally security-relevant for
+// each. Only xaa hard-errors on ambiguity (when hasMultipleUpstreams is true
+// and SubjectProviderName is empty, it returns ErrAmbiguousSubjectProvider
+// instead of defaulting), because xaa has no existing deployments to break,
+// so there is no compatibility cost. token_exchange and aws_sts keep
+// defaulting silently, since hard-erroring those would be a breaking change
+// requiring a deprecation path (see issue #5697).
 //
 // Strategies that are nil, of a different type, missing their per-type
 // sub-config, or that already have SubjectProviderName set are returned
@@ -36,21 +42,17 @@ func DefaultSubjectProviderName(
 		if strategy.TokenExchange == nil || strategy.TokenExchange.SubjectProviderName != "" {
 			return strategy, nil
 		}
-		copied := *strategy
-		teCopied := *strategy.TokenExchange
-		teCopied.SubjectProviderName = providerName
-		copied.TokenExchange = &teCopied
-		return &copied, nil
+		copied := strategy.DeepCopy()
+		copied.TokenExchange.SubjectProviderName = providerName
+		return copied, nil
 
 	case StrategyTypeAwsSts:
 		if strategy.AwsSts == nil || strategy.AwsSts.SubjectProviderName != "" {
 			return strategy, nil
 		}
-		copied := *strategy
-		stsCopied := *strategy.AwsSts
-		stsCopied.SubjectProviderName = providerName
-		copied.AwsSts = &stsCopied
-		return &copied, nil
+		copied := strategy.DeepCopy()
+		copied.AwsSts.SubjectProviderName = providerName
+		return copied, nil
 
 	case StrategyTypeXAA:
 		if strategy.XAA == nil || strategy.XAA.SubjectProviderName != "" {
@@ -59,11 +61,9 @@ func DefaultSubjectProviderName(
 		if hasMultipleUpstreams {
 			return nil, ErrAmbiguousSubjectProvider
 		}
-		copied := *strategy
-		xaaCopied := *strategy.XAA
-		xaaCopied.SubjectProviderName = providerName
-		copied.XAA = &xaaCopied
-		return &copied, nil
+		copied := strategy.DeepCopy()
+		copied.XAA.SubjectProviderName = providerName
+		return copied, nil
 
 	default:
 		return strategy, nil

--- a/pkg/vmcp/auth/types/defaults.go
+++ b/pkg/vmcp/auth/types/defaults.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import "errors"
+
+// ErrAmbiguousSubjectProvider is returned when an xaa strategy's
+// SubjectProviderName is empty and more than one upstream is configured, so
+// the first-upstream default would be ambiguous.
+var ErrAmbiguousSubjectProvider = errors.New(
+	"SubjectProviderName must be set explicitly for xaa when more than one upstream is configured")
+
+// DefaultSubjectProviderName defaults strategy's SubjectProviderName to
+// providerName for token_exchange, aws_sts, and xaa strategies whose field is
+// empty, returning a copy (the caller's strategy is never mutated in place).
+// For xaa, if hasMultipleUpstreams is true and SubjectProviderName is empty,
+// returns ErrAmbiguousSubjectProvider instead of silently defaulting, since
+// sending the wrong subject token to Step A is a security-relevant mistake
+// specific to xaa. token_exchange and aws_sts always default silently.
+//
+// Strategies that are nil, of a different type, missing their per-type
+// sub-config, or that already have SubjectProviderName set are returned
+// unchanged via the original pointer.
+func DefaultSubjectProviderName(
+	strategy *BackendAuthStrategy,
+	providerName string,
+	hasMultipleUpstreams bool,
+) (*BackendAuthStrategy, error) {
+	if strategy == nil {
+		return nil, nil
+	}
+
+	switch strategy.Type {
+	case StrategyTypeTokenExchange:
+		if strategy.TokenExchange == nil || strategy.TokenExchange.SubjectProviderName != "" {
+			return strategy, nil
+		}
+		copied := *strategy
+		teCopied := *strategy.TokenExchange
+		teCopied.SubjectProviderName = providerName
+		copied.TokenExchange = &teCopied
+		return &copied, nil
+
+	case StrategyTypeAwsSts:
+		if strategy.AwsSts == nil || strategy.AwsSts.SubjectProviderName != "" {
+			return strategy, nil
+		}
+		copied := *strategy
+		stsCopied := *strategy.AwsSts
+		stsCopied.SubjectProviderName = providerName
+		copied.AwsSts = &stsCopied
+		return &copied, nil
+
+	case StrategyTypeXAA:
+		if strategy.XAA == nil || strategy.XAA.SubjectProviderName != "" {
+			return strategy, nil
+		}
+		if hasMultipleUpstreams {
+			return nil, ErrAmbiguousSubjectProvider
+		}
+		copied := *strategy
+		xaaCopied := *strategy.XAA
+		xaaCopied.SubjectProviderName = providerName
+		copied.XAA = &xaaCopied
+		return &copied, nil
+
+	default:
+		return strategy, nil
+	}
+}

--- a/pkg/vmcp/auth/types/defaults_test.go
+++ b/pkg/vmcp/auth/types/defaults_test.go
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultSubjectProviderName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		strategy             *BackendAuthStrategy
+		providerName         string
+		hasMultipleUpstreams bool
+		wantErr              error
+		wantSame             bool // expect result pointer identical to input strategy
+		checkResult          func(t *testing.T, result *BackendAuthStrategy)
+	}{
+		{
+			name:     "nil strategy returns nil unchanged",
+			strategy: nil,
+			wantSame: false, // nil == nil, assert.Same doesn't apply; checked separately
+			checkResult: func(t *testing.T, result *BackendAuthStrategy) {
+				t.Helper()
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "token_exchange nil sub-config returned unchanged",
+			strategy: &BackendAuthStrategy{
+				Type: StrategyTypeTokenExchange,
+			},
+			providerName: "upstream1",
+			wantSame:     true,
+		},
+		{
+			name: "aws_sts nil sub-config returned unchanged",
+			strategy: &BackendAuthStrategy{
+				Type: StrategyTypeAwsSts,
+			},
+			providerName: "upstream1",
+			wantSame:     true,
+		},
+		{
+			name: "xaa nil sub-config returned unchanged",
+			strategy: &BackendAuthStrategy{
+				Type: StrategyTypeXAA,
+			},
+			providerName: "upstream1",
+			wantSame:     true,
+		},
+		{
+			name: "token_exchange already-set not overridden",
+			strategy: &BackendAuthStrategy{
+				Type:          StrategyTypeTokenExchange,
+				TokenExchange: &TokenExchangeConfig{SubjectProviderName: "explicit"},
+			},
+			providerName: "upstream1",
+			wantSame:     true,
+			checkResult: func(t *testing.T, result *BackendAuthStrategy) {
+				t.Helper()
+				assert.Equal(t, "explicit", result.TokenExchange.SubjectProviderName)
+			},
+		},
+		{
+			name: "aws_sts already-set not overridden",
+			strategy: &BackendAuthStrategy{
+				Type:   StrategyTypeAwsSts,
+				AwsSts: &AwsStsConfig{SubjectProviderName: "explicit"},
+			},
+			providerName: "upstream1",
+			wantSame:     true,
+			checkResult: func(t *testing.T, result *BackendAuthStrategy) {
+				t.Helper()
+				assert.Equal(t, "explicit", result.AwsSts.SubjectProviderName)
+			},
+		},
+		{
+			name: "xaa already-set not overridden",
+			strategy: &BackendAuthStrategy{
+				Type: StrategyTypeXAA,
+				XAA:  &XAAConfig{SubjectProviderName: "explicit"},
+			},
+			providerName: "upstream1",
+			wantSame:     true,
+			checkResult: func(t *testing.T, result *BackendAuthStrategy) {
+				t.Helper()
+				assert.Equal(t, "explicit", result.XAA.SubjectProviderName)
+			},
+		},
+		{
+			name: "token_exchange empty gets defaulted",
+			strategy: &BackendAuthStrategy{
+				Type:          StrategyTypeTokenExchange,
+				TokenExchange: &TokenExchangeConfig{},
+			},
+			providerName:         "upstream1",
+			hasMultipleUpstreams: false,
+			wantSame:             false,
+			checkResult: func(t *testing.T, result *BackendAuthStrategy) {
+				t.Helper()
+				assert.Equal(t, "upstream1", result.TokenExchange.SubjectProviderName)
+			},
+		},
+		{
+			name: "aws_sts empty gets defaulted",
+			strategy: &BackendAuthStrategy{
+				Type:   StrategyTypeAwsSts,
+				AwsSts: &AwsStsConfig{},
+			},
+			providerName:         "upstream1",
+			hasMultipleUpstreams: false,
+			wantSame:             false,
+			checkResult: func(t *testing.T, result *BackendAuthStrategy) {
+				t.Helper()
+				assert.Equal(t, "upstream1", result.AwsSts.SubjectProviderName)
+			},
+		},
+		{
+			name: "xaa empty gets defaulted with single upstream",
+			strategy: &BackendAuthStrategy{
+				Type: StrategyTypeXAA,
+				XAA:  &XAAConfig{},
+			},
+			providerName:         "upstream1",
+			hasMultipleUpstreams: false,
+			wantSame:             false,
+			checkResult: func(t *testing.T, result *BackendAuthStrategy) {
+				t.Helper()
+				assert.Equal(t, "upstream1", result.XAA.SubjectProviderName)
+			},
+		},
+		{
+			name: "xaa ambiguous with multiple upstreams returns error",
+			strategy: &BackendAuthStrategy{
+				Type: StrategyTypeXAA,
+				XAA:  &XAAConfig{},
+			},
+			providerName:         "upstream1",
+			hasMultipleUpstreams: true,
+			wantErr:              ErrAmbiguousSubjectProvider,
+			checkResult: func(t *testing.T, result *BackendAuthStrategy) {
+				t.Helper()
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "xaa already-set with multiple upstreams is not an error",
+			strategy: &BackendAuthStrategy{
+				Type: StrategyTypeXAA,
+				XAA:  &XAAConfig{SubjectProviderName: "explicit"},
+			},
+			providerName:         "upstream1",
+			hasMultipleUpstreams: true,
+			wantSame:             true,
+			checkResult: func(t *testing.T, result *BackendAuthStrategy) {
+				t.Helper()
+				assert.Equal(t, "explicit", result.XAA.SubjectProviderName)
+			},
+		},
+		{
+			name: "non-applicable strategy type returned unchanged",
+			strategy: &BackendAuthStrategy{
+				Type:            StrategyTypeHeaderInjection,
+				HeaderInjection: &HeaderInjectionConfig{HeaderName: "Authorization"},
+			},
+			providerName: "upstream1",
+			wantSame:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := DefaultSubjectProviderName(tt.strategy, tt.providerName, tt.hasMultipleUpstreams)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				if tt.checkResult != nil {
+					tt.checkResult(t, result)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.strategy == nil {
+				if tt.checkResult != nil {
+					tt.checkResult(t, result)
+				}
+				return
+			}
+
+			if tt.wantSame {
+				assert.Same(t, tt.strategy, result)
+			} else {
+				assert.NotSame(t, tt.strategy, result)
+			}
+
+			if tt.checkResult != nil {
+				tt.checkResult(t, result)
+			}
+		})
+	}
+}

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -154,9 +154,11 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 		}
 	}
 
-	// Auto-populate SubjectProviderName on any token_exchange strategy that
+	// Auto-populate SubjectProviderName on backend auth strategies that
 	// omitted it when an embedded auth server is active.
-	config.InjectSubjectProviderNames(vmcpCfg, authServerRC)
+	if err := config.InjectSubjectProviderNames(vmcpCfg, authServerRC); err != nil {
+		return fmt.Errorf("failed to default outgoing auth subject provider names: %w", err)
+	}
 
 	// Construct embedded authorization server if configured.
 	var embeddedAuthServer *authserverrunner.EmbeddedAuthServer

--- a/pkg/vmcp/config/defaults.go
+++ b/pkg/vmcp/config/defaults.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"dario.cat/mergo"
@@ -89,8 +90,8 @@ func (c *Config) EnsureOperationalDefaults() {
 }
 
 // InjectSubjectProviderNames auto-populates SubjectProviderName on every
-// token_exchange or xaa strategy in cfg.OutgoingAuth that has it unset,
-// when an embedded auth server RunConfig is active.
+// token_exchange, aws_sts, or xaa strategy in cfg.OutgoingAuth that has it
+// unset, when an embedded auth server RunConfig is active.
 //
 // This is a defaulting operation: it ensures YAML-based vMCP deployments
 // behave the same as the Kubernetes operator path. Without it a token_exchange
@@ -98,10 +99,16 @@ func (c *Config) EnsureOperationalDefaults() {
 // identity.Token (the ToolHive-issued JWT), which the exchange endpoint rejects.
 //
 // When cfg or rc is nil the call is a no-op. The provider name is derived via
-// authserver.ResolveFirstUpstreamName over rc.Upstreams.
-func InjectSubjectProviderNames(cfg *Config, rc *authserver.RunConfig) {
+// authserver.ResolveFirstUpstreamName over rc.Upstreams. For xaa, if more than
+// one upstream is configured and SubjectProviderName is empty, defaulting is
+// ambiguous and this returns an error wrapping
+// authtypes.ErrAmbiguousSubjectProvider instead of silently defaulting;
+// processing stops at the first error. Strategy structs are replaced via
+// copy-then-assign rather than mutated in place, but cfg.OutgoingAuth itself
+// is still updated by this call.
+func InjectSubjectProviderNames(cfg *Config, rc *authserver.RunConfig) error {
 	if cfg == nil || rc == nil || cfg.OutgoingAuth == nil {
-		return
+		return nil
 	}
 
 	names := make([]string, len(rc.Upstreams))
@@ -109,30 +116,21 @@ func InjectSubjectProviderNames(cfg *Config, rc *authserver.RunConfig) {
 		names[i] = u.Name
 	}
 	providerName := authserver.ResolveFirstUpstreamName(names)
+	hasMultipleUpstreams := len(names) > 1
 
-	injectIntoStrategy(cfg.OutgoingAuth.Default, providerName)
-	for _, strategy := range cfg.OutgoingAuth.Backends {
-		injectIntoStrategy(strategy, providerName)
+	defaulted, err := authtypes.DefaultSubjectProviderName(cfg.OutgoingAuth.Default, providerName, hasMultipleUpstreams)
+	if err != nil {
+		return fmt.Errorf("default backend: %w", err)
 	}
-}
+	cfg.OutgoingAuth.Default = defaulted
 
-// injectIntoStrategy sets SubjectProviderName on token_exchange and xaa
-// strategies when the field is empty. It mutates the strategy in place because
-// the OutgoingAuth maps hold pointers that are already owned by cfg.
-func injectIntoStrategy(strategy *authtypes.BackendAuthStrategy, providerName string) {
-	if strategy == nil {
-		return
-	}
-
-	if strategy.Type == authtypes.StrategyTypeTokenExchange &&
-		strategy.TokenExchange != nil &&
-		strategy.TokenExchange.SubjectProviderName == "" {
-		strategy.TokenExchange.SubjectProviderName = providerName
+	for name, strategy := range cfg.OutgoingAuth.Backends {
+		defaulted, err := authtypes.DefaultSubjectProviderName(strategy, providerName, hasMultipleUpstreams)
+		if err != nil {
+			return fmt.Errorf("backend %q: %w", name, err)
+		}
+		cfg.OutgoingAuth.Backends[name] = defaulted
 	}
 
-	if strategy.Type == authtypes.StrategyTypeXAA &&
-		strategy.XAA != nil &&
-		strategy.XAA.SubjectProviderName == "" {
-		strategy.XAA.SubjectProviderName = providerName
-	}
+	return nil
 }

--- a/pkg/vmcp/config/defaults_test.go
+++ b/pkg/vmcp/config/defaults_test.go
@@ -242,6 +242,16 @@ func TestInjectSubjectProviderNames(t *testing.T) {
 		}
 	}
 
+	makeAwsStsStrategy := func(subjectProviderName string) *authtypes.BackendAuthStrategy {
+		return &authtypes.BackendAuthStrategy{
+			Type: authtypes.StrategyTypeAwsSts,
+			AwsSts: &authtypes.AwsStsConfig{
+				Region:              "us-east-1",
+				SubjectProviderName: subjectProviderName,
+			},
+		}
+	}
+
 	makeRunConfig := func(upstreamNames ...string) *authserver.RunConfig {
 		rc := &authserver.RunConfig{}
 		for _, name := range upstreamNames {
@@ -257,6 +267,7 @@ func TestInjectSubjectProviderNames(t *testing.T) {
 		wantDefault   string
 		wantBackends  map[string]string // backend name → expected SubjectProviderName
 		wantUnchanged bool              // OutgoingAuth must not be touched
+		wantErr       error             // if set, InjectSubjectProviderNames must return an error satisfying errors.Is
 	}{
 		{
 			name:          "nil_cfg_is_a_noop",
@@ -370,20 +381,55 @@ func TestInjectSubjectProviderNames(t *testing.T) {
 			rc:          makeRunConfig("github"),
 			wantDefault: "explicit",
 		},
+		{
+			name: "aws_sts_empty_subject_provider_gets_populated",
+			cfg: &Config{
+				OutgoingAuth: &OutgoingAuthConfig{
+					Default: makeAwsStsStrategy(""),
+				},
+			},
+			rc:          makeRunConfig("github"),
+			wantDefault: "github",
+		},
+		{
+			name: "aws_sts_explicit_subject_provider_not_overridden",
+			cfg: &Config{
+				OutgoingAuth: &OutgoingAuthConfig{
+					Default: makeAwsStsStrategy("explicit"),
+				},
+			},
+			rc:          makeRunConfig("github"),
+			wantDefault: "explicit",
+		},
+		{
+			name: "xaa_ambiguous_with_multiple_upstreams_errors",
+			cfg: &Config{
+				OutgoingAuth: &OutgoingAuthConfig{
+					Default: makeXAAStrategy(""),
+				},
+			},
+			rc:      makeRunConfig("first", "second"),
+			wantErr: authtypes.ErrAmbiguousSubjectProvider,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Snapshot the default strategy pointer before calling so we can verify
-			// InjectSubjectProviderNames mutates in place rather than replacing pointers.
-			var beforeDefault *authtypes.BackendAuthStrategy
-			if tt.cfg != nil && tt.cfg.OutgoingAuth != nil {
-				beforeDefault = tt.cfg.OutgoingAuth.Default
-			}
+			err := InjectSubjectProviderNames(tt.cfg, tt.rc)
 
-			assert.NotPanics(t, func() { InjectSubjectProviderNames(tt.cfg, tt.rc) })
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				if tt.cfg != nil && tt.cfg.OutgoingAuth != nil &&
+					tt.cfg.OutgoingAuth.Default != nil && tt.cfg.OutgoingAuth.Default.XAA != nil {
+					assert.Empty(t, tt.cfg.OutgoingAuth.Default.XAA.SubjectProviderName,
+						"SubjectProviderName must be left untouched when InjectSubjectProviderNames fails")
+				}
+				return
+			}
+			require.NoError(t, err)
 
 			if tt.wantUnchanged {
 				if tt.cfg != nil && tt.cfg.OutgoingAuth != nil &&
@@ -406,10 +452,10 @@ func TestInjectSubjectProviderNames(t *testing.T) {
 				case tt.cfg.OutgoingAuth.Default.XAA != nil:
 					assert.Equal(t, tt.wantDefault, tt.cfg.OutgoingAuth.Default.XAA.SubjectProviderName,
 						"Default SubjectProviderName mismatch")
+				case tt.cfg.OutgoingAuth.Default.AwsSts != nil:
+					assert.Equal(t, tt.wantDefault, tt.cfg.OutgoingAuth.Default.AwsSts.SubjectProviderName,
+						"Default SubjectProviderName mismatch")
 				}
-				// The pointer must not have changed — mutation must be in place.
-				assert.Same(t, beforeDefault, tt.cfg.OutgoingAuth.Default,
-					"Default strategy pointer must not change: InjectSubjectProviderNames should mutate in place")
 			}
 
 			// Verify per-backend strategies.


### PR DESCRIPTION
## Summary

The YAML and operator paths each defaulted a backend's `SubjectProviderName` to the first configured upstream, but drifted apart:

- The YAML path was missing `aws_sts` entirely, so an `aws_sts` backend with an unset field failed at request time instead of being defaulted (#5687).
- Both paths silently picked `upstream[0]` for `xaa` even with multiple upstreams configured — a security-relevant footgun, since sending the wrong subject token to Step A yields a confusing IdP error or a token minted for the wrong subject (#5697).

This extracts a shared `authtypes.DefaultSubjectProviderName` helper used by both the YAML (`pkg/vmcp/config/defaults.go`) and operator (`cmd/thv-operator/controllers/virtualmcpserver_controller.go`) paths, covering `token_exchange`, `aws_sts`, and `xaa`.

- `xaa` now hard-errors on ambiguous multi-upstream configs on both paths.
- On the operator side this surfaces as a non-fatal per-backend `AuthConfigError` condition (`AmbiguousSubjectProvider`), consistent with the existing degraded-mode pattern for other auth config errors — the rest of the `VirtualMCPServer` keeps reconciling.
- On the YAML/CLI side, `InjectSubjectProviderNames` now returns an error, so `thv vmcp serve` fails fast at startup rather than silently guessing.

Fixes #5687
Fixes #5697

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Does this introduce a user-facing change?

Yes, narrowly: a `xaa` backend auth strategy with an empty `SubjectProviderName` and 2+ configured upstreams now fails validation instead of silently defaulting to the first upstream. On the operator this surfaces as a per-backend status condition (degraded mode, rest of the server keeps running); on the YAML/CLI path this causes `thv vmcp serve` to fail at startup. Since `xaa` support merged the day before this change, there are no existing deployments this affects — new `xaa` adopters will simply need to set `SubjectProviderName` explicitly when configuring more than one upstream. `token_exchange` and `aws_sts` behavior is unaffected by this change (they continue to default silently); the only behavior fix for them is that the YAML path now also defaults `aws_sts`, matching the operator path.

## Large PR Justification

Most of this PR's size is test coverage, not new production logic: of the ~1230 changed lines, ~920 are in test files (`virtualmcpserver_vmcpconfig_test.go`, `virtualmcpserver_externalauth_test.go`, `defaults_test.go` x2), covering the shared defaulting helper across both the operator and YAML/CLI paths plus the new `xaa` hard-error behavior. The remaining ~310 lines of source changes are split across 5 files because the fix is inherently cross-cutting: it unifies defaulting logic that had drifted between the operator (`virtualmcpserver_controller.go`, `virtualmcpserver_vmcpconfig.go`) and YAML/CLI (`pkg/vmcp/config/defaults.go`, `pkg/vmcp/cli/serve.go`) paths into one shared helper (`pkg/vmcp/auth/types/defaults.go`). Splitting by path would leave one of #5687 or #5697 unfixed per PR, and splitting source from tests would leave either PR without coverage for a security-relevant auth behavior change — both violate the "each PR is one logical change" guideline in a worse way than the line count does.

## Special notes for reviewers

The equivalent ambiguous-upstream defaulting in `pkg/runner/middleware.go` (Cedar's `PrimaryUpstreamProvider`) has the same footgun this PR fixes for `xaa`, but is intentionally out of scope here to keep this PR to one logical change. Worth a follow-up issue.

Generated with [Claude Code](https://claude.com/claude-code)
