### PR TITLE
Add stateless transport proxy design doc

### DIFF
--- a/.claude/agents/mcp-protocol-expert.md
+++ b/.claude/agents/mcp-protocol-expert.md
@@ -1,7 +1,7 @@
 ---
 name: mcp-protocol-expert
-description: "PROACTIVELY use for MCP protocol questions, transport implementations, JSON-RPC debugging, and spec compliance verification. Expert in MCP 2025-11-25 specification."
-tools: [Read, Write, Edit, Glob, Grep, WebFetch]
+description: "PROACTIVELY use for MCP protocol questions, transport implementations, JSON-RPC debugging, and spec compliance verification. Expert in the current stable MCP specification."
+tools: [Read, Write, Edit, Glob, Grep, WebFetch, mcp__context7__resolve-library-id, mcp__context7__get-library-docs]
 model: inherit
 ---
 
@@ -22,27 +22,24 @@ Defer to: oauth-expert (OAuth/OIDC), kubernetes-expert (K8s operator), toolhive-
 
 ## Critical: Always Fetch Latest Spec
 
-**Before providing MCP protocol guidance, ALWAYS use WebFetch to retrieve the relevant spec page.** MCP is actively evolving — the spec is the single source of truth.
+**Before providing MCP protocol guidance, ALWAYS retrieve the relevant spec page — never answer from pre-training knowledge alone.** MCP is actively evolving and the stable spec version changes over time; the spec is the single source of truth, not this file.
 
-### Spec URLs (2025-11-25)
-- Main: https://modelcontextprotocol.io/specification/2025-11-25
-- Transports: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
-- Lifecycle: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle
-- Authorization: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
-- Security: https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices
-- Tasks: https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks
-- Tools: https://modelcontextprotocol.io/specification/2025-11-25/server/tools
-- Elicitation: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation
-- MCP Auth Extensions: https://modelcontextprotocol.io/extensions/auth/overview
-- Schema: https://modelcontextprotocol.io/specification/2025-11-25/schema
-
-Check for newer spec versions — the date in the URL indicates version.
+**Prefer context7. Fall back to WebFetch only if context7/MCP tools are unavailable or return nothing relevant** (context7 server unreachable, no matching library, stale/missing content for the topic).
 
 ### Workflow
-1. Use WebFetch to retrieve the relevant spec page
-2. Cross-reference fetched spec with ToolHive's implementation
-3. Provide guidance based on the latest spec
-4. Explicitly note any discrepancies between spec and implementation
+
+1. **Try context7 first**:
+   - Call `mcp__context7__resolve-library-id` fresh every time (do not hardcode or reuse a library ID across sessions) with a query like "Model Context Protocol specification". Context7 mints a new pinned library per stable release (e.g. `/websites/modelcontextprotocol_io_specification_2025-11-25`, `_2025-06-18`), so a fresh resolve naturally surfaces whichever dated snapshot is current — don't assume any specific date.
+   - Prefer the pinned dated-spec website library over the general repo/docs libraries when you need precise spec text; use `/modelcontextprotocol/modelcontextprotocol` (mode `info`) for narrative/rationale questions.
+   - Call `mcp__context7__get-library-docs` with a topic scoped to the question (e.g. "authorization discovery", "streamable http transport").
+2. **Fall back to WebFetch** if context7 didn't resolve a library, the MCP tools aren't available in this environment, or the returned snippets don't answer the question:
+   - First resolve the current version: fetch the unversioned index `https://modelcontextprotocol.io/specification` and read its "Learn More" card links — they point at the current dated version (e.g. `/specification/2025-11-25/...`). Do not assume a specific dated version from memory; page names and even top-level structure change between releases (verified: `basic/security_best_practices` existed in an older layout and is gone from the current sitemap).
+   - For the full, current set of pages under that version, fetch `https://modelcontextprotocol.io/sitemap.xml` and filter for the resolved version string — this is self-correcting as pages are added, renamed, or removed, unlike a hand-maintained list.
+   - Common pages to expect (verify against the sitemap, don't assume the exact path): architecture, basic, basic/authorization, basic/lifecycle, basic/transports, basic/utilities/{cancellation,ping,progress,tasks}, client/{elicitation,roots,sampling}, server, server/{tools,resources,prompts}, server/utilities/{completion,logging,pagination}, schema, changelog.
+   - Also check `https://modelcontextprotocol.io/extensions/auth/overview` for MCP auth extensions, which live outside the versioned spec tree.
+3. Cross-reference whichever source answered with ToolHive's implementation.
+4. Provide guidance based on the latest spec.
+5. Explicitly note any discrepancies between spec and implementation, and note which source (context7 vs. WebFetch) backed the answer if it's non-obvious.
 
 ## Your Expertise
 
@@ -50,7 +47,7 @@ Check for newer spec versions — the date in the URL indicates version.
 - **Transport protocols**: stdio (preferred), Streamable HTTP, SSE (deprecated)
 - **JSON-RPC 2.0**: Message format, request/response/notification patterns
 - **Protocol lifecycle**: Initialization, capability negotiation, operation, shutdown
-- **Tasks & Elicitation**: Long-running operations and user input collection (new in 2025-11-25)
+- **Tasks & Elicitation**: Long-running operations and user input collection
 - **Authorization**: OAuth 2.1, RFC 9728, RFC 8707, Client ID Metadata Documents
 
 ## Key ToolHive Files
@@ -71,8 +68,8 @@ Check for newer spec versions — the date in the URL indicates version.
 5. **Protocol debugging**: Analyze JSON-RPC exchanges against spec requirements
 
 <critical_behaviors>
-1. Fetch before answering — always use WebFetch for relevant spec pages
+1. Fetch before answering — try context7 first, fall back to WebFetch, never answer from memory alone
 2. Spec is authoritative — if conflict with this doc, the fetched spec wins
-3. Check for newer versions — look for dates newer than 2025-11-25
+3. Never hardcode a version — resolve the current stable version fresh each time (context7 resolve-library-id, or the unversioned spec index for WebFetch)
 4. Call out discrepancies explicitly when ToolHive differs from spec
 </critical_behaviors>

--- a/.claude/agents/mcp-protocol-expert.md
+++ b/.claude/agents/mcp-protocol-expert.md
@@ -37,9 +37,10 @@ Defer to: oauth-expert (OAuth/OIDC), kubernetes-expert (K8s operator), toolhive-
    - For the full, current set of pages under that version, fetch `https://modelcontextprotocol.io/sitemap.xml` and filter for the resolved version string — this is self-correcting as pages are added, renamed, or removed, unlike a hand-maintained list.
    - Common pages to expect (verify against the sitemap, don't assume the exact path): architecture, basic, basic/authorization, basic/lifecycle, basic/transports, basic/utilities/{cancellation,ping,progress,tasks}, client/{elicitation,roots,sampling}, server, server/{tools,resources,prompts}, server/utilities/{completion,logging,pagination}, schema, changelog.
    - Also check `https://modelcontextprotocol.io/extensions/auth/overview` for MCP auth extensions, which live outside the versioned spec tree.
-3. Cross-reference whichever source answered with ToolHive's implementation.
-4. Provide guidance based on the latest spec.
-5. Explicitly note any discrepancies between spec and implementation, and note which source (context7 vs. WebFetch) backed the answer if it's non-obvious.
+3. **For schema-level questions (exact field names, required-vs-optional, discriminated unions, literal error-code values), prefer the raw TypeScript schema over the rendered `.../schema` page or context7 snippets.** The rendered/curated sources can summarize or truncate a ~3k-line file; the ground truth both are generated from is `https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/<version>/schema.ts` (plain text, JSDoc-commented). Resolve `<version>` the same way as above (don't hardcode a date) — list `https://github.com/modelcontextprotocol/modelcontextprotocol/tree/main/schema` if unsure which dated folder is current — then WebFetch that file directly with a narrow prompt for the type in question.
+4. Cross-reference whichever source answered with ToolHive's implementation.
+5. Provide guidance based on the latest spec.
+6. Explicitly note any discrepancies between spec and implementation, and note which source (context7, WebFetch docs, or schema.ts) backed the answer if it's non-obvious.
 
 ## Your Expertise
 

--- a/docs/arch/stateless-transport-proxies-design.md
+++ b/docs/arch/stateless-transport-proxies-design.md
@@ -1,0 +1,285 @@
+# Stateless Transport Proxy Support (MCP 2026-07-28)
+
+## Overview
+
+This document designs dual-protocol operation for ToolHive's two transport proxies —
+the transparent proxy (HTTP→HTTP reverse proxy) and the streamable proxy (HTTP→stdio
+container proxy) — so they can serve both the current stable MCP revision (2025-11-25)
+and the upcoming stateless revision (2026-07-28) on the same endpoint, discriminating
+per request rather than requiring a cutover.
+
+It is a design/sequencing document (tracking issue #5755). vMCP, the go-sdk v1.7 bump,
+and OAuth hardening are separate efforts (see [Out of scope](#out-of-scope)). File and line
+references point into `pkg/transport/proxy/` and `pkg/mcp/`; line numbers drift over time, so
+re-locate by symbol name where they no longer match.
+
+## Why this exists
+
+The 2026-07-28 MCP revision removes the pieces the proxies are currently built around:
+
+- the `initialize` handshake (replaced by per-request `_meta` metadata plus a
+  `server/discover` RPC),
+- protocol sessions and the `Mcp-Session-Id` header (traffic becomes stateless), and
+- the standalone GET SSE stream.
+
+The ecosystem will straddle both revisions for a long time — SDKs (go-sdk v1.7, TS SDK v2)
+serve both on one endpoint, and clients/servers will upgrade independently. ToolHive
+therefore needs **per-request revision discrimination**, not a flag day: a 2025-11-25 client
+must keep working unchanged while a 2026-07-28 peer is served natively.
+
+## Background: what `initialize` does today
+
+Two properties of the current implementation shape the entire approach.
+
+**The proxies parse MCP bodies themselves.** `transparent_proxy.go`, `streamable_proxy.go`,
+and `pkg/mcp/parser.go` decode JSON-RPC with `golang.org/x/exp/jsonrpc2` and `encoding/json`;
+they do not route through the go-sdk or toolhive-core's `mcpcompat` shim. Revision detection
+therefore lives in ToolHive-owned code, above any SDK. (The authz/telemetry middleware wrapping
+the proxies import `mcpcompat/mcp` for types only — a compile-time coupling, not a data-path
+dependency.)
+
+**`initialize` is used as a trigger, not as stored state.** The only field any proxy extracts
+from an `initialize` body is `clientInfo.name` (`parser.go:262-271`), used for audit/authz
+labels. Everything else keys off a single boolean — *is this request the `initialize` method?* —
+which triggers session creation, backend-pod pinning, and health-check enablement. Removing the
+handshake therefore removes a *trigger*; there is very little negotiated state to reconstruct.
+
+## How it works
+
+### Revision classification
+
+Each request is classified per-request as **Modern** (2026-07-28, stateless) or **Legacy**
+(≤2025-11-25, `initialize`-based):
+
+- **Modern** when the request body's `_meta` carries `io.modelcontextprotocol/protocolVersion`.
+  That key is required on every Modern request (`schema/draft/schema.ts`, `RequestMetaObject`),
+  so it is a reliable per-request signal. On Streamable HTTP it is mirrored into the
+  `MCP-Protocol-Version` header; a header/body mismatch is rejected with `400` and JSON-RPC
+  error `-32020` (`HeaderMismatch`). The body is authoritative.
+- **Legacy** otherwise, with `method == "initialize"` marking session start. A malformed or
+  absent `_meta` classifies as Legacy, which is the safe direction — it preserves the existing
+  session guard.
+
+The existing header validation does not stand in the way: `isSupportedMCPVersion`
+(`streamable/utils.go:62-65`, called at `streamable_proxy.go:361`) accepts any version, so the
+proxy does not reject a Modern `MCP-Protocol-Version` today. Discrimination therefore belongs at
+the body-parse seam, where the authoritative `_meta` lives, not at the optional header check.
+
+```mermaid
+flowchart TD
+    Req[Incoming request] --> Meta{_meta has<br/>protocolVersion?}
+    Meta -->|yes| Modern[Modern: stateless path<br/>no session, per-request token]
+    Meta -->|no| Init{method ==<br/>initialize?}
+    Init -->|yes| LegacyNew[Legacy: create session]
+    Init -->|no| LegacyExisting[Legacy: existing-session path]
+```
+
+Classification is a pure function in `pkg/mcp`, called at the existing decode points rather
+than threaded through a shared context object (neither proxy reads `ParsedMCPRequest` on its
+routing path — the transparent proxy sniffs bytes inside `RoundTrip`, the streamable proxy
+decodes a `jsonrpc2.Request` directly):
+
+```go
+// pkg/mcp
+func ClassifyRevision(method string, meta map[string]any, protoHeader string) (Revision, error)
+```
+
+A connection does not change revision mid-stream, so the transparent proxy classifies once and
+stores the `Revision` in session metadata (as it already does for `sessionMetadataBackendSID`),
+letting `RoundTrip` read one field instead of re-deriving it.
+
+A Modern-aware parser must also recognize the mandatory request headers introduced alongside
+the metadata model: `Mcp-Method` (required on every Modern POST) and `Mcp-Name` (required for
+`tools/call`, `resources/read`, `prompts/get`). Both are validated against the body with the
+same `-32020` code. As an intermediary that reads bodies for authz/audit, ToolHive should verify
+that the protocol version indicates a header-validation-required revision before trusting any
+mirrored header value.
+
+### Security invariant
+
+The `_meta` protocol fields and the mirrored headers are entirely client-controlled and now
+appear on every request. They are telemetry and labels, never a security principal — the
+authenticated identity established by the middleware chain (which runs before session handling)
+remains the only principal, and authorization policies must not key off client-asserted `_meta`.
+Registering `server/discover` in the parser's method tables is partly a security measure: an
+unknown method currently yields an empty resource ID, so this confirms authorization
+default-denies rather than matching a broad allow rule.
+
+### The dual-era matrix
+
+A proxy fronts one backend and serves whatever client connects; the two sides have independent
+revisions.
+
+| Client | Backend | Proxy behavior |
+|--------|---------|----------------|
+| Legacy | Legacy | Today's path, unchanged. |
+| Modern | Modern | Stateless pass-through (the streamable proxy's existing sessionless branch). |
+| Legacy | Modern | Client expects the handshake and a session; backend has neither. The gateway must terminate the handshake itself. |
+| Modern | Legacy | Client uses `server/discover` and per-request `_meta`; backend requires `initialize`. The gateway must synthesize `initialize` toward the backend. |
+
+The two diagonal cells are the supported scope. The off-diagonal cells require the gateway to
+translate between eras and are deferred (see [decision D2](#decisions-and-rationale)). The MCP
+specification's probe-then-fallback mechanism is normative but only protects a client talking
+*directly* to a server; its compatibility matrix marks the Legacy-client/Modern-server case as
+"Fails" with no fall-forward, so a gateway is the only thing that could bridge it. The
+agentgateway project reached the same conclusion — it ships the diagonals and the
+Modern-client/Legacy-server synthetic-initialize path, and deliberately declined the
+Legacy-client/Modern-server case as unsound.
+
+This binary Modern/Legacy classification suffices while there is a single Modern revision. When
+a second ships, `DiscoverResult.supportedVersions` and `UnsupportedProtocolVersionError.data.supported`
+are version lists, and the classifier will need real version-string negotiation.
+
+## Implementation phases
+
+Each phase is independently shippable. Everything classifies as Legacy by default, so behavior
+is unchanged until a Modern request actually arrives.
+
+### Phase 1 — Classifier and parser vocabulary (no behavior change)
+
+Add `ClassifyRevision` and wire it at the three decode points; store `Revision` in the
+transparent proxy's session metadata. In `parser.go` (method tables at `:186-211`), source
+`clientInfo`/protocolVersion from `_meta` for Modern requests, and register `server/discover`,
+`Mcp-Method`, and `Mcp-Name` so they are labeled for authz/audit (`server/discover` is currently
+unlabeled). Verification: existing tests stay green; a Modern-shaped request classifies Modern;
+a request with spoofed or absent `_meta` classifies Legacy.
+
+### Phase 2 — Streamable proxy: Modern is stateless
+
+In `resolveSessionForRequest` (`streamable_proxy.go:761-804`), Modern requests must
+unconditionally mint a fresh per-request routing token and ignore any client-supplied
+`Mcp-Session-Id`. This is stronger than "take the sessionless path": that branch is guarded by
+`if sessID == ""` (`:789-796`), so a Modern request carrying a session header would otherwise
+fall through to session lookup and risk delivering one client's response to another. The
+per-request token is a load-bearing confidentiality invariant (`:722-729`, `:751-758`): a unique
+token prevents concurrent sessionless requests from colliding on the same
+`compositeKey(sessID, idKey)` in the response-correlation maps. Modern is sessionless by
+definition, so the client has no legitimate session header. `ensureSession` (`:712`) is unused
+on this path, and no `Mcp-Session-Id` is minted.
+
+This token is easy to mistake for surviving MCP-session state; it is not. The two must be kept
+distinct:
+
+- **MCP-protocol session state is dropped** — `session.Manager` and its storage, `ensureSession`,
+  the lookup/`initialize` branches, and the `Mcp-Session-Id` response header all no-op for Modern.
+- **The per-request token is transport plumbing that survives regardless of protocol.** The
+  streamable proxy multiplexes every concurrent request onto a single stdio pipe to the container,
+  and one reader goroutine (`dispatchResponses`, `dispatcher.go:16-54`) demuxes backend responses
+  back to the correct blocked HTTP handler by JSON-RPC id, via `compositeKey(sessID, idKey)`
+  (`utils.go:57-60`) into the `waiters` map. Two independent clients can both pick id `1`, so a
+  unique per-request key is required even with no session — otherwise they collide and cross-deliver.
+  On the Modern path the `sessID` slot is therefore a correlation nonce, not a session id; a
+  from-scratch stateless HTTP→stdio proxy would have to reinvent it. Verification (security
+critical): two concurrent Modern requests sharing a JSON-RPC id, one carrying a foreign session
+header, must not cross-deliver responses.
+
+### Phase 3 — Transparent proxy: gate the initialize-triggered machinery
+
+Unlike the streamable proxy, the transparent proxy keeps **no** session code on the Modern path
+and needs no correlation token: there is no shared pipe, so Go's `http.Transport` matches responses
+to requests natively per connection, and the Modern path collapses to a plain reverse proxy.
+Because Modern requests never mint a session, most of the sticky-session machinery simply never
+engages, rather than needing a branch at every site. The session guard (`:600-609`), pod-pinning
+and init-body storage (`:632-640`, `:708-734`), and `reinitializeAndReplay` (`:944-1055`, invoked
+at `:652`/`:700`) all already key off `sawInitialize` or session presence. The backend-SID rewrite
+(`:620-626`) must additionally be gated so a Modern request's session header is never rewritten
+onto a pinned backend.
+
+The health gate needs care. `serverInitialized` gates only the internal `monitorHealth` loop
+(read at `:1365`; failure calls `p.Stop()` at `:1341`), not Kubernetes probes or request
+forwarding — the Kubernetes probes hit `/health` on the proxy pod and return 200 for both
+Healthy and Degraded. For Legacy, the loop is deferred until the first successful `initialize`
+to avoid pinging a cold backend. Modern must not simply "default to ready," which would start
+the loop immediately and could self-terminate the proxy during a slow backend cold-start;
+instead, gate off the first successful backend contact (the existing `StatelessMCPPinger`
+POST-ping is a suitable signal). Verification: a Modern request to a multi-replica backend routes
+without pod-pinning and does not re-initialize on a backend `404`; a Modern request carrying a
+foreign session header is not rewritten onto a pinned backend; Legacy traffic keeps its sticky
+behavior; and the internal monitor does not self-terminate on a cold-starting Modern backend.
+
+### Phase 4 — Off-diagonal translation (deferred; see D2)
+
+If the cross-era cells are taken on later: for Modern-client/Legacy-server, synthesize
+`initialize` toward the backend before the first forward and rewrite responses (strip
+`resultType`/`ttlMs`/`cacheScope` for a Legacy downstream, add `resultType: "complete"` for a
+Modern one). The Legacy-client/Modern-server cell — the gateway terminating the client handshake
+and holding a gateway-side session — is the highest-risk and likely stays deferred.
+
+### Session manager
+
+No change. `session/manager.go:161-211` is trigger-agnostic; only the proxy call sites that
+create sessions move behind the Legacy branch.
+
+## Kubernetes and operational considerations
+
+Statelessness removes the cross-replica affinity problem **for unary request/response only**:
+any Modern request may hit any backend pod, so pod-pinning and re-initialization become
+unnecessary. Server-push traffic (GET SSE notifications, resource subscriptions, progress) still
+binds a client to the pod that accepted the stream, so that traffic remains affinity-bound even
+under Modern.
+
+A single backend Deployment may receive both Legacy (session-pinned) and Modern (any-pod) traffic
+at once, while `SessionAffinity` on the client-facing Service is a per-Service switch
+(`ClientIP` or `None`). Mixed traffic across more than one replica therefore requires shared
+session storage (Redis) — already enforced by `validateSessionStorageForReplicas` — after which
+`SessionAffinity: None` is safe for both eras. The per-request classifier is auto-detected from
+`_meta` and needs no CRD or operator change, so a rolling upgrade is safe: old and new proxy pods
+share one Service and Redis, and Modern adds no session writes.
+
+## Relationship to the existing `--stateless` flag
+
+ToolHive already has a `--stateless` run flag (`run_flags.go:280`), an operator opt-in that
+declares a server "POST-only, no SSE." It is orthogonal to this design and composes additively.
+The flag affects only the transparent proxy, and only its method layer and health check: it
+rejects GET/HEAD/DELETE with 405 (`statelessMethodGate`, `:1229-1230`) and swaps in
+`StatelessMCPPinger`. It does not touch the POST session/initialize path, and the streamable
+proxy ignores it entirely. The Modern classifier operates on exactly the layer the flag leaves
+alone.
+
+The one interaction is the GET/DELETE gate: its server-global 405 would reject a Legacy client's
+SSE stream on a dual-era endpoint, so under per-request classification the gate must become
+revision-aware (rejecting GET/DELETE only for connections presenting a Modern
+`MCP-Protocol-Version`). When `--stateless` is set the operator has asserted there are no Legacy
+SSE clients, so the existing global gate remains correct.
+
+## Decisions and rationale
+
+- **D1 — Independent of the go-sdk v1.7 bump.** The proxy routing/session/forwarding path never
+  constructs an `mcpcompat`/go-sdk client or server (only `bridge.go`, used by the `thv proxy
+  stdio` CLI, does, and it is not a transport proxy). This work is ToolHive-owned and can proceed
+  in parallel with the SDK bump rather than behind it.
+- **D2 — Diagonals-only scope; off-diagonal deferred.** Phases 1–3 cover the Legacy↔Legacy and
+  Modern↔Modern cells. For Modern-client/Legacy-server, rely on the spec's normative client
+  fallback; the Legacy-client/Modern-server cell is deferred. Full bidirectional era translation
+  belongs to the vMCP gateway, not the transport proxies.
+- **D3 — Backend revision detection (deferred with the off-diagonal work).** When needed: a stdio
+  backend is probed once with `server/discover` and cached per backend; an HTTP backend is
+  detected by attempting a Modern request and inspecting the `400` body (the two transports use
+  different mechanisms). A "recognized modern error" includes `-32020`, `-32022`
+  (`UnsupportedProtocolVersion`), and `MissingRequiredClientCapability`. The health gate keys off
+  backend revision, not client revision.
+- **D4 — Orthogonal to `--stateless`.** See [the section above](#relationship-to-the-existing---stateless-flag);
+  additive, with one gate refinement, no CRD surface.
+
+## Out of scope
+
+- vMCP stateless support and the cross-generation bridge (#5756).
+- The go-sdk v1.7 bump and `mcpcompat` stateless plumbing (#5754); D1 de-gates this design from it.
+- OAuth RFC 9207 `iss` validation, which is genuine uncovered work in ToolHive's own
+  `pkg/auth/oauth` (ToolHive uses `golang.org/x/oauth2` and `go-oidc`, not the go-sdk OAuth
+  helpers), tracked separately (#5760).
+- MRTR, Tasks, the `x-mcp-header` tool-parameter mirroring extension (distinct from the mandatory
+  `Mcp-Method`/`Mcp-Name` headers, which are in scope), and caching metadata.
+
+## Related documentation
+
+- [Transport Architecture](03-transport-architecture.md) — the two proxy types and session model.
+- [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md) — where the cross-generation
+  bridge (#5756) lives.
+- [vMCP Scalability Limits](13-vmcp-scalability.md) — session-cache and Redis constraints.
+- Specification: draft `basic/versioning` (era terminology, compatibility matrix, fallback),
+  `server/discover`, and `basic/transports/{stdio,streamable-http}`.
+- Prior art — agentgateway: `crates/agentgateway/src/mcp/README.md` (dual-era design rationale) and
+  `session.rs` (`stateless_send_and_initialize`, the Modern/Legacy forward decision); the evolution
+  is traceable through issue #221 and PRs #262, #2365, and #2477 (pragmatic synthetic-initialize to
+  spec-aligned per-request handling).


### PR DESCRIPTION
## Summary

The 2026-07-28 MCP revision removes the pieces ToolHive's transport proxies are built around: the `initialize` handshake (replaced by per-request `_meta` metadata plus a `server/discover` RPC), protocol sessions and the `Mcp-Session-Id` header, and the standalone GET SSE stream. The ecosystem will straddle both revisions for a long time, so ToolHive must serve 2025-11-25 and 2026-07-28 peers on the same endpoint, discriminating per request rather than at a cutover.

This PR adds the design-doc deliverable for that work (the deliverable #5755 explicitly calls for). It is documentation only — no code changes.

- Adds `docs/arch/stateless-transport-proxies-design.md` covering:
  - a per-request Modern/Legacy classifier (`ClassifyRevision`) homed at the body-parse seam, since the proxies parse JSON-RPC themselves and don't read `ParsedMCPRequest` on their routing path;
  - the client × backend dual-era matrix, with the two diagonal cells in scope and off-diagonal era-translation deferred;
  - a phased implementation (classifier/vocabulary → streamable stateless → transparent gating → deferred translation);
  - the security invariant separating MCP session state (dropped for Modern) from the streamable proxy's per-request response-correlation token (structural, stdio-demux only);
  - Kubernetes/operational impact (affinity, mixed traffic, rollout) and the relationship to the existing `--stateless` flag.

Closes #5755

## Type of change

- [x] Documentation

## Test plan

- [x] Manual testing (describe below)

Documentation-only change. Verified: file/line references were checked against the proxy packages (`pkg/transport/proxy/`, `pkg/mcp/`) during authoring; the Mermaid fence matches the style used by sibling `docs/arch` documents; internal cross-links (`03-transport-architecture.md`, `10-virtual-mcp-architecture.md`, `13-vmcp-scalability.md`) resolve.

## Does this introduce a user-facing change?

No — internal architecture documentation.

## Special notes for reviewers

- Design only; the phases map to follow-up implementation issues to be filed after this lands (the "then implementation issues" half of #5755).
- Two decisions in the doc are worth a look: **D1** argues this work is independent of the go-sdk v1.7 bump (#5754) — the proxy routing/session path never touches the SDK — so the dependency edge stated on #5755 can be dropped. **D2** scopes to the diagonal cells only and defers the cross-generation bridge to vMCP (#5756).
- Line numbers are anchored on current proxy code and will drift; the doc notes to re-locate by symbol name.
