### PR TITLE
Add Codex App LLM setup support

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -246,9 +246,13 @@ which also calls "thv llm token". It reads its configuration only at launch, so
 fully quit and relaunch it after setup. Pass --models to list the models it
 should offer until the gateway serves model discovery itself.
 
-Codex is configured with a custom model_provider in ~/.codex/config.toml whose
-auth command invokes "thv llm token" directly (no shell), keeping the existing
-model_providers and mcp_servers entries in that file untouched.
+Codex CLI and the ChatGPT desktop app use the same user configuration:
+~/.codex/config.toml by default, or %USERPROFILE%\.codex\config.toml on Windows.
+ToolHive adds a custom model_provider whose auth command invokes "thv llm token"
+directly (no shell), keeping existing model_providers and mcp_servers entries
+untouched. Desktop app detection is supported on macOS and Windows; the canonical
+--client target remains "codex". If the desktop app is running, fully quit and
+reopen it after setup.
 
 Proxy-mode tools (Cursor, VS Code, Xcode) are configured to send requests to
 the localhost reverse proxy started by "thv llm proxy start".
@@ -296,7 +300,7 @@ Run "thv llm teardown" to revert all changes.`,
 		"Path prefix appended to the gateway URL when writing ANTHROPIC_BASE_URL for direct-mode tools "+
 			"(e.g. /anthropic). When omitted, the gateway is probed automatically.")
 	cmd.Flags().StringVar(&targetClient, "client", "",
-		"Configure only this AI tool by name (e.g. claude-code, cursor). Omit to configure all detected tools.")
+		"Configure only this AI tool by name (e.g. claude-code, cursor, codex). Omit to configure all detected tools.")
 	cmd.Flags().BoolVar(&lazy, "lazy", false,
 		"Skip the interactive OIDC login and defer it until the first time a configured tool "+
 			"accesses the gateway. Tool config and persisted settings are written normally. "+

--- a/docs/cli/thv_llm_setup.md
+++ b/docs/cli/thv_llm_setup.md
@@ -27,9 +27,13 @@ which also calls "thv llm token". It reads its configuration only at launch, so
 fully quit and relaunch it after setup. Pass --models to list the models it
 should offer until the gateway serves model discovery itself.
 
-Codex is configured with a custom model_provider in ~/.codex/config.toml whose
-auth command invokes "thv llm token" directly (no shell), keeping the existing
-model_providers and mcp_servers entries in that file untouched.
+Codex CLI and the ChatGPT desktop app use the same user configuration:
+~/.codex/config.toml by default, or %USERPROFILE%\.codex\config.toml on Windows.
+ToolHive adds a custom model_provider whose auth command invokes "thv llm token"
+directly (no shell), keeping existing model_providers and mcp_servers entries
+untouched. Desktop app detection is supported on macOS and Windows; the canonical
+--client target remains "codex". If the desktop app is running, fully quit and
+reopen it after setup.
 
 Proxy-mode tools (Cursor, VS Code, Xcode) are configured to send requests to
 the localhost reverse proxy started by "thv llm proxy start".
@@ -53,7 +57,7 @@ thv llm setup [flags]
       --anthropic-path-prefix string   Path prefix appended to the gateway URL when writing ANTHROPIC_BASE_URL for direct-mode tools (e.g. /anthropic). When omitted, the gateway is probed automatically.
       --audience string                OIDC audience (optional)
       --callback-port int              OIDC callback port (omit to keep current; default: ephemeral)
-      --client string                  Configure only this AI tool by name (e.g. claude-code, cursor). Omit to configure all detected tools.
+      --client string                  Configure only this AI tool by name (e.g. claude-code, cursor, codex). Omit to configure all detected tools.
       --client-id string               OIDC client ID
       --gateway-url string             LLM gateway base URL (must use HTTPS)
   -h, --help                           help for setup

--- a/pkg/client/codex_desktop.go
+++ b/pkg/client/codex_desktop.go
@@ -6,6 +6,7 @@ package client
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +17,10 @@ const (
 	codexWindowsPackageFamily = "OpenAI.Codex_2p2nqsd0c76g0"
 	codexWindowsPackageName   = "OpenAI.Codex"
 	codexWindowsInstalledMark = "installed"
+	// plutilPath is the absolute path to plutil on macOS. Using the absolute
+	// path avoids PATH-resolution failures in stripped-environment contexts
+	// (launchd jobs, sandboxes, CI) where /usr/bin is not on $PATH.
+	plutilPath = "/usr/bin/plutil"
 )
 
 type codexDesktopDetector struct {
@@ -31,7 +36,10 @@ func newCodexDesktopDetector(homeDir, goos string) codexDesktopDetector {
 		goos:    goos,
 		stat:    os.Stat,
 		command: func(name string, args ...string) ([]byte, error) {
-			return exec.Command(name, args...).Output() // #nosec G204 -- name and args are fixed below
+			// #nosec G204 -- the command name is a fixed compile-time literal
+			// ("plutil" or "powershell.exe"); args include derived file paths
+			// from os.UserHomeDir, not user input.
+			return exec.Command(name, args...).Output()
 		},
 	}
 }
@@ -55,8 +63,13 @@ func (d codexDesktopDetector) installedOnDarwin() (bool, error) {
 			if _, err := d.stat(infoPlist); err != nil {
 				continue
 			}
-			output, err := d.command("plutil", "-extract", "CFBundleIdentifier", "raw", "-o", "-", infoPlist)
+			output, err := d.command(plutilPath, "-extract", "CFBundleIdentifier", "raw", "-o", "-", infoPlist)
 			if err != nil {
+				// Log the plutil failure so it's distinguishable from "app absent."
+				// A failure here means the plist exists but its bundle identifier
+				// could not be extracted (e.g. plist corruption or plutil error).
+				slog.Warn("failed to extract CFBundleIdentifier from Codex app plist",
+					"app", appName, "plist", infoPlist, "error", err)
 				continue
 			}
 			if string(bytes.TrimSpace(output)) == codexBundleIdentifier {

--- a/pkg/client/codex_desktop.go
+++ b/pkg/client/codex_desktop.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const (
+	codexBundleIdentifier     = "com.openai.codex"
+	codexWindowsPackageFamily = "OpenAI.Codex_2p2nqsd0c76g0"
+	codexWindowsPackageName   = "OpenAI.Codex"
+	codexWindowsInstalledMark = "installed"
+)
+
+type codexDesktopDetector struct {
+	homeDir string
+	goos    string
+	stat    func(string) (os.FileInfo, error)
+	command func(string, ...string) ([]byte, error)
+}
+
+func newCodexDesktopDetector(homeDir, goos string) codexDesktopDetector {
+	return codexDesktopDetector{
+		homeDir: homeDir,
+		goos:    goos,
+		stat:    os.Stat,
+		command: func(name string, args ...string) ([]byte, error) {
+			return exec.Command(name, args...).Output() // #nosec G204 -- name and args are fixed below
+		},
+	}
+}
+
+func (d codexDesktopDetector) installed() (bool, error) {
+	switch d.goos {
+	case "darwin":
+		return d.installedOnDarwin()
+	case "windows":
+		return d.installedOnWindows()
+	default:
+		return false, nil
+	}
+}
+
+func (d codexDesktopDetector) installedOnDarwin() (bool, error) {
+	applicationDirs := []string{"/Applications", filepath.Join(d.homeDir, "Applications")}
+	for _, dir := range applicationDirs {
+		for _, appName := range []string{"Codex.app", "ChatGPT.app"} {
+			infoPlist := filepath.Join(dir, appName, "Contents", "Info.plist")
+			if _, err := d.stat(infoPlist); err != nil {
+				continue
+			}
+			output, err := d.command("plutil", "-extract", "CFBundleIdentifier", "raw", "-o", "-", infoPlist)
+			if err != nil {
+				continue
+			}
+			if string(bytes.TrimSpace(output)) == codexBundleIdentifier {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func (d codexDesktopDetector) installedOnWindows() (bool, error) {
+	const query = "$p = Get-AppxPackage -Name '" + codexWindowsPackageName + "' -ErrorAction SilentlyContinue | " +
+		"Where-Object { $_.PackageFamilyName -eq '" + codexWindowsPackageFamily + "' -and $_.SignatureKind -eq 'Store' } | " +
+		"Select-Object -First 1; if ($p) { Write-Output '" + codexWindowsInstalledMark + "' }"
+	output, err := d.command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", query)
+	if err != nil {
+		return false, fmt.Errorf("querying Codex Microsoft Store package: %w", err)
+	}
+	return string(bytes.TrimSpace(output)) == codexWindowsInstalledMark, nil
+}

--- a/pkg/client/codex_desktop_test.go
+++ b/pkg/client/codex_desktop_test.go
@@ -72,7 +72,7 @@ func TestCodexDesktopDetectorDarwin(t *testing.T) {
 					return nil, os.ErrNotExist
 				},
 				command: func(name string, args ...string) ([]byte, error) {
-					assert.Equal(t, "plutil", name)
+					assert.Equal(t, plutilPath, name)
 					assert.Equal(t, []string{"-extract", "CFBundleIdentifier", "raw", "-o", "-", plist}, args)
 					return []byte(tt.bundleID + "\n"), tt.commandErr
 				},

--- a/pkg/client/codex_desktop_test.go
+++ b/pkg/client/codex_desktop_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexDesktopDetectorDarwin(t *testing.T) {
+	t.Parallel()
+
+	home := filepath.Join(string(filepath.Separator), "Users", "test")
+	candidates := []string{
+		filepath.Join("/Applications", "Codex.app", "Contents", "Info.plist"),
+		filepath.Join("/Applications", "ChatGPT.app", "Contents", "Info.plist"),
+		filepath.Join(home, "Applications", "Codex.app", "Contents", "Info.plist"),
+		filepath.Join(home, "Applications", "ChatGPT.app", "Contents", "Info.plist"),
+	}
+
+	t.Run("checks all exact candidates without invoking plutil when absent", func(t *testing.T) {
+		t.Parallel()
+		var checked []string
+		commandCalled := false
+		detector := codexDesktopDetector{
+			homeDir: home,
+			goos:    "darwin",
+			stat: func(path string) (os.FileInfo, error) {
+				checked = append(checked, path)
+				return nil, os.ErrNotExist
+			},
+			command: func(_ string, _ ...string) ([]byte, error) {
+				commandCalled = true
+				return nil, nil
+			},
+		}
+
+		installed, err := detector.installed()
+		require.NoError(t, err)
+		assert.False(t, installed)
+		assert.Equal(t, candidates, checked)
+		assert.False(t, commandCalled)
+	})
+
+	tests := []struct {
+		name       string
+		bundleID   string
+		commandErr error
+		want       bool
+	}{
+		{name: "accepts exact Codex bundle identifier", bundleID: codexBundleIdentifier, want: true},
+		{name: "rejects ChatGPT bundle identifier", bundleID: "com.openai.chat"},
+		{name: "plutil failure is not detected", commandErr: errors.New("plutil failed")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			plist := candidates[0]
+			detector := codexDesktopDetector{
+				homeDir: home,
+				goos:    "darwin",
+				stat: func(path string) (os.FileInfo, error) {
+					if path == plist {
+						return nil, nil
+					}
+					return nil, os.ErrNotExist
+				},
+				command: func(name string, args ...string) ([]byte, error) {
+					assert.Equal(t, "plutil", name)
+					assert.Equal(t, []string{"-extract", "CFBundleIdentifier", "raw", "-o", "-", plist}, args)
+					return []byte(tt.bundleID + "\n"), tt.commandErr
+				},
+			}
+
+			installed, err := detector.installed()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, installed)
+		})
+	}
+}
+
+func TestCodexDesktopDetectorWindows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		output     string
+		commandErr error
+		want       bool
+		wantErr    bool
+	}{
+		{name: "accepts installed marker after filtering multiple objects", output: codexWindowsInstalledMark + "\r\n", want: true},
+		{name: "rejects marker mixed with output from another object", output: "noise\r\n" + codexWindowsInstalledMark + "\r\n"},
+		{name: "rejects no matching package", output: ""},
+		{name: "query failure", commandErr: errors.New("query failed"), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			detector := codexDesktopDetector{
+				goos: "windows",
+				command: func(name string, args ...string) ([]byte, error) {
+					assert.Equal(t, "powershell.exe", name)
+					require.Len(t, args, 4)
+					assert.Equal(t, []string{"-NoProfile", "-NonInteractive", "-Command"}, args[:3])
+					assert.Contains(t, args[3], "Get-AppxPackage -Name 'OpenAI.Codex'")
+					assert.Contains(t, args[3], "Where-Object")
+					assert.Contains(t, args[3], "$_.PackageFamilyName -eq 'OpenAI.Codex_2p2nqsd0c76g0'")
+					assert.Contains(t, args[3], "$_.SignatureKind -eq 'Store'")
+					assert.Contains(t, args[3], "Select-Object -First 1")
+					assert.Contains(t, args[3], "Write-Output 'installed'")
+					return []byte(tt.output), tt.commandErr
+				},
+			}
+
+			installed, err := detector.installed()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, installed)
+		})
+	}
+}
+
+func TestCodexDesktopDetectorUnsupportedPlatform(t *testing.T) {
+	t.Parallel()
+
+	installed, err := (codexDesktopDetector{goos: "linux"}).installed()
+	require.NoError(t, err)
+	assert.False(t, installed)
+}

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -85,7 +85,7 @@ const (
 	VSCodeServer ClientApp = "vscode-server"
 	// MistralVibe represents the Mistral Vibe IDE.
 	MistralVibe ClientApp = "mistral-vibe"
-	// Codex represents the OpenAI Codex CLI.
+	// Codex represents the OpenAI Codex CLI and desktop app.
 	Codex ClientApp = "codex"
 	// KimiCli represents the Kimi Code CLI.
 	KimiCli ClientApp = "kimi-cli"
@@ -245,8 +245,8 @@ type clientAppConfig struct {
 	// If nil or missing an entry for the current OS, no prefix is added.
 	PluginsPlatformPrefix map[Platform][]string
 	// LLM gateway configuration ─────────────────────────────────────────────
-	// LLMGatewayMode is "direct" (token-helper) or "proxy" (static key via
-	// localhost reverse proxy), or "" when the tool has no LLM gateway support.
+	// LLMGatewayMode identifies the gateway integration strategy (direct token
+	// helper, proxy, credential helper, or Codex auth), or "" when unsupported.
 	LLMGatewayMode string
 	// LLMBinaryName is the executable name looked up via exec.LookPath to
 	// confirm the tool is actually installed (not just a leftover config

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -286,6 +286,13 @@ type clientAppConfig struct {
 	// LLMSettingsRelPath / LLMSettingsPlatformPrefix.
 	LLMDetectRelPath        []string
 	LLMDetectPlatformPrefix map[Platform][]string
+	// LLMInstalledDetector is an optional per-client detection hook that runs
+	// in addition to the shared settings-dir + binary-on-PATH check. Used by
+	// clients that have installation evidence beyond the CLI (e.g. Codex's
+	// desktop app). When set, the client is considered installed if either
+	// the shared check or this hook returns true. The hook must be set at
+	// construction time (NewClientManager), not in static config.
+	LLMInstalledDetector func() (bool, error)
 	// LLMManagedProfileDomain is the macOS managed-preferences plist domain
 	// (e.g. "com.anthropic.claudefordesktop.plist") that, when present, overrides
 	// the client's local config. Setup warns when detected. Empty when the client

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -19,12 +19,11 @@ import (
 //
 //nolint:revive // ClientManager is intentionally named to avoid conflict with existing Manager interface
 type ClientManager struct {
-	homeDir               string
-	groupManager          groups.Manager
-	clientIntegrations    []clientAppConfig
-	configProvider        config.Provider
-	lookPath              func(string) (string, error)
-	codexDesktopInstalled func() (bool, error)
+	homeDir            string
+	groupManager       groups.Manager
+	clientIntegrations []clientAppConfig
+	configProvider     config.Provider
+	lookPath           func(string) (string, error)
 }
 
 // HomeDir returns the home directory this ClientManager is rooted at. Exported
@@ -48,13 +47,24 @@ func NewClientManager() (*ClientManager, error) {
 		groupManager = nil
 	}
 
+	// Copy the static integration list so we can wire per-client detectors
+	// without mutating the shared supportedClientIntegrations slice.
+	integrations := make([]clientAppConfig, len(supportedClientIntegrations))
+	copy(integrations, supportedClientIntegrations)
+	codexDetector := newCodexDesktopDetector(home, runtime.GOOS).installed
+	for i := range integrations {
+		if integrations[i].ClientType == Codex {
+			integrations[i].LLMInstalledDetector = codexDetector
+			break
+		}
+	}
+
 	return &ClientManager{
-		homeDir:               home,
-		groupManager:          groupManager,
-		clientIntegrations:    supportedClientIntegrations,
-		configProvider:        config.NewDefaultProvider(),
-		lookPath:              exec.LookPath,
-		codexDesktopInstalled: newCodexDesktopDetector(home, runtime.GOOS).installed,
+		homeDir:            home,
+		groupManager:       groupManager,
+		clientIntegrations: integrations,
+		configProvider:     config.NewDefaultProvider(),
+		lookPath:           exec.LookPath,
 	}, nil
 }
 

--- a/pkg/client/discovery.go
+++ b/pkg/client/discovery.go
@@ -19,11 +19,12 @@ import (
 //
 //nolint:revive // ClientManager is intentionally named to avoid conflict with existing Manager interface
 type ClientManager struct {
-	homeDir            string
-	groupManager       groups.Manager
-	clientIntegrations []clientAppConfig
-	configProvider     config.Provider
-	lookPath           func(string) (string, error)
+	homeDir               string
+	groupManager          groups.Manager
+	clientIntegrations    []clientAppConfig
+	configProvider        config.Provider
+	lookPath              func(string) (string, error)
+	codexDesktopInstalled func() (bool, error)
 }
 
 // HomeDir returns the home directory this ClientManager is rooted at. Exported
@@ -48,15 +49,17 @@ func NewClientManager() (*ClientManager, error) {
 	}
 
 	return &ClientManager{
-		homeDir:            home,
-		groupManager:       groupManager,
-		clientIntegrations: supportedClientIntegrations,
-		configProvider:     config.NewDefaultProvider(),
-		lookPath:           exec.LookPath,
+		homeDir:               home,
+		groupManager:          groupManager,
+		clientIntegrations:    supportedClientIntegrations,
+		configProvider:        config.NewDefaultProvider(),
+		lookPath:              exec.LookPath,
+		codexDesktopInstalled: newCodexDesktopDetector(home, runtime.GOOS).installed,
 	}, nil
 }
 
-// NewTestClientManager creates a new ClientManager with test dependencies
+// NewTestClientManager creates a ClientManager with test dependencies. Native
+// Codex desktop detection is intentionally omitted to keep tests deterministic.
 func NewTestClientManager(
 	homeDir string,
 	groupManager groups.Manager,

--- a/pkg/client/llm_gateway.go
+++ b/pkg/client/llm_gateway.go
@@ -6,6 +6,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -273,9 +274,10 @@ func (cm *ClientManager) LLMGatewayModeFor(clientType ClientApp) string {
 
 // DetectedLLMGatewayClients returns the subset of LLM-gateway-capable clients
 // that are installed on this machine. Most clients require their settings
-// directory and, when configured, their binary on $PATH. Codex is also detected
-// when its desktop app is installed on macOS or Windows; CLI and desktop
-// evidence still produce one canonical Codex result.
+// directory and, when configured, their binary on $PATH. A client with an
+// LLMInstalledDetector hook (e.g. Codex's desktop app) is also detected when
+// the hook returns true; CLI and desktop evidence still produce one canonical
+// result.
 //
 // Requiring both CLI signals prevents false positives from leftover config
 // directories (e.g. ~/.claude or ~/.gemini) after a tool is uninstalled.
@@ -286,50 +288,61 @@ func (cm *ClientManager) DetectedLLMGatewayClients() []ClientApp {
 		if cfg.LLMGatewayMode == "" {
 			continue
 		}
-		if cfg.ClientType == Codex && cm.isCodexInstalled(cfg) {
+		if cm.isClientInstalled(cfg) {
 			result = append(result, cfg.ClientType)
-			continue
 		}
-		// Detection directory: for GUI apps whose settings directory does not
-		// exist until first configured (e.g. Claude Desktop's configLibrary),
-		// LLMDetectRelPath points at a directory that exists once the app is
-		// installed. Otherwise fall back to the settings directory.
-		detectDir := func() string {
-			if cfg.LLMDetectRelPath != nil {
-				return buildConfigFilePath("", cfg.LLMDetectRelPath, cfg.LLMDetectPlatformPrefix, []string{cm.homeDir})
-			}
-			return filepath.Dir(cm.buildLLMSettingsPath(cfg))
-		}()
-		if _, err := os.Stat(detectDir); err != nil {
-			continue
-		}
-		if cfg.LLMBinaryName != "" {
-			if _, err := cm.lookPath(cfg.LLMBinaryName); err != nil {
-				continue
-			}
-		}
-		result = append(result, cfg.ClientType)
 	}
 	return result
 }
 
-func (cm *ClientManager) isCodexInstalled(cfg *clientAppConfig) bool {
-	settingsDirExists := func() bool {
-		_, err := os.Stat(filepath.Dir(cm.buildLLMSettingsPath(cfg)))
-		return err == nil
-	}()
-	cliInstalled := settingsDirExists && cfg.LLMBinaryName != "" && cm.lookPath != nil && func() bool {
-		_, err := cm.lookPath(cfg.LLMBinaryName)
-		return err == nil
-	}()
-	if cliInstalled {
+// isClientInstalled reports whether a single LLM-gateway-capable client appears
+// to be installed. The shared check (settings/detection directory exists and,
+// when configured, the binary is on $PATH) is augmented by an optional
+// per-client LLMInstalledDetector hook (e.g. Codex desktop app detection).
+func (cm *ClientManager) isClientInstalled(cfg *clientAppConfig) bool {
+	if cm.sharedCLIDetection(cfg) {
 		return true
 	}
-	if cm.codexDesktopInstalled == nil {
+	if cfg.LLMInstalledDetector == nil {
 		return false
 	}
-	desktopInstalled, err := cm.codexDesktopInstalled()
-	return err == nil && desktopInstalled
+	installed, err := cfg.LLMInstalledDetector()
+	if err != nil {
+		// Log the detector failure so it's distinguishable from "not installed"
+		// rather than silently treating a detection error as absence.
+		slog.Warn("LLM client detection hook failed",
+			"client", cfg.ClientType, "error", err)
+		return false
+	}
+	return installed
+}
+
+// sharedCLIDetection implements the generic CLI detection shared by all
+// LLM-gateway-capable clients: the detection directory (or settings directory)
+// must exist, and when LLMBinaryName is set the binary must be found on $PATH.
+func (cm *ClientManager) sharedCLIDetection(cfg *clientAppConfig) bool {
+	// Detection directory: for GUI apps whose settings directory does not
+	// exist until first configured (e.g. Claude Desktop's configLibrary),
+	// LLMDetectRelPath points at a directory that exists once the app is
+	// installed. Otherwise fall back to the settings directory.
+	detectDir := func() string {
+		if cfg.LLMDetectRelPath != nil {
+			return buildConfigFilePath("", cfg.LLMDetectRelPath, cfg.LLMDetectPlatformPrefix, []string{cm.homeDir})
+		}
+		return filepath.Dir(cm.buildLLMSettingsPath(cfg))
+	}()
+	if _, err := os.Stat(detectDir); err != nil {
+		return false
+	}
+	if cfg.LLMBinaryName != "" {
+		if cm.lookPath == nil {
+			return false
+		}
+		if _, err := cm.lookPath(cfg.LLMBinaryName); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 // buildLLMSettingsPath resolves the absolute path to the LLM settings file

--- a/pkg/client/llm_gateway.go
+++ b/pkg/client/llm_gateway.go
@@ -261,7 +261,8 @@ func (cm *ClientManager) IsManaged(clientType ClientApp) bool {
 	return cfg != nil && managedProfilePresent(cfg.LLMManagedProfileDomain)
 }
 
-// LLMGatewayModeFor returns "direct", "proxy", or "" for the given client.
+// LLMGatewayModeFor returns the client's configured gateway integration mode,
+// or "" when the client is unknown or does not support an LLM gateway.
 func (cm *ClientManager) LLMGatewayModeFor(clientType ClientApp) string {
 	cfg := cm.lookupClientAppConfig(clientType)
 	if cfg == nil {
@@ -271,17 +272,22 @@ func (cm *ClientManager) LLMGatewayModeFor(clientType ClientApp) string {
 }
 
 // DetectedLLMGatewayClients returns the subset of LLM-gateway-capable clients
-// that are installed on this machine. A client is considered installed when:
-//  1. Its settings directory exists on disk.
-//  2. If LLMBinaryName is set, the binary is also present on $PATH.
+// that are installed on this machine. Most clients require their settings
+// directory and, when configured, their binary on $PATH. Codex is also detected
+// when its desktop app is installed on macOS or Windows; CLI and desktop
+// evidence still produce one canonical Codex result.
 //
-// The binary check prevents false positives from leftover config directories
-// (e.g. ~/.claude or ~/.gemini) that remain after a tool is uninstalled.
+// Requiring both CLI signals prevents false positives from leftover config
+// directories (e.g. ~/.claude or ~/.gemini) after a tool is uninstalled.
 func (cm *ClientManager) DetectedLLMGatewayClients() []ClientApp {
 	var result []ClientApp
 	for i := range cm.clientIntegrations {
 		cfg := &cm.clientIntegrations[i]
 		if cfg.LLMGatewayMode == "" {
+			continue
+		}
+		if cfg.ClientType == Codex && cm.isCodexInstalled(cfg) {
+			result = append(result, cfg.ClientType)
 			continue
 		}
 		// Detection directory: for GUI apps whose settings directory does not
@@ -305,6 +311,25 @@ func (cm *ClientManager) DetectedLLMGatewayClients() []ClientApp {
 		result = append(result, cfg.ClientType)
 	}
 	return result
+}
+
+func (cm *ClientManager) isCodexInstalled(cfg *clientAppConfig) bool {
+	settingsDirExists := func() bool {
+		_, err := os.Stat(filepath.Dir(cm.buildLLMSettingsPath(cfg)))
+		return err == nil
+	}()
+	cliInstalled := settingsDirExists && cfg.LLMBinaryName != "" && cm.lookPath != nil && func() bool {
+		_, err := cm.lookPath(cfg.LLMBinaryName)
+		return err == nil
+	}()
+	if cliInstalled {
+		return true
+	}
+	if cm.codexDesktopInstalled == nil {
+		return false
+	}
+	desktopInstalled, err := cm.codexDesktopInstalled()
+	return err == nil && desktopInstalled
 }
 
 // buildLLMSettingsPath resolves the absolute path to the LLM settings file

--- a/pkg/client/llm_gateway_test.go
+++ b/pkg/client/llm_gateway_test.go
@@ -480,6 +480,9 @@ func TestDetectedLLMGatewayClients_Codex(t *testing.T) {
 				LLMSettingsFile:    "config.toml",
 				LLMSettingsRelPath: []string{".codex"},
 			}}
+			if !tt.nilDetector {
+				cfgs[0].LLMInstalledDetector = func() (bool, error) { return tt.desktop, tt.detectorErr }
+			}
 			if tt.configDir {
 				require.NoError(t, os.MkdirAll(filepath.Join(home, ".codex"), 0o700))
 			}
@@ -489,9 +492,6 @@ func TestDetectedLLMGatewayClients_Codex(t *testing.T) {
 					return "/bin/codex", nil
 				}
 				return "", os.ErrNotExist
-			}
-			if !tt.nilDetector {
-				cm.codexDesktopInstalled = func() (bool, error) { return tt.desktop, tt.detectorErr }
 			}
 
 			detected := cm.DetectedLLMGatewayClients()

--- a/pkg/client/llm_gateway_test.go
+++ b/pkg/client/llm_gateway_test.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -447,6 +448,62 @@ func TestConfigureLLMGateway_ProxyMode(t *testing.T) {
 
 // ── DetectedLLMGatewayClients ─────────────────────────────────────────────────
 
+func TestDetectedLLMGatewayClients_Codex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		configDir   bool
+		binary      bool
+		desktop     bool
+		detectorErr error
+		nilDetector bool
+		want        bool
+	}{
+		{name: "CLI only", configDir: true, binary: true, want: true},
+		{name: "app only without config directory or PATH", desktop: true, want: true},
+		{name: "CLI and app append once", configDir: true, binary: true, desktop: true, want: true},
+		{name: "stale settings only", configDir: true},
+		{name: "no CLI or desktop evidence"},
+		{name: "nil desktop detector is not detected", nilDetector: true},
+		{name: "detector failure is not detected", detectorErr: errors.New("query failed")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			home := t.TempDir()
+			cfgs := []clientAppConfig{{
+				ClientType:         Codex,
+				LLMGatewayMode:     llmgateway.ModeCodexAuth,
+				LLMBinaryName:      "codex",
+				LLMSettingsFile:    "config.toml",
+				LLMSettingsRelPath: []string{".codex"},
+			}}
+			if tt.configDir {
+				require.NoError(t, os.MkdirAll(filepath.Join(home, ".codex"), 0o700))
+			}
+			cm := NewTestClientManager(home, nil, cfgs, nil)
+			cm.lookPath = func(_ string) (string, error) {
+				if tt.binary {
+					return "/bin/codex", nil
+				}
+				return "", os.ErrNotExist
+			}
+			if !tt.nilDetector {
+				cm.codexDesktopInstalled = func() (bool, error) { return tt.desktop, tt.detectorErr }
+			}
+
+			detected := cm.DetectedLLMGatewayClients()
+			if tt.want {
+				require.Equal(t, []ClientApp{Codex}, detected)
+			} else {
+				assert.Empty(t, detected)
+			}
+		})
+	}
+}
+
 // TestDetectedLLMGatewayClients_DirOnly verifies that a client without a
 // BinaryName set is detected based solely on the settings directory existing.
 func TestDetectedLLMGatewayClients_DirOnly(t *testing.T) {
@@ -561,6 +618,7 @@ func TestRealClientConfigs_LLMBinaryNames(t *testing.T) {
 		Cursor:        "cursor",
 		ClaudeCode:    "claude",
 		GeminiCli:     "gemini",
+		Codex:         "codex",
 		// Tools without a binary check (dir-only detection) are omitted.
 	}
 

--- a/test/e2e/cli_llm_all_clients_test.go
+++ b/test/e2e/cli_llm_all_clients_test.go
@@ -1103,8 +1103,9 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				_, err = os.Stat(filepath.Join(binDir, "codex"))
 				Expect(os.IsNotExist(err)).To(BeTrue(), "no fake codex binary should exist")
 
-				// Keep system tools such as plutil available while excluding user-level
-				// package-manager paths that may contain a real Codex CLI.
+				// plutil is invoked by absolute path (/usr/bin/plutil) so it does
+				// not need to be on $PATH. The PATH is still restricted to exclude
+				// user-level package-manager paths that may contain a real Codex CLI.
 				appOnlyTHVCmd := func(args ...string) *e2e.THVCommand {
 					return thvCmd(args...).WithEnv("PATH=" + binDir + ":/usr/bin:/bin")
 				}

--- a/test/e2e/cli_llm_all_clients_test.go
+++ b/test/e2e/cli_llm_all_clients_test.go
@@ -1083,6 +1083,76 @@ var _ = Describe("thv llm — all-client matrix", Label("cli", "llm", "clients",
 				return config
 			}
 
+			It("detects the macOS desktop app without CLI evidence", func() {
+				if runtime.GOOS != osDarwin {
+					Skip("Codex desktop detection is macOS-only")
+				}
+
+				issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
+				configPath := filepath.Join(tempDir, ".codex", "config.toml")
+				plistPath := filepath.Join(tempDir, "Applications", "ChatGPT.app", "Contents", "Info.plist")
+				plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.openai.codex</string></dict></plist>`
+
+				By("creating only the ChatGPT desktop app bundle evidence")
+				Expect(os.MkdirAll(filepath.Dir(plistPath), 0750)).To(Succeed())
+				Expect(os.WriteFile(plistPath, []byte(plist), 0600)).To(Succeed())
+				_, err := os.Stat(filepath.Join(tempDir, ".codex"))
+				Expect(os.IsNotExist(err)).To(BeTrue(), ".codex must not exist before setup")
+				_, err = os.Stat(filepath.Join(binDir, "codex"))
+				Expect(os.IsNotExist(err)).To(BeTrue(), "no fake codex binary should exist")
+
+				// Keep system tools such as plutil available while excluding user-level
+				// package-manager paths that may contain a real Codex CLI.
+				appOnlyTHVCmd := func(args ...string) *e2e.THVCommand {
+					return thvCmd(args...).WithEnv("PATH=" + binDir + ":/usr/bin:/bin")
+				}
+				stdout, stderr, err := runSetupWithOIDCCompletion(
+					appOnlyTHVCmd, oidcServer,
+					"--client", "codex",
+					"--gateway-url", gatewayURL,
+					"--issuer", issuerURL,
+					"--client-id", clientID,
+				)
+				Expect(err).ToNot(HaveOccurred(),
+					"setup should succeed; stdout=%q stderr=%q", stdout, stderr)
+
+				By("verifying app-only detection wrote the canonical Codex configuration")
+				config := readCodexConfig(configPath)
+				Expect(config["model_provider"]).To(Equal("toolhive-gateway"))
+				providers, ok := config["model_providers"].(map[string]any)
+				Expect(ok).To(BeTrue())
+				provider, ok := providers["toolhive-gateway"].(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(provider["base_url"]).To(Equal(gatewayURL + "/v1"))
+				auth, ok := provider["auth"].(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(auth["command"]).ToNot(BeEmpty())
+				Expect(auth["args"]).To(Equal([]any{"llm", "token", "--skip-browser"}))
+
+				showOut, _ := appOnlyTHVCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+				var cfg llm.Config
+				Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+				Expect(cfg.ConfiguredTools).To(HaveLen(1))
+				Expect(string(cfg.ConfiguredTools[0].Tool)).To(Equal("codex"))
+				Expect(cfg.ConfiguredTools[0].Mode).To(Equal("codex-auth"))
+
+				By("tearing down and verifying the provider is removed")
+				appOnlyTHVCmd("llm", "teardown", "codex").ExpectSuccess()
+				config = readCodexConfig(configPath)
+				_, hasModelProvider := config["model_provider"]
+				Expect(hasModelProvider).To(BeFalse())
+				if providers, ok := config["model_providers"].(map[string]any); ok {
+					_, stillPresent := providers["toolhive-gateway"]
+					Expect(stillPresent).To(BeFalse())
+				}
+				showOut, _ = appOnlyTHVCmd("llm", "config", "show", "--format", "json").ExpectSuccess()
+				cfg = llm.Config{}
+				Expect(json.Unmarshal([]byte(showOut), &cfg)).To(Succeed())
+				Expect(cfg.ConfiguredTools).To(BeEmpty())
+			})
+
 			It("writes the model_provider and auth command, then reverts them", func() {
 				issuerURL := fmt.Sprintf("http://localhost:%d", oidcPort)
 				codexDir := filepath.Join(tempDir, ".codex")


### PR DESCRIPTION
## Summary

Codex desktop users could not run `thv llm setup` unless the separate Codex CLI was installed and had already created `~/.codex`. The desktop app uses the same Codex user configuration, so requiring CLI installation prevented ToolHive from configuring otherwise valid app-only installations.

- Detect the Codex desktop app independently on macOS and Windows while retaining the existing CLI detection path.
- Keep one canonical `codex` setup and teardown target because the CLI and desktop app share the same user configuration.
- Validate the macOS bundle identifier and the exact Store-signed Windows package family before treating the app as installed.
- Document the shared configuration and supported desktop platforms.
- Add unit coverage and a Darwin app-only CLI E2E scenario.

Fixes #5785

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Additional verification:
- `task build`
- `task docs`

The full E2E suite was attempted but could not complete because its API test server reported that no usable container runtime was available. The new Darwin app-only E2E scenario is included for CI/macOS execution.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/client/codex_desktop.go` | Detect and validate Codex desktop installations on macOS and Windows. |
| `pkg/client/llm_gateway.go` | Treat CLI or desktop evidence as one canonical Codex installation. |
| `pkg/client/discovery.go` | Wire the native detector into the production client manager. |
| `pkg/client/*_test.go` | Cover platform identities and CLI/app detection combinations. |
| `test/e2e/cli_llm_all_clients_test.go` | Exercise app-only setup and teardown through the real CLI on macOS. |
| `cmd/thv/app/llm.go`, `docs/cli/thv_llm_setup.md` | Explain shared configuration, platforms, and the canonical `codex` target. |

## Does this introduce a user-facing change?

Yes. `thv llm setup --client codex` now detects Codex desktop installations on macOS and Windows even when the Codex CLI is absent. CLI and desktop installations continue to share one `codex` configuration and teardown target.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

1. Keep the existing canonical `codex` client identity and reuse its `~/.codex/config.toml` writer and teardown logic.
2. Extend Codex installation detection with OR semantics: existing CLI evidence or native desktop evidence, returning one result when both exist.
3. Detect legacy and current macOS bundles and validate `CFBundleIdentifier = com.openai.codex`.
4. Detect the exact Store-signed Windows package family without scanning protected, versioned `WindowsApps` paths.
5. Preserve Linux as CLI-only and leave all other clients' detection behavior unchanged.
6. Add deterministic unit coverage for CLI-only, app-only, combined, stale-directory, platform identity, and detector-failure cases.
7. Add app-only setup/teardown coverage through the existing CLI E2E harness on macOS.
8. Regenerate CLI documentation and run build, unit tests, lint, and E2E verification where supported.

Runtime model discoverability is not applicable because this is host application detection and local configuration.

</details>

## Special notes for reviewers

The current unified macOS application is named `ChatGPT.app` but retains the Codex bundle identifier `com.openai.codex`; the detector also supports the legacy `Codex.app` path. Windows detection verifies the exact package family `OpenAI.Codex_2p2nqsd0c76g0` and requires a Microsoft Store signature.