### PR TITLE
Preserve external annotations on operator Services

### DIFF
--- a/cmd/thv-operator/controllers/embeddingserver_controller.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller.go
@@ -287,8 +287,11 @@ func (r *EmbeddingServerReconciler) ensureService(
 	if r.serviceNeedsUpdate(service, embedding) {
 		desiredService := r.serviceForEmbedding(ctx, embedding)
 		service.Spec.Ports = desiredService.Spec.Ports
-		service.Labels = desiredService.Labels
-		service.Annotations = desiredService.Annotations
+		// Merge (not replace) Labels/Annotations so keys written by external controllers
+		// (e.g. GKE NEG's cloud.google.com/* annotations) are preserved while the
+		// operator-owned values are applied.
+		service.Labels = ctrlutil.MergeLabels(desiredService.Labels, service.Labels)
+		service.Annotations = ctrlutil.MergeAnnotations(desiredService.Annotations, service.Annotations)
 		// Preserve ClusterIP as it's immutable
 		if err := r.Update(ctx, service); err != nil {
 			ctxLogger.Error(err, "Failed to update Service",
@@ -330,18 +333,16 @@ func (*EmbeddingServerReconciler) serviceNeedsUpdate(
 		}
 	}
 
-	// Check if expected annotations are present in service
-	for key, value := range expectedAnnotations {
-		if service.Annotations[key] != value {
-			return true
-		}
+	// Subset check rather than exact equality: the Service is co-owned by external
+	// controllers (e.g. GKE NEG/Gateway writes cloud.google.com/* annotations), so only
+	// the operator-owned keys must match. Exact equality would treat those external
+	// annotations as drift and hot-loop Update against the concurrent writer.
+	if !ctrlutil.MapIsSubset(expectedAnnotations, service.Annotations) {
+		return true
 	}
 
-	// Check if expected labels are present in service
-	for key, value := range expectedLabels {
-		if service.Labels[key] != value {
-			return true
-		}
+	if !ctrlutil.MapIsSubset(expectedLabels, service.Labels) {
+		return true
 	}
 
 	return false

--- a/cmd/thv-operator/controllers/embeddingserver_controller_test.go
+++ b/cmd/thv-operator/controllers/embeddingserver_controller_test.go
@@ -1161,3 +1161,79 @@ func TestEmbeddingServer_PodTemplateSpec_EmptyObjectIsNoOp(t *testing.T) {
 	assert.Contains(t, c.Args, "--model-id")
 	assert.Contains(t, c.Args, "test-model")
 }
+
+// TestEmbeddingServerServiceNeedsUpdate_ExternalAnnotationsIgnored is a regression test
+// for #5730: external controllers (e.g. GKE NEG/Gateway) write cloud.google.com/*
+// annotations on the Service; these are not operator-owned and must not be treated as
+// drift. A genuine operator-owned change (port) must still be detected.
+func TestEmbeddingServerServiceNeedsUpdate_ExternalAnnotationsIgnored(t *testing.T) {
+	t.Parallel()
+
+	embedding := v1beta1test.NewEmbeddingServer("embed", testNamespaceDefault,
+		v1beta1test.WithEmbeddingPort(9000))
+	r := &EmbeddingServerReconciler{}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"cloud.google.com/neg-status": `{"network_endpoint_groups":{"9000":"k8s1-abc"}}`,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Name: "http", Port: 9000}},
+		},
+	}
+	assert.False(t, r.serviceNeedsUpdate(svc, embedding),
+		"external annotation must not be treated as drift")
+
+	svc.Spec.Ports[0].Port = 1234
+	assert.True(t, r.serviceNeedsUpdate(svc, embedding),
+		"operator-owned port drift must still be detected")
+}
+
+// TestEmbeddingServerEnsureService_PreservesExternalAnnotations is a regression test for
+// #5730: when a genuine operator-owned change triggers a Service update, annotations
+// written by an external controller (e.g. GKE NEG) must be merged, not stripped.
+func TestEmbeddingServerEnsureService_PreservesExternalAnnotations(t *testing.T) {
+	t.Parallel()
+
+	embedding := v1beta1test.NewEmbeddingServer("embed-ext", testNamespaceDefault,
+		v1beta1test.WithEmbeddingPort(9000))
+
+	// Existing Service co-owned by GKE (external annotation) with a drifted operator-owned
+	// field (wrong port) so serviceNeedsUpdate fires.
+	existing := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      embedding.Name,
+			Namespace: embedding.Namespace,
+			Annotations: map[string]string{
+				"cloud.google.com/neg-status": `{"network_endpoint_groups":{"9000":"k8s1-abc"}}`,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Name: "http", Port: 1234}},
+		},
+	}
+
+	scheme := testutil.NewScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(embedding, existing).
+		Build()
+	r := &EmbeddingServerReconciler{Client: fakeClient, Scheme: scheme}
+
+	_, err := r.ensureService(context.TODO(), embedding)
+	require.NoError(t, err)
+
+	updated := &corev1.Service{}
+	require.NoError(t, fakeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      embedding.Name,
+		Namespace: embedding.Namespace,
+	}, updated))
+	// External annotation preserved...
+	assert.Equal(t, `{"network_endpoint_groups":{"9000":"k8s1-abc"}}`,
+		updated.Annotations["cloud.google.com/neg-status"])
+	// ...and the operator-owned port corrected.
+	require.Len(t, updated.Spec.Ports, 1)
+	assert.Equal(t, int32(9000), updated.Spec.Ports[0].Port)
+}

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -376,8 +376,11 @@ func (r *MCPRemoteProxyReconciler) ensureService(
 		}
 		service.Spec.Ports = newService.Spec.Ports
 		service.Spec.SessionAffinity = newService.Spec.SessionAffinity
-		service.Labels = newService.Labels
-		service.Annotations = newService.Annotations
+		// Merge (not replace) Labels/Annotations so keys written by external controllers
+		// (e.g. GKE NEG's cloud.google.com/* annotations) are preserved while the
+		// operator-owned values are applied.
+		service.Labels = ctrlutil.MergeLabels(newService.Labels, service.Labels)
+		service.Annotations = ctrlutil.MergeAnnotations(newService.Annotations, service.Annotations)
 
 		ctxLogger.Info("Updating Service", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
 		if err := r.Update(ctx, service); err != nil {
@@ -1642,11 +1645,15 @@ func (*MCPRemoteProxyReconciler) serviceNeedsUpdate(service *corev1.Service, pro
 		}
 	}
 
-	if !maps.Equal(service.Labels, expectedLabels) {
+	// Subset check rather than exact equality: the Service is co-owned by external
+	// controllers (e.g. GKE NEG/Gateway writes cloud.google.com/* annotations), so only
+	// the operator-owned keys must match. maps.Equal would treat those external
+	// annotations as drift and hot-loop Update against the concurrent writer.
+	if !ctrlutil.MapIsSubset(expectedLabels, service.Labels) {
 		return true
 	}
 
-	if !maps.Equal(service.Annotations, expectedAnnotations) {
+	if !ctrlutil.MapIsSubset(expectedAnnotations, service.Annotations) {
 		return true
 	}
 

--- a/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_deployment_test.go
@@ -26,6 +26,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
@@ -605,6 +606,55 @@ func TestEnsureService(t *testing.T) {
 	}
 }
 
+// TestMCPRemoteProxyEnsureService_PreservesExternalAnnotations is a regression test for
+// #5730: when a genuine operator-owned change triggers a Service update, annotations
+// written by an external controller (e.g. GKE NEG) must be merged, not stripped.
+func TestMCPRemoteProxyEnsureService_PreservesExternalAnnotations(t *testing.T) {
+	t.Parallel()
+
+	proxy := v1beta1test.NewMCPRemoteProxy("ext-annot-proxy", "default")
+
+	// Existing Service co-owned by GKE (external annotation) with an operator-owned field
+	// drifted (empty session affinity) so serviceNeedsUpdate fires.
+	existing := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      createProxyServiceName(proxy.Name),
+			Namespace: proxy.Namespace,
+			Labels:    labelsForMCPRemoteProxy(proxy.Name),
+			Annotations: map[string]string{
+				"cloud.google.com/neg-status": `{"network_endpoint_groups":{"8080":"k8s1-abc"}}`,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			SessionAffinity: "",
+			Ports:           []corev1.ServicePort{{Port: 8080}},
+		},
+	}
+
+	scheme := testutil.NewScheme(t)
+	_ = rbacv1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(proxy, existing).
+		Build()
+	reconciler := &MCPRemoteProxyReconciler{Client: fakeClient, Scheme: scheme}
+
+	_, err := reconciler.ensureService(context.TODO(), proxy)
+	require.NoError(t, err)
+
+	updated := &corev1.Service{}
+	require.NoError(t, fakeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      createProxyServiceName(proxy.Name),
+		Namespace: proxy.Namespace,
+	}, updated))
+	// External annotation preserved...
+	assert.Equal(t, `{"network_endpoint_groups":{"8080":"k8s1-abc"}}`,
+		updated.Annotations["cloud.google.com/neg-status"])
+	// ...and the operator-owned field corrected.
+	assert.Equal(t, corev1.ServiceAffinityClientIP, updated.Spec.SessionAffinity)
+}
+
 func TestMCPRemoteProxyDeploymentNeedsUpdate_EmbeddedAuthLegacyEnvStable(t *testing.T) {
 	t.Parallel()
 
@@ -1180,6 +1230,19 @@ func TestMCPRemoteProxyServiceNeedsUpdate(t *testing.T) {
 				p.Spec.SessionAffinity = string(corev1.ServiceAffinityNone)
 				return p
 			}(),
+			needsUpdate: false,
+		},
+		{
+			// Regression for #5730: external controllers (e.g. GKE NEG/Gateway) write
+			// cloud.google.com/* annotations on the Service. These are not operator-owned
+			// and must not be treated as drift, or the operator hot-loops Update.
+			name: "external cloud annotations ignored",
+			service: func() *corev1.Service {
+				s := baseService.DeepCopy()
+				s.Annotations["cloud.google.com/neg-status"] = `{"network_endpoint_groups":{"8080":"k8s1-abc"}}`
+				return s
+			}(),
+			proxy:       baseProxy.DeepCopy(),
 			needsUpdate: false,
 		},
 	}

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -526,8 +526,11 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		newService := r.serviceForMCPServer(ctx, mcpServer)
 		service.Spec.Ports = newService.Spec.Ports
 		service.Spec.SessionAffinity = newService.Spec.SessionAffinity
-		service.Labels = newService.Labels
-		service.Annotations = newService.Annotations
+		// Merge (not replace) Labels/Annotations so keys written by external controllers
+		// (e.g. GKE NEG's cloud.google.com/* annotations) are preserved while the
+		// operator-owned values are applied.
+		service.Labels = ctrlutil.MergeLabels(newService.Labels, service.Labels)
+		service.Annotations = ctrlutil.MergeAnnotations(newService.Annotations, service.Annotations)
 		err = r.Update(ctx, service)
 		if err != nil {
 			ctxLogger.Error(err, "Failed to update Service", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
@@ -2062,11 +2065,15 @@ func serviceNeedsUpdate(service *corev1.Service, mcpServer *mcpv1beta1.MCPServer
 		}
 	}
 
-	if !maps.Equal(service.Labels, expectedLabels) {
+	// Subset check rather than exact equality: the Service is co-owned by external
+	// controllers (e.g. GKE NEG/Gateway writes cloud.google.com/* annotations), so only
+	// the operator-owned keys must match. maps.Equal would treat those external
+	// annotations as drift and hot-loop Update against the concurrent writer.
+	if !ctrlutil.MapIsSubset(expectedLabels, service.Labels) {
 		return true
 	}
 
-	if !maps.Equal(service.Annotations, expectedAnnotations) {
+	if !ctrlutil.MapIsSubset(expectedAnnotations, service.Annotations) {
 		return true
 	}
 

--- a/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_resource_overrides_test.go
@@ -1135,6 +1135,19 @@ func TestMCPServerServiceNeedsUpdate(t *testing.T) {
 			}(),
 			needsUpdate: false,
 		},
+		{
+			// Regression for #5730: external controllers (e.g. GKE NEG/Gateway) write
+			// cloud.google.com/* annotations on the Service. These are not operator-owned
+			// and must not be treated as drift, or the operator hot-loops Update.
+			name: "external cloud annotations ignored",
+			service: func() *corev1.Service {
+				s := baseService.DeepCopy()
+				s.Annotations["cloud.google.com/neg-status"] = `{"network_endpoint_groups":{"8080":"k8s1-abc"}}`
+				return s
+			}(),
+			mcpServer:   baseMCPServer.DeepCopy(),
+			needsUpdate: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/thv-operator/controllers/mcpserver_service_annotations_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_service_annotations_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
+	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/pkg/container/kubernetes"
+)
+
+// TestMCPServerReconcile_PreservesExternalServiceAnnotations is a regression test for
+// #5730: when a genuine operator-owned change triggers the inline Service update in
+// Reconcile, annotations written by an external controller (e.g. GKE NEG) must be
+// merged, not stripped, otherwise the operator hot-loops Update against the concurrent
+// writer.
+func TestMCPServerReconcile_PreservesExternalServiceAnnotations(t *testing.T) {
+	t.Parallel()
+
+	const name = "ext-annot-server"
+	namespace := testNamespaceDefault
+
+	mcpServer := v1beta1test.NewMCPServer(name, namespace, v1beta1test.WithTransport("sse"))
+
+	scheme := testutil.NewScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mcpServer).
+		WithStatusSubresource(&mcpv1beta1.MCPServer{}).
+		Build()
+	r := newTestMCPServerReconciler(fakeClient, scheme, kubernetes.PlatformKubernetes)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}}
+	// Drive to steady state; successive passes create the Deployment and Service.
+	for range 6 {
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+	}
+
+	svcName := ctrlutil.CreateProxyServiceName(name)
+	svcKey := types.NamespacedName{Name: svcName, Namespace: namespace}
+
+	// An external controller (GKE NEG) writes an annotation, and an operator-owned field
+	// drifts (empty session affinity) so serviceNeedsUpdate fires on the next reconcile.
+	svc := &corev1.Service{}
+	require.NoError(t, fakeClient.Get(t.Context(), svcKey, svc))
+	if svc.Annotations == nil {
+		svc.Annotations = map[string]string{}
+	}
+	svc.Annotations["cloud.google.com/neg-status"] = `{"network_endpoint_groups":{"8080":"k8s1-abc"}}`
+	svc.Spec.SessionAffinity = ""
+	require.NoError(t, fakeClient.Update(t.Context(), svc))
+
+	// Reconcile again; the inline Service update path merges rather than replaces.
+	for range 3 {
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+	}
+
+	updated := &corev1.Service{}
+	require.NoError(t, fakeClient.Get(t.Context(), svcKey, updated))
+	// External annotation preserved...
+	assert.Equal(t, `{"network_endpoint_groups":{"8080":"k8s1-abc"}}`,
+		updated.Annotations["cloud.google.com/neg-status"],
+		"external annotation must survive the operator Service update")
+	// ...and the operator-owned field corrected.
+	assert.Equal(t, corev1.ServiceAffinityClientIP, updated.Spec.SessionAffinity,
+		"operator-owned session affinity should be reconciled back to the default")
+}

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -1597,11 +1597,15 @@ func (r *VirtualMCPServerReconciler) ensureService(
 		// - Preserve Spec.ClusterIP: Immutable field, cannot be changed
 		// - Preserve Spec.HealthCheckNodePort: Set by cloud provider for LoadBalancer
 		// - Preserve ResourceVersion, UID: Required for optimistic concurrency control
+		// - Merge (not replace) Labels/Annotations: preserve keys written by external
+		//   controllers (e.g. GKE NEG's cloud.google.com/* annotations) while applying
+		//   the operator-owned values; a wholesale replace would strip them and race the
+		//   concurrent writer.
 		service.Spec.Ports = newService.Spec.Ports
 		service.Spec.Type = newService.Spec.Type
 		service.Spec.SessionAffinity = newService.Spec.SessionAffinity
-		service.Labels = newService.Labels
-		service.Annotations = newService.Annotations
+		service.Labels = ctrlutil.MergeLabels(newService.Labels, service.Labels)
+		service.Annotations = ctrlutil.MergeAnnotations(newService.Annotations, service.Annotations)
 
 		ctxLogger.Info("Updating Service", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
 		if err := r.Update(ctx, service); err != nil {
@@ -1878,17 +1882,21 @@ func (*VirtualMCPServerReconciler) serviceNeedsUpdate(
 		return true
 	}
 
-	// Check if service metadata has changed
+	// Check if service metadata has changed. Use a subset check rather than exact
+	// equality: the Service is co-owned by external controllers (e.g. GKE NEG/Gateway
+	// writes cloud.google.com/* annotations), so only the operator-owned keys must
+	// match. Comparing with maps.Equal would treat those external annotations as drift
+	// and hot-loop Update against the concurrent writer.
 	expectedLabels := labelsForVirtualMCPServer(vmcp.Name)
 	expectedAnnotations := make(map[string]string)
 
 	// TODO: Add support for ResourceOverrides if needed in the future
 
-	if !maps.Equal(service.Labels, expectedLabels) {
+	if !ctrlutil.MapIsSubset(expectedLabels, service.Labels) {
 		return true
 	}
 
-	if !maps.Equal(service.Annotations, expectedAnnotations) {
+	if !ctrlutil.MapIsSubset(expectedAnnotations, service.Annotations) {
 		return true
 	}
 

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -864,6 +864,33 @@ func TestVirtualMCPServerServiceNeedsUpdate(t *testing.T) {
 			}(),
 			needsUpdate: false,
 		},
+		{
+			// Regression for #5730: a Service co-owned by GKE NEG/Gateway gets
+			// cloud.google.com/* annotations written by the cloud controller. These are
+			// not operator-owned and must not be treated as drift, or the operator
+			// hot-loops Update and races the concurrent writer.
+			name: "external cloud annotations ignored",
+			service: func() *corev1.Service {
+				s := baseService.DeepCopy()
+				s.Annotations = map[string]string{
+					"cloud.google.com/neg":        `{"ingress":true}`,
+					"cloud.google.com/neg-status": `{"network_endpoint_groups":{"8080":"k8s1-abc"}}`,
+				}
+				return s
+			}(),
+			vmcp:        baseVmcp.DeepCopy(),
+			needsUpdate: false,
+		},
+		{
+			name: "external label ignored",
+			service: func() *corev1.Service {
+				s := baseService.DeepCopy()
+				s.Labels["external.example.com/managed"] = "true"
+				return s
+			}(),
+			vmcp:        baseVmcp.DeepCopy(),
+			needsUpdate: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2595,6 +2622,61 @@ func TestVirtualMCPServerEnsureService_UpdateService(t *testing.T) {
 	}, service)
 	assert.NoError(t, err)
 	assert.Equal(t, corev1.ServiceTypeLoadBalancer, service.Spec.Type)
+}
+
+// TestVirtualMCPServerEnsureService_PreservesExternalAnnotations is a regression test
+// for #5730: when a genuine operator-owned change triggers a Service update, annotations
+// written by an external controller (e.g. GKE NEG) must be preserved, not stripped.
+func TestVirtualMCPServerEnsureService_PreservesExternalAnnotations(t *testing.T) {
+	t.Parallel()
+
+	scheme := testutil.NewScheme(t)
+
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+		v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+			v.Spec.ServiceType = "LoadBalancer"
+		}),
+	)
+
+	// Existing service with wrong type (triggers update) plus a cloud-owned annotation.
+	oldService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmcpServiceName(vmcp.Name),
+			Namespace: "default",
+			Labels:    labelsForVirtualMCPServer(vmcp.Name),
+			Annotations: map[string]string{
+				"cloud.google.com/neg-status": `{"network_endpoint_groups":{"8080":"k8s1-abc"}}`,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: labelsForVirtualMCPServer(vmcp.Name),
+			Ports:    []corev1.ServicePort{{Port: 4483, TargetPort: intstr.FromInt(4483)}},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(vmcp, oldService).
+		Build()
+
+	reconciler := &VirtualMCPServerReconciler{Client: k8sClient, Scheme: scheme}
+
+	_, err := reconciler.ensureService(context.Background(), vmcp)
+	assert.NoError(t, err)
+
+	service := &corev1.Service{}
+	err = k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      vmcpServiceName(vmcp.Name),
+		Namespace: vmcp.Namespace,
+	}, service)
+	assert.NoError(t, err)
+	// Operator-owned field applied...
+	assert.Equal(t, corev1.ServiceTypeLoadBalancer, service.Spec.Type)
+	// ...and the external annotation preserved.
+	assert.Equal(t, `{"network_endpoint_groups":{"8080":"k8s1-abc"}}`,
+		service.Annotations["cloud.google.com/neg-status"])
 }
 
 func TestVirtualMCPServerEnsureService_NoUpdateNeeded(t *testing.T) {

--- a/cmd/thv-operator/pkg/controllerutil/resources_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/resources_test.go
@@ -302,3 +302,54 @@ func TestEnsureRequiredEnvVars(t *testing.T) {
 		assert.Equal(t, "regular", envMap["REGULAR_VAR"])
 	})
 }
+
+// TestMergeStringMaps documents the precedence the Service reconcilers rely on when
+// merging operator-owned annotations/labels over pre-existing (possibly externally
+// written) ones: on a key collision the default map (first arg) wins, and keys present
+// only in the override map (e.g. an external controller's cloud.google.com/* annotation)
+// are preserved. See #5730.
+func TestMergeStringMaps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		defaultMap  map[string]string
+		overrideMap map[string]string
+		want        map[string]string
+	}{
+		{
+			name:        "default wins on key collision",
+			defaultMap:  map[string]string{"shared": "operator"},
+			overrideMap: map[string]string{"shared": "external"},
+			want:        map[string]string{"shared": "operator"},
+		},
+		{
+			name:        "override-only keys preserved",
+			defaultMap:  map[string]string{"app": "vmcp"},
+			overrideMap: map[string]string{"cloud.google.com/neg-status": "x"},
+			want:        map[string]string{"app": "vmcp", "cloud.google.com/neg-status": "x"},
+		},
+		{
+			name:        "collision plus preserved external key",
+			defaultMap:  map[string]string{"app": "vmcp"},
+			overrideMap: map[string]string{"app": "stale", "cloud.google.com/neg": "y"},
+			want:        map[string]string{"app": "vmcp", "cloud.google.com/neg": "y"},
+		},
+		{
+			name:        "nil default preserves override",
+			defaultMap:  nil,
+			overrideMap: map[string]string{"cloud.google.com/neg": "y"},
+			want:        map[string]string{"cloud.google.com/neg": "y"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, MergeStringMaps(tt.defaultMap, tt.overrideMap))
+			// MergeAnnotations/MergeLabels are thin wrappers with identical semantics.
+			assert.Equal(t, tt.want, MergeAnnotations(tt.defaultMap, tt.overrideMap))
+			assert.Equal(t, tt.want, MergeLabels(tt.defaultMap, tt.overrideMap))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A `VirtualMCPServer`'s backing `vmcp-<name>` Service (and the equivalent Services for `MCPServer`, `MCPRemoteProxy`, and `EmbeddingServer`) is co-owned by external controllers on some platforms. On GKE with the Gateway API, the NEG/Gateway controllers continuously write `cloud.google.com/*` annotations onto it. The operator's Service reconcile did not tolerate this:

* `serviceNeedsUpdate` compared annotations with `maps.Equal` against an operator-only expected set, so any externally-added annotation read as drift and the check returned `true` on **every** reconcile.
* The update path then did `service.Annotations = newService.Annotations`, wholesale-replacing the map and stripping the external annotations.

The result was a tight hot-loop of `Update` calls racing the concurrent cloud controller, each losing the `resourceVersion` race with `the object has been modified` and requeuing immediately (~700-835 conflict log lines/minute observed). Serving was unaffected, but it drove continuous kube-apiserver churn and ~1M+ log lines/day per workload.

This is the Service-object sibling of #5616 (which fixed the same class of build/diff asymmetry on the Deployment). The fix reuses helpers that already exist in the repo rather than introducing Server-Side Apply (which `.claude/rules/operator.md` explicitly disallows as a one-off):

* **Detection:** compare operator-owned labels/annotations with `ctrlutil.MapIsSubset` instead of `maps.Equal`, so externally-managed keys are ignored and the reconcile is a genuine no-op once converged.
* **Write:** merge rather than replace labels/annotations via `ctrlutil.MergeLabels` / `ctrlutil.MergeAnnotations` (operator-owned values win, external keys preserved), matching what the Deployment path already does.

Applied consistently to all four controllers that reconcile a proxy Service: `VirtualMCPServer`, `MCPServer`, `MCPRemoteProxy`, and `EmbeddingServer`. `EmbeddingServer` already tolerated external annotations in *detection* but still stripped them on *write*, so it would flap the NEG annotations on every legitimate Service update; it is fixed here too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

| File | Change |
|------|--------|
| `virtualmcpserver_controller.go` | `serviceNeedsUpdate` subset check; merge-on-write for labels/annotations |
| `mcpserver_controller.go` | Same fix |
| `mcpremoteproxy_controller.go` | Same fix |
| `embeddingserver_controller.go` | Merge-on-write fix; detection loops replaced with `MapIsSubset` for consistency |
| `*_test.go` (4 files) | Detection regression cases for all four controllers, plus write-path tests proving external annotations survive an `Update` |

## Test plan

- [x] Unit tests pass (`cmd/thv-operator/controllers` and `pkg/controllerutil`)
- [x] Detection regression tests: a `cloud.google.com/neg-status` annotation must not trigger an update (all four controllers)
- [x] Write-path regression tests: when a genuine operator-owned change triggers an update, the external annotation must survive and the operator-owned field must still be corrected (all four controllers)
- [x] `task lint-fix` (no new findings on changed files)

## Does this introduce a user-facing change?

No. Behavior is unchanged for Services with no external co-owner; the fix only stops spurious `Update`/conflict churn when another controller writes annotations on the operator's Service.

## Special notes for reviewers

* Not addressing the issue's "backoff on conflict" suggestion: controller-runtime already backs off on returned errors, and once the write stops firing there are no conflicts left to back off from.
* Known limitation (shared with the existing merge-patch approach): removing an operator-owned annotation from spec won't delete it from an existing Service, since the subset check can't distinguish "operator no longer wants this key" from "external controller owns this key". Full removal semantics would require Server-Side Apply, which is out of scope here.

Fixes #5730
