### PR TITLE
Add Codex CLI direct-mode support to thv llm setup

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -235,8 +235,8 @@ func newLLMSetupCommand() *cobra.Command {
 		Use:   "setup",
 		Short: "Configure detected AI tools to use the LLM gateway",
 		Long: `Detect installed AI tools (Claude Code, Gemini CLI, Cursor, VS Code, Xcode,
-Claude Desktop) and patch each tool's configuration to route through the LLM
-gateway.
+Claude Desktop, Codex) and patch each tool's configuration to route through the
+LLM gateway.
 
 Token-helper tools (Claude Code, Gemini CLI) are configured to call
 "thv llm token" to obtain a fresh OIDC token on demand.
@@ -245,6 +245,10 @@ Claude Desktop is configured via its third-party inference credential helper,
 which also calls "thv llm token". It reads its configuration only at launch, so
 fully quit and relaunch it after setup. Pass --models to list the models it
 should offer until the gateway serves model discovery itself.
+
+Codex is configured with a custom model_provider in ~/.codex/config.toml whose
+auth command invokes "thv llm token" directly (no shell), keeping the existing
+model_providers and mcp_servers entries in that file untouched.
 
 Proxy-mode tools (Cursor, VS Code, Xcode) are configured to send requests to
 the localhost reverse proxy started by "thv llm proxy start".

--- a/docs/cli/thv_llm_setup.md
+++ b/docs/cli/thv_llm_setup.md
@@ -16,8 +16,8 @@ Configure detected AI tools to use the LLM gateway
 ### Synopsis
 
 Detect installed AI tools (Claude Code, Gemini CLI, Cursor, VS Code, Xcode,
-Claude Desktop) and patch each tool's configuration to route through the LLM
-gateway.
+Claude Desktop, Codex) and patch each tool's configuration to route through the
+LLM gateway.
 
 Token-helper tools (Claude Code, Gemini CLI) are configured to call
 "thv llm token" to obtain a fresh OIDC token on demand.
@@ -26,6 +26,10 @@ Claude Desktop is configured via its third-party inference credential helper,
 which also calls "thv llm token". It reads its configuration only at launch, so
 fully quit and relaunch it after setup. Pass --models to list the models it
 should offer until the gateway serves model discovery itself.
+
+Codex is configured with a custom model_provider in ~/.codex/config.toml whose
+auth command invokes "thv llm token" directly (no shell), keeping the existing
+model_providers and mcp_servers entries in that file untouched.
 
 Proxy-mode tools (Cursor, VS Code, Xcode) are configured to send requests to
 the localhost reverse proxy started by "thv llm proxy start".

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -917,6 +917,12 @@ var supportedClientIntegrations = []clientAppConfig{
 		// reference it with a relative "./toolhive/<name>" source.
 		PluginsGlobalPath:  []string{".agents", "plugins", "toolhive"},
 		PluginsProjectPath: []string{".agents", "plugins", "toolhive"},
+		// LLM gateway: patches the same config.toml its MCP config uses, via a
+		// dedicated TOML writer (llm_gateway_codex.go) rather than LLMGatewayKeys.
+		LLMGatewayMode:     llmgateway.ModeCodexAuth,
+		LLMBinaryName:      "codex",
+		LLMSettingsFile:    "config.toml",
+		LLMSettingsRelPath: []string{".codex"},
 	},
 	{
 		ClientType:           KimiCli,

--- a/pkg/client/llm_gateway.go
+++ b/pkg/client/llm_gateway.go
@@ -46,6 +46,11 @@ func (cm *ClientManager) ConfigureLLMGateway(clientType ClientApp, cfg llmgatewa
 	if appCfg.LLMGatewayMode == llmgateway.ModeCredentialHelper {
 		return cm.configureCredentialHelper(appCfg, cfg)
 	}
+	// Codex's config is TOML, not JSON, and authenticates via a command-backed
+	// bearer token rather than JSON-Pointer keys; dispatch to its writer.
+	if appCfg.LLMGatewayMode == llmgateway.ModeCodexAuth {
+		return cm.configureCodexAuth(appCfg, cfg)
+	}
 
 	path := cm.buildLLMSettingsPath(appCfg)
 
@@ -178,7 +183,18 @@ func (cm *ClientManager) RevertLLMGateway(clientType ClientApp, configPath strin
 	if appCfg.LLMGatewayMode == llmgateway.ModeCredentialHelper {
 		return cm.revertCredentialHelper(appCfg, configPath)
 	}
+	// Codex reverts via its dedicated TOML writer.
+	if appCfg.LLMGatewayMode == llmgateway.ModeCodexAuth {
+		return cm.revertCodexAuth(appCfg, configPath)
+	}
 
+	return revertJSONPointerGateway(appCfg, configPath)
+}
+
+// revertJSONPointerGateway removes appCfg.LLMGatewayKeys from configPath, the
+// JSON-Pointer-based revert path shared by every LLM-gateway mode except
+// ModeCredentialHelper and ModeCodexAuth (which use dedicated writers).
+func revertJSONPointerGateway(appCfg *clientAppConfig, configPath string) error {
 	// Guard against a missing file (or deleted parent directory) before trying
 	// to acquire the lock — WithFileLock creates configPath+".lock", which
 	// fails when the directory no longer exists.

--- a/pkg/client/llm_gateway_codex.go
+++ b/pkg/client/llm_gateway_codex.go
@@ -62,7 +62,13 @@ func (cm *ClientManager) configureCodexAuth(appCfg *clientAppConfig, cfg llmgate
 
 		config["model_provider"] = codexProviderID
 
-		providers, _ := config["model_providers"].(map[string]any)
+		// Refuse to overwrite a pre-existing model_providers that isn't a table
+		// (malformed file, or a future Codex schema): clobbering it would silently
+		// destroy the user's config. The revert path makes the same ok check.
+		providers, ok := config["model_providers"].(map[string]any)
+		if existing, present := config["model_providers"]; present && !ok {
+			return fmt.Errorf("existing model_providers in %s is not a table (%T); refusing to overwrite", path, existing)
+		}
 		if providers == nil {
 			providers = map[string]any{}
 		}
@@ -77,6 +83,10 @@ func (cm *ClientManager) configureCodexAuth(appCfg *clientAppConfig, cfg llmgate
 			"auth": map[string]any{
 				"command": cfg.TokenHelperPath,
 				"args":    cfg.TokenHelperArgs,
+				// How often Codex re-invokes the token helper. Kept in sync with the
+				// TTL the other clients write (see pkg/llmgateway constants) so the
+				// token source's preemptive-refresh invariant holds for Codex too.
+				"refresh_interval_ms": llmgateway.CodexHelperTTL.Milliseconds(),
 			},
 		}
 		config["model_providers"] = providers
@@ -95,6 +105,11 @@ func (cm *ClientManager) configureCodexAuth(appCfg *clientAppConfig, cfg llmgate
 // changed since setup (by the user or another tool) is left alone, mirroring
 // revertCredentialHelper's appliedId check for Claude Desktop. A missing file
 // is treated as already-reverted.
+//
+// Revert removes model_provider rather than restoring whatever it was before
+// setup: configureCodexAuth does not stash the prior selection, so a user who
+// had e.g. model_provider = "openai" before setup is left with none after
+// revert (Codex then falls back to its own default).
 func (*ClientManager) revertCodexAuth(_ *clientAppConfig, configPath string) error {
 	if configPath == "" || !fileExistsAt(configPath) {
 		return nil

--- a/pkg/client/llm_gateway_codex.go
+++ b/pkg/client/llm_gateway_codex.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stacklok/toolhive/pkg/fileutils"
+	"github.com/stacklok/toolhive/pkg/llmgateway"
+)
+
+// Codex's LLM gateway config lives in the same config.toml its MCP-server
+// registration already uses (~/.codex/config.toml). Unlike the JSON-Pointer
+// LLMGatewayKeys clients, Codex authenticates via a command-backed bearer
+// token ([model_providers.<id>.auth]), so it gets a dedicated TOML writer
+// here rather than going through the hujson JSON-Pointer machinery, which
+// cannot write TOML at all.
+
+// codexProviderID is the stable table name ToolHive owns under
+// [model_providers.<id>]. Reusing a fixed id (rather than minting one per
+// run) keeps repeated "thv llm setup" calls idempotent and avoids orphaned
+// tables, mirroring the fixed-name approach configureCredentialHelper uses
+// for Claude Desktop's _meta.json entry.
+const codexProviderID = "toolhive-gateway"
+
+// configureCodexAuth writes (or updates) ToolHive's model_provider entry in
+// Codex's config.toml: a custom provider pointed at the LLM gateway,
+// authenticated via a command that invokes "thv llm token". Any other
+// model_providers entries and the mcp_servers table (used by the unrelated
+// MCP-client feature) are left untouched. Returns the config file path, which
+// RevertLLMGateway later passes back to revertCodexAuth.
+func (cm *ClientManager) configureCodexAuth(appCfg *clientAppConfig, cfg llmgateway.ApplyConfig) (string, error) {
+	path := cm.buildLLMSettingsPath(appCfg)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
+	}
+
+	err := fileutils.WithFileLock(path, func() error {
+		config, err := readTOMLConfig(path)
+		if err != nil {
+			return err
+		}
+
+		config["model_provider"] = codexProviderID
+
+		providers, _ := config["model_providers"].(map[string]any)
+		if providers == nil {
+			providers = map[string]any{}
+		}
+		providers[codexProviderID] = map[string]any{
+			"name": "ToolHive Gateway",
+			// Codex's Responses-API client appends "/responses" directly to
+			// base_url (the same convention OpenAI's own base_url="…/v1" uses),
+			// so the gateway's "/v1" prefix must be baked in here rather than
+			// left to the caller like AnthropicBaseURL's optional prefix.
+			"base_url": strings.TrimSuffix(cfg.GatewayURL, "/") + "/v1",
+			"wire_api": "responses",
+			"auth": map[string]any{
+				"command": cfg.TokenHelperPath,
+				"args":    cfg.TokenHelperArgs,
+			},
+		}
+		config["model_providers"] = providers
+
+		return writeTOMLConfig(path, config)
+	})
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// revertCodexAuth undoes configureCodexAuth: it removes ToolHive's
+// model_providers.<id> table (leaving any other providers untouched) and
+// clears model_provider only if it still points at ToolHive's entry — a value
+// changed since setup (by the user or another tool) is left alone, mirroring
+// revertCredentialHelper's appliedId check for Claude Desktop. A missing file
+// is treated as already-reverted.
+func (*ClientManager) revertCodexAuth(_ *clientAppConfig, configPath string) error {
+	if configPath == "" || !fileExistsAt(configPath) {
+		return nil
+	}
+
+	return fileutils.WithFileLock(configPath, func() error {
+		config, err := readTOMLConfig(configPath)
+		if err != nil {
+			return err
+		}
+
+		if providers, ok := config["model_providers"].(map[string]any); ok {
+			delete(providers, codexProviderID)
+			if len(providers) == 0 {
+				delete(config, "model_providers")
+			} else {
+				config["model_providers"] = providers
+			}
+		}
+
+		if provider, ok := config["model_provider"].(string); ok && provider == codexProviderID {
+			delete(config, "model_provider")
+		}
+
+		return writeTOMLConfig(configPath, config)
+	})
+}

--- a/pkg/client/llm_gateway_codex.go
+++ b/pkg/client/llm_gateway_codex.go
@@ -27,6 +27,17 @@ import (
 // for Claude Desktop's _meta.json entry.
 const codexProviderID = "toolhive-gateway"
 
+// codexBaseURL returns gatewayURL with a "/v1" suffix, avoiding a double
+// "/v1/v1" if the configured gateway URL already ends in one (e.g. a gateway
+// mounted behind its own "/v1" path prefix).
+func codexBaseURL(gatewayURL string) string {
+	base := strings.TrimSuffix(gatewayURL, "/")
+	if strings.HasSuffix(base, "/v1") {
+		return base
+	}
+	return base + "/v1"
+}
+
 // configureCodexAuth writes (or updates) ToolHive's model_provider entry in
 // Codex's config.toml: a custom provider pointed at the LLM gateway,
 // authenticated via a command that invokes "thv llm token". Any other
@@ -34,6 +45,10 @@ const codexProviderID = "toolhive-gateway"
 // MCP-client feature) are left untouched. Returns the config file path, which
 // RevertLLMGateway later passes back to revertCodexAuth.
 func (cm *ClientManager) configureCodexAuth(appCfg *clientAppConfig, cfg llmgateway.ApplyConfig) (string, error) {
+	if cfg.TokenHelperPath == "" || len(cfg.TokenHelperArgs) == 0 {
+		return "", fmt.Errorf("codex-auth requires TokenHelperPath and TokenHelperArgs to be set")
+	}
+
 	path := cm.buildLLMSettingsPath(appCfg)
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return "", fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
@@ -57,7 +72,7 @@ func (cm *ClientManager) configureCodexAuth(appCfg *clientAppConfig, cfg llmgate
 			// base_url (the same convention OpenAI's own base_url="…/v1" uses),
 			// so the gateway's "/v1" prefix must be baked in here rather than
 			// left to the caller like AnthropicBaseURL's optional prefix.
-			"base_url": strings.TrimSuffix(cfg.GatewayURL, "/") + "/v1",
+			"base_url": codexBaseURL(cfg.GatewayURL),
 			"wire_api": "responses",
 			"auth": map[string]any{
 				"command": cfg.TokenHelperPath,

--- a/pkg/client/llm_gateway_codex_test.go
+++ b/pkg/client/llm_gateway_codex_test.go
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/llmgateway"
+)
+
+// newCodexManager returns a ClientManager rooted at a temp home with the real
+// Codex integration, plus the resolved config.toml path.
+func newCodexManager(t *testing.T) (*ClientManager, string) {
+	t.Helper()
+	home := t.TempDir()
+	cm := NewTestClientManager(home, nil, supportedClientIntegrations, nil)
+	cfg := cm.lookupClientAppConfig(ClientApp(Codex))
+	require.NotNil(t, cfg, "Codex must be a supported integration")
+	require.Equal(t, llmgateway.ModeCodexAuth, cfg.LLMGatewayMode, "Codex must use the codex-auth model")
+	return cm, cm.buildLLMSettingsPath(cfg)
+}
+
+func codexApplyCfg() llmgateway.ApplyConfig {
+	return llmgateway.ApplyConfig{
+		GatewayURL:      "https://gw.example.com",
+		TokenHelperPath: "/usr/local/bin/thv",
+		TokenHelperArgs: []string{"llm", "token", "--skip-browser"},
+	}
+}
+
+func TestConfigureCodexAuth_WritesProviderAndAuth(t *testing.T) {
+	t.Parallel()
+	cm, configPath := newCodexManager(t)
+
+	path, err := cm.ConfigureLLMGateway(ClientApp(Codex), codexApplyCfg())
+	require.NoError(t, err)
+	assert.Equal(t, configPath, path)
+
+	config, err := readTOMLConfig(configPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, codexProviderID, config["model_provider"])
+	providers, ok := config["model_providers"].(map[string]any)
+	require.True(t, ok)
+	provider, ok := providers[codexProviderID].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "ToolHive Gateway", provider["name"])
+	assert.Equal(t, "https://gw.example.com/v1", provider["base_url"])
+	assert.Equal(t, "responses", provider["wire_api"])
+
+	auth, ok := provider["auth"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "/usr/local/bin/thv", auth["command"])
+	assert.Equal(t, []any{"llm", "token", "--skip-browser"}, auth["args"])
+}
+
+func TestConfigureCodexAuth_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	cm, configPath := newCodexManager(t)
+
+	first, err := cm.ConfigureLLMGateway(ClientApp(Codex), codexApplyCfg())
+	require.NoError(t, err)
+	second, err := cm.ConfigureLLMGateway(ClientApp(Codex), codexApplyCfg())
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+
+	config, err := readTOMLConfig(configPath)
+	require.NoError(t, err)
+	providers, ok := config["model_providers"].(map[string]any)
+	require.True(t, ok)
+	assert.Len(t, providers, 1, "repeated setup must not duplicate the provider entry")
+}
+
+func TestConfigureCodexAuth_PreservesForeignEntries(t *testing.T) {
+	t.Parallel()
+	cm, configPath := newCodexManager(t)
+
+	// Seed a user-owned provider and an unrelated mcp_servers table, the way the
+	// existing MCP-client feature or the user's own edits would.
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o700))
+	seed := map[string]any{
+		"model_providers": map[string]any{
+			"my-bedrock": map[string]any{"name": "My Bedrock"},
+		},
+		"mcp_servers": map[string]any{
+			"github": map[string]any{"command": "docker"},
+		},
+	}
+	require.NoError(t, writeTOMLConfig(configPath, seed))
+
+	_, err := cm.ConfigureLLMGateway(ClientApp(Codex), codexApplyCfg())
+	require.NoError(t, err)
+
+	config, err := readTOMLConfig(configPath)
+	require.NoError(t, err)
+	providers, ok := config["model_providers"].(map[string]any)
+	require.True(t, ok)
+	assert.Len(t, providers, 2, "the foreign provider must survive alongside ours")
+	_, ok = providers["my-bedrock"]
+	assert.True(t, ok, "foreign provider must be untouched")
+
+	mcpServers, ok := config["mcp_servers"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, mcpServers, "github", "unrelated mcp_servers table must be untouched")
+}
+
+func TestRevertCodexAuth_RemovesProviderOnly(t *testing.T) {
+	t.Parallel()
+	cm, configPath := newCodexManager(t)
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o700))
+	seed := map[string]any{
+		"model_providers": map[string]any{
+			"my-bedrock": map[string]any{"name": "My Bedrock"},
+		},
+	}
+	require.NoError(t, writeTOMLConfig(configPath, seed))
+
+	path, err := cm.ConfigureLLMGateway(ClientApp(Codex), codexApplyCfg())
+	require.NoError(t, err)
+
+	require.NoError(t, cm.RevertLLMGateway(ClientApp(Codex), path))
+
+	config, err := readTOMLConfig(configPath)
+	require.NoError(t, err)
+	_, hasProvider := config["model_provider"]
+	assert.False(t, hasProvider, "model_provider must be cleared since it pointed at ours")
+	providers, ok := config["model_providers"].(map[string]any)
+	require.True(t, ok)
+	assert.Len(t, providers, 1, "only our provider entry should be removed")
+	_, ok = providers["my-bedrock"]
+	assert.True(t, ok, "foreign provider must survive revert")
+}
+
+func TestRevertCodexAuth_LeavesForeignModelProviderIntact(t *testing.T) {
+	t.Parallel()
+	cm, configPath := newCodexManager(t)
+
+	path, err := cm.ConfigureLLMGateway(ClientApp(Codex), codexApplyCfg())
+	require.NoError(t, err)
+
+	// Simulate the user (or another tool) selecting a different provider after setup.
+	config, err := readTOMLConfig(configPath)
+	require.NoError(t, err)
+	config["model_provider"] = "my-bedrock"
+	require.NoError(t, writeTOMLConfig(configPath, config))
+
+	require.NoError(t, cm.RevertLLMGateway(ClientApp(Codex), path))
+
+	config, err = readTOMLConfig(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "my-bedrock", config["model_provider"], "a changed selection must not be clobbered by revert")
+}
+
+func TestRevertCodexAuth_MissingFileIsNoOp(t *testing.T) {
+	t.Parallel()
+	cm, configPath := newCodexManager(t)
+
+	require.NoError(t, cm.RevertLLMGateway(ClientApp(Codex), configPath))
+	assert.NoFileExists(t, configPath)
+}

--- a/pkg/client/llm_gateway_codex_test.go
+++ b/pkg/client/llm_gateway_codex_test.go
@@ -158,6 +158,36 @@ func TestRevertCodexAuth_LeavesForeignModelProviderIntact(t *testing.T) {
 	assert.Equal(t, "my-bedrock", config["model_provider"], "a changed selection must not be clobbered by revert")
 }
 
+func TestConfigureCodexAuth_RejectsMissingTokenHelper(t *testing.T) {
+	t.Parallel()
+	cm, _ := newCodexManager(t)
+
+	_, err := cm.ConfigureLLMGateway(ClientApp(Codex), llmgateway.ApplyConfig{
+		GatewayURL: "https://gw.example.com",
+	})
+	require.Error(t, err)
+}
+
+func TestCodexBaseURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		gatewayURL string
+		want       string
+	}{
+		{"appends v1", "https://gw.example.com", "https://gw.example.com/v1"},
+		{"trims trailing slash before appending", "https://gw.example.com/", "https://gw.example.com/v1"},
+		{"does not double-append existing v1 suffix", "https://gw.example.com/v1", "https://gw.example.com/v1"},
+		{"does not double-append with trailing slash", "https://gw.example.com/v1/", "https://gw.example.com/v1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, codexBaseURL(tt.gatewayURL))
+		})
+	}
+}
+
 func TestRevertCodexAuth_MissingFileIsNoOp(t *testing.T) {
 	t.Parallel()
 	cm, configPath := newCodexManager(t)

--- a/pkg/client/llm_gateway_codex_test.go
+++ b/pkg/client/llm_gateway_codex_test.go
@@ -58,6 +58,25 @@ func TestConfigureCodexAuth_WritesProviderAndAuth(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "/usr/local/bin/thv", auth["command"])
 	assert.Equal(t, []any{"llm", "token", "--skip-browser"}, auth["args"])
+	assert.Equal(t, llmgateway.CodexHelperTTL.Milliseconds(), auth["refresh_interval_ms"],
+		"refresh_interval_ms keeps Codex's token-helper cadence in sync with the refresh window")
+}
+
+func TestConfigureCodexAuth_RejectsNonTableModelProviders(t *testing.T) {
+	t.Parallel()
+	cm, configPath := newCodexManager(t)
+
+	// A malformed (or future-schema) config where model_providers is not a table.
+	// Setup must refuse rather than silently overwrite the user's value.
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o700))
+	require.NoError(t, writeTOMLConfig(configPath, map[string]any{"model_providers": "garbage"}))
+
+	_, err := cm.ConfigureLLMGateway(ClientApp(Codex), codexApplyCfg())
+	require.Error(t, err)
+
+	config, err := readTOMLConfig(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "garbage", config["model_providers"], "the user's original value must be left untouched")
 }
 
 func TestConfigureCodexAuth_IsIdempotent(t *testing.T) {

--- a/pkg/llm/config.go
+++ b/pkg/llm/config.go
@@ -42,7 +42,8 @@ type ProxyConfig struct {
 type ToolConfig struct {
 	// Tool is the canonical tool identifier (e.g. "claude-code", "cursor").
 	Tool string `yaml:"tool" json:"tool"`
-	// Mode is the authentication mode: "direct" or "proxy".
+	// Mode is the authentication mode: one of the llmgateway.Mode* values
+	// ("direct", "proxy", "credential-helper", "codex-auth").
 	Mode string `yaml:"mode" json:"mode"`
 	// ConfigPath is the absolute path to the tool's config file that was patched.
 	ConfigPath string `yaml:"config_path" json:"config_path"`

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -87,15 +87,6 @@ func Setup(
 		return fmt.Errorf("LLM gateway is not configured — run \"thv llm config set\" first")
 	}
 
-	tokenHelperCommand, err := buildTokenHelperCommand()
-	if err != nil {
-		return err
-	}
-	tokenHelperPath, tokenHelperArgs, err := buildTokenHelperArgv()
-	if err != nil {
-		return err
-	}
-
 	proxyBaseURL := fmt.Sprintf("http://localhost:%d/v1", llmCfg.EffectiveProxyPort())
 
 	// Detect tools before login so we skip the interactive browser flow when
@@ -109,6 +100,21 @@ func Setup(
 	if len(detected) == 0 {
 		_, _ = fmt.Fprintln(out, "No supported AI tools detected.")
 		return nil
+	}
+
+	// Only build the shell-string token helper if a detected tool actually
+	// consumes it — its shell-safety check on the thv executable path would
+	// otherwise fail setup for e.g. a Codex-only run, which never uses it.
+	var tokenHelperCommand string
+	if tokenHelperCommandNeeded(gm, detected) {
+		tokenHelperCommand, err = buildTokenHelperCommand()
+		if err != nil {
+			return err
+		}
+	}
+	tokenHelperPath, tokenHelperArgs, err := buildTokenHelperArgv()
+	if err != nil {
+		return err
 	}
 
 	// In lazy mode the interactive login is deferred until a configured tool
@@ -473,6 +479,20 @@ func probeAnthropicPrefix(ctx context.Context, gatewayURL string, tlsSkipVerify 
 		return "/anthropic"
 	}
 	return ""
+}
+
+// tokenHelperCommandNeeded reports whether any detected client's mode consumes
+// the shell-string token helper (TokenHelperCommand) — direct-mode's
+// apiKeyHelper-style JSON-Pointer clients and Claude Desktop's credential
+// helper. Proxy-mode tools and Codex (argv-based auth) never use it.
+func tokenHelperCommandNeeded(gm GatewayManager, detected []string) bool {
+	for _, clientType := range detected {
+		switch gm.LLMGatewayModeFor(clientType) {
+		case llmgateway.ModeDirect, llmgateway.ModeCredentialHelper:
+			return true
+		}
+	}
+	return false
 }
 
 // buildTokenHelperCommand returns the shell command string used as the

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -91,6 +91,10 @@ func Setup(
 	if err != nil {
 		return err
 	}
+	tokenHelperPath, tokenHelperArgs, err := buildTokenHelperArgv()
+	if err != nil {
+		return err
+	}
 
 	proxyBaseURL := fmt.Sprintf("http://localhost:%d/v1", llmCfg.EffectiveProxyPort())
 
@@ -134,7 +138,7 @@ func Setup(
 
 	configured, err := configureDetectedTools(
 		out, errOut, gm, detected, llmCfg.GatewayURL, proxyBaseURL, tokenHelperCommand,
-		llmCfg.TLSSkipVerify, anthropicPrefix, models,
+		tokenHelperPath, tokenHelperArgs, llmCfg.TLSSkipVerify, anthropicPrefix, models,
 	)
 	if err != nil {
 		return err
@@ -315,6 +319,11 @@ func warnTLSSkipVerify(errOut io.Writer, skip bool, configured []ToolConfig) {
 					"Warning: %s uses proxy mode — TLS certificate verification is disabled for the "+
 						"proxy's upstream gateway connection only. Use only in isolated local environments.\n", tc.Tool)
 			}
+		case llmgateway.ModeCodexAuth:
+			_, _ = fmt.Fprintf(errOut,
+				"Note: --tls-skip-verify is not supported for Codex "+
+					"(its config.toml has no documented TLS-skip option). "+
+					"Ensure your gateway certificate is trusted by the system store instead.\n")
 		}
 	}
 }
@@ -342,6 +351,7 @@ func configureDetectedTools(
 	gm GatewayManager,
 	detected []string,
 	gatewayURL, proxyBaseURL, tokenHelperCommand string,
+	tokenHelperPath string, tokenHelperArgs []string,
 	tlsSkipVerify bool,
 	anthropicPathPrefix string,
 	models []string,
@@ -368,6 +378,8 @@ func configureDetectedTools(
 			AnthropicBaseURL:   anthropicBaseURL,
 			ProxyBaseURL:       proxyBaseURL,
 			TokenHelperCommand: tokenHelperCommand,
+			TokenHelperPath:    tokenHelperPath,
+			TokenHelperArgs:    tokenHelperArgs,
 			TLSSkipVerify:      tlsSkipVerify,
 			Models:             models,
 		}
@@ -488,6 +500,20 @@ func buildTokenHelperCommand() (string, error) {
 				"(Windows paths are not supported by thv llm setup)", self)
 	}
 	return fmt.Sprintf(`"%s" llm token`, self), nil
+}
+
+// buildTokenHelperArgv returns the argv-form of the token helper, for config
+// formats that invoke an executable directly (no shell) — e.g. Codex's
+// [model_providers.<id>.auth] command/args table. Since args are passed as a
+// TOML array rather than interpolated into a shell string, no shell-metacharacter
+// validation is needed. --skip-browser is always included since Codex has no
+// interactive-context signal like Claude Desktop's credential-helper shim.
+func buildTokenHelperArgv() (string, []string, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return "", nil, fmt.Errorf("resolving thv executable path: %w", err)
+	}
+	return self, []string{"llm", "token", "--skip-browser"}, nil
 }
 
 // usesAnthropicBaseURL reports whether a client mode consumes the Anthropic base

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -308,13 +308,13 @@ func warnTLSSkipVerify(errOut io.Writer, skip bool, configured []ToolConfig) {
 	}
 	for _, tc := range configured {
 		switch tc.Mode {
-		case "direct":
+		case llmgateway.ModeDirect:
 			_, _ = fmt.Fprintf(errOut,
 				"Warning: %s uses direct mode — NODE_TLS_REJECT_UNAUTHORIZED=0 has been written to its "+
 					"settings, disabling TLS certificate verification for ALL of %s's outbound connections "+
 					"(LLM provider APIs, MCP registry, etc.), not just the LLM gateway. "+
 					"Use only in isolated local environments.\n", tc.Tool, tc.Tool)
-		case "proxy":
+		case llmgateway.ModeProxy:
 			if tc.Tool == "gemini-cli" {
 				_, _ = fmt.Fprintf(errOut,
 					"Note: --tls-skip-verify is not supported for Gemini CLI "+

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -327,9 +327,9 @@ func warnTLSSkipVerify(errOut io.Writer, skip bool, configured []ToolConfig) {
 			}
 		case llmgateway.ModeCodexAuth:
 			_, _ = fmt.Fprintf(errOut,
-				"Note: --tls-skip-verify is not supported for Codex "+
-					"(its config.toml has no documented TLS-skip option). "+
-					"Ensure your gateway certificate is trusted by the system store instead.\n")
+				"Warning: --tls-skip-verify was NOT applied to %s — its config.toml has no "+
+					"TLS-skip option. Codex will fail against a self-signed gateway until you "+
+					"trust the certificate in the system store.\n", tc.Tool)
 		}
 	}
 }

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -424,12 +424,14 @@ func TestBuildTokenHelperArgv(t *testing.T) {
 	assert.Equal(t, []string{"llm", "token", "--skip-browser"}, args)
 }
 
-func TestWarnTLSSkipVerify_CodexNote(t *testing.T) {
+func TestWarnTLSSkipVerify_CodexWarning(t *testing.T) {
 	t.Parallel()
 
 	var errOut bytes.Buffer
 	warnTLSSkipVerify(&errOut, true, []ToolConfig{{Tool: "codex", Mode: llmgateway.ModeCodexAuth}})
-	assert.Contains(t, errOut.String(), "not supported for Codex")
+	out := errOut.String()
+	assert.Contains(t, out, "Warning:")
+	assert.Contains(t, out, "was NOT applied to codex")
 }
 
 // ── probeAnthropicPrefix ──────────────────────────────────────────────────────

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -348,6 +348,73 @@ func TestConfigureDetectedTools_PrefixNotAppliedForProxyMode(t *testing.T) {
 	assert.Empty(t, gm.applied[0].AnthropicBaseURL)
 }
 
+func TestTokenHelperCommandNeeded(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		modes    map[string]string
+		detected []string
+		want     bool
+	}{
+		{
+			name:     "codex-only run never needs the shell-string helper",
+			modes:    map[string]string{"codex": llmgateway.ModeCodexAuth},
+			detected: []string{"codex"},
+			want:     false,
+		},
+		{
+			name:     "proxy-only run never needs the shell-string helper",
+			modes:    map[string]string{"cursor": llmgateway.ModeProxy},
+			detected: []string{"cursor"},
+			want:     false,
+		},
+		{
+			name:     "direct mode needs it",
+			modes:    map[string]string{"claude-code": llmgateway.ModeDirect},
+			detected: []string{"claude-code"},
+			want:     true,
+		},
+		{
+			name:     "credential-helper mode needs it",
+			modes:    map[string]string{"claude-desktop": llmgateway.ModeCredentialHelper},
+			detected: []string{"claude-desktop"},
+			want:     true,
+		},
+		{
+			name: "any detected tool needing it is enough",
+			modes: map[string]string{
+				"codex":       llmgateway.ModeCodexAuth,
+				"claude-code": llmgateway.ModeDirect,
+			},
+			detected: []string{"codex", "claude-code"},
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gm := &modeLookupGatewayManager{modes: tt.modes}
+			assert.Equal(t, tt.want, tokenHelperCommandNeeded(gm, tt.detected))
+		})
+	}
+}
+
+// modeLookupGatewayManager is a minimal GatewayManager whose LLMGatewayModeFor
+// returns a per-client mode from a fixed map, for tokenHelperCommandNeeded tests.
+type modeLookupGatewayManager struct{ modes map[string]string }
+
+func (*modeLookupGatewayManager) DetectedLLMGatewayClients() []string { return nil }
+func (*modeLookupGatewayManager) ConfigureLLMGateway(_ string, _ llmgateway.ApplyConfig) (string, error) {
+	return "", nil
+}
+func (g *modeLookupGatewayManager) LLMGatewayModeFor(c string) string { return g.modes[c] }
+func (*modeLookupGatewayManager) IsManaged(_ string) bool             { return false }
+func (*modeLookupGatewayManager) ConfigureEnvFile(_ string, _ llmgateway.ApplyConfig) (string, error) {
+	return "", nil
+}
+func (*modeLookupGatewayManager) RevertEnvFile(_, _ string) error    { return nil }
+func (*modeLookupGatewayManager) RevertLLMGateway(_, _ string) error { return nil }
+
 func TestBuildTokenHelperArgv(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -297,6 +297,7 @@ func TestConfigureDetectedTools_PathPrefixAppendedForDirectMode(t *testing.T) {
 		&out, &errOut, gm,
 		[]string{"claude-code"},
 		"https://gw.example.com", "http://localhost:14000/v1", `"thv" llm token`,
+		"/usr/local/bin/thv", []string{"llm", "token", "--skip-browser"},
 		false, "/anthropic", nil,
 	)
 	require.NoError(t, err)
@@ -317,6 +318,7 @@ func TestConfigureDetectedTools_NoPrefixWhenEmpty(t *testing.T) {
 		&out, &errOut, gm,
 		[]string{"claude-code"},
 		"https://gw.example.com", "http://localhost:14000/v1", `"thv" llm token`,
+		"/usr/local/bin/thv", []string{"llm", "token", "--skip-browser"},
 		false, "", nil, // no prefix
 	)
 	require.NoError(t, err)
@@ -336,6 +338,7 @@ func TestConfigureDetectedTools_PrefixNotAppliedForProxyMode(t *testing.T) {
 		&out, &errOut, gm,
 		[]string{"cursor"},
 		"https://gw.example.com", "http://localhost:14000/v1", `"thv" llm token`,
+		"/usr/local/bin/thv", []string{"llm", "token", "--skip-browser"},
 		false, "/anthropic", nil,
 	)
 	require.NoError(t, err)
@@ -343,6 +346,23 @@ func TestConfigureDetectedTools_PrefixNotAppliedForProxyMode(t *testing.T) {
 
 	// Proxy-mode tools must never receive an AnthropicBaseURL.
 	assert.Empty(t, gm.applied[0].AnthropicBaseURL)
+}
+
+func TestBuildTokenHelperArgv(t *testing.T) {
+	t.Parallel()
+
+	path, args, err := buildTokenHelperArgv()
+	require.NoError(t, err)
+	assert.NotEmpty(t, path)
+	assert.Equal(t, []string{"llm", "token", "--skip-browser"}, args)
+}
+
+func TestWarnTLSSkipVerify_CodexNote(t *testing.T) {
+	t.Parallel()
+
+	var errOut bytes.Buffer
+	warnTLSSkipVerify(&errOut, true, []ToolConfig{{Tool: "codex", Mode: llmgateway.ModeCodexAuth}})
+	assert.Contains(t, errOut.String(), "not supported for Codex")
 }
 
 // ── probeAnthropicPrefix ──────────────────────────────────────────────────────

--- a/pkg/llmgateway/config.go
+++ b/pkg/llmgateway/config.go
@@ -52,6 +52,12 @@ const (
 	// ModeCredentialHelper routes traffic through a document + selector +
 	// helper-script model (Claude Desktop's third-party inference surface).
 	ModeCredentialHelper = "credential-helper" //nolint:gosec // G101: mode identifier, not a credential
+	// ModeCodexAuth routes traffic through a custom model_provider written into
+	// Codex's TOML config, using Codex's command-backed bearer-token auth
+	// ([model_providers.<id>.auth]) to invoke the token helper directly (no
+	// shell), rather than the JSON-Pointer LLMGatewayKeys mechanism the other
+	// modes share.
+	ModeCodexAuth = "codex-auth" //nolint:gosec // G101: mode identifier, not a credential
 )
 
 // ProxyOriginOf returns rawURL with its path, query, fragment, and userinfo
@@ -85,7 +91,12 @@ type ApplyConfig struct {
 	AnthropicBaseURL   string // direct-mode: effective ANTHROPIC_BASE_URL (gateway + optional path prefix)
 	ProxyBaseURL       string // proxy-mode: URL of the localhost reverse proxy
 	TokenHelperCommand string // direct-mode: shell command that prints a fresh token
-	TLSSkipVerify      bool   // when true, instruct the tool to skip TLS verification
+	// TokenHelperPath and TokenHelperArgs are the argv-form of the token helper,
+	// for config formats where auth invokes an executable directly (no shell) —
+	// e.g. Codex's [model_providers.<id>.auth] command/args table.
+	TokenHelperPath string
+	TokenHelperArgs []string
+	TLSSkipVerify   bool // when true, instruct the tool to skip TLS verification
 	// Models is the optional explicit model list written to clients that support
 	// a model override (e.g. Claude Desktop's inferenceModels). Empty means the
 	// client falls back to gateway-side model auto-discovery.

--- a/pkg/llmgateway/config.go
+++ b/pkg/llmgateway/config.go
@@ -39,6 +39,13 @@ const ClaudeDesktopHelperTTL = ClaudeCodeHelperTTL
 // performs up front so the steady-state helper call stays fast.
 const ClaudeDesktopHelperTimeout = 30 * time.Second
 
+// CodexHelperTTL is written to config.toml as
+// [model_providers.<id>.auth].refresh_interval_ms: how often Codex re-invokes
+// the token helper ("thv llm token"). Kept equal to ClaudeCodeHelperTTL so the
+// same LLMTokenRefreshWindow invariant holds — every invocation in the final
+// window forces a refresh, so Codex never receives an about-to-expire token.
+const CodexHelperTTL = ClaudeCodeHelperTTL
+
 // LLM gateway client modes. The single source of truth dispatched on in
 // pkg/client (ConfigureLLMGateway/RevertLLMGateway) and pkg/llm
 // (usesAnthropicBaseURL/warnCredentialHelperTools). Kept here so both packages

--- a/pkg/llmgateway/config_test.go
+++ b/pkg/llmgateway/config_test.go
@@ -28,6 +28,10 @@ func TestRefreshWindowExceedsHelperTTL(t *testing.T) {
 	assert.Equal(t, int64(300000), llmgateway.ClaudeCodeHelperTTL.Milliseconds(),
 		"helper TTL is written to settings.json in milliseconds")
 	assert.Equal(t, 10*time.Minute, llmgateway.LLMTokenRefreshWindow)
+
+	// Codex writes refresh_interval_ms and relies on the same invariant.
+	assert.Greater(t, llmgateway.LLMTokenRefreshWindow, llmgateway.CodexHelperTTL,
+		"refresh window must exceed Codex's helper TTL for the same reason it exceeds Claude Code's")
 }
 
 func TestProxyOriginOf(t *testing.T) {

--- a/test/e2e/cli_llm_all_clients_test.go
+++ b/test/e2e/cli_llm_all_clients_test.go
@@ -16,6 +16,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pelletier/go-toml/v2"
 
 	"github.com/stacklok/toolhive/pkg/auth/tokensource"
 	"github.com/stacklok/toolhive/pkg/llm"
@@ -1060,6 +1061,90 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				Expect(meta["entries"]).To(BeEmpty(), "ToolHive entry should be removed after teardown")
 				_, shimStatErr := os.Stat(shim)
 				Expect(os.IsNotExist(shimStatErr)).To(BeTrue(), "shim should be deleted after teardown")
+
+				showOut, _ = thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+				cfg = llm.Config{}
+				Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+				Expect(cfg.ConfiguredTools).To(BeEmpty(),
+					"ConfiguredTools should be empty after teardown")
+			})
+		})
+
+		Describe("codex (codex-auth) setup and teardown", func() {
+			// Codex's LLM gateway config lives in ~/.codex/config.toml, patched via a
+			// dedicated TOML writer (auth is a command/args table, not a JSON pointer
+			// key), so it gets its own assertions rather than the allClientTestCases
+			// matrix, which only understands JSON.
+			readCodexConfig := func(configPath string) map[string]any {
+				data, err := os.ReadFile(configPath)
+				Expect(err).ToNot(HaveOccurred(), "config.toml should exist")
+				var config map[string]any
+				Expect(toml.Unmarshal(data, &config)).To(Succeed())
+				return config
+			}
+
+			It("writes the model_provider and auth command, then reverts them", func() {
+				issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+				codexDir := filepath.Join(tempDir, ".codex")
+				configPath := filepath.Join(codexDir, "config.toml")
+
+				By("creating the .codex directory and codex binary so detection succeeds")
+				Expect(os.MkdirAll(codexDir, 0750)).To(Succeed())
+				Expect(createFakeBinary(binDir, "codex")).To(Succeed())
+
+				By("running thv llm setup --client codex")
+				stdout, stderr, err := runSetupWithOIDCCompletion(
+					thvCmd, oidcServer,
+					"--client", "codex",
+					"--gateway-url", gatewayURL,
+					"--issuer", issuerURL,
+					"--client-id", clientID,
+				)
+				Expect(err).ToNot(HaveOccurred(),
+					"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+				By("verifying config.toml contains the toolhive-gateway provider")
+				config := readCodexConfig(configPath)
+				Expect(config["model_provider"]).To(Equal("toolhive-gateway"))
+				providers, ok := config["model_providers"].(map[string]any)
+				Expect(ok).To(BeTrue(), "model_providers table should exist")
+				provider, ok := providers["toolhive-gateway"].(map[string]any)
+				Expect(ok).To(BeTrue(), "model_providers.toolhive-gateway table should exist")
+				Expect(provider["name"]).To(Equal("ToolHive Gateway"))
+				Expect(provider["base_url"]).To(Equal(gatewayURL + "/v1"))
+				Expect(provider["wire_api"]).To(Equal("responses"))
+
+				auth, ok := provider["auth"].(map[string]any)
+				Expect(ok).To(BeTrue(), "model_providers.toolhive-gateway.auth table should exist")
+				Expect(auth["command"]).ToNot(BeEmpty(), "auth.command should point at the thv executable")
+				args, ok := auth["args"].([]any)
+				Expect(ok).To(BeTrue(), "auth.args should be an array")
+				Expect(args).To(Equal([]any{"llm", "token", "--skip-browser"}))
+
+				By("verifying config show lists codex in codex-auth mode")
+				showOut, _ := thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+				var cfg llm.Config
+				Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+				var found bool
+				for _, toolCfg := range cfg.ConfiguredTools {
+					if string(toolCfg.Tool) == "codex" {
+						found = true
+						Expect(toolCfg.Mode).To(Equal("codex-auth"))
+					}
+				}
+				Expect(found).To(BeTrue(), "codex should appear in ConfiguredTools")
+
+				By("running thv llm teardown codex")
+				thvCmd("llm", "teardown", "codex").ExpectSuccess()
+
+				By("verifying model_provider and the toolhive-gateway table were removed")
+				config = readCodexConfig(configPath)
+				_, hasModelProvider := config["model_provider"]
+				Expect(hasModelProvider).To(BeFalse(), "model_provider should be cleared after teardown")
+				if providers, ok := config["model_providers"].(map[string]any); ok {
+					_, stillPresent := providers["toolhive-gateway"]
+					Expect(stillPresent).To(BeFalse(), "toolhive-gateway provider should be removed after teardown")
+				}
 
 				showOut, _ = thvCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
 				cfg = llm.Config{}


### PR DESCRIPTION
## Summary

Codex CLI isn't a supported target for `thv llm setup` yet — it can't be
pointed at the LLM gateway the way Claude Code, Cursor, and other clients
already are. This adds direct-mode support for Codex.

- Codex gets a custom `model_provider` entry written into its
  `~/.codex/config.toml` (the same file its MCP-server registration already
  uses), authenticated via a command-backed bearer token
  (`[model_providers.<id>.auth]` invoking `thv llm token --skip-browser`)
  rather than a static API key — mirroring Claude Code's `apiKeyHelper`,
  but shaped for Codex's TOML/argv config instead of JSON/shell-string.
- Codex's Responses-API client appends `/responses` directly onto
  `base_url` (the same convention OpenAI's own `base_url=".../v1"` follows),
  so the gateway's `/v1` prefix is baked into `base_url` at write time
  rather than left to Codex to add.
- Setup/teardown are idempotent and preserve any other `model_providers.*`
  entries or `mcp_servers` config already in the file; revert only clears
  ToolHive's own provider and only clears `model_provider` if it still
  points at ours.
- New dedicated TOML writer (`pkg/client/llm_gateway_codex.go`) since
  Codex's config format and auth shape don't fit the existing JSON-Pointer
  `LLMGatewayKeys` mechanism the other direct-mode clients share.

Closes #5783

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manually ran `thv llm setup --client codex` and `thv llm teardown --client codex`
against a live gateway, confirming `~/.codex/config.toml` gets the expected
`model_provider`/`model_providers.toolhive-gateway` table on setup and a clean
removal (with foreign entries untouched) on teardown.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

# Add Codex CLI direct-mode support to `thv llm setup` (#5783)

**Why**: `thv llm setup` doesn't support Codex CLI yet. We're adding direct mode: Codex's `~/.codex/config.toml` gets a custom `model_provider` pointed at the gateway, using Codex's command-backed auth (`[model_providers.<id>.auth]`) to invoke `thv llm token`, same idea as Claude Code's `apiKeyHelper` but TOML/argv-shaped instead of JSON/shell-string.

**What**:
- `pkg/llmgateway/config.go`: new `ModeCodexAuth` constant; add `TokenHelperPath`/`TokenHelperArgs` to `ApplyConfig` (argv form, vs. Claude Code's shell-string `TokenHelperCommand`).
- `pkg/client/config.go`: give the existing `Codex` client entry `LLMGatewayMode: ModeCodexAuth`, `LLMBinaryName: "codex"`, `LLMSettingsFile/RelPath` pointing at `~/.codex/config.toml` (same file its MCP config already uses).
- `pkg/client/llm_gateway_codex.go` (new): `configureCodexAuth`/`revertCodexAuth`, reusing `readTOMLConfig`/`writeTOMLConfig` from `config_editor.go`. Writes `model_provider = "toolhive-gateway"` + a `model_providers.toolhive-gateway` table (`name`, `base_url`, `wire_api = "responses"`, `auth.command`/`auth.args`), preserving any other `model_providers.*` entries. Revert deletes just that sub-table and clears `model_provider` only if still ours.
- `pkg/client/llm_gateway.go`: add a dispatch branch for `ModeCodexAuth` next to the existing `ModeCredentialHelper` one.
- `pkg/llm/setup.go`: `buildTokenHelperArgv()` (mirrors `buildTokenHelperCommand` but returns argv `(path, []string{"llm","token","--skip-browser"})`; always `--skip-browser` since Codex has no interactive-context signal like Claude Desktop's shim); wire into `configureDetectedTools`; add a `warnTLSSkipVerify` case for Codex ("not supported", like the Gemini CLI case). `usesAnthropicBaseURL` stays unchanged — Codex is deliberately excluded so it gets plain `GatewayURL`, not the Anthropic-prefixed URL.
- Tests: unit tests for configure/revert round-trip + idempotency in `pkg/client`; a dedicated e2e `Describe` block in `cli_llm_all_clients_test.go` (parallel to the existing claude-desktop block, since the generic matrix asserts via JSON and can't parse TOML).
- `task docs` after, per CLAUDE.md.

**Verification**: `task test`, `task lint-fix`, `task test-e2e`, then manually run `thv llm setup --client codex` + `codex` against staging to confirm an actual request round-trips through the gateway, then `thv llm teardown --client codex` to confirm clean removal.

</details>

## Does this introduce a user-facing change?

Yes — `thv llm setup`/`thv llm teardown` now support Codex CLI as a direct-mode
client, alongside the existing supported clients.

## Special notes for reviewers

The gateway's `/v1` path segment is baked directly into the written `base_url`,
unlike the optional Anthropic path prefix other clients use — this is required
because Codex's Responses-API client always appends `/responses` straight onto
whatever `base_url` is configured, with no separate path-prefix concept of
its own.

Generated with [Claude Code](https://claude.com/claude-code)