### PR TITLE
Stop VirtualMCPServer hot-reconcile on cleared imagePullSecrets

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -1512,7 +1512,7 @@ func (r *VirtualMCPServerReconciler) ensureDeployment(
 		// loop will retry automatically. Kubernetes' optimistic locking prevents data loss.
 		deployment.Spec.Template = newDeployment.Spec.Template
 		deployment.Labels = newDeployment.Labels
-		deployment.Annotations = ctrlutil.MergeAnnotations(newDeployment.Annotations, deployment.Annotations)
+		deployment.Annotations = mergeDeploymentAnnotations(newDeployment.Annotations, deployment.Annotations)
 		if newDeployment.Spec.Replicas != nil {
 			deployment.Spec.Replicas = newDeployment.Spec.Replicas
 		}
@@ -1815,6 +1815,22 @@ func (*VirtualMCPServerReconciler) podTemplateSpecNeedsUpdate(
 	return deployment.Annotations[podTemplateSpecHashAnnotation] != expectedHash
 }
 
+// mergeDeploymentAnnotations merges desired Deployment annotations onto the
+// live ones via ctrlutil.MergeAnnotations, then prunes imagePullRefsHashAnnotation
+// from the result if desired no longer wants it. MergeAnnotations preserves any
+// live key absent from desired so externally-managed annotations survive, but
+// imagePullRefsHashAnnotation is operator-owned: when the desired imagePullSecrets
+// list is empty, desired carries no annotation for it, and a stale value left by
+// a prior reconcile must be pruned explicitly or it survives forever and
+// imagePullSecretsNeedsUpdate flags drift on every reconcile (#5817).
+func mergeDeploymentAnnotations(desired, live map[string]string) map[string]string {
+	merged := ctrlutil.MergeAnnotations(desired, live)
+	if _, wantHash := desired[imagePullRefsHashAnnotation]; !wantHash {
+		delete(merged, imagePullRefsHashAnnotation)
+	}
+	return merged
+}
+
 // imagePullSecretsNeedsUpdate detects drift on the desired imagePullSecrets
 // list (chart-level defaults merged with vmcp.Spec.ImagePullSecrets) by
 // comparing a hash of the desired list against the value stored in
@@ -1825,6 +1841,12 @@ func (*VirtualMCPServerReconciler) podTemplateSpecNeedsUpdate(
 // would either flag spurious drift or miss real changes depending on
 // PodTemplateSpec content. PodTemplateSpec drift is covered separately by
 // podTemplateSpecNeedsUpdate.
+//
+// A missing annotation reads as "" via map indexing, which equals an empty
+// expected hash — so an absent annotation with an empty desired list is
+// correctly the steady state. The write path in ensureDeployment is
+// responsible for actually deleting the annotation once it is no longer
+// wanted; without that, this comparison would flag drift every reconcile.
 func (r *VirtualMCPServerReconciler) imagePullSecretsNeedsUpdate(
 	ctx context.Context,
 	deployment *appsv1.Deployment,
@@ -1838,12 +1860,6 @@ func (r *VirtualMCPServerReconciler) imagePullSecretsNeedsUpdate(
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to hash imagePullSecrets, assuming update needed")
 		return true
-	}
-	// An empty desired list means the annotation should be absent; an absent annotation
-	// with an empty desired list is the steady state and must not trigger an update.
-	_, present := deployment.Annotations[imagePullRefsHashAnnotation]
-	if expectedHash == "" {
-		return present
 	}
 	return deployment.Annotations[imagePullRefsHashAnnotation] != expectedHash
 }

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -2534,6 +2534,117 @@ func TestVirtualMCPServerEnsureDeployment_NoUpdateNeeded(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, result)
 }
 
+// TestVirtualMCPServerEnsureDeployment_RemovesStaleImagePullSecretsHash is a
+// regression test for #5817: a stale imagePullRefsHashAnnotation left over
+// from a prior reconcile (when imagePullSecrets was non-empty) must be
+// removed once the desired list is empty, and reconciling again from that
+// cleaned-up state must be a no-op rather than looping forever.
+func TestVirtualMCPServerEnsureDeployment_RemovesStaleImagePullSecretsHash(t *testing.T) {
+	t.Parallel()
+
+	scheme := testutil.NewScheme(t)
+
+	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+		v1beta1test.WithVMCPGroupRef(testGroupName),
+	)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmcpConfigMapName(vmcp.Name),
+			Namespace: "default",
+			Annotations: map[string]string{
+				checksum.ContentChecksumAnnotation: "test-checksum",
+			},
+		},
+		Data: map[string]string{
+			"config.yaml": "test-config",
+		},
+	}
+
+	reconciler := &VirtualMCPServerReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme: scheme,
+	}
+
+	expectedLabels, expectedAnnotations := reconciler.buildPodTemplateMetadata(
+		labelsForVirtualMCPServer(vmcp.Name), vmcp, "test-checksum",
+	)
+
+	// Deployment otherwise matches the desired state exactly, except it
+	// carries a stale imagePullRefsHashAnnotation from before imagePullSecrets
+	// was cleared on the VirtualMCPServer.
+	staleDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVmcpName,
+			Namespace: "default",
+			Labels:    labelsForVirtualMCPServer(vmcp.Name),
+			Annotations: map[string]string{
+				imagePullRefsHashAnnotation: "stale-hash",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labelsForVirtualMCPServer(vmcp.Name),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      expectedLabels,
+					Annotations: expectedAnnotations,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "vmcp",
+							Image: getVmcpImage(),
+							Ports: []corev1.ContainerPort{
+								{ContainerPort: 4483},
+							},
+							Env: mustBuildEnvVarsForVmcp(reconciler, vmcp),
+						},
+					},
+					ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
+				},
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(vmcp, configMap, staleDeployment).
+		Build()
+	reconciler.Client = k8sClient
+
+	// First reconcile cleans up the stale annotation.
+	result, err := reconciler.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      vmcp.Name,
+		Namespace: vmcp.Namespace,
+	}, deployment))
+	_, present := deployment.Annotations[imagePullRefsHashAnnotation]
+	assert.False(t, present, "stale imagePullRefsHashAnnotation must be removed once desired list is empty")
+
+	resourceVersionAfterCleanup := deployment.ResourceVersion
+
+	// Second reconcile from the now-clean steady state must be a no-op.
+	// Without both fixes, this would keep re-detecting drift and updating
+	// forever — the hot-reconcile loop from #5817.
+	result, err = reconciler.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	deployment = &appsv1.Deployment{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      vmcp.Name,
+		Namespace: vmcp.Namespace,
+	}, deployment))
+	assert.Equal(t, resourceVersionAfterCleanup, deployment.ResourceVersion,
+		"reconciling from steady state must not write again")
+}
+
 func TestVirtualMCPServerEnsureService_CreateService(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

VirtualMCPServer's Deployment reconciler entered a hot-reconcile loop
whenever `spec.imagePullSecrets` was cleared on an existing CR: a stale
`imagePullRefsHashAnnotation` left over from a prior reconcile (when the
list was non-empty) survived every `MergeAnnotations` call, because the
desired annotations map no longer carried a key to overwrite it with. That
made `imagePullSecretsNeedsUpdate` report drift on every single reconcile,
updating the Deployment roughly twice every 30 seconds indefinitely — on a
kind cluster this saturates etcd write bandwidth and can starve
leader-election lease renewals, causing the operator to restart.

- Made `imagePullSecretsNeedsUpdate` a plain `stored != expected` hash
  comparison instead of the previous asymmetric check that always reported
  drift when the annotation was present and the expected hash was empty.
- Extracted a `mergeDeploymentAnnotations` helper that merges annotations
  and explicitly prunes `imagePullRefsHashAnnotation` when the desired
  state no longer wants it, so the stale key is actually removed instead of
  being resurrected by `MergeAnnotations` on every subsequent reconcile.
- Added a regression test that reconciles twice from a stale-annotation
  fixture and asserts the second reconcile is a true no-op (unchanged
  `ResourceVersion`).

Fixes #5817

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

No — this only fixes an operator-internal reconcile bug; no CRD field or observable behavior changes for users beyond the loop no longer happening.

## Special notes for reviewers

The fix has two parts and both are required together: making the comparison
symmetric alone does not stop the loop, since the write path would still
never remove the stale annotation via `MergeAnnotations`. Only pruning it
explicitly at the write site converges to a steady state.

Companion bugs for `podTemplateSpecHashAnnotation` and
`podTemplateMetadataNeedsUpdate` were mentioned in #5817 as filed
separately and are intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)