### PR TITLE
Add runtime-stage environment variables to protocol Dockerfiles

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1041,6 +1041,13 @@ const docTemplate = `{
                     "builder_image": {
                         "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
                         "type": "string"
+                    },
+                    "runtime_env": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "RuntimeEnv contains environment variables to inject into the Dockerfile's\nfinal runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),\nwhich only affects the builder stage, these variables are baked into the\nshipped image and are present in the running container's process\nenvironment at startup. Use this for values a packaged MCP server reads at\nprocess start (e.g. feature flags, cache backend selection), not for\nbuild-time package manager configuration.\nKeys must be uppercase with underscores, values are validated for safety.",
+                        "type": "object"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1034,6 +1034,13 @@
                     "builder_image": {
                         "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
                         "type": "string"
+                    },
+                    "runtime_env": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "RuntimeEnv contains environment variables to inject into the Dockerfile's\nfinal runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),\nwhich only affects the builder stage, these variables are baked into the\nshipped image and are present in the running container's process\nenvironment at startup. Use this for values a packaged MCP server reads at\nprocess start (e.g. feature flags, cache backend selection), not for\nbuild-time package manager configuration.\nKeys must be uppercase with underscores, values are validated for safety.",
+                        "type": "object"
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1102,6 +1102,19 @@ components:
             An empty string signals "use the default for this transport type" during config merging.
             Examples: "golang:1.26-alpine", "node:24-alpine", "python:3.14-slim"
           type: string
+        runtime_env:
+          additionalProperties:
+            type: string
+          description: |-
+            RuntimeEnv contains environment variables to inject into the Dockerfile's
+            final runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),
+            which only affects the builder stage, these variables are baked into the
+            shipped image and are present in the running container's process
+            environment at startup. Use this for values a packaged MCP server reads at
+            process start (e.g. feature flags, cache backend selection), not for
+            build-time package manager configuration.
+            Keys must be uppercase with underscores, values are validated for safety.
+          type: object
       type: object
     github_com_stacklok_toolhive_pkg_core.Workload:
       properties:

--- a/pkg/container/templates/go.tmpl
+++ b/pkg/container/templates/go.tmpl
@@ -76,6 +76,11 @@ RUN package="{{.MCPPackage}}"; \
 # Final stage - minimal runtime image
 FROM index.docker.io/library/alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
+{{if .RuntimeConfig.RuntimeEnv}}
+# Custom runtime environment variables
+{{range $key, $value := .RuntimeConfig.RuntimeEnv}}ENV {{$key}}="{{$value}}"
+{{end}}
+{{end}}
 {{if .CACertContent}}
 # Add custom CA certificate for runtime
 COPY ca-cert.crt /tmp/custom-ca.crt

--- a/pkg/container/templates/npx.tmpl
+++ b/pkg/container/templates/npx.tmpl
@@ -63,6 +63,11 @@ RUN npm install --save {{.MCPPackage}}
 # Final stage - runtime image with pre-installed packages
 FROM {{.RuntimeConfig.BuilderImage}}
 
+{{if .RuntimeConfig.RuntimeEnv}}
+# Custom runtime environment variables
+{{range $key, $value := .RuntimeConfig.RuntimeEnv}}ENV {{$key}}="{{$value}}"
+{{end}}
+{{end}}
 {{if .CACertContent}}
 # Add custom CA certificate for runtime
 COPY ca-cert.crt /tmp/custom-ca.crt

--- a/pkg/container/templates/runtime_config.go
+++ b/pkg/container/templates/runtime_config.go
@@ -20,6 +20,27 @@ const maxPackageNameLength = 128
 // dots, underscores, plus signs, or hyphens.
 var packageNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+\-]*$`)
 
+// envKeyPattern matches valid environment variable names for RuntimeEnv.
+// Must start with an uppercase letter, followed by uppercase letters, numbers, or underscores.
+var envKeyPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// reservedRuntimeEnvKeys lists environment variable names that RuntimeEnv must
+// not override, either because the generated Dockerfile sets them itself
+// (e.g. PATH) or because overriding them could destabilize the runtime image.
+var reservedRuntimeEnvKeys = map[string]bool{
+	"PATH": true, "HOME": true, "USER": true, "SHELL": true, "PWD": true,
+	"HOSTNAME": true, "TERM": true, "LANG": true, "LC_ALL": true,
+	"LD_PRELOAD": true, "LD_LIBRARY_PATH": true,
+}
+
+// runtimeEnvDangerousValuePatterns lists substrings that must not appear in a
+// RuntimeEnv value. Values are interpolated verbatim into a Dockerfile ENV
+// line (ENV KEY="value") with no shell-escaping, so these characters could
+// break out of the quoted value and inject arbitrary Dockerfile/shell content.
+var runtimeEnvDangerousValuePatterns = []string{
+	"`", "$(", "${", "\\", "\n", "\r", "\"", ";", "&&", "||", "|", ">", "<",
+}
+
 // RuntimeConfig defines the base images and versions for a specific runtime
 type RuntimeConfig struct {
 	// BuilderImage is the full image reference for the builder stage.
@@ -32,6 +53,16 @@ type RuntimeConfig struct {
 	// Examples for Alpine: ["git", "make", "gcc"]
 	// Examples for Debian: ["git", "build-essential"]
 	AdditionalPackages []string `json:"additional_packages,omitempty" yaml:"additional_packages,omitempty"`
+
+	// RuntimeEnv contains environment variables to inject into the Dockerfile's
+	// final runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),
+	// which only affects the builder stage, these variables are baked into the
+	// shipped image and are present in the running container's process
+	// environment at startup. Use this for values a packaged MCP server reads at
+	// process start (e.g. feature flags, cache backend selection), not for
+	// build-time package manager configuration.
+	// Keys must be uppercase with underscores, values are validated for safety.
+	RuntimeEnv map[string]string `json:"runtime_env,omitempty" yaml:"runtime_env,omitempty"`
 }
 
 // Validate checks that all RuntimeConfig fields contain safe values that cannot
@@ -66,6 +97,29 @@ func (rc *RuntimeConfig) Validate() error {
 				"invalid package name %q: must match %s",
 				pkg, packageNamePattern.String(),
 			))
+		}
+	}
+
+	// Validate each RuntimeEnv entry to ensure keys and values are safe to
+	// interpolate into a Dockerfile ENV instruction.
+	for key, value := range rc.RuntimeEnv {
+		if !envKeyPattern.MatchString(key) {
+			errs = append(errs, fmt.Errorf(
+				"invalid runtime env key %q: must match %s", key, envKeyPattern.String(),
+			))
+			continue
+		}
+		if reservedRuntimeEnvKeys[key] {
+			errs = append(errs, fmt.Errorf("runtime env key %q is reserved and cannot be overridden", key))
+			continue
+		}
+		for _, pattern := range runtimeEnvDangerousValuePatterns {
+			if strings.Contains(value, pattern) {
+				errs = append(errs, fmt.Errorf(
+					"runtime env value for key %q contains potentially dangerous characters: %q", key, pattern,
+				))
+				break
+			}
 		}
 	}
 

--- a/pkg/container/templates/runtime_config_test.go
+++ b/pkg/container/templates/runtime_config_test.go
@@ -330,3 +330,130 @@ func TestRuntimeConfigValidate_DefaultConfigsAreValid(t *testing.T) {
 		})
 	}
 }
+
+func TestRuntimeConfigValidate_ValidRuntimeEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key   string
+		value string
+	}{
+		{key: "PYTHON_KEYRING_BACKEND", value: "keyrings.alt.file.PlaintextKeyring"},
+		{key: "NODE_ENV", value: "production"},
+		{key: "FOO_BAR_123", value: "some-value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+
+			rc := &RuntimeConfig{
+				RuntimeEnv: map[string]string{tt.key: tt.value},
+			}
+			assert.NoError(t, rc.Validate())
+		})
+	}
+}
+
+func TestRuntimeConfigValidate_InvalidRuntimeEnvKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "lowercase key", key: "path_backend"},
+		{name: "starts with digit", key: "1FOO"},
+		{name: "contains hyphen", key: "FOO-BAR"},
+		{name: "empty key", key: ""},
+		{name: "contains space", key: "FOO BAR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rc := &RuntimeConfig{
+				RuntimeEnv: map[string]string{tt.key: "some-value"},
+			}
+			err := rc.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid runtime env key")
+		})
+	}
+}
+
+func TestRuntimeConfigValidate_ReservedRuntimeEnvKeys(t *testing.T) {
+	t.Parallel()
+
+	reservedKeys := []string{"PATH", "HOME", "LD_PRELOAD"}
+
+	for _, key := range reservedKeys {
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+
+			rc := &RuntimeConfig{
+				RuntimeEnv: map[string]string{key: "some-value"},
+			}
+			err := rc.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "is reserved and cannot be overridden")
+		})
+	}
+}
+
+func TestRuntimeConfigValidate_InvalidRuntimeEnvValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "backtick command substitution", value: "`id`"},
+		{name: "dollar-paren command substitution", value: "$(curl evil)"},
+		{name: "dollar-brace expansion", value: "${HOME}"},
+		{name: "trailing backslash", value: `value\`},
+		{name: "embedded newline", value: "value\nRUN evil"},
+		{name: "embedded carriage return", value: "value\rRUN evil"},
+		{name: "embedded double quote breaks out of ENV quoting", value: `value" && RUN evil`},
+		{name: "semicolon separator", value: "value;rm -rf /"},
+		{name: "command chaining with &&", value: "value && evil"},
+		{name: "command chaining with ||", value: "value || evil"},
+		{name: "pipe operator", value: "value|cat"},
+		{name: "redirect operator >", value: "value>file"},
+		{name: "redirect operator <", value: "value<file"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rc := &RuntimeConfig{
+				RuntimeEnv: map[string]string{"FOO": tt.value},
+			}
+			err := rc.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "contains potentially dangerous characters")
+		})
+	}
+}
+
+func TestRuntimeConfigValidate_MultipleErrorsWithRuntimeEnv(t *testing.T) {
+	t.Parallel()
+
+	rc := &RuntimeConfig{
+		BuilderImage:       "alpine\nRUN evil",
+		AdditionalPackages: []string{"git", "pkg;ls"},
+		RuntimeEnv: map[string]string{
+			"PATH": "/custom/path",
+			"FOO":  "$(evil)",
+		},
+	}
+	err := rc.Validate()
+	require.Error(t, err)
+	// Should report the builder image, package, and RuntimeEnv errors together.
+	assert.Contains(t, err.Error(), "builder_image")
+	assert.Contains(t, err.Error(), "pkg;ls")
+	assert.Contains(t, err.Error(), "is reserved and cannot be overridden")
+	assert.Contains(t, err.Error(), "contains potentially dangerous characters")
+}

--- a/pkg/container/templates/templates.go
+++ b/pkg/container/templates/templates.go
@@ -32,8 +32,11 @@ type TemplateData struct {
 	// These are typically required subcommands (e.g., "start") that must always be present.
 	// Runtime arguments passed via "-- <args>" will be appended after these build args.
 	BuildArgs []string
-	// BuildEnv contains environment variables to inject into the Dockerfile builder stage.
-	// These are used for configuring package managers (e.g., custom registry URLs).
+	// BuildEnv contains environment variables to inject into the Dockerfile builder stage only.
+	// These are used for configuring package managers (e.g., custom registry URLs) and do NOT
+	// persist into the final runtime image or the running container's environment.
+	// For environment variables the running container's process needs at startup
+	// (e.g. feature flags, cache backend selection), use RuntimeConfig.RuntimeEnv instead.
 	// Keys must be uppercase with underscores, values are validated for safety.
 	BuildEnv map[string]string
 	// BuildAuthFiles contains auth file contents keyed by file type (npmrc, netrc, etc).

--- a/pkg/container/templates/templates_test.go
+++ b/pkg/container/templates/templates_test.go
@@ -348,6 +348,81 @@ func TestGetDockerfileTemplate(t *testing.T) {
 			wantNotContains: nil,
 			wantErr:         false,
 		},
+		{
+			// Okta MCP server needs a non-default keyring backend at container
+			// startup, since the default backend requires a desktop session.
+			name:          "UVX transport with RuntimeEnv",
+			transportType: TransportTypeUVX,
+			data: TemplateData{
+				MCPPackage: "okta-mcp-server",
+				RuntimeConfig: &RuntimeConfig{
+					BuilderImage: "python:3.14-slim",
+					RuntimeEnv: map[string]string{
+						"PYTHON_KEYRING_BACKEND": "keyrings.alt.file.PlaintextKeyring",
+					},
+				},
+			},
+			wantContains: []string{
+				"FROM python:",
+				"# Custom runtime environment variables",
+				`ENV PYTHON_KEYRING_BACKEND="keyrings.alt.file.PlaintextKeyring"`,
+				"uv tool install",
+			},
+			wantMatches: []string{
+				`FROM python:\d+\.\d+-slim AS builder`,
+				`FROM python:\d+\.\d+-slim`,
+			},
+			wantNotContains: nil,
+			wantErr:         false,
+		},
+		{
+			name:          "NPX transport with RuntimeEnv",
+			transportType: TransportTypeNPX,
+			data: TemplateData{
+				MCPPackage: "example-package",
+				RuntimeConfig: &RuntimeConfig{
+					BuilderImage: "node:24-alpine",
+					RuntimeEnv: map[string]string{
+						"NODE_ENV": "production",
+					},
+				},
+			},
+			wantContains: []string{
+				"FROM node:",
+				"# Custom runtime environment variables",
+				`ENV NODE_ENV="production"`,
+				"npm install --save example-package",
+			},
+			wantMatches: []string{
+				`FROM node:\d+-alpine AS builder`,
+			},
+			wantNotContains: nil,
+			wantErr:         false,
+		},
+		{
+			name:          "GO transport with RuntimeEnv",
+			transportType: TransportTypeGO,
+			data: TemplateData{
+				MCPPackage: "example-package",
+				RuntimeConfig: &RuntimeConfig{
+					BuilderImage: "golang:1.26-alpine",
+					RuntimeEnv: map[string]string{
+						"LOG_LEVEL": "debug",
+					},
+				},
+			},
+			wantContains: []string{
+				"FROM golang:",
+				"# Custom runtime environment variables",
+				`ENV LOG_LEVEL="debug"`,
+				"go install",
+			},
+			wantMatches: []string{
+				`FROM golang:\d+\.\d+-alpine AS builder`,
+			},
+			wantNotContains: nil,
+			wantErr:         false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -454,6 +529,83 @@ func TestRuntimeStageInstallsAdditionalPackages(t *testing.T) {
 
 			if !strings.Contains(runtimeStage, tt.wantInRuntime) {
 				t.Errorf("runtime stage does not install %q.\nRuntime stage:\n%s", tt.wantInRuntime, runtimeStage)
+			}
+		})
+	}
+}
+
+func TestRuntimeEnvOnlyAppearsInRuntimeStage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		transportType TransportType
+		runtimeConfig *RuntimeConfig
+		wantEnvLine   string // ENV line that must appear AFTER the second FROM, and nowhere before it
+	}{
+		{
+			name:          "NPX runtime stage sets RuntimeEnv",
+			transportType: TransportTypeNPX,
+			runtimeConfig: &RuntimeConfig{
+				BuilderImage: "node:24-alpine",
+				RuntimeEnv: map[string]string{
+					"NPX_RUNTIME_FLAG": "enabled",
+				},
+			},
+			wantEnvLine: `ENV NPX_RUNTIME_FLAG="enabled"`,
+		},
+		{
+			name:          "UVX runtime stage sets RuntimeEnv",
+			transportType: TransportTypeUVX,
+			runtimeConfig: &RuntimeConfig{
+				BuilderImage: "python:3.14-slim",
+				RuntimeEnv: map[string]string{
+					"PYTHON_KEYRING_BACKEND": "keyrings.alt.file.PlaintextKeyring",
+				},
+			},
+			wantEnvLine: `ENV PYTHON_KEYRING_BACKEND="keyrings.alt.file.PlaintextKeyring"`,
+		},
+		{
+			name:          "GO runtime stage sets RuntimeEnv",
+			transportType: TransportTypeGO,
+			runtimeConfig: &RuntimeConfig{
+				BuilderImage: "golang:1.26-alpine",
+				RuntimeEnv: map[string]string{
+					"GO_RUNTIME_FLAG": "enabled",
+				},
+			},
+			wantEnvLine: `ENV GO_RUNTIME_FLAG="enabled"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := TemplateData{
+				MCPPackage:    "test-package",
+				RuntimeConfig: tt.runtimeConfig,
+			}
+
+			result, err := GetDockerfileTemplate(tt.transportType, data)
+			if err != nil {
+				t.Fatalf("GetDockerfileTemplate() error = %v", err)
+			}
+
+			// Find the runtime stage (second FROM) and check that RuntimeEnv
+			// appears there, and only there - not in the builder stage.
+			parts := strings.SplitN(result, "\nFROM ", 2)
+			if len(parts) < 2 {
+				t.Fatal("Dockerfile does not contain a second FROM (runtime stage)")
+			}
+			builderStage := parts[0]
+			runtimeStage := parts[1]
+
+			if !strings.Contains(runtimeStage, tt.wantEnvLine) {
+				t.Errorf("runtime stage does not contain %q.\nRuntime stage:\n%s", tt.wantEnvLine, runtimeStage)
+			}
+			if strings.Contains(builderStage, tt.wantEnvLine) {
+				t.Errorf("builder stage unexpectedly contains %q.\nBuilder stage:\n%s", tt.wantEnvLine, builderStage)
 			}
 		})
 	}

--- a/pkg/container/templates/uvx.tmpl
+++ b/pkg/container/templates/uvx.tmpl
@@ -85,6 +85,11 @@ RUN package="{{.MCPPackage}}"; \
 # Final stage - runtime image with pre-installed packages
 FROM {{.RuntimeConfig.BuilderImage}}
 
+{{if .RuntimeConfig.RuntimeEnv}}
+# Custom runtime environment variables
+{{range $key, $value := .RuntimeConfig.RuntimeEnv}}ENV {{$key}}="{{$value}}"
+{{end}}
+{{end}}
 {{if .CACertContent}}
 # Add custom CA certificate for runtime
 COPY ca-cert.crt /tmp/custom-ca.crt

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -214,6 +215,20 @@ func mergeRuntimeConfig(transportType templates.TransportType, override *templat
 		}
 	}
 
+	merged.RuntimeEnv = mergeEnvMaps(defaults.RuntimeEnv, override.RuntimeEnv)
+
+	return merged
+}
+
+// mergeEnvMaps merges two environment variable maps without mutating either
+// input. Entries in override take precedence over entries in base.
+func mergeEnvMaps(base, override map[string]string) map[string]string {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(base)+len(override))
+	maps.Copy(merged, base)
+	maps.Copy(merged, override)
 	return merged
 }
 

--- a/pkg/runner/protocol_test.go
+++ b/pkg/runner/protocol_test.go
@@ -5,6 +5,7 @@ package runner
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -245,12 +246,13 @@ func TestTemplateDataWithLocalPath(t *testing.T) {
 func TestBuildFromProtocolSchemeWithNameDryRun(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name          string
-		serverOrImage string
-		caCertPath    string
-		buildArgs     []string
-		wantContains  []string
-		wantErr       bool
+		name            string
+		serverOrImage   string
+		caCertPath      string
+		buildArgs       []string
+		runtimeOverride *templates.RuntimeConfig
+		wantContains    []string
+		wantErr         bool
 	}{
 		{
 			name:          "NPX with buildArgs in dry-run",
@@ -290,6 +292,22 @@ func TestBuildFromProtocolSchemeWithNameDryRun(t *testing.T) {
 			buildArgs:     []string{"start"},
 			wantErr:       true,
 		},
+		{
+			// Motivating case: the Okta MCP server needs a non-default keyring
+			// backend baked into the runtime image since the default backend
+			// requires a desktop session that isn't available in a container.
+			name:          "UVX with RuntimeEnv override in dry-run (Okta case)",
+			serverOrImage: "uvx://okta-mcp-server@1.1.3",
+			runtimeOverride: &templates.RuntimeConfig{
+				RuntimeEnv: map[string]string{
+					"PYTHON_KEYRING_BACKEND": "keyrings.alt.file.PlaintextKeyring",
+				},
+			},
+			wantContains: []string{
+				`ENV PYTHON_KEYRING_BACKEND="keyrings.alt.file.PlaintextKeyring"`,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -299,7 +317,7 @@ func TestBuildFromProtocolSchemeWithNameDryRun(t *testing.T) {
 
 			// Call BuildFromProtocolSchemeWithName with dry-run=true
 			dockerfileContent, err := BuildFromProtocolSchemeWithName(
-				ctx, nil, tt.serverOrImage, tt.caCertPath, "", tt.buildArgs, nil, true)
+				ctx, nil, tt.serverOrImage, tt.caCertPath, "", tt.buildArgs, tt.runtimeOverride, true)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildFromProtocolSchemeWithName() error = %v, wantErr %v", err, tt.wantErr)
@@ -320,11 +338,12 @@ func TestBuildFromProtocolSchemeWithNameDryRun(t *testing.T) {
 func TestMergeRuntimeConfig(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name         string
-		transport    templates.TransportType
-		override     *templates.RuntimeConfig
-		wantImage    string
-		wantPackages []string
+		name           string
+		transport      templates.TransportType
+		override       *templates.RuntimeConfig
+		wantImage      string
+		wantPackages   []string
+		wantRuntimeEnv map[string]string
 	}{
 		{
 			name:      "only packages override, no image — image falls back to default",
@@ -333,8 +352,9 @@ func TestMergeRuntimeConfig(t *testing.T) {
 				BuilderImage:       "",
 				AdditionalPackages: []string{"curl"},
 			},
-			wantImage:    "node:24-alpine",
-			wantPackages: []string{"git", "ca-certificates", "curl"},
+			wantImage:      "node:24-alpine",
+			wantPackages:   []string{"git", "ca-certificates", "curl"},
+			wantRuntimeEnv: nil,
 		},
 		{
 			name:      "both image and packages override — image from override, packages merged",
@@ -343,8 +363,9 @@ func TestMergeRuntimeConfig(t *testing.T) {
 				BuilderImage:       "node:20-alpine",
 				AdditionalPackages: []string{"curl"},
 			},
-			wantImage:    "node:20-alpine",
-			wantPackages: []string{"git", "ca-certificates", "curl"},
+			wantImage:      "node:20-alpine",
+			wantPackages:   []string{"git", "ca-certificates", "curl"},
+			wantRuntimeEnv: nil,
 		},
 		{
 			name:      "duplicate package in override — not added twice",
@@ -353,8 +374,9 @@ func TestMergeRuntimeConfig(t *testing.T) {
 				BuilderImage:       "",
 				AdditionalPackages: []string{"git"},
 			},
-			wantImage:    "node:24-alpine",
-			wantPackages: []string{"git", "ca-certificates"},
+			wantImage:      "node:24-alpine",
+			wantPackages:   []string{"git", "ca-certificates"},
+			wantRuntimeEnv: nil,
 		},
 		{
 			name:      "empty override — all defaults",
@@ -363,8 +385,9 @@ func TestMergeRuntimeConfig(t *testing.T) {
 				BuilderImage:       "",
 				AdditionalPackages: nil,
 			},
-			wantImage:    "node:24-alpine",
-			wantPackages: []string{"git", "ca-certificates"},
+			wantImage:      "node:24-alpine",
+			wantPackages:   []string{"git", "ca-certificates"},
+			wantRuntimeEnv: nil,
 		},
 		{
 			name:      "go transport — defaults apply",
@@ -373,8 +396,9 @@ func TestMergeRuntimeConfig(t *testing.T) {
 				BuilderImage:       "",
 				AdditionalPackages: []string{"make"},
 			},
-			wantImage:    "golang:1.26-alpine",
-			wantPackages: []string{"ca-certificates", "git", "make"},
+			wantImage:      "golang:1.26-alpine",
+			wantPackages:   []string{"ca-certificates", "git", "make"},
+			wantRuntimeEnv: nil,
 		},
 		{
 			name:      "uvx transport — defaults apply",
@@ -383,8 +407,29 @@ func TestMergeRuntimeConfig(t *testing.T) {
 				BuilderImage:       "",
 				AdditionalPackages: []string{"curl"},
 			},
-			wantImage:    "python:3.14-slim",
-			wantPackages: []string{"ca-certificates", "git", "curl"},
+			wantImage:      "python:3.14-slim",
+			wantPackages:   []string{"ca-certificates", "git", "curl"},
+			wantRuntimeEnv: nil,
+		},
+		{
+			name:      "override sets RuntimeEnv — passes through",
+			transport: templates.TransportTypeNPX,
+			override: &templates.RuntimeConfig{
+				RuntimeEnv: map[string]string{"NODE_ENV": "production"},
+			},
+			wantImage:      "node:24-alpine",
+			wantPackages:   []string{"git", "ca-certificates"},
+			wantRuntimeEnv: map[string]string{"NODE_ENV": "production"},
+		},
+		{
+			name:      "override RuntimeEnv nil — result nil since defaults never set RuntimeEnv",
+			transport: templates.TransportTypeNPX,
+			override: &templates.RuntimeConfig{
+				RuntimeEnv: nil,
+			},
+			wantImage:      "node:24-alpine",
+			wantPackages:   []string{"git", "ca-certificates"},
+			wantRuntimeEnv: nil,
 		},
 	}
 
@@ -405,8 +450,73 @@ func TestMergeRuntimeConfig(t *testing.T) {
 					}
 				}
 			}
+			if !reflect.DeepEqual(got.RuntimeEnv, tt.wantRuntimeEnv) {
+				t.Errorf("RuntimeEnv = %v, want %v", got.RuntimeEnv, tt.wantRuntimeEnv)
+			}
 		})
 	}
+}
+
+func TestMergeEnvMaps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		base     map[string]string
+		override map[string]string
+		want     map[string]string
+	}{
+		{
+			name:     "both nil",
+			base:     nil,
+			override: nil,
+			want:     nil,
+		},
+		{
+			name:     "base only",
+			base:     map[string]string{"FOO": "bar"},
+			override: nil,
+			want:     map[string]string{"FOO": "bar"},
+		},
+		{
+			name:     "override only",
+			base:     nil,
+			override: map[string]string{"FOO": "bar"},
+			want:     map[string]string{"FOO": "bar"},
+		},
+		{
+			name:     "override wins on shared key",
+			base:     map[string]string{"FOO": "base-value", "BAR": "base-bar"},
+			override: map[string]string{"FOO": "override-value"},
+			want:     map[string]string{"FOO": "override-value", "BAR": "base-bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeEnvMaps(tt.base, tt.override)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMergeEnvMapsDoesNotMutateInputs(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]string{"FOO": "base-value"}
+	override := map[string]string{"BAR": "override-value"}
+
+	got := mergeEnvMaps(base, override)
+	require.NotNil(t, got)
+
+	// Mutate the returned map and confirm neither input map is affected.
+	got["FOO"] = "mutated"
+	got["BAZ"] = "new"
+
+	assert.Equal(t, map[string]string{"FOO": "base-value"}, base)
+	assert.Equal(t, map[string]string{"BAR": "override-value"}, override)
 }
 
 func TestLoadRuntimeConfigMergesOverrideWithDefaults(t *testing.T) {


### PR DESCRIPTION
## Summary

Dockyard packages third-party MCP servers into containers via `runner.BuildFromProtocolSchemeWithName`, and hit a case where a packaged server needs an environment variable set on the *running* container, not just during the build. Okta's official MCP server (`okta-mcp-server`) uses Python's `keyring` library to cache OAuth tokens, and needs `PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring` set at process start so `keyring` doesn't try to reach an OS secret-service backend that doesn't exist in a minimal container. The existing `BuildEnv` mechanism only reaches the Dockerfile builder stage, so there was no way to inject a variable into the shipped image.

- Added `RuntimeEnv map[string]string` to `templates.RuntimeConfig`, validated by `Validate()` against Dockerfile/shell injection (mirrors the existing `AdditionalPackages` validation approach; duplicates rather than imports `pkg/config`'s equivalent key/value validation, since `pkg/config` already imports `pkg/container/templates` and importing back would create a cycle)
- Rendered `RuntimeEnv` as `ENV` lines in the final runtime stage of `uvx.tmpl`, `npx.tmpl`, and `go.tmpl`, leaving the existing builder-stage `BuildEnv` block untouched
- Threaded the new field through `mergeRuntimeConfig` in `pkg/runner/protocol.go` via a new non-mutating `mergeEnvMaps` helper — no signature changes needed anywhere, since it flows through the existing `runtimeOverride *templates.RuntimeConfig` parameter already accepted by `BuildFromProtocolSchemeWithName`
- Updated doc comments to clarify the `BuildEnv` (builder-only) vs `RuntimeConfig.RuntimeEnv` (shipped image) distinction

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Added validation edge-case tests (valid/invalid keys, reserved keys, 13 injection-pattern categories), template-rendering tests confirming the `ENV` line lands only in the runtime stage for all three transports, and an end-to-end dry-run test using the exact Okta case. Also manually generated a Dockerfile for `uvx://okta-mcp-server@1.1.3` with `PYTHON_KEYRING_BACKEND` set and confirmed it lands correctly in the final stage, before `USER appuser`/`ENTRYPOINT`.

## Changes

| File | Change |
|------|--------|
| `pkg/container/templates/runtime_config.go` | Add `RuntimeEnv` field + validation |
| `pkg/container/templates/runtime_config_test.go` | Validation tests |
| `pkg/container/templates/templates.go` | Clarify `BuildEnv` doc comment |
| `pkg/container/templates/templates_test.go` | Template-rendering tests |
| `pkg/container/templates/uvx.tmpl` | Render `RuntimeEnv` in final stage |
| `pkg/container/templates/npx.tmpl` | Render `RuntimeEnv` in final stage |
| `pkg/container/templates/go.tmpl` | Render `RuntimeEnv` in final stage |
| `pkg/runner/protocol.go` | Merge `RuntimeEnv` in `mergeRuntimeConfig` |
| `pkg/runner/protocol_test.go` | Merge + end-to-end dry-run tests |

## Does this introduce a user-facing change?

Yes, for Go API consumers (e.g. Dockyard): `templates.RuntimeConfig` gains a new optional `RuntimeEnv` field. No CLI flag is added and no existing behavior changes for callers who don't set it.

## Special notes for reviewers

The Dockyard-side consumer change (bumping its toolhive dependency, adding an `env:` field to its package spec schema) is out of scope here and will follow in a separate PR against `stacklok/dockyard` once this lands and releases.

Generated with [Claude Code](https://claude.com/claude-code)