### PR TITLE
Support nested map claims in Cedar authorization for act claim

### DIFF
--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -146,7 +146,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 	// Test cases
 	testCases := []struct {
 		name             string
-		policy           string
+		policies         []string
 		claims           jwt.MapClaims
 		feature          authorizers.MCPFeature
 		operation        authorizers.MCPOperation
@@ -156,7 +156,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 	}{
 		{
 			name: "User with correct name can call weather tool",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"call_tool",
@@ -165,7 +165,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			when {
 				context.claim_name == "John Doe"
 			};
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub":   "user123",
 				"name":  "John Doe",
@@ -179,7 +179,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "User with incorrect name cannot call weather tool",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"call_tool",
@@ -188,7 +188,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			when {
 				context.claim_name == "John Doe"
 			};
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub":   "user123",
 				"name":  "Jane Smith",
@@ -202,7 +202,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "Admin user can call any tool",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"call_tool",
@@ -211,7 +211,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			when {
 				context.claim_role == "admin"
 			};
-			`,
+			`},
 			claims: map[string]interface{}{
 				"sub":  "admin123",
 				"name": "Admin User",
@@ -225,7 +225,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "User with specific argument value can call tool",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"call_tool",
@@ -234,7 +234,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			when {
 				context.arg_operation == "add" && context.arg_value1 == 5
 			};
-			`,
+			`},
 			claims: map[string]interface{}{
 				"sub":  "user123",
 				"name": "John Doe",
@@ -251,7 +251,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "User with specific role in array can access resource",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"read_resource",
@@ -260,7 +260,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			when {
 				context.claim_groups.contains("editor")
 			};
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub":    "user123",
 				"name":   "John Doe",
@@ -274,7 +274,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "Resource entity exposes name attribute for Cedar schema",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"read_resource",
@@ -283,7 +283,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			when {
 				resource.name == "sensitive_data"
 			};
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub": "user123",
 			},
@@ -295,7 +295,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "Resource entity retains uri attribute for backward compat",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"read_resource",
@@ -304,7 +304,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			when {
 				resource.uri == "sensitive_data"
 			};
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub": "user123",
 			},
@@ -316,7 +316,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "Resource name and uri attributes carry the same value",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"read_resource",
@@ -325,7 +325,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			when {
 				resource.name == resource.uri
 			};
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub": "user123",
 			},
@@ -337,13 +337,13 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "User can get prompt",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"get_prompt",
 				resource == Prompt::"greeting"
 			);
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
@@ -357,13 +357,13 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "User can list tools",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"list_tools",
 				resource == FeatureType::"tool"
 			);
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
@@ -377,13 +377,13 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "User can list prompts",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"list_prompts",
 				resource == FeatureType::"prompt"
 			);
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
@@ -397,13 +397,13 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 		},
 		{
 			name: "User can list resources",
-			policy: `
+			policies: []string{`
 			permit(
 				principal,
 				action == Action::"list_resources",
 				resource == FeatureType::"resource"
 			);
-			`,
+			`},
 			claims: jwt.MapClaims{
 				"sub":  "user123",
 				"name": "John Doe",
@@ -414,6 +414,115 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 			resourceID:       "",
 			arguments:        nil,
 			expectAuthorized: true,
+		},
+		{
+			name: "Delegated access permitted when act claim matches SPIFFE ID pattern",
+			policies: []string{`
+			permit(
+				principal,
+				action == Action::"call_tool",
+				resource == Tool::"deploy"
+			)
+			when {
+				context.claim_sub == "user@example.com" &&
+				context has claim_act &&
+				context.claim_act.sub like "spiffe://toolhive.dev/ns/agents/sa/*"
+			};
+			`},
+			claims: jwt.MapClaims{
+				"sub": "user@example.com",
+				"act": map[string]interface{}{
+					"sub": "spiffe://toolhive.dev/ns/agents/sa/devops-agent",
+				},
+			},
+			feature:          authorizers.MCPFeatureTool,
+			operation:        authorizers.MCPOperationCall,
+			resourceID:       "deploy",
+			arguments:        nil,
+			expectAuthorized: true,
+		},
+		{
+			name: "Delegated access denied when act claim has wrong SPIFFE ID",
+			policies: []string{`
+			permit(
+				principal,
+				action == Action::"call_tool",
+				resource == Tool::"deploy"
+			)
+			when {
+				context.claim_sub == "user@example.com" &&
+				context has claim_act &&
+				context.claim_act.sub like "spiffe://toolhive.dev/ns/agents/sa/*"
+			};
+			`},
+			claims: jwt.MapClaims{
+				"sub": "user@example.com",
+				"act": map[string]interface{}{
+					"sub": "spiffe://evil.example.com/ns/agents/sa/attacker",
+				},
+			},
+			feature:          authorizers.MCPFeatureTool,
+			operation:        authorizers.MCPOperationCall,
+			resourceID:       "deploy",
+			arguments:        nil,
+			expectAuthorized: false,
+		},
+		{
+			name: "Forbid delegated access to admin tools when act claim present",
+			policies: []string{
+				`permit(principal, action == Action::"call_tool", resource);`,
+				`forbid(principal, action == Action::"call_tool", resource == Tool::"admin_reset")
+				when { context has claim_act };`,
+			},
+			claims: jwt.MapClaims{
+				"sub": "user@example.com",
+				"act": map[string]interface{}{
+					"sub": "spiffe://toolhive.dev/ns/agents/sa/devops-agent",
+				},
+			},
+			feature:          authorizers.MCPFeatureTool,
+			operation:        authorizers.MCPOperationCall,
+			resourceID:       "admin_reset",
+			arguments:        nil,
+			expectAuthorized: false,
+		},
+		{
+			name: "Direct access to admin tools allowed when no act claim",
+			policies: []string{
+				`permit(principal, action == Action::"call_tool", resource);`,
+				`forbid(principal, action == Action::"call_tool", resource == Tool::"admin_reset")
+				when { context has claim_act };`,
+			},
+			claims: jwt.MapClaims{
+				"sub": "user@example.com",
+			},
+			feature:          authorizers.MCPFeatureTool,
+			operation:        authorizers.MCPOperationCall,
+			resourceID:       "admin_reset",
+			arguments:        nil,
+			expectAuthorized: true,
+		},
+		{
+			name: "Policy with has operator does not match when act claim absent",
+			policies: []string{`
+			permit(
+				principal,
+				action == Action::"call_tool",
+				resource == Tool::"deploy"
+			)
+			when {
+				context has claim_act &&
+				context.claim_act.sub like "spiffe://toolhive.dev/ns/agents/sa/*"
+			};
+			`},
+			claims: jwt.MapClaims{
+				"sub": "user@example.com",
+			},
+			feature:          authorizers.MCPFeatureTool,
+			operation:        authorizers.MCPOperationCall,
+			resourceID:       "deploy",
+			arguments:        nil,
+			expectAuthorized: false,
 		},
 	}
 
@@ -426,7 +535,7 @@ func TestAuthorizeWithJWTClaims(t *testing.T) {
 
 			// Create a Cedar authorizer
 			authorizer, err := NewCedarAuthorizer(ConfigOptions{
-				Policies:     []string{tc.policy},
+				Policies:     tc.policies,
 				EntitiesJSON: `[]`,
 			}, "")
 			require.NoError(t, err, "Failed to create Cedar authorizer")

--- a/pkg/authz/authorizers/cedar/entity.go
+++ b/pkg/authz/authorizers/cedar/entity.go
@@ -5,8 +5,17 @@
 package cedar
 
 import (
+	"log/slog"
+
 	cedar "github.com/cedar-policy/cedar-go"
 )
+
+// maxClaimNestingDepth caps how deeply nested maps/arrays in JWT claims are
+// converted into Cedar records/sets. Claims can originate from an unverified
+// upstream token (see parseUpstreamJWTClaims in core.go, which uses
+// jwt.ParseUnverified), so recursion here has no other bound. Matches
+// maxSchemaDepth in pkg/vmcp/composer/elicitation_handler.go for consistency.
+const maxClaimNestingDepth = 10
 
 // EntityTypeTHVGroup is the default Cedar entity type representing group membership.
 // It is used when ConfigOptions.GroupEntityType is empty. Principals are added as
@@ -181,8 +190,15 @@ func (f *EntityFactory) CreateEntitiesForRequest(
 	return entities, nil
 }
 
-// convertMapToCedarRecord converts a Go map to a Cedar record.
+// convertMapToCedarRecord converts a Go map to a Cedar record. Nesting beyond
+// maxClaimNestingDepth is dropped (see convertToCedarValueAtDepth).
 func convertMapToCedarRecord(data map[string]interface{}) cedar.Record {
+	return convertMapToCedarRecordAtDepth(data, 0)
+}
+
+// convertMapToCedarRecordAtDepth is the depth-tracking implementation behind
+// convertMapToCedarRecord.
+func convertMapToCedarRecordAtDepth(data map[string]interface{}, depth int) cedar.Record {
 	if data == nil {
 		return cedar.NewRecord(cedar.RecordMap{})
 	}
@@ -191,7 +207,7 @@ func convertMapToCedarRecord(data map[string]interface{}) cedar.Record {
 
 	for k, v := range data {
 		// Convert Go values to Cedar values
-		cedarValue := convertToCedarValue(v)
+		cedarValue := convertToCedarValueAtDepth(v, depth)
 		if cedarValue != nil {
 			recordMap[cedar.String(k)] = cedarValue
 		}
@@ -200,8 +216,20 @@ func convertMapToCedarRecord(data map[string]interface{}) cedar.Record {
 	return cedar.NewRecord(recordMap)
 }
 
-// convertToCedarValue converts a Go value to a Cedar value.
-func convertToCedarValue(v interface{}) cedar.Value {
+// convertToCedarValueAtDepth converts a Go value to a Cedar value. Maps and
+// arrays nested deeper than maxClaimNestingDepth are dropped rather than
+// causing unbounded recursion, since claim values can originate from an
+// unverified upstream JWT (see parseUpstreamJWTClaims in core.go). depth
+// counts how many maps/arrays have already been unwrapped to reach v; once
+// it exceeds maxClaimNestingDepth, v is dropped (returns nil) and a warning
+// is logged instead of recursing further.
+func convertToCedarValueAtDepth(v interface{}, depth int) cedar.Value {
+	if depth > maxClaimNestingDepth {
+		slog.Warn("claim attribute nested too deeply, dropping",
+			"max_depth", maxClaimNestingDepth)
+		return nil
+	}
+
 	switch val := v.(type) {
 	case bool:
 		return convertBoolToCedar(val)
@@ -214,9 +242,11 @@ func convertToCedarValue(v interface{}) cedar.Value {
 	case float64:
 		return convertFloatToCedar(val)
 	case []interface{}:
-		return convertInterfaceArrayToCedar(val)
+		return convertInterfaceArrayToCedar(val, depth)
 	case []string:
 		return convertStringArrayToCedar(val)
+	case map[string]interface{}:
+		return convertMapToCedarRecordAtDepth(val, depth+1)
 	default:
 		// Skip unsupported types
 		return nil
@@ -241,33 +271,15 @@ func convertFloatToCedar(val float64) cedar.Value {
 }
 
 // convertInterfaceArrayToCedar converts an array of interfaces to a Cedar set.
-func convertInterfaceArrayToCedar(val []interface{}) cedar.Value {
+func convertInterfaceArrayToCedar(val []interface{}, depth int) cedar.Value {
 	values := make([]cedar.Value, 0, len(val))
 	for _, item := range val {
-		cedarItem := convertArrayItemToCedar(item)
+		cedarItem := convertToCedarValueAtDepth(item, depth+1)
 		if cedarItem != nil {
 			values = append(values, cedarItem)
 		}
 	}
 	return cedar.NewSet(values...)
-}
-
-// convertArrayItemToCedar converts an array item to a Cedar value.
-func convertArrayItemToCedar(item interface{}) cedar.Value {
-	switch itemVal := item.(type) {
-	case string:
-		return cedar.String(itemVal)
-	case bool:
-		return convertBoolToCedar(itemVal)
-	case int:
-		return cedar.Long(itemVal)
-	case int64:
-		return cedar.Long(itemVal)
-	case float64:
-		return convertFloatToCedar(itemVal)
-	default:
-		return nil
-	}
 }
 
 // convertStringArrayToCedar converts a string array to a Cedar set.

--- a/pkg/authz/authorizers/cedar/record_test.go
+++ b/pkg/authz/authorizers/cedar/record_test.go
@@ -161,13 +161,63 @@ func TestConvertMapToCedarRecord(t *testing.T) {
 		{
 			name: "Unsupported types",
 			input: map[string]interface{}{
-				"map":    map[string]interface{}{"nested": "value"},
 				"struct": struct{ Name string }{"test"},
 				"valid":  "this should be included",
 			},
 			expected: map[string]cedar.Value{
 				"valid": cedar.String("this should be included"),
-				// Other keys should be skipped
+				// struct key should be skipped
+			},
+		},
+		{
+			name: "Nested map converts to Cedar record",
+			input: map[string]interface{}{
+				"act": map[string]interface{}{
+					"sub": "spiffe://toolhive.dev/ns/agents/sa/devops-agent",
+				},
+			},
+			expected: map[string]cedar.Value{
+				"act": cedar.NewRecord(cedar.RecordMap{
+					cedar.String("sub"): cedar.String("spiffe://toolhive.dev/ns/agents/sa/devops-agent"),
+				}),
+			},
+		},
+		{
+			name: "Deeply nested map",
+			input: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner": map[string]interface{}{
+						"value": "deep",
+					},
+				},
+			},
+			expected: map[string]cedar.Value{
+				"outer": cedar.NewRecord(cedar.RecordMap{
+					cedar.String("inner"): cedar.NewRecord(cedar.RecordMap{
+						cedar.String("value"): cedar.String("deep"),
+					}),
+				}),
+			},
+		},
+		{
+			name: "Map nested exactly at depth limit converts fully",
+			input: map[string]interface{}{
+				"claim": buildNestedMap(maxClaimNestingDepth, "reachable"),
+			},
+			expected: map[string]cedar.Value{
+				"claim": nestedCedarRecord(maxClaimNestingDepth, cedar.String("reachable")),
+			},
+		},
+		{
+			name: "Map nested beyond depth limit truncates the deep branch",
+			input: map[string]interface{}{
+				"claim": buildNestedMap(maxClaimNestingDepth+2, "unreachable"),
+			},
+			expected: map[string]cedar.Value{
+				// Everything past maxClaimNestingDepth is dropped: the chain
+				// converts down to the limit and bottoms out in an empty
+				// record instead of reaching "unreachable".
+				"claim": nestedCedarRecord(maxClaimNestingDepth, cedar.NewRecord(cedar.RecordMap{})),
 			},
 		},
 		{
@@ -191,6 +241,36 @@ func TestConvertMapToCedarRecord(t *testing.T) {
 			},
 			expected: map[string]cedar.Value{
 				"int64s": cedar.NewSet(cedar.Long(9223372036854775807)),
+			},
+		},
+		{
+			name: "Array of maps converts to Cedar set of records",
+			input: map[string]interface{}{
+				"act_chain": []interface{}{
+					map[string]interface{}{"sub": "spiffe://toolhive.dev/ns/agents/sa/agent-a"},
+					map[string]interface{}{"sub": "spiffe://toolhive.dev/ns/agents/sa/agent-b"},
+				},
+			},
+			expected: map[string]cedar.Value{
+				"act_chain": cedar.NewSet(
+					cedar.NewRecord(cedar.RecordMap{cedar.String("sub"): cedar.String("spiffe://toolhive.dev/ns/agents/sa/agent-a")}),
+					cedar.NewRecord(cedar.RecordMap{cedar.String("sub"): cedar.String("spiffe://toolhive.dev/ns/agents/sa/agent-b")}),
+				),
+			},
+		},
+		{
+			name: "Array of arrays converts to Cedar set of sets",
+			input: map[string]interface{}{
+				"groups": []interface{}{
+					[]interface{}{"a", "b"},
+					[]interface{}{"c"},
+				},
+			},
+			expected: map[string]cedar.Value{
+				"groups": cedar.NewSet(
+					cedar.NewSet(cedar.String("a"), cedar.String("b")),
+					cedar.NewSet(cedar.String("c")),
+				),
 			},
 		},
 	}
@@ -220,4 +300,27 @@ func TestConvertMapToCedarRecord(t *testing.T) {
 			}
 		})
 	}
+}
+
+// buildNestedMap wraps leaf in `levels` maps nested under the key "nested",
+// e.g. buildNestedMap(2, "x") == map[string]interface{}{"nested":
+// map[string]interface{}{"nested": "x"}}. levels must be >= 1 so the return
+// value is always a map[string]interface{}. Used to exercise the recursion
+// depth cap in convertMapToCedarRecord.
+func buildNestedMap(levels int, leaf interface{}) map[string]interface{} {
+	value := leaf
+	for range levels {
+		value = map[string]interface{}{"nested": value}
+	}
+	return value.(map[string]interface{})
+}
+
+// nestedCedarRecord wraps leaf in `levels` Cedar records nested under the
+// key "nested" — the expected-value counterpart to buildNestedMap.
+func nestedCedarRecord(levels int, leaf cedar.Value) cedar.Value {
+	value := leaf
+	for range levels {
+		value = cedar.NewRecord(cedar.RecordMap{cedar.String("nested"): value})
+	}
+	return value
 }


### PR DESCRIPTION
## Summary

Cedar policies flatten JWT claims into `context`/`principal` attributes, but nested map claims were silently dropped during conversion — most notably an RFC 8693 actor-delegation claim (`act`), shaped like `{"act": {"sub": "spiffe://..."}}`. This meant Cedar could never express delegation-aware policies such as "the user can write, but an agent acting on the user's behalf can only read."

This PR adds recursive conversion of nested map/array claims into nested Cedar records/sets, bounded by a depth cap (`maxClaimNestingDepth = 10`) so a claim from an unverified upstream JWT can't drive unbounded recursion. With this change, policies can now do:

```
permit(principal, action == Action::"call_tool", resource == Tool::"deploy")
when {
    context.claim_sub == "user@example.com" &&
    context has claim_act &&
    context.claim_act.sub like "spiffe://toolhive.dev/ns/agents/sa/*"
};
```

- Adds `maxClaimNestingDepth` guard and depth-tracked variants of `convertMapToCedarRecord`/`convertToCedarValue`
- Generalizes array conversion to recurse through the same converter (arrays of maps/arrays are now supported; previously silently dropped)
- Adds test coverage for nested-map conversion, the depth-limit boundary, and delegation-style permit/forbid policies gated on `act`

Refs #5194

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Does this introduce a user-facing change?

Yes. Cedar policies can now read nested JWT claims via dot-access (e.g. `context.claim_act.sub`), not just flat scalar/array claims. Claims nested more than 10 levels deep are silently dropped (with a warning logged) rather than causing unbounded recursion.

## Special notes for reviewers

- This implements item 4 of #5194's proposed solution (Cedar reading the `act` claim) as a standalone, additive slice. The producer side — the embedded AS's own RFC 8693 token-exchange handler that mints `act` claims, plus `actor_token` and `oidc-trust` support — is being developed separately on `token-delegation` and isn't part of this PR.
- Cedar's consumption of `act` isn't dependent on that producer landing first: per #5194's federated trust model, `act` can also arrive on a subject token issued by any external IdP the deployment already trusts, so this is useful standalone.
- The depth cap is defensive: claims can originate from an unverified upstream token (`parseUpstreamJWTClaims` in `core.go` uses `jwt.ParseUnverified`, relying on the token having already been validated upstream), so nesting depth has no other bound.

Generated with [Claude Code](https://claude.com/claude-code)