### PR TITLE
Fix tool-filter terminal drain dropping error bodies

### DIFF
--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -198,7 +198,11 @@ func NewListToolsMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewa
 			// buffering middleware (e.g. authz's response filter) may write the final
 			// body into our buffer during its own post-ServeHTTP flush; without this
 			// call that body is stranded and the client gets a 0-byte response. See #5797.
-			rw.Flush()
+			//
+			// This is the terminal drain, not a streaming Flush: there is no more data
+			// coming, so a body we can't process (wrong/missing content type, malformed
+			// tools list) is written through unchanged rather than dropped. See #5809 (review).
+			rw.finish()
 		})
 	}, nil
 }
@@ -339,41 +343,83 @@ func (rw *toolFilterWriter) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
-// Flush processes any remaining buffered data and writes it to the underlying ResponseWriter
+// Flush processes any remaining buffered data, writes it to the underlying
+// ResponseWriter, and forwards the flush downstream. This is the interim/
+// streaming path: a downstream handler or reverse proxy may call this
+// mid-response, so an incomplete SSE event or partial JSON body is left
+// buffered for a later call to complete. Use finish() for the one-time
+// terminal drain after the wrapped handler has returned.
 func (rw *toolFilterWriter) Flush() {
-	if len(rw.buffer) > 0 {
-		mimeType := strings.Split(rw.ResponseWriter.Header().Get("Content-Type"), ";")[0]
-
-		if mimeType == "" {
-			_, err := rw.ResponseWriter.Write(rw.buffer)
-			if err != nil {
-				slog.Error("error writing buffer", "error", err)
-			}
-			rw.buffer = rw.buffer[:0] // Reset buffer
-			return
-		}
-
-		var b bytes.Buffer
-		err := processBuffer(rw.config, rw.buffer, mimeType, &b)
-		if errors.Is(err, errKeepBuffering) {
-			slog.Debug("keep buffering", "buffered_bytes", len(rw.buffer))
-			return
-		}
-		if err != nil {
-			slog.Error("error flushing response", "error", err)
-		}
-
-		slog.Debug("flushing buffer", "bytes", len(b.Bytes()))
-		_, err = rw.ResponseWriter.Write(b.Bytes())
-		if err != nil {
-			slog.Error("error writing buffer", "error", err)
-		}
-		rw.buffer = rw.buffer[:0] // Reset buffer
-	}
+	rw.drainBuffer(false)
 
 	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}
+}
+
+// finish performs the terminal drain of any remaining buffered data after the
+// wrapped handler has returned. Unlike Flush, there is no more data coming:
+// a body that can't be processed -- an unsupported/missing Content-Type, or a
+// malformed tools list -- is written through unchanged instead of being held
+// forever (stranding it) or discarded (losing it). It does not forward a
+// transport flush, since returning from ServeHTTP already completes the
+// response.
+func (rw *toolFilterWriter) finish() {
+	rw.drainBuffer(true)
+}
+
+// drainBuffer processes the buffered response body according to its MIME
+// type and writes the result to the underlying ResponseWriter.
+//
+// When terminal is false (Flush, mid-stream), a body that processBuffer
+// reports as incomplete is left buffered for a later call. When terminal is
+// true (finish, called once ServeHTTP has returned), there won't be a later
+// call, so any body that can't be processed -- because its MIME type isn't
+// recognized, or because processing itself failed -- is written through
+// unchanged rather than dropped.
+func (rw *toolFilterWriter) drainBuffer(terminal bool) {
+	if len(rw.buffer) == 0 {
+		return
+	}
+
+	mimeType := strings.Split(rw.ResponseWriter.Header().Get("Content-Type"), ";")[0]
+
+	if mimeType == "" {
+		rw.writeBuffer(rw.buffer)
+		return
+	}
+
+	var b bytes.Buffer
+	err := processBuffer(rw.config, rw.buffer, mimeType, &b)
+	if errors.Is(err, errKeepBuffering) {
+		if !terminal {
+			slog.Debug("keep buffering", "buffered_bytes", len(rw.buffer))
+			return
+		}
+		slog.Warn("response ended with an incomplete buffered body; writing it through unchanged",
+			"buffered_bytes", len(rw.buffer))
+		rw.writeBuffer(rw.buffer)
+		return
+	}
+	if err != nil {
+		slog.Error("error processing buffered response; writing it through unchanged", "error", err)
+		rw.writeBuffer(rw.buffer)
+		return
+	}
+
+	slog.Debug("flushing buffer", "bytes", len(b.Bytes()))
+	rw.writeBuffer(b.Bytes())
+}
+
+// writeBuffer writes data to the underlying ResponseWriter and resets rw.buffer.
+// data is expected to be either rw.buffer itself or a value derived from it, so
+// resetting after the write is always correct.
+func (rw *toolFilterWriter) writeBuffer(data []byte) {
+	_, err := rw.ResponseWriter.Write(data)
+	if err != nil {
+		slog.Error("error writing buffer", "error", err)
+	}
+	rw.buffer = rw.buffer[:0] // Reset buffer
 }
 
 type toolsListResponse struct {

--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -19,6 +19,7 @@ import (
 var errToolNameNotFound = errors.New("tool name not found")
 var errBug = errors.New("there's a bug")
 var errKeepBuffering = errors.New("keep buffering")
+var errUnsupportedMimeType = errors.New("unsupported mime type")
 
 // toolOverrideEntry is a struct that represents a tool override entry.
 type toolOverrideEntry struct {
@@ -189,6 +190,7 @@ func NewListToolsMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewa
 			rw := &toolFilterWriter{
 				ResponseWriter: w,
 				config:         config,
+				statusCode:     http.StatusOK, // matches net/http's implicit status when WriteHeader is never called
 			}
 
 			// Call the next handler
@@ -321,8 +323,9 @@ func NewToolCallMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewar
 // toolFilterWriter wraps http.ResponseWriter to capture and process SSE responses
 type toolFilterWriter struct {
 	http.ResponseWriter
-	buffer []byte
-	config *toolMiddlewareConfig
+	buffer     []byte
+	config     *toolMiddlewareConfig
+	statusCode int
 }
 
 // WriteHeader captures the status code.
@@ -333,6 +336,7 @@ type toolFilterWriter struct {
 // Content-Length" and the client receives only the headers. Removing the
 // header lets Go fall back to chunked transfer encoding.
 func (rw *toolFilterWriter) WriteHeader(statusCode int) {
+	rw.statusCode = statusCode
 	rw.ResponseWriter.Header().Del("Content-Length")
 	rw.ResponseWriter.WriteHeader(statusCode)
 }
@@ -347,10 +351,14 @@ func (rw *toolFilterWriter) Write(data []byte) (int, error) {
 // ResponseWriter, and forwards the flush downstream. This is the interim/
 // streaming path: a downstream handler or reverse proxy may call this
 // mid-response, so an incomplete SSE event or partial JSON body is left
-// buffered for a later call to complete. Use finish() for the one-time
-// terminal drain after the wrapped handler has returned.
+// buffered for a later call to complete, and the transport flush is not
+// forwarded in that case -- there's nothing new to push over the wire, and
+// forwarding it could send a still-incomplete frame. Use finish() for the
+// one-time terminal drain after the wrapped handler has returned.
 func (rw *toolFilterWriter) Flush() {
-	rw.drainBuffer(false)
+	if !rw.drainBuffer(false) {
+		return
+	}
 
 	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
 		flusher.Flush()
@@ -359,56 +367,79 @@ func (rw *toolFilterWriter) Flush() {
 
 // finish performs the terminal drain of any remaining buffered data after the
 // wrapped handler has returned. Unlike Flush, there is no more data coming:
-// a body that can't be processed -- an unsupported/missing Content-Type, or a
-// malformed tools list -- is written through unchanged instead of being held
-// forever (stranding it) or discarded (losing it). It does not forward a
-// transport flush, since returning from ServeHTTP already completes the
-// response.
+// an incomplete body (a truncated stream, a connection cut short) is written
+// through unchanged rather than held forever, and an unrecognized/missing
+// Content-Type on a response with nothing to filter is likewise passed
+// through as-is. It does not forward a transport flush, since returning from
+// ServeHTTP already completes the response.
+//
+// A body that DOES look like a tools list but fails to filter is the one
+// case finish() will not pass through -- see drainBuffer.
 func (rw *toolFilterWriter) finish() {
 	rw.drainBuffer(true)
 }
 
 // drainBuffer processes the buffered response body according to its MIME
-// type and writes the result to the underlying ResponseWriter.
+// type and writes the result to the underlying ResponseWriter. It reports
+// whether the caller may safely forward a transport-level flush: false means
+// data is being deliberately withheld, either because it's incomplete and
+// more is expected (Flush, non-terminal) or because it looked like a tools
+// list we could not safely filter (fail closed, in both Flush and finish).
 //
-// When terminal is false (Flush, mid-stream), a body that processBuffer
-// reports as incomplete is left buffered for a later call. When terminal is
-// true (finish, called once ServeHTTP has returned), there won't be a later
-// call, so any body that can't be processed -- because its MIME type isn't
-// recognized, or because processing itself failed -- is written through
-// unchanged rather than dropped.
-func (rw *toolFilterWriter) drainBuffer(terminal bool) {
+// When terminal is false (Flush, mid-stream), a body processBuffer reports as
+// incomplete is left buffered for a later call. When terminal is true
+// (finish, called once ServeHTTP has returned), there won't be a later call,
+// so an incomplete body is written through unchanged instead of being
+// stranded.
+//
+// A hard filtering failure -- a response that resolved to a tools list
+// (whether correctly labeled or sniffed, see processUnrecognizedMimeType) but
+// couldn't be filtered, e.g. a tool missing its required name -- is never
+// passed through, in either mode: doing so would leak the unfiltered list.
+func (rw *toolFilterWriter) drainBuffer(terminal bool) bool {
 	if len(rw.buffer) == 0 {
-		return
+		return true
 	}
 
 	mimeType := strings.Split(rw.ResponseWriter.Header().Get("Content-Type"), ";")[0]
-
-	if mimeType == "" {
-		rw.writeBuffer(rw.buffer)
-		return
-	}
+	successResponse := rw.statusCode == http.StatusOK || rw.statusCode == http.StatusAccepted
 
 	var b bytes.Buffer
-	err := processBuffer(rw.config, rw.buffer, mimeType, &b)
-	if errors.Is(err, errKeepBuffering) {
+	err := processBuffer(rw.config, rw.buffer, mimeType, successResponse, &b)
+
+	switch {
+	case errors.Is(err, errKeepBuffering):
 		if !terminal {
 			slog.Debug("keep buffering", "buffered_bytes", len(rw.buffer))
-			return
+			return false
 		}
 		slog.Warn("response ended with an incomplete buffered body; writing it through unchanged",
 			"buffered_bytes", len(rw.buffer))
 		rw.writeBuffer(rw.buffer)
-		return
-	}
-	if err != nil {
-		slog.Error("error processing buffered response; writing it through unchanged", "error", err)
-		rw.writeBuffer(rw.buffer)
-		return
-	}
+		return true
 
-	slog.Debug("flushing buffer", "bytes", len(b.Bytes()))
-	rw.writeBuffer(b.Bytes())
+	case errors.Is(err, errUnsupportedMimeType):
+		// processBuffer only returns this once it has ruled out the buffer being
+		// a tools list: either the response has nothing to filter (a non-2xx
+		// error body), or it's a 2xx body that doesn't look like a tools list
+		// under either supported wire format. Either way, passing it through
+		// unchanged cannot leak an unfiltered list.
+		rw.writeBuffer(rw.buffer)
+		return true
+
+	case err != nil:
+		// A recognized (or sniffed) tools list that failed to filter -- e.g. a
+		// malformed tool entry. Fail closed: writing the raw, unfiltered body
+		// through would defeat the filter entirely.
+		slog.Error("error filtering buffered response; refusing to pass through unfiltered", "error", err)
+		rw.buffer = rw.buffer[:0]
+		return false
+
+	default:
+		slog.Debug("flushing buffer", "bytes", len(b.Bytes()))
+		rw.writeBuffer(b.Bytes())
+		return true
+	}
 }
 
 // writeBuffer writes data to the underlying ResponseWriter and resets rw.buffer.
@@ -437,11 +468,16 @@ type toolCallRequest struct {
 	Params  *map[string]any `json:"params,omitempty"`
 }
 
-// processSSEBuffer processes any complete SSE events in the buffer
+// processBuffer processes the buffered response body according to its
+// declared MIME type. successResponse indicates whether the response's
+// status code was 200/202: it's only consulted for an unrecognized MIME type,
+// to decide whether the body needs sniffing before it can safely be passed
+// through -- see processUnrecognizedMimeType.
 func processBuffer(
 	config *toolMiddlewareConfig,
 	buffer []byte,
 	mimeType string,
+	successResponse bool,
 	w io.Writer,
 ) error {
 	if len(buffer) == 0 {
@@ -450,32 +486,101 @@ func processBuffer(
 
 	switch mimeType {
 	case "application/json":
-		var toolsListResponse toolsListResponse
-		var syntaxError *json.SyntaxError
-		err := json.Unmarshal(buffer, &toolsListResponse)
-		if errors.As(err, &syntaxError) {
-			return fmt.Errorf("%w: %w", errKeepBuffering, err)
-		}
-		if err == nil && toolsListResponse.Result.Tools != nil {
-			return processToolsListResponse(config, toolsListResponse, w)
-		}
+		return processJSONBuffer(config, buffer, w)
 	case "text/event-stream":
 		return processEventStream(config, buffer, w)
 	default:
-		// NOTE: Content-Type header is mandatory in the spec, and as of the
-		// time of this writing, the only allowed content types are
-		// * application/json, and
-		// * text/event-stream
-		//
-		// As a result, we should never get here and it is safe to return an
-		// error.
-		return fmt.Errorf("unsupported mime type: %s", mimeType)
+		return processUnrecognizedMimeType(config, buffer, mimeType, successResponse, w)
+	}
+}
+
+// processJSONBuffer filters a JSON-RPC response body if it carries a tools
+// list, otherwise passes it through unchanged (e.g. a tools/call result, or
+// any other JSON-RPC message this middleware isn't meant to touch).
+func processJSONBuffer(config *toolMiddlewareConfig, buffer []byte, w io.Writer) error {
+	var toolsListResponse toolsListResponse
+	var syntaxError *json.SyntaxError
+	err := json.Unmarshal(buffer, &toolsListResponse)
+	if errors.As(err, &syntaxError) {
+		return fmt.Errorf("%w: %w", errKeepBuffering, err)
+	}
+	if err == nil && toolsListResponse.Result.Tools != nil {
+		return processToolsListResponse(config, toolsListResponse, w)
 	}
 
-	// If we get this far, we have a valid buffer that we cannot process
-	// in any other way, so we just write it to the underlying writer.
-	_, err := w.Write(buffer)
+	_, err = w.Write(buffer)
 	return err
+}
+
+// processUnrecognizedMimeType handles a body whose Content-Type is missing or
+// isn't one of the two MCP-supported types (application/json,
+// text/event-stream).
+//
+// A non-2xx response has nothing to filter -- the tool filter only ever acts
+// on a tools/list result, which a non-2xx status can't carry -- so it's
+// always safe to pass through.
+//
+// A 2xx response, on the other hand, is spec-required to declare one of the
+// two supported Content-Types. A missing or wrong header there could be an
+// accident, or a backend deliberately omitting/mislabeling it to smuggle an
+// unfiltered tools list past the filter (the same disguised-result concern
+// handled in pkg/authz for #5257). So the raw body is sniffed the same way a
+// correctly-labeled response would be processed: if it resolves to a tools
+// list under either supported shape, it's filtered (or, on failure, rejected)
+// exactly as it would be under the correct Content-Type. Only once neither
+// shape resolves to a tools list is it safe to pass through unchanged.
+//
+// Known limitation: unlike the correctly-labeled paths, this sniff has no
+// notion of "incomplete, wait for more" -- a tools list that both omits/
+// mislabels its Content-Type AND arrives across multiple Flush() calls may
+// be sniffed as "not a tools list" on an early, truncated call and passed
+// through piecemeal before the full body is available. A compliant backend
+// that streams a tools list always declares text/event-stream, so this only
+// affects a backend that is already violating the spec on two axes at once.
+func processUnrecognizedMimeType(
+	config *toolMiddlewareConfig,
+	buffer []byte,
+	mimeType string,
+	successResponse bool,
+	w io.Writer,
+) error {
+	if !successResponse {
+		return fmt.Errorf("%w: %s", errUnsupportedMimeType, mimeType)
+	}
+
+	var candidate toolsListResponse
+	if err := json.Unmarshal(buffer, &candidate); err == nil && candidate.Result.Tools != nil {
+		return processToolsListResponse(config, candidate, w)
+	}
+
+	if sniffSSEToolsList(buffer) {
+		return processEventStream(config, buffer, w)
+	}
+
+	return fmt.Errorf("%w: %s", errUnsupportedMimeType, mimeType)
+}
+
+// sniffSSEToolsList reports whether buffer contains an SSE "data:" line whose
+// payload decodes to a tools list. It's a lightweight detector only, used to
+// decide whether a mislabeled/untyped 2xx body needs the full SSE processing
+// path (which enforces its own completeness and separator rules).
+func sniffSSEToolsList(buffer []byte) bool {
+	normalized := bytes.ReplaceAll(buffer, []byte("\r\n"), []byte("\n"))
+	normalized = bytes.ReplaceAll(normalized, []byte("\r"), []byte("\n"))
+
+	for _, line := range bytes.Split(normalized, []byte("\n")) {
+		data, ok := bytes.CutPrefix(line, []byte("data:"))
+		if !ok {
+			continue
+		}
+
+		var candidate toolsListResponse
+		if json.Unmarshal(bytes.TrimSpace(data), &candidate) == nil && candidate.Result.Tools != nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 //nolint:gocyclo

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -838,11 +839,14 @@ func TestProcessBuffer(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		config      *toolMiddlewareConfig
-		buffer      []byte
-		mimeType    string
-		expectError bool
+		name              string
+		config            *toolMiddlewareConfig
+		buffer            []byte
+		mimeType          string
+		successResponse   bool
+		expectError       bool
+		expectUnsupported bool
+		expectFiltered    bool // asserts allowed_tool survives and blocked_tool is filtered out
 	}{
 		{
 			name: "JSON with tools list",
@@ -851,9 +855,10 @@ func TestProcessBuffer(t *testing.T) {
 					"allowed_tool": {},
 				},
 			},
-			buffer:      []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","description":"Allowed"},{"name":"blocked_tool","description":"Blocked"}]}}`),
-			mimeType:    "application/json",
-			expectError: false,
+			buffer:          []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","description":"Allowed"},{"name":"blocked_tool","description":"Blocked"}]}}`),
+			mimeType:        "application/json",
+			successResponse: true,
+			expectFiltered:  true,
 		},
 		{
 			name: "SSE with tools list",
@@ -866,19 +871,80 @@ func TestProcessBuffer(t *testing.T) {
 data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","description":"Allowed"},{"name":"blocked_tool","description":"Blocked"}]}}
 
 `),
-			mimeType:    "text/event-stream",
-			expectError: false,
+			mimeType:        "text/event-stream",
+			successResponse: true,
+			expectFiltered:  true,
 		},
 		{
-			name: "Unsupported mime type",
+			name: "Unsupported mime type on an error response",
 			config: &toolMiddlewareConfig{
 				filterTools: map[string]struct{}{
 					"any_tool": {},
 				},
 			},
-			buffer:      []byte(`some data`),
-			mimeType:    "text/plain",
-			expectError: true,
+			buffer:            []byte(`some data`),
+			mimeType:          "text/plain",
+			successResponse:   false,
+			expectError:       true,
+			expectUnsupported: true,
+		},
+		{
+			name: "Unsupported mime type on a success response that isn't a tools list",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"any_tool": {},
+				},
+			},
+			buffer:            []byte(`{"test":"data"}`),
+			mimeType:          "",
+			successResponse:   true,
+			expectError:       true,
+			expectUnsupported: true,
+		},
+		{
+			// Regression test for a follow-up to #5809: a backend cannot bypass
+			// the filter by omitting/mislabeling Content-Type on an otherwise
+			// valid, successful tools/list response.
+			name: "Missing Content-Type on a success response cannot smuggle a JSON tools list",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
+			},
+			buffer:          []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","description":"Allowed"},{"name":"blocked_tool","description":"Blocked"}]}}`),
+			mimeType:        "",
+			successResponse: true,
+			expectFiltered:  true,
+		},
+		{
+			name: "Missing Content-Type on a success response cannot smuggle an SSE tools list",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
+			},
+			buffer: []byte(`event: message
+data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","description":"Allowed"},{"name":"blocked_tool","description":"Blocked"}]}}
+
+`),
+			mimeType:        "",
+			successResponse: true,
+			expectFiltered:  true,
+		},
+		{
+			// Regression test for a follow-up to #5809: a hard filtering failure
+			// (a tool missing its required name) must fail closed, not fall back
+			// to passing the unfiltered body through.
+			name: "Malformed tools list under a sniffed missing Content-Type fails closed",
+			config: &toolMiddlewareConfig{
+				filterTools: map[string]struct{}{
+					"allowed_tool": {},
+				},
+			},
+			buffer:          []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"description":"no name"}]}}`),
+			mimeType:        "",
+			successResponse: true,
+			expectError:     true,
 		},
 		{
 			name: "Empty buffer",
@@ -887,9 +953,9 @@ data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","descrip
 					"any_tool": {},
 				},
 			},
-			buffer:      []byte{},
-			mimeType:    "application/json",
-			expectError: false,
+			buffer:          []byte{},
+			mimeType:        "application/json",
+			successResponse: true,
 		},
 	}
 
@@ -898,12 +964,19 @@ data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"allowed_tool","descrip
 			t.Parallel()
 
 			var buf bytes.Buffer
-			err := processBuffer(tt.config, tt.buffer, tt.mimeType, &buf)
+			err := processBuffer(tt.config, tt.buffer, tt.mimeType, tt.successResponse, &buf)
 
 			if tt.expectError {
 				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
+				assert.Equal(t, tt.expectUnsupported, errors.Is(err, errUnsupportedMimeType),
+					"errors.Is(err, errUnsupportedMimeType) mismatch")
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.expectFiltered {
+				assert.Contains(t, buf.String(), "allowed_tool")
+				assert.NotContains(t, buf.String(), "blocked_tool")
 			}
 		})
 	}
@@ -1282,6 +1355,98 @@ func TestToolFilterWriter_Flush_NoContentTypeDoesNotDuplicateOnRepeatedFlush(t *
 	assert.Equal(t, string(data), mockWriter.buffer.String(), "second flush should not rewrite already-flushed bytes")
 }
 
+// TestToolFilterWriter_Flush_IncompleteBodyStaysBufferedAndDoesNotFlush is a
+// regression test for a follow-up to #5809: Flush() must not forward the
+// transport-level flush when the buffered body is incomplete (an SSE event
+// with no trailing separator, or a truncated JSON object). Forwarding it
+// there would flush a partial frame to the wire; the original Flush()
+// implementation returned before reaching the transport flush in this case,
+// but an early refactor of this fix lost that guard.
+func TestToolFilterWriter_Flush_IncompleteBodyStaysBufferedAndDoesNotFlush(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contentType string
+		writeData   []byte
+	}{
+		{
+			name:        "truncated JSON",
+			contentType: "application/json",
+			writeData:   []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name"`),
+		},
+		{
+			name:        "SSE event with no trailing separator",
+			contentType: "text/event-stream",
+			writeData:   []byte(`data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"tool1"}]}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockWriter := &mockResponseWriter{
+				headers: make(http.Header),
+				buffer:  &bytes.Buffer{},
+			}
+			mockWriter.headers.Set("Content-Type", tt.contentType)
+
+			rw := &toolFilterWriter{
+				ResponseWriter: mockWriter,
+				config:         &toolMiddlewareConfig{},
+				statusCode:     http.StatusOK,
+			}
+
+			_, err := rw.Write(tt.writeData)
+			require.NoError(t, err)
+
+			rw.Flush()
+
+			assert.Equal(t, 0, mockWriter.writeCount, "incomplete body must not be written to the client yet")
+			assert.Equal(t, 0, mockWriter.flushCount, "an incomplete body must not trigger a transport-level flush")
+			assert.Equal(t, tt.writeData, rw.buffer, "incomplete body must remain buffered for a later Flush")
+		})
+	}
+}
+
+// TestToolFilterWriter_FlushThenFinishDoesNotDuplicate is a regression test
+// for a follow-up to #5809: once an explicit Flush() has fully drained and
+// processed a body, a later terminal finish() call (e.g. because the
+// wrapped ServeHTTP has returned) must be a no-op -- it must not rewrite the
+// body a second time, and must not trigger an extra transport-level flush,
+// since finish() never forwards one by design.
+func TestToolFilterWriter_FlushThenFinishDoesNotDuplicate(t *testing.T) {
+	t.Parallel()
+
+	mockWriter := &mockResponseWriter{
+		headers: make(http.Header),
+		buffer:  &bytes.Buffer{},
+	}
+	mockWriter.headers.Set("Content-Type", "application/json")
+
+	rw := &toolFilterWriter{
+		ResponseWriter: mockWriter,
+		config:         &toolMiddlewareConfig{filterTools: map[string]struct{}{"tool1": {}}},
+		statusCode:     http.StatusOK,
+	}
+
+	body := `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"tool1","description":"d1"},{"name":"tool2","description":"d2"}]}}`
+	_, err := rw.Write([]byte(body))
+	require.NoError(t, err)
+
+	rw.Flush()
+	require.Equal(t, 1, mockWriter.writeCount, "Flush should have written the filtered body exactly once")
+	require.Equal(t, 1, mockWriter.flushCount, "Flush should have forwarded exactly one transport flush")
+
+	rw.finish()
+
+	assert.Equal(t, 1, mockWriter.writeCount, "finish must not rewrite a body Flush already drained")
+	assert.Equal(t, 1, mockWriter.flushCount, "finish must not forward an additional transport flush")
+	assert.Contains(t, mockWriter.buffer.String(), "tool1")
+	assert.NotContains(t, mockWriter.buffer.String(), "tool2")
+}
+
 // TestToolFilterWriter_WriteHeader verifies that Content-Length is stripped
 // from the underlying ResponseWriter's headers regardless of content type.
 // The middleware re-encodes tool list responses to apply filters/overrides,
@@ -1344,12 +1509,14 @@ func TestToolFilterWriter_WriteHeader(t *testing.T) {
 	}
 }
 
-// mockResponseWriter implements http.ResponseWriter for testing
+// mockResponseWriter implements http.ResponseWriter (and http.Flusher, so
+// tests can observe whether a transport-level flush was forwarded) for testing.
 type mockResponseWriter struct {
 	headers    http.Header
 	buffer     *bytes.Buffer
 	writeCount int
 	statusCode int
+	flushCount int
 }
 
 func (m *mockResponseWriter) Header() http.Header {
@@ -1363,6 +1530,10 @@ func (m *mockResponseWriter) Write(data []byte) (int, error) {
 
 func (m *mockResponseWriter) WriteHeader(statusCode int) {
 	m.statusCode = statusCode
+}
+
+func (m *mockResponseWriter) Flush() {
+	m.flushCount++
 }
 
 func TestNewToolFilterMiddleware(t *testing.T) {
@@ -1610,6 +1781,97 @@ func TestNewListToolsMappingMiddleware_TerminalDrainPassesThroughUnsupportedCont
 			assert.Equal(t, tt.statusCode, recorder.Code)
 			assert.Contains(t, recorder.Body.String(), "backend unavailable",
 				"the original error body must reach the client unchanged")
+		})
+	}
+}
+
+// TestNewListToolsMappingMiddleware_FailsClosedOnMalformedToolsList is a
+// regression test for a follow-up to #5809: a successful, correctly-labeled
+// tools/list response that fails our own filtering logic (here, a tool
+// missing its required name) must not fall back to passing the raw,
+// unfiltered body through -- that would defeat the tool filter entirely.
+func TestNewListToolsMappingMiddleware_FailsClosedOnMalformedToolsList(t *testing.T) {
+	t.Parallel()
+
+	middleware, err := NewListToolsMappingMiddleware(WithToolsFilter("tool1"))
+	require.NoError(t, err)
+
+	// "blocked_tool" is missing its required "name" field, so filtering fails.
+	body := `{"jsonrpc":"2.0","id":1,"result":{"tools":[` +
+		`{"name":"tool1","description":"desc1"},` +
+		`{"description":"missing name"}]}}`
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, writeErr := w.Write([]byte(body))
+		require.NoError(t, writeErr)
+	})
+
+	handler := middleware(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	assert.NotContains(t, recorder.Body.String(), "tool1",
+		"a hard filtering failure must not leak the unfiltered tools list")
+	assert.NotContains(t, recorder.Body.String(), "missing name")
+}
+
+// TestNewListToolsMappingMiddleware_MissingContentTypeCannotSmuggleToolsList
+// is a regression test for a follow-up to #5809: a backend cannot bypass the
+// configured tool filter by returning an otherwise-valid, successful
+// tools/list response without a Content-Type header (or with an unrelated
+// one). Covers both wire formats the filter supports.
+func TestNewListToolsMappingMiddleware_MissingContentTypeCannotSmuggleToolsList(t *testing.T) {
+	t.Parallel()
+
+	middleware, err := NewListToolsMappingMiddleware(WithToolsFilter("tool1"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "JSON tools list with no Content-Type",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"tools":[` +
+				`{"name":"tool1","description":"desc1"},` +
+				`{"name":"tool2","description":"desc2"}]}}`,
+		},
+		{
+			name: "SSE tools list with no Content-Type",
+			body: "event: message\n" +
+				`data: {"jsonrpc":"2.0","id":1,"result":{"tools":[` +
+				`{"name":"tool1","description":"desc1"},` +
+				`{"name":"tool2","description":"desc2"}]}}` + "\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				// No Content-Type set: the backend is either buggy or actively
+				// trying to bypass the filter by not declaring one.
+				w.WriteHeader(http.StatusOK)
+				_, writeErr := w.Write([]byte(tt.body))
+				require.NoError(t, writeErr)
+			})
+
+			handler := middleware(inner)
+
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			assert.Contains(t, recorder.Body.String(), "tool1")
+			assert.NotContains(t, recorder.Body.String(), "tool2",
+				"the excluded tool must not be exposed just because Content-Type was missing")
 		})
 	}
 }

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -1569,3 +1569,47 @@ func TestNewListToolsMappingMiddleware_FlushesStrandedBuffer(t *testing.T) {
 	assert.Contains(t, recorder.Body.String(), "tool1")
 	assert.NotContains(t, recorder.Body.String(), "tool2")
 }
+
+// TestNewListToolsMappingMiddleware_TerminalDrainPassesThroughUnsupportedContentType
+// is a regression test for a follow-up to #5797/#5809: the terminal drain added
+// to flush a stranded buffer must not discard a body it doesn't know how to
+// process. An inner handler that fails with a plain-text error (e.g.
+// http.Error, which sets "text/plain; charset=utf-8") is neither
+// application/json nor text/event-stream, so processBuffer() rejects it with
+// an "unsupported mime type" error. Before this fix, that error path wrote an
+// empty buffer to the client and discarded the original error body.
+func TestNewListToolsMappingMiddleware_TerminalDrainPassesThroughUnsupportedContentType(t *testing.T) {
+	t.Parallel()
+
+	middleware, err := NewListToolsMappingMiddleware(WithToolsFilter("tool1"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{name: "4xx body", statusCode: http.StatusBadRequest},
+		{name: "5xx body", statusCode: http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "backend unavailable", tt.statusCode)
+			})
+
+			handler := middleware(inner)
+
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			assert.Equal(t, tt.statusCode, recorder.Code)
+			assert.Contains(t, recorder.Body.String(), "backend unavailable",
+				"the original error body must reach the client unchanged")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Why**: [#5809](https://github.com/stacklok/toolhive/pull/5809) added an unconditional `Flush()` call after the wrapped handler returns, to drain a response that a downstream buffering middleware (e.g. authz's response filter) may have written into the tool-filter's buffer without ever calling `Flush()` itself. That terminal call reused the streaming `Flush()` logic, which treats any body with an unsupported/missing Content-Type as an error and discards it. In practice this meant a downstream error response with `Content-Type: text/plain` (e.g. from `http.Error`) reached the client with the correct status code but an empty body — the original error text was silently dropped. Raised as a post-merge follow-up on #5809 by @JAORMX.
- **What**: Split the buffer-draining logic into a shared `drainBuffer(terminal bool)` helper. `Flush()` keeps its existing streaming behavior (unrecognized/incomplete bodies stay buffered for a later call). The new `finish()`, called once after `ServeHTTP` returns, is the terminal case: since there's no more data coming, a body that can't be processed is written through unchanged instead of being dropped. `finish()` also skips the downstream transport `Flush()` call, since returning from `ServeHTTP` already completes the response.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Added `TestNewListToolsMappingMiddleware_TerminalDrainPassesThroughUnsupportedContentType`, covering a `4xx` and a `5xx` plain-text error body through the middleware, asserting the original body reaches the client unchanged. Existing `Flush()` and stranded-buffer regression tests still pass unmodified.

## Does this introduce a user-facing change?

Yes: MCP servers configured with tool filtering/override (`--tools-filter`/`--tools-override`) now return the original body for downstream error responses with unsupported content types (e.g. plain-text errors), instead of an empty body.

## Special notes for reviewers

This is a narrowly-scoped follow-up to #5809 addressing https://github.com/stacklok/toolhive/pull/5809#issuecomment-4980349875. No related GitHub issue exists yet for this specific bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)