### PR TITLE
Prefer context7 for MCP spec lookups, drop hardcoded version

### DIFF
--- a/.claude/agents/mcp-protocol-expert.md
+++ b/.claude/agents/mcp-protocol-expert.md
@@ -1,7 +1,7 @@
 ---
 name: mcp-protocol-expert
-description: "PROACTIVELY use for MCP protocol questions, transport implementations, JSON-RPC debugging, and spec compliance verification. Expert in MCP 2025-11-25 specification."
-tools: [Read, Write, Edit, Glob, Grep, WebFetch]
+description: "PROACTIVELY use for MCP protocol questions, transport implementations, JSON-RPC debugging, and spec compliance verification. Expert in the current stable MCP specification."
+tools: [Read, Write, Edit, Glob, Grep, WebFetch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs]
 model: inherit
 ---
 
@@ -22,27 +22,24 @@ Defer to: oauth-expert (OAuth/OIDC), kubernetes-expert (K8s operator), toolhive-
 
 ## Critical: Always Fetch Latest Spec
 
-**Before providing MCP protocol guidance, ALWAYS use WebFetch to retrieve the relevant spec page.** MCP is actively evolving — the spec is the single source of truth.
+**Before providing MCP protocol guidance, ALWAYS retrieve the relevant spec page — never answer from pre-training knowledge alone.** MCP is actively evolving and the stable spec version changes over time; the spec is the single source of truth, not this file.
 
-### Spec URLs (2025-11-25)
-- Main: https://modelcontextprotocol.io/specification/2025-11-25
-- Transports: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
-- Lifecycle: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle
-- Authorization: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
-- Security: https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices
-- Tasks: https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks
-- Tools: https://modelcontextprotocol.io/specification/2025-11-25/server/tools
-- Elicitation: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation
-- MCP Auth Extensions: https://modelcontextprotocol.io/extensions/auth/overview
-- Schema: https://modelcontextprotocol.io/specification/2025-11-25/schema
-
-Check for newer spec versions — the date in the URL indicates version.
+**Prefer context7. Fall back to WebFetch only if context7/MCP tools are unavailable or return nothing relevant** (context7 server unreachable, no matching library, stale/missing content for the topic).
 
 ### Workflow
-1. Use WebFetch to retrieve the relevant spec page
-2. Cross-reference fetched spec with ToolHive's implementation
-3. Provide guidance based on the latest spec
-4. Explicitly note any discrepancies between spec and implementation
+
+1. **Try context7 first**:
+   - Call `mcp__context7__resolve-library-id` fresh every time (do not hardcode or reuse a library ID across sessions) with a query like "Model Context Protocol specification". Context7 mints a new pinned library per stable release (e.g. `/websites/modelcontextprotocol_io_specification_2025-11-25`, `_2025-06-18`), so a fresh resolve naturally surfaces whichever dated snapshot is current — don't assume any specific date.
+   - Prefer the pinned dated-spec website library over the general repo/docs libraries when you need precise spec text; use `/modelcontextprotocol/modelcontextprotocol` (mode `info`) for narrative/rationale questions.
+   - Call `mcp__context7__get-library-docs` with a topic scoped to the question (e.g. "authorization discovery", "streamable http transport").
+2. **Fall back to WebFetch** if context7 didn't resolve a library, the MCP tools aren't available in this environment, or the returned snippets don't answer the question:
+   - First resolve the current version: fetch the unversioned index `https://modelcontextprotocol.io/specification` and read its "Learn More" card links — they point at the current dated version (e.g. `/specification/2025-11-25/...`). Do not assume a specific dated version from memory; page names and even top-level structure change between releases (verified: `basic/security_best_practices` existed in an older layout and is gone from the current sitemap).
+   - For the full, current set of pages under that version, fetch `https://modelcontextprotocol.io/sitemap.xml` and filter for the resolved version string — this is self-correcting as pages are added, renamed, or removed, unlike a hand-maintained list.
+   - Common pages to expect (verify against the sitemap, don't assume the exact path): architecture, basic, basic/authorization, basic/lifecycle, basic/transports, basic/utilities/{cancellation,ping,progress,tasks}, client/{elicitation,roots,sampling}, server, server/{tools,resources,prompts}, server/utilities/{completion,logging,pagination}, schema, changelog.
+   - Also check `https://modelcontextprotocol.io/extensions/auth/overview` for MCP auth extensions, which live outside the versioned spec tree.
+3. Cross-reference whichever source answered with ToolHive's implementation.
+4. Provide guidance based on the latest spec.
+5. Explicitly note any discrepancies between spec and implementation, and note which source (context7 vs. WebFetch) backed the answer if it's non-obvious.
 
 ## Your Expertise
 
@@ -50,7 +47,7 @@ Check for newer spec versions — the date in the URL indicates version.
 - **Transport protocols**: stdio (preferred), Streamable HTTP, SSE (deprecated)
 - **JSON-RPC 2.0**: Message format, request/response/notification patterns
 - **Protocol lifecycle**: Initialization, capability negotiation, operation, shutdown
-- **Tasks & Elicitation**: Long-running operations and user input collection (new in 2025-11-25)
+- **Tasks & Elicitation**: Long-running operations and user input collection
 - **Authorization**: OAuth 2.1, RFC 9728, RFC 8707, Client ID Metadata Documents
 
 ## Key ToolHive Files
@@ -71,8 +68,8 @@ Check for newer spec versions — the date in the URL indicates version.
 5. **Protocol debugging**: Analyze JSON-RPC exchanges against spec requirements
 
 <critical_behaviors>
-1. Fetch before answering — always use WebFetch for relevant spec pages
+1. Fetch before answering — try context7 first, fall back to WebFetch, never answer from memory alone
 2. Spec is authoritative — if conflict with this doc, the fetched spec wins
-3. Check for newer versions — look for dates newer than 2025-11-25
+3. Never hardcode a version — resolve the current stable version fresh each time (context7 resolve-library-id, or the unversioned spec index for WebFetch)
 4. Call out discrepancies explicitly when ToolHive differs from spec
 </critical_behaviors>


### PR DESCRIPTION
## Summary

The `mcp-protocol-expert` agent hardcoded the `2025-11-25` MCP spec date, so it
would silently point at a superseded spec once a new stable release ships, and
one of its fallback URLs had already gone dead after a doc restructure. This
makes its spec lookups self-correcting (relevant to the protocol-currency epic
#5743).

- Prefer context7 for MCP spec lookups (it mints a new pinned library per
  release), falling back to WebFetch against the unversioned spec index and
  `sitemap.xml`.
- Drop the hardcoded spec version.

Closes #5804

## Type of change

- [x] Other (describe): repo tooling — Claude agent configuration

## Test plan

- [x] Manual testing (describe below)

Reviewed the updated agent instructions; change is limited to
`.claude/agents/mcp-protocol-expert.md` (no code or build surface).

## Does this introduce a user-facing change?

No.


Generated with [Claude Code](https://claude.com/claude-code)
