### PR TITLE
Suppress GO-2026-5932 (x/crypto/openpgp deprecated-by-design, no fix available)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -65,7 +65,14 @@ jobs:
           # CI's `setup-go: stable` still resolves to go1.26.3 because the
           # actions/go-versions manifest lags the Go release. Temporary
           # exclusion; remove once CI builds on go1.26.4 or later.
-          IGNORED_VULNS="GO-2026-5037 GO-2026-5038 GO-2026-5039"
+          #
+          # GO-2026-5932: golang.org/x/crypto/openpgp is deprecated-by-design
+          # ("unsafe, not maintained, should not be used"). No fixed version
+          # exists and none is planned. ToolHive does not import openpgp
+          # directly; it is pulled transitively via sigstore (rekor/sigstore-go)
+          # for backward-compatible OpenPGP verification. Remove when sigstore
+          # drops the openpgp dependency.
+          IGNORED_VULNS="GO-2026-5037 GO-2026-5038 GO-2026-5039 GO-2026-5932"
 
           # Show the raw output for debugging
           echo "::group::govulncheck raw output"


### PR DESCRIPTION
## Summary

Adds `GO-2026-5932` to the govulncheck ignore list in the Security Scan workflow.

## Why this can't be fixed by bumping a dependency

`GO-2026-5932` flags `golang.org/x/crypto/openpgp` as **deprecated-by-design** — the advisory states the package is "unsafe, not maintained, and should not be used." There is **no fixed version and none is planned**. The recommendation is to migrate to `github.com/ProtonMail/go-crypto/openpgp`, but that's a transitive dependency change that must come from upstream (sigstore).

ToolHive does not import `openpgp` directly:
```
$ go mod why golang.org/x/crypto/openpgp
# golang.org/x/crypto/openpgp
github.com/stacklok/toolhive/pkg/runner/retriever
github.com/stacklok/toolhive-core/container/verifier
github.com/sigstore/sigstore-go/pkg/bundle
github.com/sigstore/sigstore-go/pkg/tlog
github.com/sigstore/rekor/pkg/types/dsse/v0.0.1
golang.org/x/crypto/openpgp
```

The `openpgp` package is pulled in via sigstore (rekor/sigstore-go) for backward-compatible OpenPGP signature verification. Removing it requires sigstore to drop the dependency upstream.

## What this PR does

Adds `GO-2026-5932` to the `IGNORED_VULNS` list with a comment documenting the justification and when to remove the exclusion (when sigstore drops the openpgp dependency).

## Type of change

- [x] CI/CD fix

## Test plan

- [x] The suppression logic is already proven by the existing `GO-2026-5037`/`5038`/`5039` exclusions using the same mechanism