### PR TITLE
Drop unconditional ACL password guard from auth server Redis storage

### DIFF
--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -107,16 +107,14 @@ type storedSession struct {
 
 // NewRedisStorage creates Redis-backed storage. Connection-mode topology,
 // timeouts, TLS, and credentials are configured through cfg; keyPrefix is the
-// per-tenant key prefix (e.g. "thv:auth:{ns}:{name}:"). The auth server
-// requires ACL authentication, so cfg.Password and keyPrefix must be non-empty.
+// per-tenant key prefix (e.g. "thv:auth:{ns}:{name}:") and must be non-empty.
 //
 // Connection-mode validation, timeout defaults, client construction (standalone,
 // cluster, or sentinel), TLS plumbing, and connectivity verification are
-// delegated to the shared toolhive-core redis package.
+// delegated to the shared toolhive-core redis package. cfg.Password may be
+// empty when the Redis server does not require authentication (the auth server
+// does not mandate ACL auth); the keyPrefix is storage-specific and required.
 func NewRedisStorage(ctx context.Context, cfg tcredis.Config, keyPrefix string) (*RedisStorage, error) {
-	if cfg.Password == "" {
-		return nil, errors.New("invalid redis configuration: ACL password is required")
-	}
 	if keyPrefix == "" {
 		return nil, errors.New("invalid redis configuration: key prefix is required")
 	}

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -99,12 +99,13 @@ func requireRedisNotFoundError(t *testing.T, err error) {
 
 // TestNewRedisStorage_Validation covers the auth-server-specific invariants
 // enforced by NewRedisStorage. Connection-mode topology (Addr XOR Sentinel,
-// cluster requires Addr, sentinel master name and addresses) is validated by
-// the shared toolhive-core redis package and exercised in its own tests.
+// cluster requires Addr, sentinel master name and addresses) and credentials
+// are validated by the shared toolhive-core redis package and exercised in its
+// own tests; NewRedisStorage does not mandate a password.
 func TestNewRedisStorage_Validation(t *testing.T) {
 	t.Parallel()
 
-	validACL := func() tcredis.Config {
+	validCfg := func() tcredis.Config {
 		return tcredis.Config{Addr: "localhost:6379", Username: "user", Password: "pass"}
 	}
 
@@ -115,14 +116,8 @@ func TestNewRedisStorage_Validation(t *testing.T) {
 		wantErr   string
 	}{
 		{
-			name:      "missing ACL password",
-			cfg:       tcredis.Config{Addr: "localhost:6379", Username: "user"},
-			keyPrefix: "test:",
-			wantErr:   "ACL password is required",
-		},
-		{
 			name:      "missing key prefix",
-			cfg:       validACL(),
+			cfg:       validCfg(),
 			keyPrefix: "",
 			wantErr:   "key prefix is required",
 		},
@@ -205,6 +200,24 @@ func TestNewRedisStorage_Standalone_WithMiniredis(t *testing.T) {
 		Username: "testuser",
 		Password: "testpass",
 	}
+
+	ctx := context.Background()
+	s, err := NewRedisStorage(ctx, cfg, "test:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	require.NoError(t, s.Health(ctx))
+}
+
+// TestNewRedisStorage_Standalone_Passwordless verifies that an auth-disabled
+// Redis (no ACL) is accepted, matching toolhive-core's Config contract where
+// Password "may be empty when the server does not require authentication".
+func TestNewRedisStorage_Standalone_Passwordless(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t) // no RequireUserAuth → auth disabled
+
+	cfg := tcredis.Config{Addr: mr.Addr()}
 
 	ctx := context.Background()
 	s, err := NewRedisStorage(ctx, cfg, "test:")


### PR DESCRIPTION
## Summary

`pkg/authserver/storage.NewRedisStorage` enforced an unconditional `cfg.Password != ""` guard that contradicted the `toolhive-core` `Config` type it consumes — whose `Password` is documented as _"May be empty when the server does not require authentication"_ and whose `Validate()` does not require one. This blocked passwordless Redis (in-cluster auth-disabled Valkey, dev miniredis without `RequireUserAuth`) for no security reason the auth server itself needs.

The guard originated as a Phase-1 design choice in #3639 and was carried forward through the toolhive-core migration in #5318. It also contradicted the sibling `pkg/transport/session/storage_redis.go`, which already validates only its own invariants (key prefix, TTL) and delegates the rest to `tcredis.NewClient` — no password guard.

## Changes

- **`pkg/authserver/storage/redis.go`** — drop the `cfg.Password == ""` guard from `NewRedisStorage`; keep the storage-specific `keyPrefix` invariant. Connection-mode validation, timeout defaults, TLS, client construction, and Ping verification remain delegated to `tcredis.NewClient`/`Config.Validate()`.
- **`pkg/authserver/storage/redis_test.go`** — remove the "missing ACL password" validation case; add `TestNewRedisStorage_Standalone_Passwordless` proving auth-disabled Redis is accepted; rename `validACL` → `validCfg`.

## Backward compatibility

- **Signature unchanged** — `NewRedisStorage(ctx, cfg tcredis.Config, keyPrefix string)` is identical; no API break.
- **Behavioral:** deployments that previously failed fast on a missing password now proceed to `tcredis.NewClient`, which Pings. If the Redis truly requires auth and the operator forgot the password, the Ping fails with a Redis-native auth error — the failure still surfaces, one layer deeper. This matches the behavior `pkg/transport/session` already ships.
- **Config schema unchanged** — `AuthType="aclUser"` and `ACLUserRunConfig` remain the documented path for ACL Redis; `resolveEnvVar` already permits an empty password value for unauthenticated backends.

## Verification

- `task test` — green
- `task lint` — 0 issues
