### PR TITLE
Use llmgateway mode constants for direct/proxy modes

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -414,7 +414,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		SkillsGlobalPath:  []string{".copilot", skillsDirName},
 		SkillsProjectPath: []string{".github", skillsDirName},
 		// LLM gateway: patches settings.json (same dir as mcp.json, different file)
-		LLMGatewayMode:     "proxy",
+		LLMGatewayMode:     llmgateway.ModeProxy,
 		LLMBinaryName:      "code-insiders",
 		LLMSettingsFile:    "settings.json",
 		LLMSettingsRelPath: []string{"Code - Insiders", "User"},
@@ -457,7 +457,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		SkillsGlobalPath:  []string{".copilot", skillsDirName},
 		SkillsProjectPath: []string{".github", skillsDirName},
 		// LLM gateway: patches settings.json (same dir as mcp.json, different file)
-		LLMGatewayMode:     "proxy",
+		LLMGatewayMode:     llmgateway.ModeProxy,
 		LLMBinaryName:      "code",
 		LLMSettingsFile:    "settings.json",
 		LLMSettingsRelPath: []string{"Code", "User"},
@@ -495,7 +495,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		SkillsGlobalPath:  []string{".cursor", skillsDirName},
 		SkillsProjectPath: []string{".cursor", skillsDirName},
 		// LLM gateway: patches the editor settings.json (different from the MCP mcp.json)
-		LLMGatewayMode:     "proxy",
+		LLMGatewayMode:     llmgateway.ModeProxy,
 		LLMBinaryName:      "cursor",
 		LLMSettingsFile:    "settings.json",
 		LLMSettingsRelPath: []string{"Cursor", "User"},
@@ -534,7 +534,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		PluginsGlobalPath:  []string{".claude", "plugins"},
 		PluginsProjectPath: []string{".claude", "plugins"},
 		// LLM gateway: patches ~/.claude/settings.json (different from the MCP .claude.json)
-		LLMGatewayMode:     "direct",
+		LLMGatewayMode:     llmgateway.ModeDirect,
 		LLMBinaryName:      "claude",
 		LLMSettingsFile:    "settings.json",
 		LLMSettingsRelPath: []string{".claude"},
@@ -834,7 +834,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		// TLS handshake on that leg. Setting the env var would globally disable
 		// TLS verification for all other HTTPS requests the Gemini CLI process
 		// makes, which is an unacceptable side-effect.
-		LLMGatewayMode:     "proxy",
+		LLMGatewayMode:     llmgateway.ModeProxy,
 		LLMBinaryName:      "gemini",
 		LLMSettingsFile:    "settings.json",
 		LLMSettingsRelPath: []string{".gemini"},
@@ -984,7 +984,7 @@ var supportedClientIntegrations = []clientAppConfig{
 		ClientType:     ClientApp(Xcode),
 		Description:    "GitHub Copilot for Xcode",
 		LLMGatewayOnly: true,
-		LLMGatewayMode: "proxy",
+		LLMGatewayMode: llmgateway.ModeProxy,
 		// Full path is macOS-specific; on Linux/Windows this directory will not
 		// exist, so DetectedLLMGatewayClients() naturally returns false there.
 		LLMSettingsFile:    "editorSettings.json",

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -561,7 +561,7 @@ func rollbackConfiguredTools(errOut io.Writer, gm GatewayManager, configured []T
 // hasProxyMode reports whether any of the given tool configs uses proxy mode.
 func hasProxyMode(cfgs []ToolConfig) bool {
 	for _, t := range cfgs {
-		if t.Mode == "proxy" {
+		if t.Mode == llmgateway.ModeProxy {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

The `llmgateway` package declares `ModeDirect`/`ModeProxy`/`ModeCredentialHelper`/`ModeCodexAuth` as the single compiler-checked source of truth for gateway-mode strings. Its own doc comment states they exist so both packages "reference one compiler-checked set of values rather than carrying private string copies that can drift."

`ModeCredentialHelper` (and, on the Codex branch, `ModeCodexAuth`) already follow this, but the **direct/proxy** client registrations and `hasProxyMode` still hand-typed the raw `"direct"`/`"proxy"` literals — the exact drift the constants were introduced to prevent. This was surfaced by a review comment on #5789 (Codex support); the fix there covered the `warnTLSSkipVerify` switch it touched, and this PR sweeps the rest so main is consistent.

Swapping the literals to the constants makes a typo a compile error instead of a silently-unmatched mode.

- `pkg/client/config.go`: 6 `LLMGatewayMode: "proxy"/"direct"` registrations → `llmgateway.ModeProxy`/`ModeDirect`
- `pkg/llm/setup.go`: `hasProxyMode`'s `t.Mode == "proxy"` → `llmgateway.ModeProxy`

Purely mechanical — no behaviour change.

## Type of change

- [x] Refactor (no functional change)

## Test plan

- [x] Unit tests (`task test` — pkg/client, pkg/llm)
- [x] Linting (`golangci-lint` — 0 issues)
- [x] Build (`task build`)

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

`warnTLSSkipVerify`'s `"direct"`/`"proxy"` cases are deliberately **not** touched here — they're being converted in #5789, which actively modifies that switch. Kept separate to avoid a merge conflict between the two PRs.

Generated with [Claude Code](https://claude.com/claude-code)