### PR TITLE
Security: Sensitive Header Names Not Validated for Env Var Safety

### DIFF
--- a/cmd/thv-operator/pkg/controllerutil/telemetry.go
+++ b/cmd/thv-operator/pkg/controllerutil/telemetry.go
@@ -5,6 +5,7 @@ package controllerutil
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -59,7 +60,14 @@ func GenerateOpenTelemetryEnvVarsFromRef(
 }
 
 // normalizeHeaderEnvVarName converts a header name to a valid env var suffix.
-// Dashes become underscores and the result is uppercased.
+// Dashes become underscores, invalid characters are removed, and the result is uppercased.
+// The result must start with a letter or underscore and contain only alphanumeric characters and underscores.
 func normalizeHeaderEnvVarName(name string) string {
-	return strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+	name = strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+	name = regexp.MustCompile(`[^A-Z0-9_]`).ReplaceAllString(name, "")
+	name = regexp.MustCompile(`^[^A-Z_]+`).ReplaceAllString(name, "")
+	if len(name) > 64 {
+		name = name[:64]
+	}
+	return name
 }


### PR DESCRIPTION
## Summary

Security: Sensitive Header Names Not Validated for Env Var Safety

## Problem

**Severity**: `Medium` | **File**: `cmd/thv-operator/pkg/controllerutil/telemetry.go:L52`

In `GenerateOpenTelemetryEnvVarsFromRef`, the `normalizeHeaderEnvVarName` function converts header names to environment variable names by only replacing dashes with underscores and uppercasing. However, it does not validate that the resulting string is a valid environment variable name (e.g., it could start with a digit, contain invalid characters, or be empty). This could lead to invalid environment variable configurations in pods. More critically, if a malicious user can control header names through the CRD, they could potentially craft header names that cause unexpected behavior or conflicts with system environment variables.

## Solution

Add validation to `normalizeHeaderEnvVarName` to ensure the resulting environment variable name is valid: must start with a letter or underscore, contain only alphanumeric characters and underscores, and not exceed standard env var length limits. Also consider adding a prefix to avoid collisions with system environment variables.

## Changes

- `cmd/thv-operator/pkg/controllerutil/telemetry.go` (modified)