### PR TITLE
Add RFC 8693 token exchange handler to the embedded AS

### DIFF
--- a/pkg/authserver/server/provider.go
+++ b/pkg/authserver/server/provider.go
@@ -79,7 +79,7 @@ type AuthorizationServerConfig struct {
 // The strategy parameter is typed as any because fosite uses different strategy
 // interfaces for different flows (e.g., oauth2.CoreStrategy, openid.OpenIDConnectTokenStrategy)
 // that do not share a common base interface.
-type Factory func(config *AuthorizationServerConfig, storage fosite.Storage, strategy any) any
+type Factory func(config *AuthorizationServerConfig, storage fosite.Storage, strategy any) (any, error)
 
 // AuthorizationServerParams contains the configuration needed to create an AuthorizationServerConfig.
 // This is a minimal subset of the authserver.Config fields needed for OAuth2.
@@ -273,12 +273,15 @@ func NewAuthorizationServer(
 	storage fosite.Storage,
 	strategy any,
 	factories ...Factory,
-) fosite.OAuth2Provider {
+) (fosite.OAuth2Provider, error) {
 	fositeConfig := config.Config
 	provider := fosite.NewOAuth2Provider(storage, fositeConfig)
 
 	for _, factory := range factories {
-		result := factory(config, storage, strategy)
+		result, err := factory(config, storage, strategy)
+		if err != nil {
+			return nil, fmt.Errorf("authorization server factory failed: %w", err)
+		}
 
 		if ah, ok := result.(fosite.AuthorizeEndpointHandler); ok {
 			fositeConfig.AuthorizeEndpointHandlers.Append(ah)
@@ -301,7 +304,7 @@ func NewAuthorizationServer(
 		}
 	}
 
-	return provider
+	return provider, nil
 }
 
 // GetSigningKey returns the config's signing key.

--- a/pkg/authserver/server/provider.go
+++ b/pkg/authserver/server/provider.go
@@ -283,24 +283,35 @@ func NewAuthorizationServer(
 			return nil, fmt.Errorf("authorization server factory failed: %w", err)
 		}
 
+		var matched bool
+
 		if ah, ok := result.(fosite.AuthorizeEndpointHandler); ok {
 			fositeConfig.AuthorizeEndpointHandlers.Append(ah)
+			matched = true
 		}
 
 		if th, ok := result.(fosite.TokenEndpointHandler); ok {
 			fositeConfig.TokenEndpointHandlers.Append(th)
+			matched = true
 		}
 
 		if ti, ok := result.(fosite.TokenIntrospector); ok {
 			fositeConfig.TokenIntrospectionHandlers.Append(ti)
+			matched = true
 		}
 
 		if rh, ok := result.(fosite.RevocationHandler); ok {
 			fositeConfig.RevocationHandlers.Append(rh)
+			matched = true
 		}
 
 		if ph, ok := result.(fosite.PushedAuthorizeEndpointHandler); ok {
 			fositeConfig.PushedAuthorizeEndpointHandlers.Append(ph)
+			matched = true
+		}
+
+		if result != nil && !matched {
+			return nil, fmt.Errorf("authorization server factory returned unrecognized handler type %T", result)
 		}
 	}
 

--- a/pkg/authserver/server/provider_test.go
+++ b/pkg/authserver/server/provider_test.go
@@ -564,7 +564,7 @@ func (*mockTokenIntrospector) IntrospectToken(_ context.Context, _ string, _ fos
 // mockRevocationHandler implements fosite.RevocationHandler for testing.
 type mockRevocationHandler struct{}
 
-func (*mockRevocationHandler) RevokeToken(_ context.Context, _ string, _ string, _ fosite.Client) error {
+func (*mockRevocationHandler) RevokeToken(_ context.Context, _ string, _ fosite.TokenType, _ fosite.Client) error {
 	return nil
 }
 
@@ -660,7 +660,7 @@ func TestNewAuthorizationServer(t *testing.T) {
 		require.NotNil(t, provider)
 	})
 
-	t.Run("handles factory returning non-handler type", func(t *testing.T) {
+	t.Run("errors on factory returning non-handler type", func(t *testing.T) {
 		t.Parallel()
 
 		factory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) (any, error) {
@@ -668,7 +668,8 @@ func TestNewAuthorizationServer(t *testing.T) {
 		}
 
 		provider, err := NewAuthorizationServer(createConfig(t), storage, nil, factory)
-		require.NoError(t, err)
-		require.NotNil(t, provider)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "string")
+		require.Nil(t, provider)
 	})
 }

--- a/pkg/authserver/server/provider_test.go
+++ b/pkg/authserver/server/provider_test.go
@@ -597,72 +597,78 @@ func TestNewAuthorizationServer(t *testing.T) {
 	t.Run("creates provider with no factories", func(t *testing.T) {
 		t.Parallel()
 
-		provider := NewAuthorizationServer(createConfig(t), storage, nil)
+		provider, err := NewAuthorizationServer(createConfig(t), storage, nil)
+		require.NoError(t, err)
 		require.NotNil(t, provider)
 	})
 
 	t.Run("creates provider with authorize handler factory", func(t *testing.T) {
 		t.Parallel()
 
-		factory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) any {
-			return &mockAuthorizeHandler{}
+		factory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) (any, error) {
+			return &mockAuthorizeHandler{}, nil
 		}
 
-		provider := NewAuthorizationServer(createConfig(t), storage, nil, factory)
+		provider, err := NewAuthorizationServer(createConfig(t), storage, nil, factory)
+		require.NoError(t, err)
 		require.NotNil(t, provider)
 	})
 
 	t.Run("creates provider with token handler factory", func(t *testing.T) {
 		t.Parallel()
 
-		factory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) any {
-			return &mockTokenHandler{}
+		factory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) (any, error) {
+			return &mockTokenHandler{}, nil
 		}
 
-		provider := NewAuthorizationServer(createConfig(t), storage, nil, factory)
+		provider, err := NewAuthorizationServer(createConfig(t), storage, nil, factory)
+		require.NoError(t, err)
 		require.NotNil(t, provider)
 	})
 
 	t.Run("creates provider with multiple factories", func(t *testing.T) {
 		t.Parallel()
 
-		authorizeFactory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) any {
-			return &mockAuthorizeHandler{}
+		authorizeFactory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) (any, error) {
+			return &mockAuthorizeHandler{}, nil
 		}
-		tokenFactory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) any {
-			return &mockTokenHandler{}
+		tokenFactory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) (any, error) {
+			return &mockTokenHandler{}, nil
 		}
-		introspectorFactory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) any {
-			return &mockTokenIntrospector{}
+		introspectorFactory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) (any, error) {
+			return &mockTokenIntrospector{}, nil
 		}
-		revocationFactory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) any {
-			return &mockRevocationHandler{}
+		revocationFactory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) (any, error) {
+			return &mockRevocationHandler{}, nil
 		}
 
-		provider := NewAuthorizationServer(createConfig(t), storage, nil,
+		provider, err := NewAuthorizationServer(createConfig(t), storage, nil,
 			authorizeFactory, tokenFactory, introspectorFactory, revocationFactory)
+		require.NoError(t, err)
 		require.NotNil(t, provider)
 	})
 
 	t.Run("handles factory returning nil", func(t *testing.T) {
 		t.Parallel()
 
-		factory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) any {
-			return nil
+		factory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) (any, error) {
+			return nil, nil
 		}
 
-		provider := NewAuthorizationServer(createConfig(t), storage, nil, factory)
+		provider, err := NewAuthorizationServer(createConfig(t), storage, nil, factory)
+		require.NoError(t, err)
 		require.NotNil(t, provider)
 	})
 
 	t.Run("handles factory returning non-handler type", func(t *testing.T) {
 		t.Parallel()
 
-		factory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) any {
-			return "not a handler"
+		factory := func(_ *AuthorizationServerConfig, _ fosite.Storage, _ any) (any, error) {
+			return "not a handler", nil
 		}
 
-		provider := NewAuthorizationServer(createConfig(t), storage, nil, factory)
+		provider, err := NewAuthorizationServer(createConfig(t), storage, nil, factory)
+		require.NoError(t, err)
 		require.NotNil(t, provider)
 	})
 }

--- a/pkg/authserver/server/tokenexchange/factory.go
+++ b/pkg/authserver/server/tokenexchange/factory.go
@@ -16,11 +16,13 @@ import (
 // Factory returns a server.Factory that creates a token exchange Handler.
 // The delegationLifespan parameter sets the maximum lifetime for delegated tokens;
 // the actual lifetime is the minimum of this value and the subject token's remaining lifetime.
-// Returns an error if delegationLifespan is not positive, since a zero or negative
-// value would produce delegated tokens with an expiry already in the past.
+// Returns an error if delegationLifespan is not in (0, server.MaxAccessTokenLifespan]: a zero
+// or negative value would produce delegated tokens with an expiry already in the past, and a
+// value above the access token ceiling would only be caught at request time by the per-request cap.
 func Factory(delegationLifespan time.Duration) (server.Factory, error) {
-	if delegationLifespan <= 0 {
-		return nil, fmt.Errorf("tokenexchange: delegationLifespan must be positive, got %v", delegationLifespan)
+	if delegationLifespan <= 0 || delegationLifespan > server.MaxAccessTokenLifespan {
+		return nil, fmt.Errorf("tokenexchange: delegationLifespan must be between %v and %v, got %v",
+			time.Duration(0), server.MaxAccessTokenLifespan, delegationLifespan)
 	}
 	return func(config *server.AuthorizationServerConfig, storage fosite.Storage, strategy any) (any, error) {
 		validator, err := NewSubjectTokenValidator(config.PublicJWKS(), config.GetAccessTokenIssuer(), config.AllowedAudiences)

--- a/pkg/authserver/server/tokenexchange/factory.go
+++ b/pkg/authserver/server/tokenexchange/factory.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tokenexchange
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
+
+	"github.com/stacklok/toolhive/pkg/authserver/server"
+)
+
+// Factory returns a server.Factory that creates a token exchange Handler.
+// The delegationLifespan parameter sets the maximum lifetime for delegated tokens;
+// the actual lifetime is the minimum of this value and the subject token's remaining lifetime.
+func Factory(delegationLifespan time.Duration) server.Factory {
+	return func(config *server.AuthorizationServerConfig, storage fosite.Storage, strategy any) (any, error) {
+		validator, err := NewSubjectTokenValidator(config.SigningJWKS, config.GetAccessTokenIssuer())
+		if err != nil {
+			return nil, fmt.Errorf("tokenexchange: failed to create subject token validator: %w", err)
+		}
+
+		// Use the embedded *fosite.Config for HandleHelper and handlerConfig
+		// because AuthorizationServerConfig shadows GetAccessTokenLifespan() without
+		// a context parameter, which doesn't satisfy fosite's provider interfaces.
+		atStrategy, ok := strategy.(oauth2.AccessTokenStrategy)
+		if !ok {
+			return nil, fmt.Errorf("tokenexchange: strategy does not implement oauth2.AccessTokenStrategy (got %T)", strategy)
+		}
+		atStorage, ok := storage.(oauth2.AccessTokenStorage)
+		if !ok {
+			return nil, fmt.Errorf("tokenexchange: storage does not implement oauth2.AccessTokenStorage (got %T)", storage)
+		}
+		return &Handler{
+			HandleHelper: &oauth2.HandleHelper{
+				AccessTokenStrategy: atStrategy,
+				AccessTokenStorage:  atStorage,
+				Config:              config.Config,
+			},
+			validator:          validator,
+			delegationLifespan: delegationLifespan,
+			config:             config.Config,
+			allowedAudiences:   config.AllowedAudiences,
+		}, nil
+	}
+}

--- a/pkg/authserver/server/tokenexchange/factory.go
+++ b/pkg/authserver/server/tokenexchange/factory.go
@@ -16,9 +16,14 @@ import (
 // Factory returns a server.Factory that creates a token exchange Handler.
 // The delegationLifespan parameter sets the maximum lifetime for delegated tokens;
 // the actual lifetime is the minimum of this value and the subject token's remaining lifetime.
-func Factory(delegationLifespan time.Duration) server.Factory {
+// Returns an error if delegationLifespan is not positive, since a zero or negative
+// value would produce delegated tokens with an expiry already in the past.
+func Factory(delegationLifespan time.Duration) (server.Factory, error) {
+	if delegationLifespan <= 0 {
+		return nil, fmt.Errorf("tokenexchange: delegationLifespan must be positive, got %v", delegationLifespan)
+	}
 	return func(config *server.AuthorizationServerConfig, storage fosite.Storage, strategy any) (any, error) {
-		validator, err := NewSubjectTokenValidator(config.SigningJWKS, config.GetAccessTokenIssuer())
+		validator, err := NewSubjectTokenValidator(config.PublicJWKS(), config.GetAccessTokenIssuer(), config.AllowedAudiences)
 		if err != nil {
 			return nil, fmt.Errorf("tokenexchange: failed to create subject token validator: %w", err)
 		}
@@ -45,5 +50,5 @@ func Factory(delegationLifespan time.Duration) server.Factory {
 			config:             config.Config,
 			allowedAudiences:   config.AllowedAudiences,
 		}, nil
-	}
+	}, nil
 }

--- a/pkg/authserver/server/tokenexchange/factory_test.go
+++ b/pkg/authserver/server/tokenexchange/factory_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/authserver/server"
 )
 
 func TestFactory(t *testing.T) {
@@ -33,6 +35,20 @@ func TestFactory(t *testing.T) {
 			name:               "positive delegationLifespan succeeds",
 			delegationLifespan: 15 * time.Minute,
 		},
+		{
+			name:               "delegationLifespan at max access token lifespan succeeds",
+			delegationLifespan: server.MaxAccessTokenLifespan,
+		},
+		{
+			name:               "delegationLifespan above max access token lifespan returns error",
+			delegationLifespan: server.MaxAccessTokenLifespan + time.Hour,
+			wantErr:            true,
+		},
+		{
+			name:               "delegationLifespan of 48h returns error",
+			delegationLifespan: 48 * time.Hour,
+			wantErr:            true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -42,7 +58,7 @@ func TestFactory(t *testing.T) {
 			f, err := Factory(tt.delegationLifespan)
 			if tt.wantErr {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "delegationLifespan must be positive")
+				assert.Contains(t, err.Error(), "delegationLifespan must be between")
 				assert.Nil(t, f)
 				return
 			}

--- a/pkg/authserver/server/tokenexchange/factory_test.go
+++ b/pkg/authserver/server/tokenexchange/factory_test.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tokenexchange
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFactory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		delegationLifespan time.Duration
+		wantErr            bool
+	}{
+		{
+			name:               "zero delegationLifespan returns error",
+			delegationLifespan: 0,
+			wantErr:            true,
+		},
+		{
+			name:               "negative delegationLifespan returns error",
+			delegationLifespan: -time.Minute,
+			wantErr:            true,
+		},
+		{
+			name:               "positive delegationLifespan succeeds",
+			delegationLifespan: 15 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			f, err := Factory(tt.delegationLifespan)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "delegationLifespan must be positive")
+				assert.Nil(t, f)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, f)
+		})
+	}
+}

--- a/pkg/authserver/server/tokenexchange/handler.go
+++ b/pkg/authserver/server/tokenexchange/handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 	"time"
 
@@ -79,42 +80,9 @@ func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, requester fosi
 	// this handler runs.
 	actorID := client.GetID()
 
-	form := requester.GetRequestForm()
-
-	// Validate required RFC 8693 parameters.
-	subjectToken := form.Get("subject_token")
-	if subjectToken == "" {
-		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
-			"The 'subject_token' parameter is required for token exchange."))
-	}
-
-	subjectTokenType := form.Get("subject_token_type")
-	if subjectTokenType == "" {
-		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
-			"The 'subject_token_type' parameter is required for token exchange."))
-	}
-
-	if subjectTokenType != oauthproto.TokenTypeAccessToken && subjectTokenType != oauthproto.TokenTypeJWT {
-		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf(
-			"The 'subject_token_type' value %q is not supported. Use %q or %q.",
-			subjectTokenType, oauthproto.TokenTypeAccessToken, oauthproto.TokenTypeJWT))
-	}
-
-	// Reject actor_token parameters for now — the acting party identity is
-	// derived from the authenticated OAuth client. A later commit adds
-	// actor_token support for asserting a distinct actor.
-	if form.Get("actor_token") != "" || form.Get("actor_token_type") != "" {
-		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
-			"The 'actor_token' and 'actor_token_type' parameters are not yet supported."))
-	}
-
-	// Validate requested_token_type per RFC 8693 Section 2.1: if the client
-	// requests a token type the server does not support, the request must fail.
-	requestedTokenType := form.Get("requested_token_type")
-	if requestedTokenType != "" && requestedTokenType != oauthproto.TokenTypeAccessToken {
-		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf(
-			"The 'requested_token_type' value %q is not supported. This server only issues %q.",
-			requestedTokenType, oauthproto.TokenTypeAccessToken))
+	subjectToken, err := validateExchangeParams(requester.GetRequestForm())
+	if err != nil {
+		return err
 	}
 
 	// Validate the subject token against the server's own JWKS.
@@ -128,78 +96,24 @@ func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, requester fosi
 			"The subject token is invalid or could not be verified."))
 	}
 
-	// Delegation consent check (RFC 8693 §4.1).
-	//
-	// If the subject token carries a may_act claim, it is the authoritative
-	// consent signal: only the party named in may_act.sub may delegate.
-	// The client_id binding is skipped in this case because may_act enables
-	// cross-client delegation (the token was issued to client A but authorizes
-	// client B to act).
-	//
-	// If may_act is absent, fall back to client_id binding: the subject
-	// token's client_id must match the authenticated client. This prevents
-	// a stolen subject token from being exchanged by a different client.
-	// Legacy tokens without client_id are allowed through.
-	switch {
-	case validatedClaims.MayAct != nil:
-		if validatedClaims.MayAct.Sub != actorID {
-			return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
-				"The subject token does not authorize this client to act on behalf of the subject."))
-		}
-	case validatedClaims.ClientID != "" && validatedClaims.ClientID != actorID:
-		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
-			"The subject token was issued to a different client."))
+	if err := checkDelegationConsent(validatedClaims, actorID); err != nil {
+		return err
 	}
 
-	// Validate that each requested scope is allowed for both the client and
-	// the subject token. The delegated token's scope set is the intersection
-	// of the client's registered scopes and the subject token's granted
-	// scopes, preventing a client from escalating privileges beyond what the
-	// user authorized. A subject token without a scope claim grants no scopes.
-	subjectScopes := strings.Fields(validatedClaims.Scopes)
-	subjectScopeSet := make(map[string]bool, len(subjectScopes))
-	for _, s := range subjectScopes {
-		subjectScopeSet[s] = true
+	if err := h.grantScopes(ctx, requester, client, validatedClaims); err != nil {
+		return err
 	}
 
-	for _, scope := range requester.GetRequestedScopes() {
-		if !h.config.GetScopeStrategy(ctx)(client.GetScopes(), scope) {
-			return errorsx.WithStack(fosite.ErrInvalidScope.WithHintf(
-				"The OAuth 2.0 Client is not allowed to request scope '%s'.", scope))
-		}
-		if !subjectScopeSet[scope] {
-			return errorsx.WithStack(fosite.ErrInvalidScope.WithHintf(
-				"The scope '%s' was not granted by the subject token.", scope))
-		}
-		requester.GrantScope(scope)
+	if err := h.grantAudiences(ctx, requester, client); err != nil {
+		return err
 	}
 
-	// Validate that the requested audience is allowed for this client.
-	if err := h.config.GetAudienceStrategy(ctx)(client.GetAudience(), requester.GetRequestedAudience()); err != nil {
-		return errorsx.WithStack(err)
-	}
-	for _, aud := range requester.GetRequestedAudience() {
-		requester.GrantAudience(aud)
+	if err := grantResourceAudience(requester, h.allowedAudiences); err != nil {
+		return err
 	}
 
-	// RFC 8707: Validate the resource parameter against the server's allowed
-	// audiences. The resource value becomes an additional audience claim in
-	// the issued token, binding it to a specific resource server (e.g., an
-	// MCP server). Multiple resource parameters are rejected for security.
-	resources := form["resource"]
-	if len(resources) > 1 {
-		return errorsx.WithStack(server.ErrInvalidTarget.WithHint(
-			"Multiple resource parameters are not supported."))
-	}
-	if len(resources) == 1 && resources[0] != "" {
-		resource := resources[0]
-		if err := server.ValidateAudienceURI(resource); err != nil {
-			return errorsx.WithStack(err)
-		}
-		if err := server.ValidateAudienceAllowed(resource, h.allowedAudiences); err != nil {
-			return errorsx.WithStack(err)
-		}
-		requester.GrantAudience(resource)
+	if err := h.grantDefaultAudience(requester); err != nil {
+		return err
 	}
 
 	// Build the delegated session with the user's identity and the agent's act claim.
@@ -214,9 +128,14 @@ func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, requester fosi
 	)
 
 	// Add the RFC 8693 Section 4.1 "act" claim identifying the acting party.
-	delegatedSession.JWTClaims.Extra["act"] = map[string]interface{}{
-		"sub": actorID,
+	// If the subject token itself carries an "act" claim (i.e. it is a
+	// previously-delegated token being re-exchanged), nest it so the full
+	// delegation chain remains auditable rather than being discarded.
+	act := map[string]interface{}{"sub": actorID}
+	if priorAct, ok := validatedClaims.Extra["act"]; ok && priorAct != nil {
+		act["act"] = priorAct
 	}
+	delegatedSession.JWTClaims.Extra["act"] = act
 
 	// Compute the delegated token lifetime: the shorter of the subject token's
 	// remaining lifetime and the configured delegation lifespan.
@@ -259,7 +178,17 @@ func (h *Handler) PopulateTokenEndpointResponse(
 	atLifespan := h.config.GetAccessTokenLifespan(ctx)
 	if sessionExpiry := requester.GetSession().GetExpiresAt(fosite.AccessToken); !sessionExpiry.IsZero() {
 		remaining := time.Until(sessionExpiry)
-		if remaining > 0 && remaining < atLifespan {
+		if remaining <= 0 {
+			// The session's bound has already elapsed since HandleTokenEndpointRequest
+			// computed it. Fail closed instead of signing a token whose exp is already
+			// in the past while reporting a negative expires_in — fosite's JWT strategy
+			// sets exp directly from this session's expiry (GetExpiresAt), independent
+			// of atLifespan, so letting this fall through would not simply hand out a
+			// longer-lived token, it would issue an already-expired one.
+			return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+				"The delegated token's bound lifetime has already elapsed."))
+		}
+		if remaining < atLifespan {
 			atLifespan = remaining
 		}
 	}
@@ -288,4 +217,163 @@ func (h *Handler) computeLifetime(subjectExpiry time.Time) (time.Duration, error
 		return remaining, nil
 	}
 	return h.delegationLifespan, nil
+}
+
+// validateExchangeParams validates the required RFC 8693 form parameters and
+// returns the subject token on success.
+func validateExchangeParams(form url.Values) (string, error) {
+	subjectToken := form.Get("subject_token")
+	if subjectToken == "" {
+		return "", errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
+			"The 'subject_token' parameter is required for token exchange."))
+	}
+
+	subjectTokenType := form.Get("subject_token_type")
+	if subjectTokenType == "" {
+		return "", errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
+			"The 'subject_token_type' parameter is required for token exchange."))
+	}
+
+	if subjectTokenType != oauthproto.TokenTypeAccessToken && subjectTokenType != oauthproto.TokenTypeJWT {
+		return "", errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf(
+			"The 'subject_token_type' value %q is not supported. Use %q or %q.",
+			subjectTokenType, oauthproto.TokenTypeAccessToken, oauthproto.TokenTypeJWT))
+	}
+
+	// Reject actor_token parameters for now — the acting party identity is
+	// derived from the authenticated OAuth client. A later commit adds
+	// actor_token support for asserting a distinct actor.
+	if form.Get("actor_token") != "" || form.Get("actor_token_type") != "" {
+		return "", errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
+			"The 'actor_token' and 'actor_token_type' parameters are not yet supported."))
+	}
+
+	// Validate requested_token_type per RFC 8693 Section 2.1: if the client
+	// requests a token type the server does not support, the request must fail.
+	requestedTokenType := form.Get("requested_token_type")
+	if requestedTokenType != "" && requestedTokenType != oauthproto.TokenTypeAccessToken {
+		return "", errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf(
+			"The 'requested_token_type' value %q is not supported. This server only issues %q.",
+			requestedTokenType, oauthproto.TokenTypeAccessToken))
+	}
+
+	return subjectToken, nil
+}
+
+// checkDelegationConsent enforces the RFC 8693 §4.1 delegation consent check.
+//
+// If the subject token carries a may_act claim, it is the authoritative
+// consent signal: only the party named in may_act.sub may delegate. The
+// client_id binding is skipped in this case because may_act enables
+// cross-client delegation (the token was issued to client A but authorizes
+// client B to act).
+//
+// If may_act is absent, fall back to client_id binding: the subject token's
+// client_id must match the authenticated client. This prevents a stolen
+// subject token from being exchanged by a different client.
+//
+// If neither may_act nor client_id is present, the subject token carries no
+// verifiable binding to any client at all — this fails closed (CWE-863)
+// rather than allowing an unbound token through.
+func checkDelegationConsent(validatedClaims *ValidatedClaims, actorID string) error {
+	switch {
+	case validatedClaims.MayAct != nil:
+		if validatedClaims.MayAct.Sub != actorID {
+			return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+				"The subject token does not authorize this client to act on behalf of the subject."))
+		}
+	case validatedClaims.ClientID != "" && validatedClaims.ClientID != actorID:
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+			"The subject token was issued to a different client."))
+	case validatedClaims.ClientID == "":
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+			"The subject token carries no verifiable client binding: it has neither a 'may_act' claim nor a 'client_id' claim."))
+	}
+	return nil
+}
+
+// grantScopes validates that each requested scope is allowed for both the
+// client and the subject token, granting the intersection. The delegated
+// token's scope set is the intersection of the client's registered scopes
+// and the subject token's granted scopes, preventing a client from
+// escalating privileges beyond what the user authorized. A subject token
+// without a scope claim grants no scopes.
+func (h *Handler) grantScopes(
+	ctx context.Context, requester fosite.AccessRequester, client fosite.Client, validatedClaims *ValidatedClaims,
+) error {
+	subjectScopes := strings.Fields(validatedClaims.Scopes)
+	subjectScopeSet := make(map[string]bool, len(subjectScopes))
+	for _, s := range subjectScopes {
+		subjectScopeSet[s] = true
+	}
+
+	for _, scope := range requester.GetRequestedScopes() {
+		if !h.config.GetScopeStrategy(ctx)(client.GetScopes(), scope) {
+			return errorsx.WithStack(fosite.ErrInvalidScope.WithHintf(
+				"The OAuth 2.0 Client is not allowed to request scope '%s'.", scope))
+		}
+		if !subjectScopeSet[scope] {
+			return errorsx.WithStack(fosite.ErrInvalidScope.WithHintf(
+				"The scope '%s' was not granted by the subject token.", scope))
+		}
+		requester.GrantScope(scope)
+	}
+	return nil
+}
+
+// grantAudiences validates that the requested audience is allowed for this
+// client and grants it.
+func (h *Handler) grantAudiences(ctx context.Context, requester fosite.AccessRequester, client fosite.Client) error {
+	if err := h.config.GetAudienceStrategy(ctx)(client.GetAudience(), requester.GetRequestedAudience()); err != nil {
+		return errorsx.WithStack(err)
+	}
+	for _, aud := range requester.GetRequestedAudience() {
+		requester.GrantAudience(aud)
+	}
+	return nil
+}
+
+// grantResourceAudience validates the RFC 8707 resource parameter against
+// allowedAudiences and grants it as an additional audience claim, binding
+// the issued token to a specific resource server (e.g., an MCP server).
+// Multiple resource parameters are rejected for security.
+func grantResourceAudience(requester fosite.AccessRequester, allowedAudiences []string) error {
+	resources := requester.GetRequestForm()["resource"]
+	if len(resources) > 1 {
+		return errorsx.WithStack(server.ErrInvalidTarget.WithHint(
+			"Multiple resource parameters are not supported."))
+	}
+	if len(resources) == 1 && resources[0] != "" {
+		resource := resources[0]
+		if err := server.ValidateAudienceURI(resource); err != nil {
+			return errorsx.WithStack(err)
+		}
+		if err := server.ValidateAudienceAllowed(resource, allowedAudiences); err != nil {
+			return errorsx.WithStack(err)
+		}
+		requester.GrantAudience(resource)
+	}
+	return nil
+}
+
+// grantDefaultAudience ensures the delegated token carries at least one
+// audience, since RFC 9068 §4 makes "aud" a required claim. grantAudiences and
+// grantResourceAudience only grant an audience when the client explicitly
+// requests one; if neither was requested, this defaults to the server's sole
+// configured audience when unambiguous (mirroring handlers/token.go's
+// authorization_code fallback), or rejects the request when no unambiguous
+// default exists rather than silently issuing an audience-less token.
+func (h *Handler) grantDefaultAudience(requester fosite.AccessRequester) error {
+	if len(requester.GetGrantedAudience()) > 0 {
+		return nil
+	}
+	if len(h.allowedAudiences) == 1 {
+		slog.Debug("no resource parameter, defaulting to sole allowed audience",
+			"audience", h.allowedAudiences[0],
+		)
+		requester.GrantAudience(h.allowedAudiences[0])
+		return nil
+	}
+	return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
+		"An explicit 'resource' or 'audience' parameter is required because no unambiguous default audience is configured."))
 }

--- a/pkg/authserver/server/tokenexchange/handler.go
+++ b/pkg/authserver/server/tokenexchange/handler.go
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tokenexchange
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/x/errorsx"
+
+	"github.com/stacklok/toolhive/pkg/authserver/server"
+	"github.com/stacklok/toolhive/pkg/authserver/server/session"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
+)
+
+// Compile-time check that Handler implements fosite.TokenEndpointHandler.
+var _ fosite.TokenEndpointHandler = (*Handler)(nil)
+
+// Handler implements RFC 8693 token exchange for user-to-agent delegation.
+//
+// When an authenticated OAuth client (the acting agent) presents a user's JWT
+// as subject_token, the handler validates the token and issues a delegated JWT
+// with sub=user and an act claim containing the client's identity, per
+// RFC 8693 Section 4.1.
+type Handler struct {
+	*oauth2.HandleHelper
+	validator          *SubjectTokenValidator
+	delegationLifespan time.Duration
+	config             tokenExchangeConfig
+	allowedAudiences   []string
+}
+
+// tokenExchangeConfig defines the configuration interface needed by the handler.
+type tokenExchangeConfig interface {
+	fosite.ScopeStrategyProvider
+	fosite.AudienceStrategyProvider
+	fosite.AccessTokenLifespanProvider
+}
+
+// CanHandleTokenEndpointRequest returns true if the request's grant_type is
+// the RFC 8693 token exchange grant type.
+func (*Handler) CanHandleTokenEndpointRequest(_ context.Context, requester fosite.AccessRequester) bool {
+	return requester.GetGrantTypes().ExactOne(oauthproto.GrantTypeTokenExchange)
+}
+
+// CanSkipClientAuth returns false because client authentication is required
+// for all token exchange requests.
+func (*Handler) CanSkipClientAuth(_ context.Context, _ fosite.AccessRequester) bool {
+	return false
+}
+
+// HandleTokenEndpointRequest validates the token exchange request parameters,
+// verifies the subject token, and constructs a delegated session with the act claim.
+//
+// The delegated token's lifetime is the minimum of the subject token's remaining
+// lifetime and the configured delegation lifespan.
+func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, requester fosite.AccessRequester) error {
+	if !h.CanHandleTokenEndpointRequest(ctx, requester) {
+		return errorsx.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	client := requester.GetClient()
+
+	// The client MUST be confidential — only authenticated confidential clients
+	// may act on behalf of a user.
+	if client.IsPublic() {
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+			"The OAuth 2.0 Client is marked as public and is thus not allowed to use authorization grant 'token-exchange'."))
+	}
+
+	// The authenticated client is the acting party ("actor"). The client is
+	// already authenticated by fosite's client authentication strategy before
+	// this handler runs.
+	actorID := client.GetID()
+
+	form := requester.GetRequestForm()
+
+	// Validate required RFC 8693 parameters.
+	subjectToken := form.Get("subject_token")
+	if subjectToken == "" {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
+			"The 'subject_token' parameter is required for token exchange."))
+	}
+
+	subjectTokenType := form.Get("subject_token_type")
+	if subjectTokenType == "" {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
+			"The 'subject_token_type' parameter is required for token exchange."))
+	}
+
+	if subjectTokenType != oauthproto.TokenTypeAccessToken && subjectTokenType != oauthproto.TokenTypeJWT {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf(
+			"The 'subject_token_type' value %q is not supported. Use %q or %q.",
+			subjectTokenType, oauthproto.TokenTypeAccessToken, oauthproto.TokenTypeJWT))
+	}
+
+	// Reject actor_token parameters for now — the acting party identity is
+	// derived from the authenticated OAuth client. A later commit adds
+	// actor_token support for asserting a distinct actor.
+	if form.Get("actor_token") != "" || form.Get("actor_token_type") != "" {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
+			"The 'actor_token' and 'actor_token_type' parameters are not yet supported."))
+	}
+
+	// Validate requested_token_type per RFC 8693 Section 2.1: if the client
+	// requests a token type the server does not support, the request must fail.
+	requestedTokenType := form.Get("requested_token_type")
+	if requestedTokenType != "" && requestedTokenType != oauthproto.TokenTypeAccessToken {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf(
+			"The 'requested_token_type' value %q is not supported. This server only issues %q.",
+			requestedTokenType, oauthproto.TokenTypeAccessToken))
+	}
+
+	// Validate the subject token against the server's own JWKS.
+	validatedClaims, err := h.validator.Validate(ctx, subjectToken)
+	if err != nil {
+		slog.Debug("Subject token validation failed",
+			"error", err,
+			"actor", actorID,
+		)
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+			"The subject token is invalid or could not be verified."))
+	}
+
+	// Delegation consent check (RFC 8693 §4.1).
+	//
+	// If the subject token carries a may_act claim, it is the authoritative
+	// consent signal: only the party named in may_act.sub may delegate.
+	// The client_id binding is skipped in this case because may_act enables
+	// cross-client delegation (the token was issued to client A but authorizes
+	// client B to act).
+	//
+	// If may_act is absent, fall back to client_id binding: the subject
+	// token's client_id must match the authenticated client. This prevents
+	// a stolen subject token from being exchanged by a different client.
+	// Legacy tokens without client_id are allowed through.
+	switch {
+	case validatedClaims.MayAct != nil:
+		if validatedClaims.MayAct.Sub != actorID {
+			return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+				"The subject token does not authorize this client to act on behalf of the subject."))
+		}
+	case validatedClaims.ClientID != "" && validatedClaims.ClientID != actorID:
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+			"The subject token was issued to a different client."))
+	}
+
+	// Validate that each requested scope is allowed for both the client and
+	// the subject token. The delegated token's scope set is the intersection
+	// of the client's registered scopes and the subject token's granted
+	// scopes, preventing a client from escalating privileges beyond what the
+	// user authorized. A subject token without a scope claim grants no scopes.
+	subjectScopes := strings.Fields(validatedClaims.Scopes)
+	subjectScopeSet := make(map[string]bool, len(subjectScopes))
+	for _, s := range subjectScopes {
+		subjectScopeSet[s] = true
+	}
+
+	for _, scope := range requester.GetRequestedScopes() {
+		if !h.config.GetScopeStrategy(ctx)(client.GetScopes(), scope) {
+			return errorsx.WithStack(fosite.ErrInvalidScope.WithHintf(
+				"The OAuth 2.0 Client is not allowed to request scope '%s'.", scope))
+		}
+		if !subjectScopeSet[scope] {
+			return errorsx.WithStack(fosite.ErrInvalidScope.WithHintf(
+				"The scope '%s' was not granted by the subject token.", scope))
+		}
+		requester.GrantScope(scope)
+	}
+
+	// Validate that the requested audience is allowed for this client.
+	if err := h.config.GetAudienceStrategy(ctx)(client.GetAudience(), requester.GetRequestedAudience()); err != nil {
+		return errorsx.WithStack(err)
+	}
+	for _, aud := range requester.GetRequestedAudience() {
+		requester.GrantAudience(aud)
+	}
+
+	// RFC 8707: Validate the resource parameter against the server's allowed
+	// audiences. The resource value becomes an additional audience claim in
+	// the issued token, binding it to a specific resource server (e.g., an
+	// MCP server). Multiple resource parameters are rejected for security.
+	resources := form["resource"]
+	if len(resources) > 1 {
+		return errorsx.WithStack(server.ErrInvalidTarget.WithHint(
+			"Multiple resource parameters are not supported."))
+	}
+	if len(resources) == 1 && resources[0] != "" {
+		resource := resources[0]
+		if err := server.ValidateAudienceURI(resource); err != nil {
+			return errorsx.WithStack(err)
+		}
+		if err := server.ValidateAudienceAllowed(resource, h.allowedAudiences); err != nil {
+			return errorsx.WithStack(err)
+		}
+		requester.GrantAudience(resource)
+	}
+
+	// Build the delegated session with the user's identity and the agent's act claim.
+	delegatedSession := session.New(
+		validatedClaims.Subject,
+		"", // No IDP session link for delegated tokens.
+		actorID,
+		session.UserClaims{
+			Name:  validatedClaims.Name,
+			Email: validatedClaims.Email,
+		},
+	)
+
+	// Add the RFC 8693 Section 4.1 "act" claim identifying the acting party.
+	delegatedSession.JWTClaims.Extra["act"] = map[string]interface{}{
+		"sub": actorID,
+	}
+
+	// Compute the delegated token lifetime: the shorter of the subject token's
+	// remaining lifetime and the configured delegation lifespan.
+	lifetime, err := h.computeLifetime(validatedClaims.Expiry)
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+			"The subject token has expired."))
+	}
+	delegatedSession.SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(lifetime))
+
+	requester.SetSession(delegatedSession)
+
+	slog.Debug("Token exchange request validated",
+		"subject", validatedClaims.Subject,
+		"actor", actorID,
+		"lifetime", lifetime.String(),
+	)
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse issues the delegated access token and sets
+// the RFC 8693 issued_token_type in the response.
+func (h *Handler) PopulateTokenEndpointResponse(
+	ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder,
+) error {
+	if !h.CanHandleTokenEndpointRequest(ctx, requester) {
+		return errorsx.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	if !requester.GetClient().GetGrantTypes().Has(oauthproto.GrantTypeTokenExchange) {
+		return errorsx.WithStack(fosite.ErrUnauthorizedClient.WithHint(
+			"The OAuth 2.0 Client is not allowed to use authorization grant 'token-exchange'."))
+	}
+
+	// Use the session's ExpiresAt (set during HandleTokenEndpointRequest) as the
+	// authoritative lifetime. This respects the min(subject_remaining, delegation)
+	// bound computed earlier. Fall back to the configured access token lifespan
+	// only if no expiry was set on the session.
+	atLifespan := h.config.GetAccessTokenLifespan(ctx)
+	if sessionExpiry := requester.GetSession().GetExpiresAt(fosite.AccessToken); !sessionExpiry.IsZero() {
+		remaining := time.Until(sessionExpiry)
+		if remaining > 0 && remaining < atLifespan {
+			atLifespan = remaining
+		}
+	}
+
+	if _, err := h.IssueAccessToken(ctx, atLifespan, requester, responder); err != nil {
+		return err
+	}
+
+	// Per RFC 8693 Section 2.2.1, the response MUST include issued_token_type.
+	responder.SetExtra("issued_token_type", oauthproto.TokenTypeAccessToken)
+
+	return nil
+}
+
+// computeLifetime returns the minimum of the subject token's remaining lifetime
+// and the configured delegation lifespan. If the subject token has no expiry,
+// the delegation lifespan is used as-is. Returns an error if the subject token
+// has already expired.
+func (h *Handler) computeLifetime(subjectExpiry time.Time) (time.Duration, error) {
+	remaining := time.Until(subjectExpiry)
+	if remaining <= 0 {
+		return 0, fmt.Errorf("subject token expired %v ago", -remaining)
+	}
+
+	if remaining < h.delegationLifespan {
+		return remaining, nil
+	}
+	return h.delegationLifespan, nil
+}

--- a/pkg/authserver/server/tokenexchange/handler.go
+++ b/pkg/authserver/server/tokenexchange/handler.go
@@ -23,12 +23,27 @@ import (
 // Compile-time check that Handler implements fosite.TokenEndpointHandler.
 var _ fosite.TokenEndpointHandler = (*Handler)(nil)
 
+// maxDelegationDepth bounds how many nested "act" entries a subject token's
+// delegation chain may carry. Without a cap, a client could repeatedly
+// re-exchange a delegated token to grow the chain without limit, bloating the
+// issued token and the load it places on downstream resource servers that
+// parse it.
+const maxDelegationDepth = 10
+
 // Handler implements RFC 8693 token exchange for user-to-agent delegation.
 //
 // When an authenticated OAuth client (the acting agent) presents a user's JWT
 // as subject_token, the handler validates the token and issues a delegated JWT
 // with sub=user and an act claim containing the client's identity, per
 // RFC 8693 Section 4.1.
+//
+// Subject tokens are intentionally reusable within their lifetime: per
+// RFC 8693's security considerations, a token exchange does not invalidate
+// the subject token, so the same subject token may be exchanged more than
+// once. Replay is bounded by the delegated token's lifetime cap
+// (min(subject-remaining, delegation)), not by single-use tracking; per-jti
+// single-use enforcement is deferred to the broader M2M/sender-constrained-
+// token effort.
 type Handler struct {
 	*oauth2.HandleHelper
 	validator          *SubjectTokenValidator
@@ -75,6 +90,14 @@ func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, requester fosi
 			"The OAuth 2.0 Client is marked as public and is thus not allowed to use authorization grant 'token-exchange'."))
 	}
 
+	// Reject clients not registered for this grant type up front, before any
+	// subject-token validation work. PopulateTokenEndpointResponse repeats
+	// this check as defense-in-depth.
+	if !client.GetGrantTypes().Has(oauthproto.GrantTypeTokenExchange) {
+		return errorsx.WithStack(fosite.ErrUnauthorizedClient.WithHint(
+			"The OAuth 2.0 Client is not allowed to use authorization grant 'token-exchange'."))
+	}
+
 	// The authenticated client is the acting party ("actor"). The client is
 	// already authenticated by fosite's client authentication strategy before
 	// this handler runs.
@@ -108,11 +131,11 @@ func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, requester fosi
 		return err
 	}
 
-	if err := grantResourceAudience(requester, h.allowedAudiences); err != nil {
+	if err := h.grantResourceAudience(ctx, requester, client); err != nil {
 		return err
 	}
 
-	if err := h.grantDefaultAudience(requester); err != nil {
+	if err := h.grantDefaultAudience(ctx, requester, client); err != nil {
 		return err
 	}
 
@@ -131,8 +154,12 @@ func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, requester fosi
 	// If the subject token itself carries an "act" claim (i.e. it is a
 	// previously-delegated token being re-exchanged), nest it so the full
 	// delegation chain remains auditable rather than being discarded.
-	act := map[string]interface{}{"sub": actorID}
+	act := map[string]any{"sub": actorID}
 	if priorAct, ok := validatedClaims.Extra["act"]; ok && priorAct != nil {
+		if actChainDepth(priorAct) >= maxDelegationDepth {
+			return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint(
+				"The subject token's delegation chain is too deep."))
+		}
 		act["act"] = priorAct
 	}
 	delegatedSession.JWTClaims.Extra["act"] = act
@@ -204,8 +231,7 @@ func (h *Handler) PopulateTokenEndpointResponse(
 }
 
 // computeLifetime returns the minimum of the subject token's remaining lifetime
-// and the configured delegation lifespan. If the subject token has no expiry,
-// the delegation lifespan is used as-is. Returns an error if the subject token
+// and the configured delegation lifespan. Returns an error if the subject token
 // has already expired.
 func (h *Handler) computeLifetime(subjectExpiry time.Time) (time.Duration, error) {
 	remaining := time.Until(subjectExpiry)
@@ -334,10 +360,14 @@ func (h *Handler) grantAudiences(ctx context.Context, requester fosite.AccessReq
 }
 
 // grantResourceAudience validates the RFC 8707 resource parameter against
-// allowedAudiences and grants it as an additional audience claim, binding
-// the issued token to a specific resource server (e.g., an MCP server).
-// Multiple resource parameters are rejected for security.
-func grantResourceAudience(requester fosite.AccessRequester, allowedAudiences []string) error {
+// both the server's allowedAudiences and the client's own registered
+// audiences, and grants it as an additional audience claim, binding the
+// issued token to a specific resource server (e.g., an MCP server).
+//
+// Per RFC 8707 §2, a request MAY carry multiple resource parameters; this
+// handler deliberately narrows that to at most one, since a delegated MCP
+// token is expected to target a single resource.
+func (h *Handler) grantResourceAudience(ctx context.Context, requester fosite.AccessRequester, client fosite.Client) error {
 	resources := requester.GetRequestForm()["resource"]
 	if len(resources) > 1 {
 		return errorsx.WithStack(server.ErrInvalidTarget.WithHint(
@@ -348,8 +378,17 @@ func grantResourceAudience(requester fosite.AccessRequester, allowedAudiences []
 		if err := server.ValidateAudienceURI(resource); err != nil {
 			return errorsx.WithStack(err)
 		}
-		if err := server.ValidateAudienceAllowed(resource, allowedAudiences); err != nil {
+		if err := server.ValidateAudienceAllowed(resource, h.allowedAudiences); err != nil {
 			return errorsx.WithStack(err)
+		}
+		// The resource parameter is RFC 8707's mechanism for requesting an
+		// audience, so it must be subject to the same per-client audience
+		// registration as the "audience" parameter (grantAudiences) — otherwise
+		// a client could bypass its registered audiences simply by using
+		// "resource" instead of "audience".
+		if err := h.config.GetAudienceStrategy(ctx)(client.GetAudience(), []string{resource}); err != nil {
+			return errorsx.WithStack(server.ErrInvalidTarget.WithHintf(
+				"The client is not permitted to request a token for resource %q.", resource))
 		}
 		requester.GrantAudience(resource)
 	}
@@ -362,18 +401,46 @@ func grantResourceAudience(requester fosite.AccessRequester, allowedAudiences []
 // requests one; if neither was requested, this defaults to the server's sole
 // configured audience when unambiguous (mirroring handlers/token.go's
 // authorization_code fallback), or rejects the request when no unambiguous
-// default exists rather than silently issuing an audience-less token.
-func (h *Handler) grantDefaultAudience(requester fosite.AccessRequester) error {
+// default exists rather than silently issuing an audience-less token. The
+// default audience is checked against the client's registered audiences
+// like any explicitly requested audience, so a client is never granted an
+// audience it wasn't registered for.
+func (h *Handler) grantDefaultAudience(ctx context.Context, requester fosite.AccessRequester, client fosite.Client) error {
 	if len(requester.GetGrantedAudience()) > 0 {
 		return nil
 	}
-	if len(h.allowedAudiences) == 1 {
-		slog.Debug("no resource parameter, defaulting to sole allowed audience",
-			"audience", h.allowedAudiences[0],
-		)
-		requester.GrantAudience(h.allowedAudiences[0])
-		return nil
+	if len(h.allowedAudiences) != 1 {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
+			"An explicit 'resource' or 'audience' parameter is required because no unambiguous default audience is configured."))
 	}
-	return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint(
-		"An explicit 'resource' or 'audience' parameter is required because no unambiguous default audience is configured."))
+	defaultAudience := h.allowedAudiences[0]
+	if err := h.config.GetAudienceStrategy(ctx)(client.GetAudience(), []string{defaultAudience}); err != nil {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf(
+			"The client is not permitted to request a token for the default audience %q; "+
+				"an explicit 'resource' or 'audience' parameter is required.", defaultAudience))
+	}
+	slog.Debug("no resource parameter, defaulting to sole allowed audience",
+		"audience", defaultAudience,
+	)
+	requester.GrantAudience(defaultAudience)
+	return nil
+}
+
+// actChainDepth returns the number of nested "act" entries in a subject
+// token's delegation chain, starting from its outermost act claim. A
+// non-map act (or nil) has depth 0.
+func actChainDepth(act any) int {
+	depth := 0
+	for {
+		m, ok := act.(map[string]any)
+		if !ok {
+			return depth
+		}
+		depth++
+		next, ok := m["act"]
+		if !ok || next == nil {
+			return depth
+		}
+		act = next
+	}
 }

--- a/pkg/authserver/server/tokenexchange/handler_test.go
+++ b/pkg/authserver/server/tokenexchange/handler_test.go
@@ -1,0 +1,849 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tokenexchange
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/authserver/server/session"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
+)
+
+const testAgentClientID = "devops-agent"
+
+// newTestHandler creates a TokenExchangeHandler wired to the given test JWKS and
+// delegation lifespan. It does not need a full fosite strategy stack because
+// HandleTokenEndpointRequest (which is the focus of these tests) does not issue tokens.
+func newTestHandler(t *testing.T, tj *testJWKS, delegationLifespan time.Duration) *Handler {
+	t.Helper()
+
+	validator, err := NewSubjectTokenValidator(tj.jwks, testIssuer)
+	require.NoError(t, err)
+
+	return &Handler{
+		// HandleHelper is nil — we only test HandleTokenEndpointRequest, not
+		// PopulateTokenEndpointResponse, so IssueAccessToken is never called.
+		HandleHelper:       nil,
+		validator:          validator,
+		delegationLifespan: delegationLifespan,
+		allowedAudiences:   []string{testIssuer},
+		config: &mockConfig{
+			scopeStrategy:    fosite.ExactScopeStrategy,
+			audienceStrategy: fosite.DefaultAudienceMatchingStrategy,
+		},
+	}
+}
+
+// newAccessRequest builds a fosite.AccessRequest for token exchange tests.
+func newAccessRequest(t *testing.T, client fosite.Client, formValues url.Values) *fosite.AccessRequest {
+	t.Helper()
+
+	req := fosite.NewAccessRequest(&session.Session{})
+	req.GrantTypes = fosite.Arguments{oauthproto.GrantTypeTokenExchange}
+	req.Client = client
+	req.Form = formValues
+	return req
+}
+
+// defaultClient returns a confidential client configured for token exchange.
+func defaultClient() *fosite.DefaultClient {
+	return &fosite.DefaultClient{
+		ID:         testAgentClientID,
+		GrantTypes: fosite.Arguments{oauthproto.GrantTypeTokenExchange},
+		Scopes:     fosite.Arguments{"openid", "profile"},
+		Audience:   []string{testIssuer},
+		Public:     false,
+	}
+}
+
+// defaultFormValues returns the minimum form values for a valid token exchange request.
+func defaultFormValues(t *testing.T, tj *testJWKS) url.Values {
+	t.Helper()
+
+	token := tj.signToken(t, validClaims(), validExtraClaims())
+	return url.Values{
+		"grant_type":         {oauthproto.GrantTypeTokenExchange},
+		"subject_token":      {token},
+		"subject_token_type": {oauthproto.TokenTypeAccessToken},
+	}
+}
+
+func TestTokenExchangeHandler_CanHandleTokenEndpointRequest(t *testing.T) {
+	t.Parallel()
+
+	tj := newTestJWKS(t)
+	h := newTestHandler(t, tj, 15*time.Minute)
+
+	t.Run("matches token exchange grant type", func(t *testing.T) {
+		t.Parallel()
+		req := fosite.NewAccessRequest(&session.Session{})
+		req.GrantTypes = fosite.Arguments{oauthproto.GrantTypeTokenExchange}
+		assert.True(t, h.CanHandleTokenEndpointRequest(context.Background(), req))
+	})
+
+	t.Run("rejects other grant types", func(t *testing.T) {
+		t.Parallel()
+		req := fosite.NewAccessRequest(&session.Session{})
+		req.GrantTypes = fosite.Arguments{"client_credentials"}
+		assert.False(t, h.CanHandleTokenEndpointRequest(context.Background(), req))
+	})
+}
+
+func TestTokenExchangeHandler_CanSkipClientAuth(t *testing.T) {
+	t.Parallel()
+
+	tj := newTestJWKS(t)
+	h := newTestHandler(t, tj, 15*time.Minute)
+
+	req := fosite.NewAccessRequest(&session.Session{})
+	assert.False(t, h.CanSkipClientAuth(context.Background(), req))
+}
+
+func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
+	t.Parallel()
+
+	tj := newTestJWKS(t)
+
+	tests := []struct {
+		name         string
+		ctx          func(t *testing.T) context.Context
+		client       func() *fosite.DefaultClient
+		form         func(t *testing.T) url.Values
+		grantTypes   fosite.Arguments // Override grant type; nil means oauthproto.GrantTypeTokenExchange
+		lifespan     time.Duration
+		wantErr      bool
+		wantFositeIs *fosite.RFC6749Error // Check errors.Is against this fosite sentinel
+		hintContains string               // Check the fosite error's Reason/Hint field
+		check        func(t *testing.T, req *fosite.AccessRequest)
+	}{
+		{
+			name:     "valid exchange sets act claim and session",
+			ctx:      func(_ *testing.T) context.Context { return context.Background() },
+			client:   defaultClient,
+			form:     func(t *testing.T) url.Values { t.Helper(); return defaultFormValues(t, tj) },
+			lifespan: 15 * time.Minute,
+			check: func(t *testing.T, req *fosite.AccessRequest) {
+				t.Helper()
+
+				sess, ok := req.GetSession().(*session.Session)
+				require.True(t, ok, "session should be *session.Session")
+
+				// Verify subject is the user from the subject token.
+				assert.Equal(t, "user-123", sess.JWTClaims.Subject)
+
+				// Verify the act claim contains the authenticated client's ID.
+				actClaim, exists := sess.JWTClaims.Extra["act"]
+				require.True(t, exists, "act claim must be present")
+				actMap, ok := actClaim.(map[string]interface{})
+				require.True(t, ok, "act claim must be a map")
+				assert.Equal(t, testAgentClientID, actMap["sub"])
+
+				// Verify user claims were propagated.
+				assert.Equal(t, "Test User", sess.JWTClaims.Extra["name"])
+				assert.Equal(t, "test@example.com", sess.JWTClaims.Extra["email"])
+
+				// Verify expiry was set on the session.
+				expiry := sess.GetExpiresAt(fosite.AccessToken)
+				assert.False(t, expiry.IsZero(), "access token expiry should be set")
+			},
+		},
+		{
+			name:   "missing subject_token",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(_ *testing.T) url.Values {
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidRequest,
+			hintContains: "subject_token",
+		},
+		{
+			name:   "missing subject_token_type",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				token := tj.signToken(t, validClaims(), validExtraClaims())
+				return url.Values{
+					"grant_type":    {oauthproto.GrantTypeTokenExchange},
+					"subject_token": {token},
+				}
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidRequest,
+			hintContains: "subject_token_type",
+		},
+		{
+			name:   "invalid subject_token_type",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				token := tj.signToken(t, validClaims(), validExtraClaims())
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {"urn:ietf:params:oauth:token-type:refresh_token"},
+				}
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidRequest,
+			hintContains: "subject_token_type",
+		},
+		{
+			name:         "public client rejected",
+			ctx:          func(_ *testing.T) context.Context { return context.Background() },
+			client:       func() *fosite.DefaultClient { c := defaultClient(); c.Public = true; return c },
+			form:         func(t *testing.T) url.Values { t.Helper(); return defaultFormValues(t, tj) },
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidGrant,
+			hintContains: "public",
+		},
+		{
+			name: "subject token client_id mismatch",
+			ctx:  func(_ *testing.T) context.Context { return context.Background() },
+			client: func() *fosite.DefaultClient {
+				c := defaultClient()
+				c.ID = "different-client"
+				return c
+			},
+			form:         func(t *testing.T) url.Values { t.Helper(); return defaultFormValues(t, tj) },
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidGrant,
+			hintContains: "different client",
+		},
+		{
+			name:   "invalid subject_token — bad JWT",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(_ *testing.T) url.Values {
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {"not-a-valid-jwt"},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidGrant,
+			hintContains: "subject token is invalid",
+		},
+		{
+			name:   "unsupported requested_token_type rejected",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				f := defaultFormValues(t, tj)
+				f.Set("requested_token_type", "urn:ietf:params:oauth:token-type:id_token")
+				return f
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidRequest,
+			hintContains: "requested_token_type",
+		},
+		{
+			name:   "delegation lifetime capped by subject token expiry",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				// Subject token expires in 5 minutes.
+				claims := validClaims()
+				claims.Expiry = jwt.NewNumericDate(time.Now().Add(5 * time.Minute))
+				token := tj.signToken(t, claims, validExtraClaims())
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan: 15 * time.Minute, // Handler's max is 15 min, but subject expires in 5.
+			check: func(t *testing.T, req *fosite.AccessRequest) {
+				t.Helper()
+
+				sess, ok := req.GetSession().(*session.Session)
+				require.True(t, ok)
+
+				expiry := sess.GetExpiresAt(fosite.AccessToken)
+				// The delegated token should expire within ~5 minutes, not 15.
+				remaining := time.Until(expiry)
+				assert.Less(t, remaining, 6*time.Minute,
+					"delegated token lifetime should be capped by subject token expiry")
+				assert.Greater(t, remaining, 4*time.Minute,
+					"delegated token lifetime should be close to subject token remaining time")
+			},
+		},
+		{
+			name:         "wrong grant type returns ErrUnknownRequest",
+			ctx:          func(_ *testing.T) context.Context { return context.Background() },
+			client:       defaultClient,
+			form:         func(t *testing.T) url.Values { t.Helper(); return defaultFormValues(t, tj) },
+			grantTypes:   fosite.Arguments{"client_credentials"},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrUnknownRequest,
+		},
+		{
+			name: "requested scope not allowed by client",
+			ctx:  func(_ *testing.T) context.Context { return context.Background() },
+			client: func() *fosite.DefaultClient {
+				c := defaultClient()
+				c.Scopes = fosite.Arguments{"openid"} // No "admin" scope.
+				return c
+			},
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				f := defaultFormValues(t, tj)
+				f.Set("scope", "admin")
+				return f
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidScope,
+			hintContains: "scope",
+		},
+		{
+			name: "scope escalation blocked by subject token",
+			ctx:  func(_ *testing.T) context.Context { return context.Background() },
+			client: func() *fosite.DefaultClient {
+				c := defaultClient()
+				c.Scopes = fosite.Arguments{"openid", "profile", "admin"}
+				return c
+			},
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				// Subject token has scope="openid" only.
+				claims := validClaims()
+				extra := validExtraClaims()
+				extra["scope"] = "openid"
+				token := tj.signToken(t, claims, extra)
+				f := url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+				f.Set("scope", "admin") // Client has admin, but subject token doesn't.
+				return f
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidScope,
+			hintContains: "subject token",
+		},
+		{
+			name:   "may_act claim authorizes this client",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["may_act"] = map[string]interface{}{"sub": testAgentClientID}
+				token := tj.signToken(t, validClaims(), extra)
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan: 15 * time.Minute,
+			check: func(t *testing.T, req *fosite.AccessRequest) {
+				t.Helper()
+				sess, ok := req.GetSession().(*session.Session)
+				require.True(t, ok, "session should be *session.Session")
+				assert.Equal(t, "user-123", sess.JWTClaims.Subject)
+				actClaim, exists := sess.JWTClaims.Extra["act"]
+				require.True(t, exists, "act claim must be present")
+				actMap, ok := actClaim.(map[string]interface{})
+				require.True(t, ok, "act claim must be a map")
+				assert.Equal(t, testAgentClientID, actMap["sub"])
+			},
+		},
+		{
+			name:   "may_act claim does not authorize this client",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["may_act"] = map[string]interface{}{"sub": "different-agent"}
+				token := tj.signToken(t, validClaims(), extra)
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidGrant,
+			hintContains: "does not authorize",
+		},
+		{
+			name:   "may_act authorizes cross-client delegation",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["client_id"] = "original-client" // different from the authenticated client
+				extra["may_act"] = map[string]interface{}{"sub": testAgentClientID}
+				token := tj.signToken(t, validClaims(), extra)
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan: 15 * time.Minute,
+			check: func(t *testing.T, req *fosite.AccessRequest) {
+				t.Helper()
+				sess, ok := req.GetSession().(*session.Session)
+				require.True(t, ok, "session should be *session.Session")
+				assert.Equal(t, "user-123", sess.JWTClaims.Subject)
+				actClaim, exists := sess.JWTClaims.Extra["act"]
+				require.True(t, exists, "act claim must be present")
+				actMap, ok := actClaim.(map[string]interface{})
+				require.True(t, ok, "act claim must be a map")
+				assert.Equal(t, testAgentClientID, actMap["sub"])
+			},
+		},
+		{
+			name: "requested audience not allowed by client",
+			ctx:  func(_ *testing.T) context.Context { return context.Background() },
+			client: func() *fosite.DefaultClient {
+				c := defaultClient()
+				c.Audience = []string{"https://allowed.example.com"}
+				return c
+			},
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				f := defaultFormValues(t, tj)
+				f.Set("audience", "https://not-allowed.example.com")
+				return f
+			},
+			lifespan: 15 * time.Minute,
+			wantErr:  true,
+		},
+		{
+			name:   "valid resource parameter granted as audience",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				f := defaultFormValues(t, tj)
+				f.Set("resource", testIssuer)
+				return f
+			},
+			lifespan: 15 * time.Minute,
+			check: func(t *testing.T, req *fosite.AccessRequest) {
+				t.Helper()
+				audiences := req.GetGrantedAudience()
+				assert.Contains(t, audiences, testIssuer,
+					"resource parameter should be granted as audience")
+			},
+		},
+		{
+			name:   "resource not in allowed audiences rejected",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				f := defaultFormValues(t, tj)
+				f.Set("resource", "https://evil.example.com")
+				return f
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			hintContains: "not a registered audience",
+		},
+		{
+			name:   "multiple resource parameters rejected",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				f := defaultFormValues(t, tj)
+				f.Add("resource", testIssuer)
+				f.Add("resource", "https://other.example.com")
+				return f
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			hintContains: "Multiple resource parameters",
+		},
+		{
+			name:   "resource with invalid URI rejected",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				f := defaultFormValues(t, tj)
+				f.Set("resource", "not-a-uri")
+				return f
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			hintContains: "absolute URI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestHandler(t, tj, tt.lifespan)
+			ctx := tt.ctx(t)
+			client := tt.client()
+			form := tt.form(t)
+
+			req := newAccessRequest(t, client, form)
+
+			// Override grant type if specified in the test case.
+			if tt.grantTypes != nil {
+				req.GrantTypes = tt.grantTypes
+			}
+
+			// Set requested scopes from the form if present.
+			if scopeStr := form.Get("scope"); scopeStr != "" {
+				req.SetRequestedScopes(fosite.Arguments{scopeStr})
+			}
+
+			// Set requested audience from the form if present.
+			if audStr := form.Get("audience"); audStr != "" {
+				req.SetRequestedAudience(fosite.Arguments{audStr})
+			}
+
+			err := h.HandleTokenEndpointRequest(ctx, req)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantFositeIs != nil {
+					assert.True(t, errors.Is(err, tt.wantFositeIs),
+						"expected error to match %v, got: %v", tt.wantFositeIs.ErrorField, err)
+				}
+				if tt.hintContains != "" {
+					var rfcErr *fosite.RFC6749Error
+					require.True(t, errors.As(err, &rfcErr), "expected fosite RFC6749Error")
+					assert.Contains(t, rfcErr.Reason(), tt.hintContains,
+						"fosite error hint should contain %q", tt.hintContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, req)
+			}
+		})
+	}
+}
+
+// mockConfig implements the tokenExchangeConfig interface for testing.
+type mockConfig struct {
+	scopeStrategy    fosite.ScopeStrategy
+	audienceStrategy fosite.AudienceMatchingStrategy
+	accessLifespan   time.Duration
+}
+
+func (m *mockConfig) GetScopeStrategy(_ context.Context) fosite.ScopeStrategy {
+	return m.scopeStrategy
+}
+
+func (m *mockConfig) GetAudienceStrategy(_ context.Context) fosite.AudienceMatchingStrategy {
+	return m.audienceStrategy
+}
+
+func (m *mockConfig) GetAccessTokenLifespan(_ context.Context) time.Duration {
+	if m.accessLifespan > 0 {
+		return m.accessLifespan
+	}
+	return 15 * time.Minute
+}
+
+// mockAccessTokenStrategy is a minimal oauth2.AccessTokenStrategy that issues
+// deterministic opaque tokens without any JWT signing machinery.
+type mockAccessTokenStrategy struct {
+	generateErr error
+}
+
+func (m *mockAccessTokenStrategy) AccessTokenSignature(_ context.Context, token string) string {
+	return "sig-" + token
+}
+
+func (m *mockAccessTokenStrategy) GenerateAccessToken(_ context.Context, _ fosite.Requester) (string, string, error) {
+	if m.generateErr != nil {
+		return "", "", m.generateErr
+	}
+	return "test-access-token", "test-signature", nil
+}
+
+func (m *mockAccessTokenStrategy) ValidateAccessToken(_ context.Context, _ fosite.Requester, _ string) error {
+	return nil
+}
+
+// mockAccessTokenStorage is a minimal oauth2.AccessTokenStorage that records
+// the persisted session signature and never fails.
+type mockAccessTokenStorage struct {
+	createdSig   string
+	createErr    error
+	createdReqs  []fosite.Requester
+}
+
+func (m *mockAccessTokenStorage) CreateAccessTokenSession(_ context.Context, signature string, req fosite.Requester) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.createdSig = signature
+	m.createdReqs = append(m.createdReqs, req)
+	return nil
+}
+
+func (m *mockAccessTokenStorage) GetAccessTokenSession(_ context.Context, _ string, _ fosite.Session) (fosite.Requester, error) {
+	return nil, fosite.ErrNotFound
+}
+
+func (m *mockAccessTokenStorage) DeleteAccessTokenSession(_ context.Context, _ string) error {
+	return nil
+}
+
+// mockHandleHelperConfig implements oauth2.HandleHelperConfigProvider, providing
+// both access and refresh token lifespans required by HandleHelper.
+type mockHandleHelperConfig struct {
+	accessLifespan  time.Duration
+	refreshLifespan time.Duration
+}
+
+func (m *mockHandleHelperConfig) GetAccessTokenLifespan(_ context.Context) time.Duration {
+	if m.accessLifespan > 0 {
+		return m.accessLifespan
+	}
+	return 15 * time.Minute
+}
+
+func (m *mockHandleHelperConfig) GetRefreshTokenLifespan(_ context.Context) time.Duration {
+	if m.refreshLifespan > 0 {
+		return m.refreshLifespan
+	}
+	return 30 * 24 * time.Hour
+}
+
+// newTestHandlerWithHelper builds a Handler wired with a real oauth2.HandleHelper
+// backed by mock strategy/storage, enabling PopulateTokenEndpointResponse tests.
+func newTestHandlerWithHelper(t *testing.T, tj *testJWKS, delegationLifespan, accessLifespan time.Duration,
+	strategy *mockAccessTokenStrategy, storage *mockAccessTokenStorage) *Handler {
+	t.Helper()
+
+	validator, err := NewSubjectTokenValidator(tj.jwks, testIssuer)
+	require.NoError(t, err)
+
+	cfg := &mockConfig{
+		scopeStrategy:    fosite.ExactScopeStrategy,
+		audienceStrategy: fosite.DefaultAudienceMatchingStrategy,
+		accessLifespan:   accessLifespan,
+	}
+
+	return &Handler{
+		HandleHelper: &oauth2.HandleHelper{
+			AccessTokenStrategy: strategy,
+			AccessTokenStorage:  storage,
+			Config: &mockHandleHelperConfig{
+				accessLifespan: accessLifespan,
+			},
+		},
+		validator:          validator,
+		delegationLifespan: delegationLifespan,
+		allowedAudiences:   []string{testIssuer},
+		config:             cfg,
+	}
+}
+
+func TestTokenExchangeHandler_PopulateTokenEndpointResponse(t *testing.T) {
+	t.Parallel()
+
+	tj := newTestJWKS(t)
+
+	t.Run("wrong grant type returns ErrUnknownRequest", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockAccessTokenStrategy{}
+		storage := &mockAccessTokenStorage{}
+		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, 15*time.Minute, strategy, storage)
+
+		req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
+		// Override grant type so CanHandleTokenEndpointRequest returns false.
+		req.GrantTypes = fosite.Arguments{"client_credentials"}
+
+		responder := fosite.NewAccessResponse()
+		err := h.PopulateTokenEndpointResponse(context.Background(), req, responder)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fosite.ErrUnknownRequest),
+			"expected ErrUnknownRequest, got: %v", err)
+		// No token should have been issued on this error path.
+		assert.Empty(t, responder.GetAccessToken())
+		assert.Empty(t, storage.createdSig)
+	})
+
+	t.Run("client without token-exchange grant returns ErrUnauthorizedClient", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockAccessTokenStrategy{}
+		storage := &mockAccessTokenStorage{}
+		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, 15*time.Minute, strategy, storage)
+
+		// Client is allowed client_credentials only, not token-exchange.
+		client := defaultClient()
+		client.GrantTypes = fosite.Arguments{"client_credentials"}
+		req := newAccessRequest(t, client, defaultFormValues(t, tj))
+		req.SetSession(&session.Session{})
+
+		responder := fosite.NewAccessResponse()
+		err := h.PopulateTokenEndpointResponse(context.Background(), req, responder)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fosite.ErrUnauthorizedClient),
+			"expected ErrUnauthorizedClient, got: %v", err)
+		// No token should have been issued.
+		assert.Empty(t, responder.GetAccessToken())
+		assert.Empty(t, storage.createdSig)
+	})
+
+	t.Run("successful populate sets issued_token_type and access token", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockAccessTokenStrategy{}
+		storage := &mockAccessTokenStorage{}
+		// Access token lifespan larger than the delegation lifespan so the
+		// session expiry (capped at delegation lifespan) is the binding lifetime.
+		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, time.Hour, strategy, storage)
+
+		req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
+		require.NoError(t, h.HandleTokenEndpointRequest(context.Background(), req))
+
+		responder := fosite.NewAccessResponse()
+		require.NoError(t, h.PopulateTokenEndpointResponse(context.Background(), req, responder))
+
+		// RFC 8693 Section 2.2.1: response MUST include issued_token_type.
+		assert.Equal(t, oauthproto.TokenTypeAccessToken, responder.GetExtra("issued_token_type"))
+		// The mock strategy issues a fixed opaque token; verify it propagated.
+		assert.Equal(t, "test-access-token", responder.GetAccessToken())
+		assert.Equal(t, "bearer", responder.GetTokenType())
+		// The session should have been persisted via CreateAccessTokenSession.
+		assert.Equal(t, "test-signature", storage.createdSig)
+		require.Len(t, storage.createdReqs, 1)
+	})
+
+	t.Run("lifetime capped by subject token expiry", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockAccessTokenStrategy{}
+		storage := &mockAccessTokenStorage{}
+		// Subject token expires in 5 minutes; delegation max is 15; access
+		// token lifespan default is 1h. The effective issued lifetime must be
+		// capped at the subject token's remaining life (~5 minutes).
+		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, time.Hour, strategy, storage)
+
+		claims := validClaims()
+		claims.Expiry = jwt.NewNumericDate(time.Now().Add(5 * time.Minute))
+		token := tj.signToken(t, claims, validExtraClaims())
+		form := url.Values{
+			"grant_type":         {oauthproto.GrantTypeTokenExchange},
+			"subject_token":      {token},
+			"subject_token_type": {oauthproto.TokenTypeAccessToken},
+		}
+
+		req := newAccessRequest(t, defaultClient(), form)
+		require.NoError(t, h.HandleTokenEndpointRequest(context.Background(), req))
+
+		responder := fosite.NewAccessResponse()
+		require.NoError(t, h.PopulateTokenEndpointResponse(context.Background(), req, responder))
+
+		// getExpiresIn in HandleHelper computes expires_in from the session's
+		// ExpiresAt minus now. The capping logic in PopulateTokenEndpointResponse
+		// sets that ExpiresAt from the delegation lifetime computation (min of
+		// subject remaining and delegationLifespan). Subject expires in ~5 min,
+		// delegationLifespan is 15 min, so ExpiresIn should be ~5 min (< 6 min).
+		expiresIn := responder.ToMap()["expires_in"]
+		require.NotNil(t, expiresIn)
+		// fosite serializes expires_in as an int (seconds). Tolerate the type.
+		var secs int64
+		switch v := expiresIn.(type) {
+		case int:
+			secs = int64(v)
+		case int64:
+			secs = v
+		case float64:
+			secs = int64(v)
+		default:
+			t.Fatalf("unexpected expires_in type %T: %v", expiresIn, expiresIn)
+		}
+		assert.Greater(t, secs, int64((4*time.Minute).Seconds()),
+			"expires_in should be capped near subject token remaining (~5m), got %d", secs)
+		assert.Less(t, secs, int64((6*time.Minute).Seconds()),
+			"expires_in should be capped near subject token remaining (~5m), got %d", secs)
+	})
+
+	t.Run("AccessTokenStrategy error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockAccessTokenStrategy{
+			generateErr: errors.New("strategy failure"),
+		}
+		storage := &mockAccessTokenStorage{}
+		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, time.Hour, strategy, storage)
+
+		req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
+		require.NoError(t, h.HandleTokenEndpointRequest(context.Background(), req))
+
+		responder := fosite.NewAccessResponse()
+		err := h.PopulateTokenEndpointResponse(context.Background(), req, responder)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "strategy failure")
+		// No session should have been persisted on failure.
+		assert.Empty(t, storage.createdSig)
+	})
+
+	t.Run("AccessTokenStorage error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockAccessTokenStrategy{}
+		storage := &mockAccessTokenStorage{
+			createErr: errors.New("storage failure"),
+		}
+		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, time.Hour, strategy, storage)
+
+		req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
+		require.NoError(t, h.HandleTokenEndpointRequest(context.Background(), req))
+
+		responder := fosite.NewAccessResponse()
+		err := h.PopulateTokenEndpointResponse(context.Background(), req, responder)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "storage failure")
+		// issued_token_type must NOT be set when token issuance failed.
+		assert.Nil(t, responder.GetExtra("issued_token_type"))
+	})
+}

--- a/pkg/authserver/server/tokenexchange/handler_test.go
+++ b/pkg/authserver/server/tokenexchange/handler_test.go
@@ -6,6 +6,7 @@ package tokenexchange
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive/pkg/authserver/server"
 	"github.com/stacklok/toolhive/pkg/authserver/server/session"
 	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
@@ -77,6 +79,17 @@ func defaultFormValues(t *testing.T, tj *testJWKS) url.Values {
 		"subject_token":      {token},
 		"subject_token_type": {oauthproto.TokenTypeAccessToken},
 	}
+}
+
+// nestedActChain builds a chain of depth nested "act" maps, each holding a
+// distinct "sub", for exercising actChainDepth boundary behavior. depth must
+// be at least 1.
+func nestedActChain(depth int) map[string]any {
+	chain := map[string]any{"sub": fmt.Sprintf("agent-%d", depth-1)}
+	for i := depth - 2; i >= 0; i-- {
+		chain = map[string]any{"sub": fmt.Sprintf("agent-%d", i), "act": chain}
+	}
+	return chain
 }
 
 func TestTokenExchangeHandler_CanHandleTokenEndpointRequest(t *testing.T) {
@@ -145,7 +158,7 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 				// Verify the act claim contains the authenticated client's ID.
 				actClaim, exists := sess.JWTClaims.Extra["act"]
 				require.True(t, exists, "act claim must be present")
-				actMap, ok := actClaim.(map[string]interface{})
+				actMap, ok := actClaim.(map[string]any)
 				require.True(t, ok, "act claim must be a map")
 				assert.Equal(t, testAgentClientID, actMap["sub"])
 
@@ -359,7 +372,7 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 			form: func(t *testing.T) url.Values {
 				t.Helper()
 				extra := validExtraClaims()
-				extra["may_act"] = map[string]interface{}{"sub": testAgentClientID}
+				extra["may_act"] = map[string]any{"sub": testAgentClientID}
 				token := tj.signToken(t, validClaims(), extra)
 				return url.Values{
 					"grant_type":         {oauthproto.GrantTypeTokenExchange},
@@ -375,7 +388,7 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 				assert.Equal(t, "user-123", sess.JWTClaims.Subject)
 				actClaim, exists := sess.JWTClaims.Extra["act"]
 				require.True(t, exists, "act claim must be present")
-				actMap, ok := actClaim.(map[string]interface{})
+				actMap, ok := actClaim.(map[string]any)
 				require.True(t, ok, "act claim must be a map")
 				assert.Equal(t, testAgentClientID, actMap["sub"])
 			},
@@ -387,7 +400,7 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 			form: func(t *testing.T) url.Values {
 				t.Helper()
 				extra := validExtraClaims()
-				extra["may_act"] = map[string]interface{}{"sub": "different-agent"}
+				extra["may_act"] = map[string]any{"sub": "different-agent"}
 				token := tj.signToken(t, validClaims(), extra)
 				return url.Values{
 					"grant_type":         {oauthproto.GrantTypeTokenExchange},
@@ -408,7 +421,7 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 				t.Helper()
 				extra := validExtraClaims()
 				extra["client_id"] = "original-client" // different from the authenticated client
-				extra["may_act"] = map[string]interface{}{"sub": testAgentClientID}
+				extra["may_act"] = map[string]any{"sub": testAgentClientID}
 				token := tj.signToken(t, validClaims(), extra)
 				return url.Values{
 					"grant_type":         {oauthproto.GrantTypeTokenExchange},
@@ -424,7 +437,7 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 				assert.Equal(t, "user-123", sess.JWTClaims.Subject)
 				actClaim, exists := sess.JWTClaims.Extra["act"]
 				require.True(t, exists, "act claim must be present")
-				actMap, ok := actClaim.(map[string]interface{})
+				actMap, ok := actClaim.(map[string]any)
 				require.True(t, ok, "act claim must be a map")
 				assert.Equal(t, testAgentClientID, actMap["sub"])
 			},
@@ -435,7 +448,7 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 			client: defaultClient,
 			form: func(t *testing.T) url.Values {
 				t.Helper()
-				extra := map[string]interface{}{
+				extra := map[string]any{
 					"name":  "Test User",
 					"email": "test@example.com",
 				}
@@ -458,7 +471,7 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 			form: func(t *testing.T) url.Values {
 				t.Helper()
 				extra := validExtraClaims()
-				extra["act"] = map[string]interface{}{"sub": "original-agent"}
+				extra["act"] = map[string]any{"sub": "original-agent"}
 				token := tj.signToken(t, validClaims(), extra)
 				return url.Values{
 					"grant_type":         {oauthproto.GrantTypeTokenExchange},
@@ -473,10 +486,10 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 				require.True(t, ok, "session should be *session.Session")
 				actClaim, exists := sess.JWTClaims.Extra["act"]
 				require.True(t, exists, "act claim must be present")
-				actMap, ok := actClaim.(map[string]interface{})
+				actMap, ok := actClaim.(map[string]any)
 				require.True(t, ok, "act claim must be a map")
 				assert.Equal(t, testAgentClientID, actMap["sub"])
-				priorAct, ok := actMap["act"].(map[string]interface{})
+				priorAct, ok := actMap["act"].(map[string]any)
 				require.True(t, ok, "prior act claim should be nested under the new act claim")
 				assert.Equal(t, "original-agent", priorAct["sub"])
 			},
@@ -559,6 +572,91 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 			wantErr:      true,
 			hintContains: "absolute URI",
 		},
+		{
+			// Server-wide allowedAudiences (set by newTestHandler to testIssuer)
+			// permits testIssuer, but the client is not registered for it — the
+			// per-client audience strategy must still reject the resource param.
+			name: "resource not permitted for this client rejected",
+			ctx:  func(_ *testing.T) context.Context { return context.Background() },
+			client: func() *fosite.DefaultClient {
+				c := defaultClient()
+				c.Audience = []string{"https://other.example.com"}
+				return c
+			},
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				f := defaultFormValues(t, tj)
+				f.Set("resource", testIssuer)
+				return f
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: server.ErrInvalidTarget,
+			hintContains: "not permitted",
+		},
+		{
+			name: "confidential client without token-exchange grant type rejected",
+			ctx:  func(_ *testing.T) context.Context { return context.Background() },
+			client: func() *fosite.DefaultClient {
+				c := defaultClient()
+				c.GrantTypes = fosite.Arguments{"client_credentials"}
+				return c
+			},
+			form:         func(t *testing.T) url.Values { t.Helper(); return defaultFormValues(t, tj) },
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrUnauthorizedClient,
+			hintContains: "not allowed to use authorization grant",
+		},
+		{
+			name:   "delegation chain at max depth rejected",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["act"] = nestedActChain(maxDelegationDepth)
+				token := tj.signToken(t, validClaims(), extra)
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidGrant,
+			hintContains: "too deep",
+		},
+		{
+			name:   "delegation chain under max depth is nested",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["act"] = nestedActChain(maxDelegationDepth - 1)
+				token := tj.signToken(t, validClaims(), extra)
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan: 15 * time.Minute,
+			check: func(t *testing.T, req *fosite.AccessRequest) {
+				t.Helper()
+				sess, ok := req.GetSession().(*session.Session)
+				require.True(t, ok, "session should be *session.Session")
+				actClaim, exists := sess.JWTClaims.Extra["act"]
+				require.True(t, exists, "act claim must be present")
+				actMap, ok := actClaim.(map[string]any)
+				require.True(t, ok, "act claim must be a map")
+				assert.Equal(t, testAgentClientID, actMap["sub"])
+				assert.Equal(t, nestedActChain(maxDelegationDepth-1), actMap["act"],
+					"the prior act chain should be nested unchanged under the new act claim")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -620,7 +718,9 @@ func TestTokenExchangeHandler_DefaultAudience(t *testing.T) {
 	tests := []struct {
 		name             string
 		allowedAudiences []string
+		client           func() *fosite.DefaultClient // defaults to defaultClient if nil
 		wantErr          bool
+		hintContains     string // defaults to "unambiguous default audience" if empty
 		wantAudience     string
 	}{
 		{
@@ -638,6 +738,20 @@ func TestTokenExchangeHandler_DefaultAudience(t *testing.T) {
 			allowedAudiences: []string{testIssuer, "https://other.example.com"},
 			wantErr:          true,
 		},
+		{
+			// The sole configured audience is unambiguous server-wide, but the
+			// client is not registered for it — the per-client check must still
+			// reject rather than silently granting an unregistered audience.
+			name:             "default audience not permitted for this client rejected",
+			allowedAudiences: []string{testIssuer},
+			client: func() *fosite.DefaultClient {
+				c := defaultClient()
+				c.Audience = []string{"https://other.example.com"}
+				return c
+			},
+			wantErr:      true,
+			hintContains: "not permitted to request a token for the default audience",
+		},
 	}
 
 	for _, tt := range tests {
@@ -651,18 +765,49 @@ func TestTokenExchangeHandler_DefaultAudience(t *testing.T) {
 			h := newTestHandler(t, tj, 15*time.Minute)
 			h.allowedAudiences = tt.allowedAudiences
 
-			req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
+			client := defaultClient
+			if tt.client != nil {
+				client = tt.client
+			}
+			req := newAccessRequest(t, client(), defaultFormValues(t, tj))
 			err := h.HandleTokenEndpointRequest(context.Background(), req)
 
 			if tt.wantErr {
 				require.Error(t, err)
 				var rfcErr *fosite.RFC6749Error
 				require.True(t, errors.As(err, &rfcErr), "expected fosite RFC6749Error")
-				assert.Contains(t, rfcErr.Reason(), "unambiguous default audience")
+				hintContains := tt.hintContains
+				if hintContains == "" {
+					hintContains = "unambiguous default audience"
+				}
+				assert.Contains(t, rfcErr.Reason(), hintContains)
 				return
 			}
 			require.NoError(t, err)
 			assert.Contains(t, req.GetGrantedAudience(), tt.wantAudience)
+		})
+	}
+}
+
+func TestActChainDepth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		act  any
+		want int
+	}{
+		{name: "nil is depth 0", act: nil, want: 0},
+		{name: "non-map is depth 0", act: "not-a-map", want: 0},
+		{name: "single act entry is depth 1", act: nestedActChain(1), want: 1},
+		{name: "nested chain reports its full depth", act: nestedActChain(5), want: 5},
+		{name: "map without a nested act claim stops at depth 1", act: map[string]any{"sub": "agent"}, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, actChainDepth(tt.act))
 		})
 	}
 }

--- a/pkg/authserver/server/tokenexchange/handler_test.go
+++ b/pkg/authserver/server/tokenexchange/handler_test.go
@@ -28,7 +28,7 @@ const testAgentClientID = "devops-agent"
 func newTestHandler(t *testing.T, tj *testJWKS, delegationLifespan time.Duration) *Handler {
 	t.Helper()
 
-	validator, err := NewSubjectTokenValidator(tj.jwks, testIssuer)
+	validator, err := NewSubjectTokenValidator(tj.publicJWKS(), testIssuer, []string{testIssuer})
 	require.NoError(t, err)
 
 	return &Handler{
@@ -430,6 +430,58 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 			},
 		},
 		{
+			name:   "subject token with no may_act and no client_id rejected",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				extra := map[string]interface{}{
+					"name":  "Test User",
+					"email": "test@example.com",
+				}
+				token := tj.signToken(t, validClaims(), extra)
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: fosite.ErrInvalidGrant,
+			hintContains: "no verifiable client binding",
+		},
+		{
+			name:   "subject token's own act claim is nested under the new act claim",
+			ctx:    func(_ *testing.T) context.Context { return context.Background() },
+			client: defaultClient,
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["act"] = map[string]interface{}{"sub": "original-agent"}
+				token := tj.signToken(t, validClaims(), extra)
+				return url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+			},
+			lifespan: 15 * time.Minute,
+			check: func(t *testing.T, req *fosite.AccessRequest) {
+				t.Helper()
+				sess, ok := req.GetSession().(*session.Session)
+				require.True(t, ok, "session should be *session.Session")
+				actClaim, exists := sess.JWTClaims.Extra["act"]
+				require.True(t, exists, "act claim must be present")
+				actMap, ok := actClaim.(map[string]interface{})
+				require.True(t, ok, "act claim must be a map")
+				assert.Equal(t, testAgentClientID, actMap["sub"])
+				priorAct, ok := actMap["act"].(map[string]interface{})
+				require.True(t, ok, "prior act claim should be nested under the new act claim")
+				assert.Equal(t, "original-agent", priorAct["sub"])
+			},
+		},
+		{
 			name: "requested audience not allowed by client",
 			ctx:  func(_ *testing.T) context.Context { return context.Background() },
 			client: func() *fosite.DefaultClient {
@@ -560,6 +612,61 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 	}
 }
 
+func TestTokenExchangeHandler_DefaultAudience(t *testing.T) {
+	t.Parallel()
+
+	tj := newTestJWKS(t)
+
+	tests := []struct {
+		name             string
+		allowedAudiences []string
+		wantErr          bool
+		wantAudience     string
+	}{
+		{
+			name:             "single allowed audience defaults when none requested",
+			allowedAudiences: []string{testIssuer},
+			wantAudience:     testIssuer,
+		},
+		{
+			name:             "no allowed audiences configured rejects the request",
+			allowedAudiences: nil,
+			wantErr:          true,
+		},
+		{
+			name:             "multiple allowed audiences rejects the ambiguous request",
+			allowedAudiences: []string{testIssuer, "https://other.example.com"},
+			wantErr:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// newTestHandler wires the subject-token validator's allowed
+			// audiences to testIssuer regardless of tt.allowedAudiences —
+			// that governs the subject token's own "aud" claim, a separate
+			// concern from the delegated token's audience under test here.
+			h := newTestHandler(t, tj, 15*time.Minute)
+			h.allowedAudiences = tt.allowedAudiences
+
+			req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
+			err := h.HandleTokenEndpointRequest(context.Background(), req)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				var rfcErr *fosite.RFC6749Error
+				require.True(t, errors.As(err, &rfcErr), "expected fosite RFC6749Error")
+				assert.Contains(t, rfcErr.Reason(), "unambiguous default audience")
+				return
+			}
+			require.NoError(t, err)
+			assert.Contains(t, req.GetGrantedAudience(), tt.wantAudience)
+		})
+	}
+}
+
 // mockConfig implements the tokenExchangeConfig interface for testing.
 type mockConfig struct {
 	scopeStrategy    fosite.ScopeStrategy
@@ -588,7 +695,7 @@ type mockAccessTokenStrategy struct {
 	generateErr error
 }
 
-func (m *mockAccessTokenStrategy) AccessTokenSignature(_ context.Context, token string) string {
+func (*mockAccessTokenStrategy) AccessTokenSignature(_ context.Context, token string) string {
 	return "sig-" + token
 }
 
@@ -599,16 +706,16 @@ func (m *mockAccessTokenStrategy) GenerateAccessToken(_ context.Context, _ fosit
 	return "test-access-token", "test-signature", nil
 }
 
-func (m *mockAccessTokenStrategy) ValidateAccessToken(_ context.Context, _ fosite.Requester, _ string) error {
+func (*mockAccessTokenStrategy) ValidateAccessToken(_ context.Context, _ fosite.Requester, _ string) error {
 	return nil
 }
 
 // mockAccessTokenStorage is a minimal oauth2.AccessTokenStorage that records
 // the persisted session signature and never fails.
 type mockAccessTokenStorage struct {
-	createdSig   string
-	createErr    error
-	createdReqs  []fosite.Requester
+	createdSig  string
+	createErr   error
+	createdReqs []fosite.Requester
 }
 
 func (m *mockAccessTokenStorage) CreateAccessTokenSession(_ context.Context, signature string, req fosite.Requester) error {
@@ -620,11 +727,11 @@ func (m *mockAccessTokenStorage) CreateAccessTokenSession(_ context.Context, sig
 	return nil
 }
 
-func (m *mockAccessTokenStorage) GetAccessTokenSession(_ context.Context, _ string, _ fosite.Session) (fosite.Requester, error) {
+func (*mockAccessTokenStorage) GetAccessTokenSession(_ context.Context, _ string, _ fosite.Session) (fosite.Requester, error) {
 	return nil, fosite.ErrNotFound
 }
 
-func (m *mockAccessTokenStorage) DeleteAccessTokenSession(_ context.Context, _ string) error {
+func (*mockAccessTokenStorage) DeleteAccessTokenSession(_ context.Context, _ string) error {
 	return nil
 }
 
@@ -651,11 +758,15 @@ func (m *mockHandleHelperConfig) GetRefreshTokenLifespan(_ context.Context) time
 
 // newTestHandlerWithHelper builds a Handler wired with a real oauth2.HandleHelper
 // backed by mock strategy/storage, enabling PopulateTokenEndpointResponse tests.
-func newTestHandlerWithHelper(t *testing.T, tj *testJWKS, delegationLifespan, accessLifespan time.Duration,
+// The delegation lifespan is fixed at 15 minutes; only accessLifespan varies
+// across callers.
+func newTestHandlerWithHelper(t *testing.T, tj *testJWKS, accessLifespan time.Duration,
 	strategy *mockAccessTokenStrategy, storage *mockAccessTokenStorage) *Handler {
 	t.Helper()
 
-	validator, err := NewSubjectTokenValidator(tj.jwks, testIssuer)
+	const delegationLifespan = 15 * time.Minute
+
+	validator, err := NewSubjectTokenValidator(tj.publicJWKS(), testIssuer, []string{testIssuer})
 	require.NoError(t, err)
 
 	cfg := &mockConfig{
@@ -689,7 +800,7 @@ func TestTokenExchangeHandler_PopulateTokenEndpointResponse(t *testing.T) {
 
 		strategy := &mockAccessTokenStrategy{}
 		storage := &mockAccessTokenStorage{}
-		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, 15*time.Minute, strategy, storage)
+		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, strategy, storage)
 
 		req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
 		// Override grant type so CanHandleTokenEndpointRequest returns false.
@@ -711,7 +822,7 @@ func TestTokenExchangeHandler_PopulateTokenEndpointResponse(t *testing.T) {
 
 		strategy := &mockAccessTokenStrategy{}
 		storage := &mockAccessTokenStorage{}
-		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, 15*time.Minute, strategy, storage)
+		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, strategy, storage)
 
 		// Client is allowed client_credentials only, not token-exchange.
 		client := defaultClient()
@@ -737,7 +848,7 @@ func TestTokenExchangeHandler_PopulateTokenEndpointResponse(t *testing.T) {
 		storage := &mockAccessTokenStorage{}
 		// Access token lifespan larger than the delegation lifespan so the
 		// session expiry (capped at delegation lifespan) is the binding lifetime.
-		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, time.Hour, strategy, storage)
+		h := newTestHandlerWithHelper(t, tj, time.Hour, strategy, storage)
 
 		req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
 		require.NoError(t, h.HandleTokenEndpointRequest(context.Background(), req))
@@ -763,7 +874,7 @@ func TestTokenExchangeHandler_PopulateTokenEndpointResponse(t *testing.T) {
 		// Subject token expires in 5 minutes; delegation max is 15; access
 		// token lifespan default is 1h. The effective issued lifetime must be
 		// capped at the subject token's remaining life (~5 minutes).
-		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, time.Hour, strategy, storage)
+		h := newTestHandlerWithHelper(t, tj, time.Hour, strategy, storage)
 
 		claims := validClaims()
 		claims.Expiry = jwt.NewNumericDate(time.Now().Add(5 * time.Minute))
@@ -799,9 +910,9 @@ func TestTokenExchangeHandler_PopulateTokenEndpointResponse(t *testing.T) {
 		default:
 			t.Fatalf("unexpected expires_in type %T: %v", expiresIn, expiresIn)
 		}
-		assert.Greater(t, secs, int64((4*time.Minute).Seconds()),
+		assert.Greater(t, secs, int64((4 * time.Minute).Seconds()),
 			"expires_in should be capped near subject token remaining (~5m), got %d", secs)
-		assert.Less(t, secs, int64((6*time.Minute).Seconds()),
+		assert.Less(t, secs, int64((6 * time.Minute).Seconds()),
 			"expires_in should be capped near subject token remaining (~5m), got %d", secs)
 	})
 
@@ -812,7 +923,7 @@ func TestTokenExchangeHandler_PopulateTokenEndpointResponse(t *testing.T) {
 			generateErr: errors.New("strategy failure"),
 		}
 		storage := &mockAccessTokenStorage{}
-		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, time.Hour, strategy, storage)
+		h := newTestHandlerWithHelper(t, tj, time.Hour, strategy, storage)
 
 		req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
 		require.NoError(t, h.HandleTokenEndpointRequest(context.Background(), req))
@@ -826,6 +937,32 @@ func TestTokenExchangeHandler_PopulateTokenEndpointResponse(t *testing.T) {
 		assert.Empty(t, storage.createdSig)
 	})
 
+	t.Run("stale session expiry fails closed instead of falling back to full lifespan", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockAccessTokenStrategy{}
+		storage := &mockAccessTokenStorage{}
+		h := newTestHandlerWithHelper(t, tj, time.Hour, strategy, storage)
+
+		req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
+		require.NoError(t, h.HandleTokenEndpointRequest(context.Background(), req))
+
+		// Simulate the narrow window where the session's bound expiry (set by
+		// HandleTokenEndpointRequest) elapses before PopulateTokenEndpointResponse runs.
+		sess, ok := req.GetSession().(*session.Session)
+		require.True(t, ok)
+		sess.SetExpiresAt(fosite.AccessToken, time.Now().Add(-time.Second))
+
+		responder := fosite.NewAccessResponse()
+		err := h.PopulateTokenEndpointResponse(context.Background(), req, responder)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, fosite.ErrInvalidGrant),
+			"expected ErrInvalidGrant, got: %v", err)
+		assert.Empty(t, responder.GetAccessToken())
+		assert.Empty(t, storage.createdSig)
+	})
+
 	t.Run("AccessTokenStorage error propagates", func(t *testing.T) {
 		t.Parallel()
 
@@ -833,7 +970,7 @@ func TestTokenExchangeHandler_PopulateTokenEndpointResponse(t *testing.T) {
 		storage := &mockAccessTokenStorage{
 			createErr: errors.New("storage failure"),
 		}
-		h := newTestHandlerWithHelper(t, tj, 15*time.Minute, time.Hour, strategy, storage)
+		h := newTestHandlerWithHelper(t, tj, time.Hour, strategy, storage)
 
 		req := newAccessRequest(t, defaultClient(), defaultFormValues(t, tj))
 		require.NoError(t, h.HandleTokenEndpointRequest(context.Background(), req))

--- a/pkg/authserver/server/tokenexchange/validator.go
+++ b/pkg/authserver/server/tokenexchange/validator.go
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package tokenexchange implements RFC 8693 token exchange for the authorization server.
+// It provides validation of subject tokens that were issued by the same authorization
+// server, enabling agents to act on behalf of users through delegation.
+package tokenexchange
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// allowedSignatureAlgorithms lists the signing algorithms accepted during JWT verification.
+// This restricts which algorithms the validator will accept, preventing algorithm
+// confusion attacks where an attacker might try to use a weaker algorithm.
+var allowedSignatureAlgorithms = []jose.SignatureAlgorithm{
+	jose.ES256,
+	jose.ES384,
+	jose.RS256,
+	jose.RS384,
+	jose.RS512,
+	jose.EdDSA,
+}
+
+// ValidatedClaims holds the verified claims extracted from a subject token.
+// All fields are populated from a successfully validated JWT that was issued
+// by this authorization server.
+type ValidatedClaims struct {
+	// Subject is the user identity from the "sub" claim (required for delegation).
+	Subject string
+	// Issuer is the token issuer from the "iss" claim.
+	Issuer string
+	// Audience is the list of intended recipients from the "aud" claim.
+	Audience []string
+	// Expiry is the token expiration time from the "exp" claim.
+	Expiry time.Time
+	// IssuedAt is the token issuance time from the "iat" claim.
+	IssuedAt time.Time
+	// JWTID is the unique token identifier from the "jti" claim.
+	JWTID string
+	// Name is the user's display name from the custom "name" claim.
+	Name string
+	// Email is the user's email address from the custom "email" claim.
+	Email string
+	// ClientID is the OAuth client ID from the custom "client_id" claim.
+	ClientID string
+	// Scopes is the space-delimited scope string from the "scope" claim.
+	// Empty if the subject token carries no scope claim.
+	Scopes string
+	// MayAct holds the authorized actor from the "may_act" claim (RFC 8693 §4.1).
+	// Nil when the subject token does not carry a may_act claim.
+	MayAct *MayActClaim
+	// Extra contains all non-standard claims not captured by other fields.
+	Extra map[string]interface{}
+}
+
+// MayActClaim represents the RFC 8693 §4.1 may_act claim from a subject token.
+// It identifies the party authorized to act on behalf of the subject.
+type MayActClaim struct {
+	Sub string `json:"sub"`
+}
+
+// SubjectTokenValidator validates subject tokens presented during RFC 8693 token exchange.
+// It verifies that the token was issued by this authorization server by checking
+// the signature against the server's own JWKS, and validates standard JWT claims.
+type SubjectTokenValidator struct {
+	jwks   *jose.JSONWebKeySet
+	issuer string
+}
+
+// NewSubjectTokenValidator creates a new validator for subject tokens.
+// The jwks parameter must be non-nil and contain the authorization server's
+// signing keys (private keys are accepted; only the public portion is used
+// for verification). The issuer parameter is the expected "iss" claim value
+// and is also used as the expected audience, since tokens issued by this
+// server are intended for this server during token exchange.
+func NewSubjectTokenValidator(jwks *jose.JSONWebKeySet, issuer string) (*SubjectTokenValidator, error) {
+	if jwks == nil {
+		return nil, fmt.Errorf("JWKS must not be nil")
+	}
+	if issuer == "" {
+		return nil, fmt.Errorf("issuer must not be empty")
+	}
+	return &SubjectTokenValidator{
+		jwks:   jwks,
+		issuer: issuer,
+	}, nil
+}
+
+// Validate parses and verifies a raw JWT subject token.
+// It checks the signature against the server's JWKS, validates issuer and audience,
+// ensures the token is not expired, and requires a subject claim for delegation.
+// Returns the validated claims on success, or a descriptive error on failure.
+func (v *SubjectTokenValidator) Validate(_ context.Context, rawToken string) (*ValidatedClaims, error) {
+	parsedToken, err := jwt.ParseSigned(rawToken, allowedSignatureAlgorithms)
+	if err != nil {
+		return nil, fmt.Errorf("subject token is not a valid JWT: %w", err)
+	}
+
+	// Extract public keys from the JWKS for signature verification.
+	publicJWKS := v.publicKeys()
+
+	// Try each key in the JWKS until one verifies the signature.
+	var standardClaims jwt.Claims
+	var extraClaims map[string]interface{}
+
+	if err := verifySignature(parsedToken, publicJWKS, &standardClaims, &extraClaims); err != nil {
+		return nil, err
+	}
+
+	// Validate standard claims: issuer, audience, and expiry.
+	expected := jwt.Expected{
+		Issuer:      v.issuer,
+		AnyAudience: jwt.Audience{v.issuer},
+	}
+	if err := standardClaims.ValidateWithLeeway(expected, 0); err != nil {
+		return nil, fmt.Errorf("subject token claims validation failed: %w", err)
+	}
+
+	// Expiry is required for delegation — a subject token without an expiry
+	// cannot be safely bounded by the delegation lifetime.
+	if standardClaims.Expiry == nil {
+		return nil, fmt.Errorf("subject token is missing required 'exp' claim")
+	}
+
+	// Subject is required for delegation — the token must identify the user.
+	if standardClaims.Subject == "" {
+		return nil, fmt.Errorf("subject token is missing required 'sub' claim")
+	}
+
+	// If may_act is present, it must be a well-formed object with a string sub.
+	// A present-but-malformed may_act is treated as an invalid token, not
+	// an absent one — fail closed to prevent silent downgrade to client_id.
+	if rawMayAct, ok := extraClaims["may_act"]; ok && rawMayAct != nil {
+		m, ok := rawMayAct.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("subject token has malformed 'may_act' claim: expected a JSON object")
+		}
+		sub, ok := m["sub"].(string)
+		if !ok || sub == "" {
+			return nil, fmt.Errorf("subject token has malformed 'may_act' claim: missing or invalid 'sub'")
+		}
+	}
+
+	return buildValidatedClaims(standardClaims, extraClaims), nil
+}
+
+// verifySignature attempts to verify the JWT signature using the provided public keys.
+// If the JWT header contains a key ID (kid), it tries the matching key first for
+// efficiency, then falls back to iterating all keys. Returns on the first
+// successful verification. On failure, the last verification error is wrapped.
+func verifySignature(
+	token *jwt.JSONWebToken,
+	publicJWKS *jose.JSONWebKeySet,
+	standardClaims *jwt.Claims,
+	extraClaims *map[string]interface{},
+) error {
+	// Try kid-matched key first, then fall back to full iteration.
+	candidates := publicJWKS.Keys
+	if len(token.Headers) > 0 && token.Headers[0].KeyID != "" {
+		if matched := publicJWKS.Key(token.Headers[0].KeyID); len(matched) > 0 {
+			candidates = append(matched, candidates...)
+		}
+	}
+
+	var lastErr error
+	for _, key := range candidates {
+		*extraClaims = make(map[string]interface{})
+		if err := token.Claims(key, standardClaims, extraClaims); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("subject token signature verification failed: %w", lastErr)
+	}
+	return fmt.Errorf("subject token signature verification failed: no keys in JWKS")
+}
+
+// publicKeys extracts the public key portion of each key in the JWKS.
+func (v *SubjectTokenValidator) publicKeys() *jose.JSONWebKeySet {
+	result := &jose.JSONWebKeySet{
+		Keys: make([]jose.JSONWebKey, 0, len(v.jwks.Keys)),
+	}
+	for _, key := range v.jwks.Keys {
+		result.Keys = append(result.Keys, key.Public())
+	}
+	return result
+}
+
+// buildValidatedClaims constructs a ValidatedClaims from standard and extra claims.
+func buildValidatedClaims(
+	standard jwt.Claims,
+	extra map[string]interface{},
+) *ValidatedClaims {
+	vc := &ValidatedClaims{
+		Subject:  standard.Subject,
+		Issuer:   standard.Issuer,
+		Audience: []string(standard.Audience),
+		JWTID:    standard.ID,
+		Extra:    make(map[string]interface{}),
+	}
+
+	if standard.Expiry != nil {
+		vc.Expiry = standard.Expiry.Time()
+	}
+	if standard.IssuedAt != nil {
+		vc.IssuedAt = standard.IssuedAt.Time()
+	}
+
+	// Extract well-known custom claims and collect the rest into Extra.
+	// Standard JWT registered claims are filtered out since they are already
+	// captured in the structured fields above.
+	for k, val := range extra {
+		switch k {
+		case "name":
+			if s, ok := val.(string); ok {
+				vc.Name = s
+			}
+		case "email":
+			if s, ok := val.(string); ok {
+				vc.Email = s
+			}
+		case "client_id":
+			if s, ok := val.(string); ok {
+				vc.ClientID = s
+			}
+		case "scope":
+			if s, ok := val.(string); ok {
+				vc.Scopes = s
+			}
+		case "may_act":
+			if m, ok := val.(map[string]interface{}); ok {
+				if s, ok := m["sub"].(string); ok {
+					vc.MayAct = &MayActClaim{Sub: s}
+				}
+			}
+		case "sub", "iss", "aud", "exp", "iat", "nbf", "jti":
+			// Skip registered JWT claims — already in structured fields.
+		default:
+			vc.Extra[k] = val
+		}
+	}
+
+	return vc
+}

--- a/pkg/authserver/server/tokenexchange/validator.go
+++ b/pkg/authserver/server/tokenexchange/validator.go
@@ -57,7 +57,7 @@ type ValidatedClaims struct {
 	// Nil when the subject token does not carry a may_act claim.
 	MayAct *MayActClaim
 	// Extra contains all non-standard claims not captured by other fields.
-	Extra map[string]interface{}
+	Extra map[string]any
 }
 
 // MayActClaim represents the RFC 8693 §4.1 may_act claim from a subject token.
@@ -102,6 +102,16 @@ func NewSubjectTokenValidator(
 // Validate parses and verifies a raw JWT subject token.
 // It checks the signature against the server's JWKS, validates issuer and audience,
 // ensures the token is not expired, and requires a subject claim for delegation.
+//
+// The subject token's "aud" claim is checked against allowedAudiences, but this
+// validator deliberately does not require that the authorization server itself
+// (i.e. the token endpoint) be among those audiences. RFC 8693 leaves subject-token
+// validation criteria out of scope, and ToolHive's vMCP flow legitimately exchanges
+// tokens addressed to a downstream/upstream resource rather than the AS. The residual
+// cross-resource risk is mitigated elsewhere: the token is still pinned to the
+// server-wide allowedAudiences, and the handler enforces the requested resource
+// against the client's registered audiences.
+//
 // Returns the validated claims on success, or a descriptive error on failure.
 func (v *SubjectTokenValidator) Validate(_ context.Context, rawToken string) (*ValidatedClaims, error) {
 	parsedToken, err := jwt.ParseSigned(rawToken, allowedSignatureAlgorithms)
@@ -109,11 +119,8 @@ func (v *SubjectTokenValidator) Validate(_ context.Context, rawToken string) (*V
 		return nil, fmt.Errorf("subject token is not a valid JWT: %w", err)
 	}
 
-	// Try each key in the JWKS until one verifies the signature.
-	var standardClaims jwt.Claims
-	var extraClaims map[string]interface{}
-
-	if err := verifySignature(parsedToken, v.publicJWKS, &standardClaims, &extraClaims); err != nil {
+	standardClaims, extraClaims, err := verifySignature(parsedToken, v.publicJWKS)
+	if err != nil {
 		return nil, err
 	}
 
@@ -148,7 +155,7 @@ func (v *SubjectTokenValidator) Validate(_ context.Context, rawToken string) (*V
 	// A present-but-malformed may_act is treated as an invalid token, not
 	// an absent one — fail closed to prevent silent downgrade to client_id.
 	if rawMayAct, ok := extraClaims["may_act"]; ok && rawMayAct != nil {
-		m, ok := rawMayAct.(map[string]interface{})
+		m, ok := rawMayAct.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("subject token has malformed 'may_act' claim: expected a JSON object")
 		}
@@ -162,36 +169,37 @@ func (v *SubjectTokenValidator) Validate(_ context.Context, rawToken string) (*V
 }
 
 // verifySignature attempts to verify the JWT signature using the provided public keys.
-// If the JWT header contains a key ID (kid), it tries the matching key first for
-// efficiency, then falls back to iterating all keys. Returns on the first
-// successful verification. On failure, the last verification error is wrapped.
+// If the JWT header names a key ID (kid) that matches a key in the JWKS, only that
+// key is tried: a token naming a kid but signed by a different key is a spoofed-kid
+// attempt and must fail, not fall back to verifying against the rest of the keyset.
+// When there is no kid, or the kid doesn't match any key in the JWKS, every key is
+// tried in turn. Returns on the first successful verification. On failure, the last
+// verification error is wrapped.
 func verifySignature(
 	token *jwt.JSONWebToken,
 	publicJWKS *jose.JSONWebKeySet,
-	standardClaims *jwt.Claims,
-	extraClaims *map[string]interface{},
-) error {
-	// Try kid-matched key first, then fall back to full iteration.
+) (jwt.Claims, map[string]any, error) {
 	candidates := publicJWKS.Keys
 	if len(token.Headers) > 0 && token.Headers[0].KeyID != "" {
 		if matched := publicJWKS.Key(token.Headers[0].KeyID); len(matched) > 0 {
-			candidates = append(matched, candidates...)
+			candidates = matched
 		}
 	}
 
 	var lastErr error
 	for _, key := range candidates {
-		*extraClaims = make(map[string]interface{})
-		err := token.Claims(key, standardClaims, extraClaims)
+		var claims jwt.Claims
+		extra := map[string]any{}
+		err := token.Claims(key, &claims, &extra)
 		if err == nil {
-			return nil
+			return claims, extra, nil
 		}
 		lastErr = err
 	}
 	if lastErr != nil {
-		return fmt.Errorf("subject token signature verification failed: %w", lastErr)
+		return jwt.Claims{}, nil, fmt.Errorf("subject token signature verification failed: %w", lastErr)
 	}
-	return fmt.Errorf("subject token signature verification failed: no keys in JWKS")
+	return jwt.Claims{}, nil, fmt.Errorf("subject token signature verification failed: no keys in JWKS")
 }
 
 // validateAudience checks that tokenAudience intersects allowedAudiences.
@@ -213,14 +221,14 @@ func validateAudience(tokenAudience jwt.Audience, allowedAudiences []string) err
 // buildValidatedClaims constructs a ValidatedClaims from standard and extra claims.
 func buildValidatedClaims(
 	standard jwt.Claims,
-	extra map[string]interface{},
+	extra map[string]any,
 ) *ValidatedClaims {
 	vc := &ValidatedClaims{
 		Subject:  standard.Subject,
 		Issuer:   standard.Issuer,
 		Audience: []string(standard.Audience),
 		JWTID:    standard.ID,
-		Extra:    make(map[string]interface{}),
+		Extra:    make(map[string]any),
 	}
 
 	if standard.Expiry != nil {
@@ -244,7 +252,7 @@ func buildValidatedClaims(
 // ValidatedClaims field, or into Extra if it isn't a well-known claim.
 // Registered JWT claims (sub, iss, aud, exp, iat, nbf, jti) are dropped —
 // they're already captured in buildValidatedClaims's structured fields.
-func assignClaim(vc *ValidatedClaims, key string, val interface{}) {
+func assignClaim(vc *ValidatedClaims, key string, val any) {
 	switch key {
 	case "name":
 		if s, ok := val.(string); ok {
@@ -263,7 +271,7 @@ func assignClaim(vc *ValidatedClaims, key string, val interface{}) {
 			vc.Scopes = s
 		}
 	case "may_act":
-		if m, ok := val.(map[string]interface{}); ok {
+		if m, ok := val.(map[string]any); ok {
 			if s, ok := m["sub"].(string); ok {
 				vc.MayAct = &MayActClaim{Sub: s}
 			}

--- a/pkg/authserver/server/tokenexchange/validator.go
+++ b/pkg/authserver/server/tokenexchange/validator.go
@@ -9,6 +9,7 @@ package tokenexchange
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -69,17 +70,22 @@ type MayActClaim struct {
 // It verifies that the token was issued by this authorization server by checking
 // the signature against the server's own JWKS, and validates standard JWT claims.
 type SubjectTokenValidator struct {
-	jwks   *jose.JSONWebKeySet
-	issuer string
+	publicJWKS       *jose.JSONWebKeySet
+	issuer           string
+	allowedAudiences []string
 }
 
 // NewSubjectTokenValidator creates a new validator for subject tokens.
-// The jwks parameter must be non-nil and contain the authorization server's
-// signing keys (private keys are accepted; only the public portion is used
-// for verification). The issuer parameter is the expected "iss" claim value
-// and is also used as the expected audience, since tokens issued by this
-// server are intended for this server during token exchange.
-func NewSubjectTokenValidator(jwks *jose.JSONWebKeySet, issuer string) (*SubjectTokenValidator, error) {
+// The jwks parameter must be non-nil and contain only the authorization server's
+// public signing keys (e.g. AuthorizationServerConfig.PublicJWKS) — the validator
+// only ever verifies signatures, so it must not be handed private key material.
+// The issuer parameter is the expected "iss" claim value. allowedAudiences is the
+// set of audiences this server accepts in a subject token's "aud" claim; per the
+// same secure default as AuthorizationServerConfig.AllowedAudiences, an empty
+// allowedAudiences rejects every subject token rather than skipping the check.
+func NewSubjectTokenValidator(
+	jwks *jose.JSONWebKeySet, issuer string, allowedAudiences []string,
+) (*SubjectTokenValidator, error) {
 	if jwks == nil {
 		return nil, fmt.Errorf("JWKS must not be nil")
 	}
@@ -87,8 +93,9 @@ func NewSubjectTokenValidator(jwks *jose.JSONWebKeySet, issuer string) (*Subject
 		return nil, fmt.Errorf("issuer must not be empty")
 	}
 	return &SubjectTokenValidator{
-		jwks:   jwks,
-		issuer: issuer,
+		publicJWKS:       jwks,
+		issuer:           issuer,
+		allowedAudiences: allowedAudiences,
 	}, nil
 }
 
@@ -102,23 +109,27 @@ func (v *SubjectTokenValidator) Validate(_ context.Context, rawToken string) (*V
 		return nil, fmt.Errorf("subject token is not a valid JWT: %w", err)
 	}
 
-	// Extract public keys from the JWKS for signature verification.
-	publicJWKS := v.publicKeys()
-
 	// Try each key in the JWKS until one verifies the signature.
 	var standardClaims jwt.Claims
 	var extraClaims map[string]interface{}
 
-	if err := verifySignature(parsedToken, publicJWKS, &standardClaims, &extraClaims); err != nil {
+	if err := verifySignature(parsedToken, v.publicJWKS, &standardClaims, &extraClaims); err != nil {
 		return nil, err
 	}
 
-	// Validate standard claims: issuer, audience, and expiry.
+	// Validate issuer and expiry. Audience is intentionally excluded from
+	// jwt.Expected here — go-jose's AnyAudience check is skipped entirely when
+	// empty, which is the opposite of this server's secure default (empty
+	// AllowedAudiences means no audience is permitted). Audience is checked
+	// explicitly below so an empty allowlist fails closed.
 	expected := jwt.Expected{
-		Issuer:      v.issuer,
-		AnyAudience: jwt.Audience{v.issuer},
+		Issuer: v.issuer,
 	}
 	if err := standardClaims.ValidateWithLeeway(expected, 0); err != nil {
+		return nil, fmt.Errorf("subject token claims validation failed: %w", err)
+	}
+
+	if err := validateAudience(standardClaims.Audience, v.allowedAudiences); err != nil {
 		return nil, fmt.Errorf("subject token claims validation failed: %w", err)
 	}
 
@@ -171,11 +182,11 @@ func verifySignature(
 	var lastErr error
 	for _, key := range candidates {
 		*extraClaims = make(map[string]interface{})
-		if err := token.Claims(key, standardClaims, extraClaims); err == nil {
+		err := token.Claims(key, standardClaims, extraClaims)
+		if err == nil {
 			return nil
-		} else {
-			lastErr = err
 		}
+		lastErr = err
 	}
 	if lastErr != nil {
 		return fmt.Errorf("subject token signature verification failed: %w", lastErr)
@@ -183,15 +194,20 @@ func verifySignature(
 	return fmt.Errorf("subject token signature verification failed: no keys in JWKS")
 }
 
-// publicKeys extracts the public key portion of each key in the JWKS.
-func (v *SubjectTokenValidator) publicKeys() *jose.JSONWebKeySet {
-	result := &jose.JSONWebKeySet{
-		Keys: make([]jose.JSONWebKey, 0, len(v.jwks.Keys)),
+// validateAudience checks that tokenAudience intersects allowedAudiences.
+// Per this server's secure default (see AuthorizationServerConfig.AllowedAudiences),
+// an empty allowedAudiences means no audience is permitted, so the check fails
+// closed rather than skipping validation.
+func validateAudience(tokenAudience jwt.Audience, allowedAudiences []string) error {
+	if len(allowedAudiences) == 0 {
+		return fmt.Errorf("no audiences are configured on this server")
 	}
-	for _, key := range v.jwks.Keys {
-		result.Keys = append(result.Keys, key.Public())
+	for _, aud := range tokenAudience {
+		if slices.Contains(allowedAudiences, aud) {
+			return nil
+		}
 	}
-	return result
+	return fmt.Errorf("token audience %v does not match any allowed audience", []string(tokenAudience))
 }
 
 // buildValidatedClaims constructs a ValidatedClaims from standard and extra claims.
@@ -218,35 +234,43 @@ func buildValidatedClaims(
 	// Standard JWT registered claims are filtered out since they are already
 	// captured in the structured fields above.
 	for k, val := range extra {
-		switch k {
-		case "name":
-			if s, ok := val.(string); ok {
-				vc.Name = s
-			}
-		case "email":
-			if s, ok := val.(string); ok {
-				vc.Email = s
-			}
-		case "client_id":
-			if s, ok := val.(string); ok {
-				vc.ClientID = s
-			}
-		case "scope":
-			if s, ok := val.(string); ok {
-				vc.Scopes = s
-			}
-		case "may_act":
-			if m, ok := val.(map[string]interface{}); ok {
-				if s, ok := m["sub"].(string); ok {
-					vc.MayAct = &MayActClaim{Sub: s}
-				}
-			}
-		case "sub", "iss", "aud", "exp", "iat", "nbf", "jti":
-			// Skip registered JWT claims — already in structured fields.
-		default:
-			vc.Extra[k] = val
-		}
+		assignClaim(vc, k, val)
 	}
 
 	return vc
+}
+
+// assignClaim routes one non-standard JWT claim onto its structured
+// ValidatedClaims field, or into Extra if it isn't a well-known claim.
+// Registered JWT claims (sub, iss, aud, exp, iat, nbf, jti) are dropped —
+// they're already captured in buildValidatedClaims's structured fields.
+func assignClaim(vc *ValidatedClaims, key string, val interface{}) {
+	switch key {
+	case "name":
+		if s, ok := val.(string); ok {
+			vc.Name = s
+		}
+	case "email":
+		if s, ok := val.(string); ok {
+			vc.Email = s
+		}
+	case "client_id":
+		if s, ok := val.(string); ok {
+			vc.ClientID = s
+		}
+	case "scope":
+		if s, ok := val.(string); ok {
+			vc.Scopes = s
+		}
+	case "may_act":
+		if m, ok := val.(map[string]interface{}); ok {
+			if s, ok := m["sub"].(string); ok {
+				vc.MayAct = &MayActClaim{Sub: s}
+			}
+		}
+	case "sub", "iss", "aud", "exp", "iat", "nbf", "jti":
+		// Skip registered JWT claims — already in structured fields.
+	default:
+		vc.Extra[key] = val
+	}
 }

--- a/pkg/authserver/server/tokenexchange/validator_test.go
+++ b/pkg/authserver/server/tokenexchange/validator_test.go
@@ -1,0 +1,434 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tokenexchange
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testIssuer = "https://auth.example.com"
+
+// testJWKS holds a signing key and JWKS for test token generation.
+type testJWKS struct {
+	privateKey *ecdsa.PrivateKey
+	jwk        jose.JSONWebKey
+	jwks       *jose.JSONWebKeySet
+}
+
+// newTestJWKS generates a fresh ECDSA P-256 key pair and wraps it in a JWKS.
+func newTestJWKS(t *testing.T) *testJWKS {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	jwk := jose.JSONWebKey{
+		Key:       privateKey,
+		KeyID:     "test-key-1",
+		Algorithm: string(jose.ES256),
+		Use:       "sig",
+	}
+
+	return &testJWKS{
+		privateKey: privateKey,
+		jwk:        jwk,
+		jwks:       &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}},
+	}
+}
+
+// signToken creates a signed JWT with the given claims using the test JWKS key.
+func (tj *testJWKS) signToken(t *testing.T, claims jwt.Claims, extraClaims map[string]interface{}) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: tj.jwk},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+
+	builder := jwt.Signed(signer).Claims(claims)
+	if extraClaims != nil {
+		builder = builder.Claims(extraClaims)
+	}
+
+	raw, err := builder.Serialize()
+	require.NoError(t, err)
+
+	return raw
+}
+
+// validClaims returns a set of standard claims that pass all validation checks.
+func validClaims() jwt.Claims {
+	now := time.Now()
+	return jwt.Claims{
+		Subject:   "user-123",
+		Issuer:    testIssuer,
+		Audience:  jwt.Audience{testIssuer},
+		Expiry:    jwt.NewNumericDate(now.Add(time.Hour)),
+		IssuedAt:  jwt.NewNumericDate(now),
+		NotBefore: jwt.NewNumericDate(now.Add(-time.Minute)),
+		ID:        "jti-abc-123",
+	}
+}
+
+// validExtraClaims returns extra claims that match the session package claim keys.
+func validExtraClaims() map[string]interface{} {
+	return map[string]interface{}{
+		"name":      "Test User",
+		"email":     "test@example.com",
+		"client_id": testAgentClientID,
+		"tsid":      "session-xyz",
+	}
+}
+
+func TestSubjectTokenValidator_NewValidation(t *testing.T) {
+	t.Parallel()
+
+	tj := newTestJWKS(t)
+
+	t.Run("nil JWKS returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewSubjectTokenValidator(nil, testIssuer)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "JWKS must not be nil")
+	})
+
+	t.Run("empty issuer returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewSubjectTokenValidator(tj.jwks, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issuer must not be empty")
+	})
+
+	t.Run("valid params succeed", func(t *testing.T) {
+		t.Parallel()
+		v, err := NewSubjectTokenValidator(tj.jwks, testIssuer)
+		require.NoError(t, err)
+		assert.NotNil(t, v)
+	})
+}
+
+func TestSubjectTokenValidator_Validate(t *testing.T) {
+	t.Parallel()
+
+	tj := newTestJWKS(t)
+
+	tests := []struct {
+		name        string
+		token       func(t *testing.T) string
+		wantErr     bool
+		errContains string
+		check       func(t *testing.T, vc *ValidatedClaims)
+	}{
+		{
+			name: "valid token with all claims",
+			token: func(t *testing.T) string {
+				t.Helper()
+				return tj.signToken(t, validClaims(), validExtraClaims())
+			},
+			check: func(t *testing.T, vc *ValidatedClaims) {
+				t.Helper()
+				assert.Equal(t, "user-123", vc.Subject)
+				assert.Equal(t, testIssuer, vc.Issuer)
+				assert.Equal(t, []string{testIssuer}, vc.Audience)
+				assert.Equal(t, "jti-abc-123", vc.JWTID)
+				assert.Equal(t, "Test User", vc.Name)
+				assert.Equal(t, "test@example.com", vc.Email)
+				assert.Equal(t, testAgentClientID, vc.ClientID)
+				assert.False(t, vc.Expiry.IsZero())
+				assert.False(t, vc.IssuedAt.IsZero())
+				// tsid should be in Extra since it's not a well-known claim field
+				assert.Equal(t, "session-xyz", vc.Extra["tsid"])
+				// Standard JWT claims should NOT be in Extra
+				_, hasSub := vc.Extra["sub"]
+				assert.False(t, hasSub, "standard claim 'sub' should not be in Extra")
+				_, hasIss := vc.Extra["iss"]
+				assert.False(t, hasIss, "standard claim 'iss' should not be in Extra")
+			},
+		},
+		{
+			name: "expired token",
+			token: func(t *testing.T) string {
+				t.Helper()
+				claims := validClaims()
+				claims.Expiry = jwt.NewNumericDate(time.Now().Add(-time.Hour))
+				claims.IssuedAt = jwt.NewNumericDate(time.Now().Add(-2 * time.Hour))
+				return tj.signToken(t, claims, nil)
+			},
+			wantErr:     true,
+			errContains: "claims validation failed",
+		},
+		{
+			name: "wrong issuer",
+			token: func(t *testing.T) string {
+				t.Helper()
+				claims := validClaims()
+				claims.Issuer = "https://evil.example.com"
+				return tj.signToken(t, claims, nil)
+			},
+			wantErr:     true,
+			errContains: "claims validation failed",
+		},
+		{
+			name: "wrong audience",
+			token: func(t *testing.T) string {
+				t.Helper()
+				claims := validClaims()
+				claims.Audience = jwt.Audience{"https://other.example.com"}
+				return tj.signToken(t, claims, nil)
+			},
+			wantErr:     true,
+			errContains: "claims validation failed",
+		},
+		{
+			name: "not yet valid — nbf in the future",
+			token: func(t *testing.T) string {
+				t.Helper()
+				claims := validClaims()
+				claims.NotBefore = jwt.NewNumericDate(time.Now().Add(time.Hour))
+				return tj.signToken(t, claims, nil)
+			},
+			wantErr:     true,
+			errContains: "claims validation failed",
+		},
+		{
+			name: "bad signature — signed with different key",
+			token: func(t *testing.T) string {
+				t.Helper()
+				otherJWKS := newTestJWKS(t)
+				return otherJWKS.signToken(t, validClaims(), nil)
+			},
+			wantErr:     true,
+			errContains: "signature verification failed",
+		},
+		{
+			name: "malformed token",
+			token: func(_ *testing.T) string {
+				return "not-a-jwt"
+			},
+			wantErr:     true,
+			errContains: "not a valid JWT",
+		},
+		{
+			name: "missing subject claim",
+			token: func(t *testing.T) string {
+				t.Helper()
+				claims := validClaims()
+				claims.Subject = ""
+				return tj.signToken(t, claims, nil)
+			},
+			wantErr:     true,
+			errContains: "missing required 'sub' claim",
+		},
+		{
+			name: "missing exp claim",
+			token: func(t *testing.T) string {
+				t.Helper()
+				claims := validClaims()
+				claims.Expiry = nil
+				return tj.signToken(t, claims, nil)
+			},
+			wantErr:     true,
+			errContains: "missing required 'exp' claim",
+		},
+		{
+			name: "token with may_act claim extracts MayAct",
+			token: func(t *testing.T) string {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["may_act"] = map[string]interface{}{"sub": "authorized-agent"}
+				return tj.signToken(t, validClaims(), extra)
+			},
+			check: func(t *testing.T, vc *ValidatedClaims) {
+				t.Helper()
+				require.NotNil(t, vc.MayAct)
+				assert.Equal(t, "authorized-agent", vc.MayAct.Sub)
+			},
+		},
+		{
+			name: "malformed may_act — not an object",
+			token: func(t *testing.T) string {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["may_act"] = "not-an-object"
+				return tj.signToken(t, validClaims(), extra)
+			},
+			wantErr:     true,
+			errContains: "malformed 'may_act' claim",
+		},
+		{
+			name: "malformed may_act — missing sub",
+			token: func(t *testing.T) string {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["may_act"] = map[string]interface{}{"foo": "bar"}
+				return tj.signToken(t, validClaims(), extra)
+			},
+			wantErr:     true,
+			errContains: "malformed 'may_act' claim",
+		},
+		{
+			name: "malformed may_act — non-string sub",
+			token: func(t *testing.T) string {
+				t.Helper()
+				extra := validExtraClaims()
+				extra["may_act"] = map[string]interface{}{"sub": 123}
+				return tj.signToken(t, validClaims(), extra)
+			},
+			wantErr:     true,
+			errContains: "malformed 'may_act' claim",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			validator, err := NewSubjectTokenValidator(tj.jwks, testIssuer)
+			require.NoError(t, err)
+			rawToken := tt.token(t)
+
+			result, err := validator.Validate(context.Background(), rawToken)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+// newECDSAJWK generates a fresh ECDSA P-256 key with the given key ID.
+func newECDSAJWK(t *testing.T, kid string) (*ecdsa.PrivateKey, jose.JSONWebKey) {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{
+		Key:       privateKey,
+		KeyID:     kid,
+		Algorithm: string(jose.ES256),
+		Use:       "sig",
+	}
+	return privateKey, jwk
+}
+
+// signWithJWK signs claims with the given signing key (no extra claims).
+func signWithJWK(t *testing.T, signingKey jose.JSONWebKey, alg jose.SignatureAlgorithm, claims jwt.Claims) string {
+	t.Helper()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: alg, Key: signingKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+func TestSubjectTokenValidator_MultiKeyJWKS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("token verified with kid-matched key", func(t *testing.T) {
+		t.Parallel()
+
+		_, jwk1 := newECDSAJWK(t, "test-key-1")
+		_, jwk2 := newECDSAJWK(t, "test-key-2")
+		jwks := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk1, jwk2}}
+
+		validator, err := NewSubjectTokenValidator(jwks, testIssuer)
+		require.NoError(t, err)
+
+		rawToken := signWithJWK(t, jwk2, jose.ES256, validClaims())
+
+		result, err := validator.Validate(context.Background(), rawToken)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "user-123", result.Subject)
+	})
+
+	t.Run("token verified by full iteration when kid absent", func(t *testing.T) {
+		t.Parallel()
+
+		_, jwk1 := newECDSAJWK(t, "test-key-1")
+		_, jwk2 := newECDSAJWK(t, "test-key-2")
+		jwks := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk1, jwk2}}
+
+		validator, err := NewSubjectTokenValidator(jwks, testIssuer)
+		require.NoError(t, err)
+
+		// Sign with jwk1 (whose public half is in the JWKS) but omit the kid
+		// from the signer so the token header carries no kid — the validator
+		// must then fall back to iterating all keys rather than kid-matching.
+		signingKeyNoKID := jwk1
+		signingKeyNoKID.KeyID = ""
+		rawToken := signWithJWK(t, signingKeyNoKID, jose.ES256, validClaims())
+
+		result, err := validator.Validate(context.Background(), rawToken)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "user-123", result.Subject)
+	})
+
+	t.Run("token signed with different key in JWKS fails", func(t *testing.T) {
+		t.Parallel()
+
+		_, jwk1 := newECDSAJWK(t, "test-key-1")
+		jwks := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk1}}
+
+		validator, err := NewSubjectTokenValidator(jwks, testIssuer)
+		require.NoError(t, err)
+
+		// Key B is not in the JWKS.
+		_, otherJWK := newECDSAJWK(t, "other-key")
+		rawToken := signWithJWK(t, otherJWK, jose.ES256, validClaims())
+
+		result, err := validator.Validate(context.Background(), rawToken)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signature verification failed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("RSA-signed token accepted", func(t *testing.T) {
+		t.Parallel()
+
+		rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		rsaJWK := jose.JSONWebKey{
+			Key:       rsaKey,
+			KeyID:     "rsa-key-1",
+			Algorithm: string(jose.RS256),
+			Use:       "sig",
+		}
+		jwks := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{rsaJWK}}
+
+		validator, err := NewSubjectTokenValidator(jwks, testIssuer)
+		require.NoError(t, err)
+
+		rawToken := signWithJWK(t, rsaJWK, jose.RS256, validClaims())
+
+		result, err := validator.Validate(context.Background(), rawToken)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "user-123", result.Subject)
+	})
+}

--- a/pkg/authserver/server/tokenexchange/validator_test.go
+++ b/pkg/authserver/server/tokenexchange/validator_test.go
@@ -55,7 +55,7 @@ func (tj *testJWKS) publicJWKS() *jose.JSONWebKeySet {
 }
 
 // signToken creates a signed JWT with the given claims using the test JWKS key.
-func (tj *testJWKS) signToken(t *testing.T, claims jwt.Claims, extraClaims map[string]interface{}) string {
+func (tj *testJWKS) signToken(t *testing.T, claims jwt.Claims, extraClaims map[string]any) string {
 	t.Helper()
 
 	signer, err := jose.NewSigner(
@@ -90,8 +90,8 @@ func validClaims() jwt.Claims {
 }
 
 // validExtraClaims returns extra claims that match the session package claim keys.
-func validExtraClaims() map[string]interface{} {
-	return map[string]interface{}{
+func validExtraClaims() map[string]any {
+	return map[string]any{
 		"name":      "Test User",
 		"email":     "test@example.com",
 		"client_id": testAgentClientID,
@@ -254,7 +254,7 @@ func TestSubjectTokenValidator_Validate(t *testing.T) {
 			token: func(t *testing.T) string {
 				t.Helper()
 				extra := validExtraClaims()
-				extra["may_act"] = map[string]interface{}{"sub": "authorized-agent"}
+				extra["may_act"] = map[string]any{"sub": "authorized-agent"}
 				return tj.signToken(t, validClaims(), extra)
 			},
 			check: func(t *testing.T, vc *ValidatedClaims) {
@@ -279,7 +279,7 @@ func TestSubjectTokenValidator_Validate(t *testing.T) {
 			token: func(t *testing.T) string {
 				t.Helper()
 				extra := validExtraClaims()
-				extra["may_act"] = map[string]interface{}{"foo": "bar"}
+				extra["may_act"] = map[string]any{"foo": "bar"}
 				return tj.signToken(t, validClaims(), extra)
 			},
 			wantErr:     true,
@@ -290,7 +290,7 @@ func TestSubjectTokenValidator_Validate(t *testing.T) {
 			token: func(t *testing.T) string {
 				t.Helper()
 				extra := validExtraClaims()
-				extra["may_act"] = map[string]interface{}{"sub": 123}
+				extra["may_act"] = map[string]any{"sub": 123}
 				return tj.signToken(t, validClaims(), extra)
 			},
 			wantErr:     true,
@@ -473,6 +473,30 @@ func TestSubjectTokenValidator_MultiKeyJWKS(t *testing.T) {
 		// Key B is not in the JWKS.
 		otherJWK := newECDSAJWK(t, "other-key")
 		rawToken := signWithJWK(t, otherJWK, jose.ES256, validClaims())
+
+		result, err := validator.Validate(context.Background(), rawToken)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signature verification failed")
+		assert.Nil(t, result)
+	})
+
+	t.Run("token claiming a kid it is not signed with fails", func(t *testing.T) {
+		t.Parallel()
+
+		jwk1 := newECDSAJWK(t, "test-key-1")
+		jwk2 := newECDSAJWK(t, "test-key-2")
+		jwks := publicJWKSOf(jwk1, jwk2)
+
+		validator, err := NewSubjectTokenValidator(jwks, testIssuer, []string{testIssuer})
+		require.NoError(t, err)
+
+		// Sign with jwk2's key material but claim jwk1's kid in the header.
+		// A validator that fell back to the full keyset after a kid match
+		// would wrongly accept this via jwk2; verifySignature must try only
+		// the matched key (jwk1) and fail.
+		spoofedKey := jwk2
+		spoofedKey.KeyID = jwk1.KeyID
+		rawToken := signWithJWK(t, spoofedKey, jose.ES256, validClaims())
 
 		result, err := validator.Validate(context.Background(), rawToken)
 		require.Error(t, err)

--- a/pkg/authserver/server/tokenexchange/validator_test.go
+++ b/pkg/authserver/server/tokenexchange/validator_test.go
@@ -48,6 +48,12 @@ func newTestJWKS(t *testing.T) *testJWKS {
 	}
 }
 
+// publicJWKS returns the public-only JWKS, mirroring how Factory constructs
+// the validator from AuthorizationServerConfig.PublicJWKS().
+func (tj *testJWKS) publicJWKS() *jose.JSONWebKeySet {
+	return &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{tj.jwk.Public()}}
+}
+
 // signToken creates a signed JWT with the given claims using the test JWKS key.
 func (tj *testJWKS) signToken(t *testing.T, claims jwt.Claims, extraClaims map[string]interface{}) string {
 	t.Helper()
@@ -100,21 +106,21 @@ func TestSubjectTokenValidator_NewValidation(t *testing.T) {
 
 	t.Run("nil JWKS returns error", func(t *testing.T) {
 		t.Parallel()
-		_, err := NewSubjectTokenValidator(nil, testIssuer)
+		_, err := NewSubjectTokenValidator(nil, testIssuer, []string{testIssuer})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "JWKS must not be nil")
 	})
 
 	t.Run("empty issuer returns error", func(t *testing.T) {
 		t.Parallel()
-		_, err := NewSubjectTokenValidator(tj.jwks, "")
+		_, err := NewSubjectTokenValidator(tj.publicJWKS(), "", []string{testIssuer})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "issuer must not be empty")
 	})
 
 	t.Run("valid params succeed", func(t *testing.T) {
 		t.Parallel()
-		v, err := NewSubjectTokenValidator(tj.jwks, testIssuer)
+		v, err := NewSubjectTokenValidator(tj.publicJWKS(), testIssuer, []string{testIssuer})
 		require.NoError(t, err)
 		assert.NotNil(t, v)
 	})
@@ -296,7 +302,7 @@ func TestSubjectTokenValidator_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			validator, err := NewSubjectTokenValidator(tj.jwks, testIssuer)
+			validator, err := NewSubjectTokenValidator(tj.publicJWKS(), testIssuer, []string{testIssuer})
 			require.NoError(t, err)
 			rawToken := tt.token(t)
 
@@ -318,18 +324,84 @@ func TestSubjectTokenValidator_Validate(t *testing.T) {
 	}
 }
 
-// newECDSAJWK generates a fresh ECDSA P-256 key with the given key ID.
-func newECDSAJWK(t *testing.T, kid string) (*ecdsa.PrivateKey, jose.JSONWebKey) {
+func TestSubjectTokenValidator_AudienceValidation(t *testing.T) {
+	t.Parallel()
+
+	tj := newTestJWKS(t)
+
+	tests := []struct {
+		name             string
+		allowedAudiences []string
+		tokenAudience    jwt.Audience
+		wantErr          bool
+	}{
+		{
+			name:             "empty allowedAudiences rejects even a matching-looking token",
+			allowedAudiences: nil,
+			tokenAudience:    jwt.Audience{testIssuer},
+			wantErr:          true,
+		},
+		{
+			name:             "token audience intersects allowedAudiences",
+			allowedAudiences: []string{"https://other.example.com", testIssuer},
+			tokenAudience:    jwt.Audience{testIssuer},
+			wantErr:          false,
+		},
+		{
+			name:             "token audience does not intersect allowedAudiences",
+			allowedAudiences: []string{"https://other.example.com"},
+			tokenAudience:    jwt.Audience{testIssuer},
+			wantErr:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			validator, err := NewSubjectTokenValidator(tj.publicJWKS(), testIssuer, tt.allowedAudiences)
+			require.NoError(t, err)
+
+			claims := validClaims()
+			claims.Audience = tt.tokenAudience
+			rawToken := tj.signToken(t, claims, nil)
+
+			result, err := validator.Validate(context.Background(), rawToken)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "claims validation failed")
+				assert.Nil(t, result)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
+		})
+	}
+}
+
+// newECDSAJWK generates a fresh ECDSA P-256 key with the given key ID. The
+// returned JWK carries the private key (in its Key field), so it can be used
+// directly for both signing (signWithJWK) and JWKS construction.
+func newECDSAJWK(t *testing.T, kid string) jose.JSONWebKey {
 	t.Helper()
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
-	jwk := jose.JSONWebKey{
+	return jose.JSONWebKey{
 		Key:       privateKey,
 		KeyID:     kid,
 		Algorithm: string(jose.ES256),
 		Use:       "sig",
 	}
-	return privateKey, jwk
+}
+
+// publicJWKSOf builds a JWKS containing only the public portion of each key,
+// mirroring how Factory constructs the validator from PublicJWKS().
+func publicJWKSOf(keys ...jose.JSONWebKey) *jose.JSONWebKeySet {
+	public := make([]jose.JSONWebKey, len(keys))
+	for i, k := range keys {
+		public[i] = k.Public()
+	}
+	return &jose.JSONWebKeySet{Keys: public}
 }
 
 // signWithJWK signs claims with the given signing key (no extra claims).
@@ -351,11 +423,11 @@ func TestSubjectTokenValidator_MultiKeyJWKS(t *testing.T) {
 	t.Run("token verified with kid-matched key", func(t *testing.T) {
 		t.Parallel()
 
-		_, jwk1 := newECDSAJWK(t, "test-key-1")
-		_, jwk2 := newECDSAJWK(t, "test-key-2")
-		jwks := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk1, jwk2}}
+		jwk1 := newECDSAJWK(t, "test-key-1")
+		jwk2 := newECDSAJWK(t, "test-key-2")
+		jwks := publicJWKSOf(jwk1, jwk2)
 
-		validator, err := NewSubjectTokenValidator(jwks, testIssuer)
+		validator, err := NewSubjectTokenValidator(jwks, testIssuer, []string{testIssuer})
 		require.NoError(t, err)
 
 		rawToken := signWithJWK(t, jwk2, jose.ES256, validClaims())
@@ -369,11 +441,11 @@ func TestSubjectTokenValidator_MultiKeyJWKS(t *testing.T) {
 	t.Run("token verified by full iteration when kid absent", func(t *testing.T) {
 		t.Parallel()
 
-		_, jwk1 := newECDSAJWK(t, "test-key-1")
-		_, jwk2 := newECDSAJWK(t, "test-key-2")
-		jwks := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk1, jwk2}}
+		jwk1 := newECDSAJWK(t, "test-key-1")
+		jwk2 := newECDSAJWK(t, "test-key-2")
+		jwks := publicJWKSOf(jwk1, jwk2)
 
-		validator, err := NewSubjectTokenValidator(jwks, testIssuer)
+		validator, err := NewSubjectTokenValidator(jwks, testIssuer, []string{testIssuer})
 		require.NoError(t, err)
 
 		// Sign with jwk1 (whose public half is in the JWKS) but omit the kid
@@ -392,14 +464,14 @@ func TestSubjectTokenValidator_MultiKeyJWKS(t *testing.T) {
 	t.Run("token signed with different key in JWKS fails", func(t *testing.T) {
 		t.Parallel()
 
-		_, jwk1 := newECDSAJWK(t, "test-key-1")
-		jwks := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk1}}
+		jwk1 := newECDSAJWK(t, "test-key-1")
+		jwks := publicJWKSOf(jwk1)
 
-		validator, err := NewSubjectTokenValidator(jwks, testIssuer)
+		validator, err := NewSubjectTokenValidator(jwks, testIssuer, []string{testIssuer})
 		require.NoError(t, err)
 
 		// Key B is not in the JWKS.
-		_, otherJWK := newECDSAJWK(t, "other-key")
+		otherJWK := newECDSAJWK(t, "other-key")
 		rawToken := signWithJWK(t, otherJWK, jose.ES256, validClaims())
 
 		result, err := validator.Validate(context.Background(), rawToken)
@@ -419,9 +491,9 @@ func TestSubjectTokenValidator_MultiKeyJWKS(t *testing.T) {
 			Algorithm: string(jose.RS256),
 			Use:       "sig",
 		}
-		jwks := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{rsaJWK}}
+		jwks := publicJWKSOf(rsaJWK)
 
-		validator, err := NewSubjectTokenValidator(jwks, testIssuer)
+		validator, err := NewSubjectTokenValidator(jwks, testIssuer, []string{testIssuer})
 		require.NoError(t, err)
 
 		rawToken := signWithJWK(t, rsaJWK, jose.RS256, validClaims())

--- a/pkg/authz/authorizers/cedar/record_test.go
+++ b/pkg/authz/authorizers/cedar/record_test.go
@@ -172,9 +172,7 @@ func TestConvertMapToCedarRecord(t *testing.T) {
 		{
 			name: "Nested map converts to Cedar record",
 			input: map[string]interface{}{
-				"act": map[string]interface{}{
-					"sub": "spiffe://toolhive.dev/ns/agents/sa/devops-agent",
-				},
+				"act": map[string]interface{}{"sub": "spiffe://toolhive.dev/ns/agents/sa/devops-agent"},
 			},
 			expected: map[string]cedar.Value{
 				"act": cedar.NewRecord(cedar.RecordMap{


### PR DESCRIPTION
## Summary

ToolHive's embedded authorization server today issues JWTs that identify only the human user. In an agentic deployment — where an LLM-based agent calls an MCP server on a user's behalf — this leaves only two bad options at the backend: pretend the agent is the user (an audit log reading "Alice deleted the repo" can't tell whether Alice typed that or her agent did after a prompt injection), or treat the agent as the only identity via `client_credentials` (the user disappears, breaking per-user policy and audit).

This PR adds the core [RFC 8693 OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) grant handler to the embedded AS, so an agent can exchange a user's token for a delegated token that carries both identities: `sub` (the user) and `act.sub` (the acting agent).

- `SelfIssuedTokenValidator`: validates subject tokens against the AS's own JWKS (kid-matched key first, falls back to full iteration; algorithm allowlist excludes `none` and HS-*)
- `Handler`: implements `fosite.TokenEndpointHandler` for the `token-exchange` grant type
- `act` claim construction per RFC 8693 §4.1
- Scope intersection: delegated scopes are the intersection of the client's registered scopes and the subject token's granted scopes (fail-closed if the subject token carries no scope claim)
- Delegation consent: `client_id` binding, with `may_act` claim support for explicit cross-client delegation
- Confidential-client-only; public clients rejected
- RFC 8707 `resource` parameter support, validated against configured allowed audiences

Not yet wired into the server — that's the next PR in the stack (#5813).

Closes #5812

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

## API Compatibility

Not applicable — this PR only touches `pkg/authserver`, no operator/CRD surface.

## Special notes for reviewers

This is PR 1 of a stack implementing #5194 (embedded AS token exchange for agent delegation). It's self-contained but currently unreachable at runtime — wiring the handler into the fosite compose pipeline is PR 2 (#5813, branch `token-delegation-2-fosite-wiring`), already prepared and ready to follow this one. Subsequent PRs in the stack add multi-issuer (federated) subject-token validation (#5814) and explicit `actor_token`/`id_token` support (#5815).

Generated with [Claude Code](https://claude.com/claude-code)