### PR TITLE
Expose --allow-docker-gateway in workload API

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -2736,6 +2736,10 @@ const docTemplate = `{
             "pkg_api_v1.createRequest": {
                 "description": "Request to create a new workload",
                 "properties": {
+                    "allow_docker_gateway": {
+                        "description": "Whether to permit outbound connections to Docker gateway addresses\n(host.docker.internal, gateway.docker.internal, 172.17.0.1). These are\nblocked by default in the egress proxy even when network isolation is on.\nOnly applicable to Docker deployments with network isolation enabled.",
+                        "type": "boolean"
+                    },
                     "authz_config": {
                         "description": "Authorization configuration",
                         "type": "string"
@@ -3422,6 +3426,10 @@ const docTemplate = `{
             "pkg_api_v1.updateRequest": {
                 "description": "Request to update an existing workload (name cannot be changed)",
                 "properties": {
+                    "allow_docker_gateway": {
+                        "description": "Whether to permit outbound connections to Docker gateway addresses\n(host.docker.internal, gateway.docker.internal, 172.17.0.1). These are\nblocked by default in the egress proxy even when network isolation is on.\nOnly applicable to Docker deployments with network isolation enabled.",
+                        "type": "boolean"
+                    },
                     "authz_config": {
                         "description": "Authorization configuration",
                         "type": "string"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -2729,6 +2729,10 @@
             "pkg_api_v1.createRequest": {
                 "description": "Request to create a new workload",
                 "properties": {
+                    "allow_docker_gateway": {
+                        "description": "Whether to permit outbound connections to Docker gateway addresses\n(host.docker.internal, gateway.docker.internal, 172.17.0.1). These are\nblocked by default in the egress proxy even when network isolation is on.\nOnly applicable to Docker deployments with network isolation enabled.",
+                        "type": "boolean"
+                    },
                     "authz_config": {
                         "description": "Authorization configuration",
                         "type": "string"
@@ -3415,6 +3419,10 @@
             "pkg_api_v1.updateRequest": {
                 "description": "Request to update an existing workload (name cannot be changed)",
                 "properties": {
+                    "allow_docker_gateway": {
+                        "description": "Whether to permit outbound connections to Docker gateway addresses\n(host.docker.internal, gateway.docker.internal, 172.17.0.1). These are\nblocked by default in the egress proxy even when network isolation is on.\nOnly applicable to Docker deployments with network isolation enabled.",
+                        "type": "boolean"
+                    },
                     "authz_config": {
                         "description": "Authorization configuration",
                         "type": "string"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2572,6 +2572,13 @@ components:
     pkg_api_v1.createRequest:
       description: Request to create a new workload
       properties:
+        allow_docker_gateway:
+          description: |-
+            Whether to permit outbound connections to Docker gateway addresses
+            (host.docker.internal, gateway.docker.internal, 172.17.0.1). These are
+            blocked by default in the egress proxy even when network isolation is on.
+            Only applicable to Docker deployments with network isolation enabled.
+          type: boolean
         authz_config:
           description: Authorization configuration
           type: string
@@ -3104,6 +3111,13 @@ components:
     pkg_api_v1.updateRequest:
       description: Request to update an existing workload (name cannot be changed)
       properties:
+        allow_docker_gateway:
+          description: |-
+            Whether to permit outbound connections to Docker gateway addresses
+            (host.docker.internal, gateway.docker.internal, 172.17.0.1). These are
+            blocked by default in the egress proxy even when network isolation is on.
+            Only applicable to Docker deployments with network isolation enabled.
+          type: boolean
         authz_config:
           description: Authorization configuration
           type: string

--- a/pkg/api/v1/workload_service.go
+++ b/pkg/api/v1/workload_service.go
@@ -341,6 +341,7 @@ func (s *WorkloadService) BuildFullRunConfig(
 		runner.WithPermissionProfile(req.PermissionProfile),
 		runner.WithNetworkIsolation(networkIsolationEnabled(req.NetworkIsolation)),
 		runner.WithTrustProxyHeaders(req.TrustProxyHeaders),
+		runner.WithAllowDockerGateway(req.AllowDockerGateway),
 		runner.WithK8sPodPatch(""),
 		runner.WithProxyMode(types.ProxyMode(req.ProxyMode)),
 		runner.WithTransportAndPorts(req.Transport, req.ProxyPort, req.TargetPort),

--- a/pkg/api/v1/workload_service_test.go
+++ b/pkg/api/v1/workload_service_test.go
@@ -273,6 +273,53 @@ func TestBuildFullRunConfig_AppliesOtelFromConfig(t *testing.T) {
 		"MetricsEnabled must default to true when config does not set it, matching CLI behavior")
 }
 
+// TestBuildFullRunConfig_ThreadsAllowDockerGateway verifies that the
+// allow_docker_gateway request field reaches the resulting RunConfig, since
+// the CLI already exposes --allow-docker-gateway but the API previously
+// dropped the value on the floor.
+func TestBuildFullRunConfig_ThreadsAllowDockerGateway(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGroupManager := groupsmocks.NewMockManager(ctrl)
+	mockGroupManager.EXPECT().Exists(gomock.Any(), "default").Return(true, nil)
+
+	const testImage = "test-image"
+
+	mockRetriever := func(
+		_ context.Context,
+		_ string, _ string, _ string, _ string,
+		_ *templates.RuntimeConfig,
+	) (string, regtypes.ServerMetadata, error) {
+		return testImage, &regtypes.ImageMetadata{Image: testImage}, nil
+	}
+
+	configPath := t.TempDir() + "/config.yaml"
+	provider := config.NewPathProvider(configPath)
+
+	service := &WorkloadService{
+		groupManager:      mockGroupManager,
+		imageRetriever:    mockRetriever,
+		imagePuller:       func(_ context.Context, _ string) error { return nil },
+		configProvider:    provider,
+		imageVerification: retriever.VerifyImageWarn,
+	}
+
+	req := &createRequest{
+		Name: "testserver",
+		updateRequest: updateRequest{
+			Image:              testImage,
+			AllowDockerGateway: true,
+		},
+	}
+
+	runConfig, err := service.BuildFullRunConfig(context.Background(), req, 0)
+	require.NoError(t, err)
+	assert.True(t, runConfig.AllowDockerGateway)
+}
+
 // TestBuildFullRunConfig_NoOtelConfigLeavesTelemetryNil verifies that when no
 // OpenTelemetry config is set, the RunConfig's TelemetryConfig remains nil —
 // the API path does not invent an endpoint.

--- a/pkg/api/v1/workload_types.go
+++ b/pkg/api/v1/workload_types.go
@@ -80,6 +80,11 @@ type updateRequest struct {
 	NetworkIsolation *bool `json:"network_isolation,omitempty"`
 	// Whether to trust X-Forwarded-* headers from reverse proxies
 	TrustProxyHeaders bool `json:"trust_proxy_headers"`
+	// Whether to permit outbound connections to Docker gateway addresses
+	// (host.docker.internal, gateway.docker.internal, 172.17.0.1). These are
+	// blocked by default in the egress proxy even when network isolation is on.
+	// Only applicable to Docker deployments with network isolation enabled.
+	AllowDockerGateway bool `json:"allow_docker_gateway,omitempty"`
 	// Tools filter
 	ToolsFilter []string `json:"tools"`
 	// Tools override
@@ -357,29 +362,30 @@ func runConfigToCreateRequest(runConfig *runner.RunConfig) *createRequest {
 
 	return &createRequest{
 		updateRequest: updateRequest{
-			Image:             runConfig.Image,
-			RuntimeConfig:     runtimeConfigForResponse(runConfig),
-			Host:              runConfig.Host,
-			CmdArguments:      runConfig.CmdArgs,
-			TargetPort:        runConfig.TargetPort,
-			ProxyPort:         runConfig.Port,
-			EnvVars:           runConfig.EnvVars,
-			Secrets:           secretParams,
-			Volumes:           runConfig.Volumes,
-			Transport:         string(runConfig.Transport),
-			AuthzConfig:       authzConfigPath,
-			OIDC:              oidcConfig,
-			PermissionProfile: runConfig.PermissionProfile,
-			ProxyMode:         string(runConfig.ProxyMode),
-			NetworkIsolation:  &runConfig.IsolateNetwork,
-			TrustProxyHeaders: runConfig.TrustProxyHeaders,
-			ToolsFilter:       runConfig.ToolsFilter,
-			ToolsOverride:     toolsOverride,
-			Group:             runConfig.Group,
-			URL:               runConfig.RemoteURL,
-			OAuthConfig:       oAuthConfig,
-			Headers:           headers,
-			HeaderForward:     headerForward,
+			Image:              runConfig.Image,
+			RuntimeConfig:      runtimeConfigForResponse(runConfig),
+			Host:               runConfig.Host,
+			CmdArguments:       runConfig.CmdArgs,
+			TargetPort:         runConfig.TargetPort,
+			ProxyPort:          runConfig.Port,
+			EnvVars:            runConfig.EnvVars,
+			Secrets:            secretParams,
+			Volumes:            runConfig.Volumes,
+			Transport:          string(runConfig.Transport),
+			AuthzConfig:        authzConfigPath,
+			OIDC:               oidcConfig,
+			PermissionProfile:  runConfig.PermissionProfile,
+			ProxyMode:          string(runConfig.ProxyMode),
+			NetworkIsolation:   &runConfig.IsolateNetwork,
+			TrustProxyHeaders:  runConfig.TrustProxyHeaders,
+			AllowDockerGateway: runConfig.AllowDockerGateway,
+			ToolsFilter:        runConfig.ToolsFilter,
+			ToolsOverride:      toolsOverride,
+			Group:              runConfig.Group,
+			URL:                runConfig.RemoteURL,
+			OAuthConfig:        oAuthConfig,
+			Headers:            headers,
+			HeaderForward:      headerForward,
 		},
 		Name: runConfig.Name,
 	}

--- a/pkg/api/v1/workloads_types_test.go
+++ b/pkg/api/v1/workloads_types_test.go
@@ -89,20 +89,21 @@ func TestRunConfigToCreateRequest(t *testing.T) {
 		t.Parallel()
 
 		runConfig := &runner.RunConfig{
-			Name:           "test-workload",
-			Image:          "test-image:latest",
-			Host:           "localhost",
-			Port:           3000,
-			CmdArgs:        []string{"arg1", "arg2"},
-			TargetPort:     8080,
-			EnvVars:        map[string]string{"ENV1": "value1"},
-			Secrets:        []string{"secret1,target=/path1", "secret2,target=/path2"},
-			Volumes:        []string{"/host:/container"},
-			Transport:      types.TransportTypeSSE,
-			Group:          "test-group",
-			ProxyMode:      types.ProxyModeSSE,
-			IsolateNetwork: true,
-			ToolsFilter:    []string{"tool1", "tool2"},
+			Name:               "test-workload",
+			Image:              "test-image:latest",
+			Host:               "localhost",
+			Port:               3000,
+			CmdArgs:            []string{"arg1", "arg2"},
+			TargetPort:         8080,
+			EnvVars:            map[string]string{"ENV1": "value1"},
+			Secrets:            []string{"secret1,target=/path1", "secret2,target=/path2"},
+			Volumes:            []string{"/host:/container"},
+			Transport:          types.TransportTypeSSE,
+			Group:              "test-group",
+			ProxyMode:          types.ProxyModeSSE,
+			IsolateNetwork:     true,
+			ToolsFilter:        []string{"tool1", "tool2"},
+			AllowDockerGateway: true,
 		}
 
 		result := runConfigToCreateRequest(runConfig)
@@ -127,6 +128,7 @@ func TestRunConfigToCreateRequest(t *testing.T) {
 		require.NotNil(t, result.NetworkIsolation)
 		assert.True(t, *result.NetworkIsolation)
 		assert.Equal(t, []string{"tool1", "tool2"}, result.ToolsFilter)
+		assert.True(t, result.AllowDockerGateway)
 	})
 
 	t.Run("with plaintext header forward", func(t *testing.T) {


### PR DESCRIPTION
## Summary

required to fix https://github.com/stacklok/toolhive-studio/issues/2326



- The CLI already exposes `--allow-docker-gateway`, fully wired through `RunConfig` into the Docker egress proxy, but the HTTP workload API never surfaced it — servers created or updated through the API had no way to opt in to Docker gateway access (host.docker.internal / gateway.docker.internal / 172.17.0.1), even though the underlying support already existed.
- Adds `AllowDockerGateway` to the workload create/update request type, threads it through `WorkloadService.BuildFullRunConfig` via `runner.WithAllowDockerGateway`, and reflects it back in the runConfig-to-response conversion so `GET`/list responses report the current value.
- Regenerates the swagger/CLI docs (`task docs`) to include the new `allow_docker_gateway` field.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Added `TestBuildFullRunConfig_ThreadsAllowDockerGateway` covering the request→RunConfig path, and extended `TestRunConfigToCreateRequest` to cover the RunConfig→response path.

## Does this introduce a user-facing change?

Yes — API clients (`POST`/`PUT /api/v1/workloads`) can now set `allow_docker_gateway` to permit outbound connections to Docker gateway addresses, matching the existing `thv run --allow-docker-gateway` CLI flag. `GET` responses now also report the field.

## Special notes for reviewers

This only wires the field through the standalone HTTP workload API (Docker deployments); it does not touch the Kubernetes operator's `MCPServer` CRD, which is a separate surface and out of scope here.

Fully or partially written by an AI agent.

Generated with [Claude Code](https://claude.com/claude-code)