### PR TITLE
Sort aggregated tools by name for deterministic embedding order

### DIFF
--- a/pkg/vmcp/aggregator/aggregator.go
+++ b/pkg/vmcp/aggregator/aggregator.go
@@ -134,7 +134,8 @@ type ResolvedTool struct {
 // AggregatedCapabilities is the final unified view of all backend capabilities.
 // This is what gets exposed to MCP clients via tools/list, resources/list, prompts/list.
 type AggregatedCapabilities struct {
-	// Tools are the aggregated backend tools (ready to expose to clients).
+	// Tools are the aggregated backend tools (ready to expose to clients),
+	// sorted by name for deterministic ordering.
 	Tools []vmcp.Tool
 
 	// CompositeTools are the composite workflow tools defined in vMCP configuration.

--- a/pkg/vmcp/aggregator/default_aggregator.go
+++ b/pkg/vmcp/aggregator/default_aggregator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -352,6 +353,10 @@ func (a *defaultAggregator) MergeCapabilities(
 			routingTable.Tools[resolvedTool.ResolvedName] = target
 		}
 	}
+
+	sort.Slice(tools, func(i, j int) bool {
+		return tools[i].Name < tools[j].Name
+	})
 
 	// Add resources to routing table
 	for _, resource := range resolved.Resources {

--- a/pkg/vmcp/aggregator/default_aggregator_test.go
+++ b/pkg/vmcp/aggregator/default_aggregator_test.go
@@ -306,6 +306,47 @@ func TestDefaultAggregator_MergeCapabilities(t *testing.T) {
 	})
 }
 
+func TestDefaultAggregator_MergeCapabilities_DeterministicToolOrder(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"zebra_tool", "middle_tool", "alpha_tool", "omega_tool", "delta_tool", "beta_tool", "gamma_tool"}
+	resolvedTools := make(map[string]*ResolvedTool, len(names))
+	for _, name := range names {
+		resolvedTools[name] = &ResolvedTool{
+			ResolvedName: name,
+			OriginalName: name,
+			BackendID:    "backend1",
+		}
+	}
+
+	registry := vmcp.NewImmutableRegistry([]vmcp.Backend{
+		{
+			ID:            "backend1",
+			Name:          "Backend 1",
+			BaseURL:       "http://backend1:8080",
+			TransportType: "streamable-http",
+			HealthStatus:  vmcp.BackendHealthy,
+		},
+	})
+	agg := NewDefaultAggregator(nil, nil, nil, nil)
+
+	want := []string{"alpha_tool", "beta_tool", "delta_tool", "gamma_tool", "middle_tool", "omega_tool", "zebra_tool"}
+
+	// Repeated because map iteration order is re-randomized on every merge.
+	for range 10 {
+		aggregated, err := agg.MergeCapabilities(
+			context.Background(), &ResolvedCapabilities{Tools: resolvedTools}, registry,
+		)
+		require.NoError(t, err)
+
+		got := make([]string, len(aggregated.Tools))
+		for i, tool := range aggregated.Tools {
+			got[i] = tool.Name
+		}
+		require.Equal(t, want, got, "tools should always be sorted by name")
+	}
+}
+
 func TestDefaultAggregator_AggregateCapabilities(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`MergeCapabilities` builds the tool slice by ranging `resolved.Tools`, a map, so every fresh aggregation produces a different order. The advertised list comes out sorted, so clients never see this; the optimizer does, because it embeds the catalog in slice order. An order-sensitive cache in front of the embedding endpoint gets a new request hash each aggregation and misses.

- Sort the merged slice by resolved name, which is unique after conflict resolution. Same class of fix as #3450, which sorted discovered backends but not the tools inside the aggregation.
- Document the ordering guarantee on `AggregatedCapabilities.Tools`.
- Add a test that merges the same tool map repeatedly and asserts the order.

Fixes #5702

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

Scoped to aggregated backend tools per #5702; composite-tool ordering (`ConvertWorkflowDefsToTools` iterates a map) is a separate gap, out of scope here.

---

Assisted by [Claude Code](https://claude.com/claude-code). Design, code, and tests were directed, reviewed, and manually verified by the author.
