### PR TITLE
Add MCP conformance CI job for thv run proxy

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -154,3 +154,43 @@ jobs:
           path: |
             test/e2e/junit-report.xml
           retention-days: 7
+
+  conformance:
+    name: MCP Conformance
+    runs-on: ubuntu-8cores-32gb
+    needs: build-binary
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Download ToolHive binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: toolhive-binary
+          path: ./bin/
+
+      - name: Set binary permissions
+        run: chmod +x ./bin/thv
+
+      - name: Set up container runtime (Docker)
+        run: |
+          docker --version
+          sudo systemctl start docker
+
+      - name: Run MCP conformance suite
+        env:
+          THV_BINARY: ${{ github.workspace }}/bin/thv
+        run: ./test/conformance/run-conformance.sh
+
+      - name: Upload conformance results
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: conformance-results
+          path: test/conformance/results
+          retention-days: 7

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -215,6 +215,14 @@ tasks:
       - task: test-integration-windows
         platforms: [windows]
 
+  conformance:
+    desc: Run the MCP conformance suite against a `thv run` deployment (requires Docker + Node)
+    deps: [build]
+    env:
+      THV_BINARY: "{{.PWD}}/bin/thv"
+    cmds:
+      - ./test/conformance/run-conformance.sh
+
   test-all:
     desc: Run all tests (unit, integration, and e2e)
     deps: [test, test-integration, test-e2e]

--- a/test/conformance/.gitignore
+++ b/test/conformance/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/test/conformance/Dockerfile
+++ b/test/conformance/Dockerfile
@@ -1,0 +1,15 @@
+# Builds the MCP conformance reference server from the conformance repo's
+# examples/servers/typescript directory. This Dockerfile is copied into that
+# directory by run-conformance.sh before `docker build`, so the build context
+# is the server source (package.json, *.ts).
+#
+# The stock `npm start` (tsx) entrypoint is used unchanged: it works behind
+# `thv run` because the CLI workload container is not read-only-rootfs.
+FROM node:22-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY *.ts ./
+ENV PORT=3000
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -1,0 +1,54 @@
+# MCP Conformance
+
+Runs the [MCP conformance suite](https://github.com/modelcontextprotocol/conformance)
+against a ToolHive deployment to verify that ToolHive's proxy/transport layer is
+spec-transparent.
+
+## What it does
+
+ToolHive is a proxy in front of MCP servers, so the suite is run against the
+endpoint that `thv run` exposes. `run-conformance.sh`:
+
+1. Clones the conformance repo at a pinned version and builds its reference
+   server (`examples/servers/typescript/everything-server.ts`, which implements
+   the fixtures the suite requires) into a container image using `Dockerfile`.
+2. Starts it through `thv run --transport streamable-http`.
+3. Points `npx @modelcontextprotocol/conformance server` at the proxied
+   `/mcp` endpoint, gated by `expected-failures.yaml`.
+
+The reference server is **not** the npm `@modelcontextprotocol/server-everything`
+package — that is an unrelated server that does not implement the conformance
+fixtures.
+
+## Running locally
+
+```bash
+task conformance
+```
+
+Requires Docker and Node.js. Results are written to `test/conformance/results/`.
+
+## Version pinning
+
+`CONFORMANCE_VERSION` (default in `run-conformance.sh`) pins **both** the npm
+tool (`@modelcontextprotocol/conformance@$VERSION`) and the git server source
+(`git --branch v$VERSION`). Repo tags map 1:1 to npm versions, so bump both by
+changing this one value. Renovate does not track this pair — bump it manually.
+
+## The baseline (`expected-failures.yaml`)
+
+Lists scenarios that are known to fail and accepted. CI fails only on failures
+**not** listed here. An entry that starts passing again is reported as *stale*
+and also fails CI, so keep the list accurate. The CLI (`thv run`) proxy is
+transparent, so the list is currently empty.
+
+## Scope
+
+Covers the CLI (`thv run`) proxy path with the `active` suite. Not covered:
+
+- **Kubernetes operator proxy** — it rewrites the outbound `Host` header to the
+  upstream Service identity, which breaks MCP servers that validate `Host` (per
+  the spec's DNS-rebinding guidance). Blocked on resolving that before a k8s
+  conformance gate is meaningful.
+- **stdio→streamable-http bridge** — the reference server is HTTP-only; covering
+  the bridge needs a stdio fixture server.

--- a/test/conformance/expected-failures.yaml
+++ b/test/conformance/expected-failures.yaml
@@ -1,0 +1,9 @@
+# Conformance baseline for the ToolHive CLI (`thv run`) proxy path.
+#
+# List scenario names here that are KNOWN to fail and accepted. The suite fails
+# CI only on failures NOT listed here. Note: an entry that starts passing again
+# is reported as a STALE entry and also fails CI — keep this list accurate.
+#
+# The CLI proxy is transport-transparent, so this list is empty: every scenario
+# in the `active` suite is expected to pass.
+server: []

--- a/test/conformance/run-conformance.sh
+++ b/test/conformance/run-conformance.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Run the MCP conformance suite against a ToolHive deployment.
+#
+# Packages the conformance repo's reference server (examples/servers/typescript)
+# dynamically at a pinned version, runs it through `thv run` (streamable-http),
+# and points `npx @modelcontextprotocol/conformance` at the proxied endpoint.
+#
+# A single CONFORMANCE_VERSION pins both the npm tool and the git server source
+# (repo tags vX.Y.Z map 1:1 to npm versions), keeping fixtures and tool in sync.
+#
+# Env:
+#   CONFORMANCE_VERSION  conformance tool + server version   (default: 0.1.16)
+#   CONFORMANCE_SUITE    suite to run: active|all|pending    (default: active)
+#   THV_BINARY           path to the thv binary              (default: thv)
+set -euo pipefail
+
+CONFORMANCE_VERSION="${CONFORMANCE_VERSION:-0.1.16}"
+CONFORMANCE_SUITE="${CONFORMANCE_SUITE:-active}"
+THV_BINARY="${THV_BINARY:-thv}"
+SERVER_NAME="conf-sut-ci"
+IMAGE="mcp-conformance-server:ci"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESULTS_DIR="${SCRIPT_DIR}/results"
+EXPECTED_FAILURES="${SCRIPT_DIR}/expected-failures.yaml"
+
+# thv proxying to a container is a local-only, trusted-dev workflow.
+export TOOLHIVE_DEV=true
+export TOOLHIVE_SKIP_DESKTOP_CHECK=1
+
+CLONE_DIR=""
+cleanup() {
+  "${THV_BINARY}" rm "${SERVER_NAME}" >/dev/null 2>&1 || true
+  [ -n "${CLONE_DIR}" ] && rm -rf "${CLONE_DIR}" || true
+}
+trap cleanup EXIT
+
+echo "==> Cloning conformance repo v${CONFORMANCE_VERSION}"
+CLONE_DIR="$(mktemp -d)"
+for attempt in 1 2 3; do
+  if git clone --depth 1 --branch "v${CONFORMANCE_VERSION}" \
+      https://github.com/modelcontextprotocol/conformance "${CLONE_DIR}/repo"; then
+    break
+  fi
+  echo "clone attempt ${attempt} failed; retrying..." >&2
+  rm -rf "${CLONE_DIR}/repo"
+  sleep 5
+  [ "${attempt}" = 3 ] && { echo "ERROR: could not clone conformance repo" >&2; exit 1; }
+done
+
+SERVER_DIR="${CLONE_DIR}/repo/examples/servers/typescript"
+if [ ! -f "${SERVER_DIR}/everything-server.ts" ]; then
+  echo "ERROR: reference server not found at ${SERVER_DIR}" >&2
+  exit 1
+fi
+
+echo "==> Building reference server image"
+cp "${SCRIPT_DIR}/Dockerfile" "${SERVER_DIR}/Dockerfile"
+docker build -t "${IMAGE}" "${SERVER_DIR}"
+
+echo "==> Starting server through ToolHive"
+"${THV_BINARY}" rm -f "${SERVER_NAME}" >/dev/null 2>&1 || true
+"${THV_BINARY}" run "${IMAGE}" \
+  --transport streamable-http --target-port 3000 --name "${SERVER_NAME}"
+
+echo "==> Resolving proxy URL"
+URL=""
+for _ in $(seq 1 30); do
+  URL="$("${THV_BINARY}" list --format json 2>/dev/null \
+    | python3 -c "import sys,json;   d=json.load(sys.stdin)
+print(next((w['url'] for w in d if w.get('name')=='${SERVER_NAME}' and w.get('status')=='running' and w.get('url')), ''))" \
+    2>/dev/null || true)"
+  [ -n "${URL}" ] && break
+  sleep 2
+done
+[ -z "${URL}" ] && { echo "ERROR: could not resolve ${SERVER_NAME} URL" >&2; "${THV_BINARY}" list || true; exit 1; }
+echo "    URL: ${URL}"
+
+echo "==> Waiting for endpoint to be ready"
+for _ in $(seq 1 30); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' "${URL}" -X POST \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}' || true)"
+  [ "${code}" = "200" ] && break
+  sleep 2
+done
+[ "${code}" = "200" ] || { echo "ERROR: endpoint never became ready (last HTTP ${code})" >&2; exit 1; }
+
+echo "==> Running conformance suite (${CONFORMANCE_SUITE})"
+rm -rf "${RESULTS_DIR}"
+npx -y "@modelcontextprotocol/conformance@${CONFORMANCE_VERSION}" server \
+  --url "${URL}" \
+  --suite "${CONFORMANCE_SUITE}" \
+  --expected-failures "${EXPECTED_FAILURES}" \
+  -o "${RESULTS_DIR}"


### PR DESCRIPTION
## Summary

ToolHive is a proxy in front of MCP servers, so the fidelity of its
transport/proxy layer to the MCP spec can be measured with the upstream
[MCP conformance suite](https://github.com/modelcontextprotocol/conformance).
This adds an automated, spec-authored compliance signal that regresses loudly —
feeding the protocol-currency epic (#5743).

- New per-PR `conformance` job in `e2e-tests.yml` (reuses the `build-binary`
  artifact; adds `actions/setup-node`).
- `test/conformance/run-conformance.sh` clones the conformance repo at a pinned
  version, builds its reference fixture server into a container, runs it through
  `thv run --transport streamable-http`, and points the tool at the proxied
  `/mcp` endpoint, gated by `expected-failures.yaml` (empty — the CLI proxy is
  transparent, so any drop is a real regression).
- A single `CONFORMANCE_VERSION` pins both the npm tool and the git server
  source (repo tags map 1:1 to npm versions).
- `task conformance` target for local runs.

k8s operator-proxy conformance is intentionally out of scope pending a fix to its
`Host`-header rewriting; the stdio bridge needs a stdio fixture server. Both noted
in `test/conformance/README.md`.

Closes #5803

## Type of change

- [x] Other (describe): CI / test-only

## Test plan

- [x] Manual testing (describe below)

Ran `task conformance` locally end-to-end: reference server built and started via
`thv run`, `active` suite reported **40/40 passed** and "Baseline check passed".
Verified trap cleanup removes the workload and the pre-run remove is idempotent.

## Does this introduce a user-facing change?

No.


Generated with [Claude Code](https://claude.com/claude-code)
