### PR TITLE
Document that --allow-docker-gateway ignores allowed ports

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -271,7 +271,9 @@ func AddRunFlags(cmd *cobra.Command, config *RunFlags) {
 		"Isolate the container network from the host. Use --isolate-network=false to opt out.")
 	cmd.Flags().BoolVar(&config.AllowDockerGateway, "allow-docker-gateway", false,
 		"Allow outbound connections to Docker gateway addresses (host.docker.internal, gateway.docker.internal, 172.17.0.1). "+
-			"Only applies when --isolate-network is set. These are blocked by default even when insecure_allow_all is enabled.")
+			"Only applies when --isolate-network is set. These are blocked by default even when insecure_allow_all is enabled. "+
+			"Gateway access is port-independent: it ignores the permission profile's allowed ports, so once enabled the "+
+			"gateway is reachable on any port.")
 	cmd.Flags().BoolVar(&config.TrustProxyHeaders, "trust-proxy-headers", false,
 		"Trust X-Forwarded-* headers from reverse proxies (X-Forwarded-Proto, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Prefix) "+
 			"(default false)")

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -111,7 +111,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
 ### Options
 
 ```
-      --allow-docker-gateway                        Allow outbound connections to Docker gateway addresses (host.docker.internal, gateway.docker.internal, 172.17.0.1). Only applies when --isolate-network is set. These are blocked by default even when insecure_allow_all is enabled.
+      --allow-docker-gateway                        Allow outbound connections to Docker gateway addresses (host.docker.internal, gateway.docker.internal, 172.17.0.1). Only applies when --isolate-network is set. These are blocked by default even when insecure_allow_all is enabled. Gateway access is port-independent: it ignores the permission profile's allowed ports, so once enabled the gateway is reachable on any port.
       --allowed-origins stringArray                 Exact-match allowlist for the HTTP Origin header (repeatable). Recommended when binding publicly; loopback binds derive a default allowlist automatically, non-loopback binds log a warning when no value is supplied. Example: https://my-mcp.example.com
       --audit-config string                         Path to the audit configuration file
       --authz-config string                         Path to the authorization configuration file

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1277,7 +1277,7 @@ const docTemplate = `{
                         "uniqueItems": false
                     },
                     "allow_docker_gateway": {
-                        "description": "AllowDockerGateway permits outbound connections to Docker gateway addresses\n(host.docker.internal, gateway.docker.internal, 172.17.0.1). These are\nblocked by default in the egress proxy even when InsecureAllowAll is set.\nOnly applicable to Docker deployments with network isolation enabled.",
+                        "description": "AllowDockerGateway permits outbound connections to Docker gateway addresses\n(host.docker.internal, gateway.docker.internal, 172.17.0.1). These are\nblocked by default in the egress proxy even when InsecureAllowAll is set.\nOnly applicable to Docker deployments with network isolation enabled.\nGateway access is port-independent: it ignores the permission profile's\nallowed ports, so once enabled the gateway is reachable on any port.",
                         "type": "boolean"
                     },
                     "allowed_origins": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1270,7 +1270,7 @@
                         "uniqueItems": false
                     },
                     "allow_docker_gateway": {
-                        "description": "AllowDockerGateway permits outbound connections to Docker gateway addresses\n(host.docker.internal, gateway.docker.internal, 172.17.0.1). These are\nblocked by default in the egress proxy even when InsecureAllowAll is set.\nOnly applicable to Docker deployments with network isolation enabled.",
+                        "description": "AllowDockerGateway permits outbound connections to Docker gateway addresses\n(host.docker.internal, gateway.docker.internal, 172.17.0.1). These are\nblocked by default in the egress proxy even when InsecureAllowAll is set.\nOnly applicable to Docker deployments with network isolation enabled.\nGateway access is port-independent: it ignores the permission profile's\nallowed ports, so once enabled the gateway is reachable on any port.",
                         "type": "boolean"
                     },
                     "allowed_origins": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1323,6 +1323,8 @@ components:
             (host.docker.internal, gateway.docker.internal, 172.17.0.1). These are
             blocked by default in the egress proxy even when InsecureAllowAll is set.
             Only applicable to Docker deployments with network isolation enabled.
+            Gateway access is port-independent: it ignores the permission profile's
+            allowed ports, so once enabled the gateway is reachable on any port.
           type: boolean
         allowed_origins:
           description: |-

--- a/pkg/container/runtime/types.go
+++ b/pkg/container/runtime/types.go
@@ -283,6 +283,8 @@ type DeployWorkloadOptions struct {
 	// (host.docker.internal, gateway.docker.internal, 172.17.0.1). These are
 	// blocked by default in the egress proxy even when InsecureAllowAll is set.
 	// Only applicable to Docker deployments with network isolation enabled.
+	// Gateway access is port-independent: it ignores the permission profile's
+	// allowed ports, so once enabled the gateway is reachable on any port.
 	AllowDockerGateway bool
 
 	// RunConfigMCPServerGeneration is the monotonic version stamp from the source RunConfig

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -200,6 +200,8 @@ type RunConfig struct {
 	// (host.docker.internal, gateway.docker.internal, 172.17.0.1). These are
 	// blocked by default in the egress proxy even when InsecureAllowAll is set.
 	// Only applicable to Docker deployments with network isolation enabled.
+	// Gateway access is port-independent: it ignores the permission profile's
+	// allowed ports, so once enabled the gateway is reachable on any port.
 	AllowDockerGateway bool `json:"allow_docker_gateway,omitempty" yaml:"allow_docker_gateway,omitempty"`
 
 	// TrustProxyHeaders indicates whether to trust X-Forwarded-* headers from reverse proxies


### PR DESCRIPTION
## Summary

A [review comment on #5707](https://github.com/stacklok/toolhive/pull/5707#discussion_r3513713683) pointed out that the `--allow-docker-gateway` help text doesn't mention that gateway access is port-independent. An operator running `--allow-docker-gateway` alongside a restrictive permission profile (e.g. only allowing port 8080) could reasonably expect gateway traffic to be bound by those allowed ports, when in fact the gateway is reachable on any port once the flag is enabled. The maintainer-facing doc comment in `squid.go` already explains the design rationale; this PR closes the gap in the operator-facing docs.

What changed:
- Updated the `--allow-docker-gateway` CLI flag help text in `run_flags.go` to state that gateway access ignores the permission profile's allowed ports.
- Updated the matching Go doc comments on `RunConfig.AllowDockerGateway` (`pkg/runner/config.go`) and `runtime.AllowDockerGateway` (`pkg/container/runtime/types.go`) for consistency.
- Regenerated CLI docs (`task docs`) and the swagger/OpenAPI spec, which picks up the updated `RunConfig` field description.

## Type of change

- [x] Documentation

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Ran `task docs` to confirm the CLI markdown and swagger docs regenerate cleanly from the updated doc comments, and `task build` to confirm the flag registration still compiles.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes, documentation only: the `--allow-docker-gateway` help text and API docs now clarify that gateway access ignores the permission profile's allowed ports. No behavior change.

## Special notes for reviewers

This is a docs-only follow-up to #5707, addressing the highest-value item from that PR's review feedback. `AllowDockerGateway` has no CRD/operator equivalent (Docker-only feature), so there was no operator API surface to update.

Generated with [Claude Code](https://claude.com/claude-code)