### PR TITLE
Pin swag version in swagger-install task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,8 +17,13 @@ tasks:
 
   swagger-install:
     desc: Install the swag tool for OpenAPI/Swagger generation
+    vars:
+      # Pinned to the version already resolved in go.mod, so `task docs` always
+      # uses the same generator instead of drifting to whatever @latest is that day.
+      SWAG_VERSION:
+        sh: go list -m github.com/swaggo/swag/v2 | awk '{print $2}'
     cmds:
-      - go install github.com/swaggo/swag/v2/cmd/swag@latest
+      - go install github.com/swaggo/swag/v2/cmd/swag@{{.SWAG_VERSION}}
 
   helm-docs:
     desc: Generate Helm chart documentation


### PR DESCRIPTION
## Summary

- `task docs` (via the `swagger-install` task) installs `swag` with `go install .../swag@latest`, so every run resolves to whatever swag release is newest *that day* — independent of the version already pinned in `go.mod`. If a future swag release changes internal schema-name disambiguation behavior (or anything else about generation), two contributors running `task docs` on different days, or one contributor rebasing weeks later, can produce a divergent `docs/server/{docs.go,swagger.json,swagger.yaml}` with no underlying API change, masquerading as a large, unrelated diff on their PR (as happened on #5800, which tripped the "Large PR Detected" gate).
- This PR resolves the swag version from `go.mod` (`go list -m github.com/swaggo/swag/v2`) instead of `@latest`, so `swagger-install` always builds the same generator that the rest of the module graph is pinned to.

## Investigation notes (for reviewers)

While root-causing #5800's diff, I confirmed a few things worth recording here so this isn't re-litigated later:

- **JSON/YAML key ordering is already deterministic.** `encoding/json.Marshal` sorts `map[string]...` keys alphabetically, and swag's YAML output goes through `sigs.k8s.io/yaml` (`gopkg.in/yaml.v2`), which also sorts map keys. Five to six consecutive fresh `swag init` runs against identical source (same machine, same swag binary) produced byte-identical output every time. A "canonically sort JSON/YAML output" post-processing step, as one might first assume is needed, would be a no-op today, so I didn't add one.
- **The actual instability is in swag's schema *naming*, not ordering.** ToolHive's dependency graph has many packages that legitimately share simple type names (several internal packages named `Config`/`RunConfig`, plus a `registry` package name collision between `pkg/registry`, `toolhive-core/registry/types`, and `oras.land/oras-go/v2/registry`). Swag's `v2.0.0-rc5` disambiguates these by qualifying colliding names with a sanitized full import path, decided while walking an unordered `map[*ast.File]*AstFileInfo` — this is upstream swag internals, not something we control from this repo. Within one stable environment (fixed swag version + fixed `go.sum`), this comes out fully deterministic (verified with repeated reruns, and across `GOOS=linux` vs. native macOS — identical). The divergence in #5800's committed file appears tied to some other difference in the *authoring* environment (e.g., module cache state) at generation time rather than plain map-iteration randomness, and I couldn't fully pin it down beyond that.
- Given the above, the practical, in-scope fix is closing the one confirmed drift source (`@latest`) rather than chasing further into swag internals. If drift is observed again after this fix, the strongest follow-up would be a CI job that regenerates `docs/server` and fails the build on any diff — that's a separate change and not included here.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

Ran `task swagger-install` and confirmed it now installs the version pinned in `go.mod` (`v2.0.0-rc5`) rather than whatever `@latest` resolves to. Ran `task docs` three times in a row and diffed `docs/server/` between runs — byte-identical every time, and no diff against the currently-committed docs on this branch.

## Special notes for reviewers

The deeper schema-naming sensitivity described above is a known swag limitation, not something this PR attempts to fix — see the investigation notes for what's understood about it and why a CI verification job is the recommended fast-follow if it recurs.

Generated with [Claude Code](https://claude.com/claude-code)