### PR TITLE
Add upstream identity to DCR credential cache key

### DIFF
--- a/pkg/auth/dcr/request.go
+++ b/pkg/auth/dcr/request.go
@@ -43,13 +43,16 @@ type Request struct {
 	//     RFC 8252 §7.3, so the redirect-URI defaulting is never
 	//     exercised on this path.
 	//
-	// The resolver's cache key is (Issuer, RedirectURI, ScopesHash); the
-	// two consumers do not collide on the key because the embedded
-	// authserver's RedirectURI lives on the authserver's origin and the
-	// CLI's lives on a loopback (RFC 8252 §7.3) — even when Issuer
-	// happens to match between the two profiles, the RedirectURI
-	// component keeps the cache key distinct. See the cross-consumer
-	// caveat on dcrFlight in resolver.go for the wider invariant.
+	// The resolver's cache key is (Issuer, UpstreamID, RedirectURI,
+	// ScopesHash), where UpstreamID is derived by the resolver from
+	// DiscoveryURL / RegistrationEndpoint (issue #5823). The two consumers
+	// do not collide on the key because the embedded authserver's
+	// RedirectURI lives on the authserver's origin and the CLI's lives on a
+	// loopback (RFC 8252 §7.3) — even when Issuer happens to match between
+	// the two profiles, the RedirectURI component keeps the cache key
+	// distinct; UpstreamID additionally keeps two upstreams within a single
+	// consumer apart. See the cross-consumer caveat on dcrFlight in
+	// resolver.go for the wider invariant.
 	//
 	// Issuer is *not* used for RFC 8414 §3.3 metadata verification —
 	// that uses an issuer recovered from DiscoveryURL inside the
@@ -71,7 +74,9 @@ type Request struct {
 	// document. The resolver fetches this URL exactly once and reads
 	// registration_endpoint, authorization_endpoint, token_endpoint,
 	// token_endpoint_auth_methods_supported, scopes_supported, and
-	// code_challenge_methods_supported from it.
+	// code_challenge_methods_supported from it. On this branch the resolver
+	// also derives the cache key's UpstreamID from the upstream issuer
+	// recovered from this URL.
 	//
 	// Mutually exclusive with RegistrationEndpoint.
 	DiscoveryURL string
@@ -80,7 +85,8 @@ type Request struct {
 	// On this branch the caller is expected to also supply AuthorizationEndpoint
 	// and TokenEndpoint explicitly; the resolver's auth-method selection
 	// defaults to client_secret_basic because no server-capability fields
-	// are available unless CodeChallengeMethodsSupported is also set.
+	// are available unless CodeChallengeMethodsSupported is also set. This
+	// URL is also the cache key's UpstreamID on this branch.
 	//
 	// Mutually exclusive with DiscoveryURL.
 	RegistrationEndpoint string

--- a/pkg/auth/dcr/resolver.go
+++ b/pkg/auth/dcr/resolver.go
@@ -104,13 +104,25 @@ import (
 var dcrFlight singleflight.Group
 
 // flightKeyOf canonicalises a Key into the singleflight string used by
-// dcrFlight. The "\n" separator is safe because newline is not a valid
-// byte in any of the four components: URI reference characters in Issuer,
-// UpstreamID, and RedirectURI (RFC 3986 §2), and hex digits in ScopesHash
-// (the form storage.ScopesHash always emits). Exposed as a function so
-// tests and future inspection helpers can compute the exact key the
-// resolver would route through dcrFlight without re-implementing the
-// concatenation.
+// dcrFlight. Each field is length-prefixed (the same scheme redisDCRKey
+// uses in pkg/authserver/storage) so the key is unambiguous regardless of
+// field contents; ScopesHash is a SHA-256 hex digest with no colons, so it
+// is appended without a prefix, exactly as redisDCRKey does. Exposed as a
+// function so tests and future inspection helpers can compute the exact key
+// the resolver would route through dcrFlight without re-implementing the
+// encoding.
+//
+// Length-prefixing rather than a "separator byte that never appears":
+// UpstreamID is NOT guaranteed to be a clean URL when this key is built. On
+// the CLI/remote path it is req.RegistrationEndpoint copied verbatim from
+// the upstream's discovery-document JSON, and validateUpstreamEndpointURL
+// does not run until later, inside the singleflight body
+// (resolveDCREndpoints) — after this key already exists. A newline (or any
+// byte) in a discovery-supplied registration_endpoint would therefore reach
+// a naive "\n"-joined key, where a crafted value could byte-collide with a
+// concurrently-registering upstream and, as the singleflight follower,
+// observe that upstream's Resolution. Length-prefixing removes the
+// assumption entirely and aligns the flight key with the persisted DCRKey.
 //
 // UpstreamID keeps two upstreams that share Issuer, RedirectURI, and
 // scopes from coalescing into a single flight (issue #5823) — the same
@@ -125,7 +137,11 @@ var dcrFlight singleflight.Group
 // DCRKey from cross-profile coalescence; the two layers are aligned
 // rather than asymmetric.
 func flightKeyOf(key Key) string {
-	return key.Issuer + "\n" + key.UpstreamID + "\n" + key.RedirectURI + "\n" + key.ScopesHash
+	return fmt.Sprintf("%d:%s:%d:%s:%d:%s:%s",
+		len(key.Issuer), key.Issuer,
+		len(key.UpstreamID), key.UpstreamID,
+		len(key.RedirectURI), key.RedirectURI,
+		key.ScopesHash)
 }
 
 // defaultUpstreamRedirectPath is the redirect path derived from the issuer

--- a/pkg/auth/dcr/resolver.go
+++ b/pkg/auth/dcr/resolver.go
@@ -943,10 +943,12 @@ func resolveDCREndpoints(
 // collide. This is intentional: UpstreamID names the authorization server
 // (aligned with the RFC 8414 §3.3 issuer used for metadata verification), so
 // two configs that resolve to the same issuer are the same AS and correctly
-// share one registration. The collision only surfaces for the nonstandard
-// case of one issuer serving distinct registration endpoints under custom
-// paths; if the two upstreams instead declared different issuers, at least
-// one would fail §3.3 verification loudly rather than reuse credentials.
+// share one registration. The collision is therefore confined to the
+// nonstandard case where a single issuer serves distinct registration
+// endpoints under custom (non-well-known) discovery paths: both upstreams
+// resolve to that one issuer, so their UpstreamIDs match. Upstreams that
+// resolve to different issuers derive different UpstreamIDs and never collide
+// — the key itself keeps them apart, independent of §3.3 verification.
 func resolveUpstreamKeyIdentity(req *Request) (string, error) {
 	if req.RegistrationEndpoint != "" {
 		return req.RegistrationEndpoint, nil

--- a/pkg/auth/dcr/resolver.go
+++ b/pkg/auth/dcr/resolver.go
@@ -462,6 +462,7 @@ func registerAndCache(
 	//nolint:gosec // G706: client_id is public metadata per RFC 7591.
 	slog.Debug("dcr: registered new client",
 		"local_issuer", req.Issuer,
+		"upstream_id", key.UpstreamID,
 		"redirect_uri", redirectURI,
 		"client_id", resolution.ClientID,
 	)
@@ -675,6 +676,7 @@ func lookupCachedResolution(
 		//nolint:gosec // G706: client_id is public metadata per RFC 7591.
 		slog.Debug("dcr: cache hit ignored; cached secret expired per upstream client_secret_expires_at",
 			"local_issuer", localIssuer,
+			"upstream_id", key.UpstreamID,
 			"redirect_uri", redirectURI,
 			"client_id", cached.ClientID,
 			"client_secret_expires_at", cached.ClientSecretExpiresAt.UTC().Format(time.RFC3339),
@@ -688,6 +690,7 @@ func lookupCachedResolution(
 	//nolint:gosec // G706: client_id is public metadata per RFC 7591.
 	slog.Debug("dcr: cache hit",
 		"local_issuer", localIssuer,
+		"upstream_id", key.UpstreamID,
 		"redirect_uri", redirectURI,
 		"client_id", cached.ClientID,
 		"dcr_age_days", ageDays,
@@ -700,6 +703,7 @@ func lookupCachedResolution(
 				"consider rotating the registration via RFC 7592 deregistration "+
 				"and re-registering at next startup",
 			"local_issuer", localIssuer,
+			"upstream_id", key.UpstreamID,
 			"redirect_uri", redirectURI,
 			"client_id", cached.ClientID,
 			"dcr_age_days", ageDays,

--- a/pkg/auth/dcr/resolver.go
+++ b/pkg/auth/dcr/resolver.go
@@ -933,6 +933,20 @@ func resolveDCREndpoints(
 // keeps the cache-hit path free of I/O; a malformed DiscoveryURL that fails
 // here could never have produced a stored entry to hit anyway, because a
 // successful registration requires the same derivation to succeed first.
+//
+// Residual limitation: on the DiscoveryURL branch the identity is the derived
+// upstream *issuer*, not the discovery URL. For a custom (non-well-known)
+// discovery URL, deriveExpectedIssuerFromDiscoveryURL falls back to the bare
+// origin and discards the path, so two upstreams on the same host with
+// distinct custom metadata paths, the same scopes, and both declaring that
+// origin as their metadata "issuer" derive the same UpstreamID and still
+// collide. This is intentional: UpstreamID names the authorization server
+// (aligned with the RFC 8414 §3.3 issuer used for metadata verification), so
+// two configs that resolve to the same issuer are the same AS and correctly
+// share one registration. The collision only surfaces for the nonstandard
+// case of one issuer serving distinct registration endpoints under custom
+// paths; if the two upstreams instead declared different issuers, at least
+// one would fail §3.3 verification loudly rather than reuse credentials.
 func resolveUpstreamKeyIdentity(req *Request) (string, error) {
 	if req.RegistrationEndpoint != "" {
 		return req.RegistrationEndpoint, nil

--- a/pkg/auth/dcr/resolver.go
+++ b/pkg/auth/dcr/resolver.go
@@ -34,12 +34,12 @@
 // # Concurrency
 //
 // The package maintains a process-global singleflight keyed on the tuple
-// (issuer, redirectURI, scopesHash) so concurrent ResolveCredentials calls
-// across all consumers in a single process coalesce when their cache keys
-// match. Consumers that share any of those three values will share a flight
-// — the deduplication is a feature for the embedded authserver but means
-// callers cannot assume per-call-site flight isolation. See the dcrFlight
-// doc comment below for the rationale.
+// (issuer, upstreamID, redirectURI, scopesHash) so concurrent
+// ResolveCredentials calls across all consumers in a single process
+// coalesce when their cache keys match. Consumers that share all four
+// values will share a flight — the deduplication is a feature for the
+// embedded authserver but means callers cannot assume per-call-site flight
+// isolation. See the dcrFlight doc comment below for the rationale.
 //
 // See issue #5145 for the design discussion that motivated lifting this out
 // of pkg/authserver/runner.
@@ -88,8 +88,9 @@ import (
 //
 // Cross-consumer caveat: because dcrFlight is package-global, two
 // consumers that happen to construct identical Keys (same issuer, same
-// redirect URI, same scopes hash) will share a single in-flight
-// registration even if they semantically want different client profiles.
+// upstream ID, same redirect URI, same scopes hash) will share a single
+// in-flight registration even if they semantically want different client
+// profiles.
 // The two current call sites do not collide by construction — the embedded
 // authserver's redirect URI lives on the AS origin, and the CLI flow's
 // redirect URI lives on a loopback (http://localhost:{port}/callback per
@@ -104,12 +105,17 @@ var dcrFlight singleflight.Group
 
 // flightKeyOf canonicalises a Key into the singleflight string used by
 // dcrFlight. The "\n" separator is safe because newline is not a valid
-// byte in any of the three components: URI reference characters in
-// Issuer and RedirectURI (RFC 3986 §2), and hex digits in ScopesHash
+// byte in any of the four components: URI reference characters in Issuer,
+// UpstreamID, and RedirectURI (RFC 3986 §2), and hex digits in ScopesHash
 // (the form storage.ScopesHash always emits). Exposed as a function so
 // tests and future inspection helpers can compute the exact key the
 // resolver would route through dcrFlight without re-implementing the
 // concatenation.
+//
+// UpstreamID keeps two upstreams that share Issuer, RedirectURI, and
+// scopes from coalescing into a single flight (issue #5823) — the same
+// distinction the persisted DCRKey draws, so the singleflight and cache
+// layers stay aligned.
 //
 // PublicClient is intentionally NOT part of the flight key — the
 // dcrFlight doc above explains why: today's two consumers register on
@@ -119,7 +125,7 @@ var dcrFlight singleflight.Group
 // DCRKey from cross-profile coalescence; the two layers are aligned
 // rather than asymmetric.
 func flightKeyOf(key Key) string {
-	return key.Issuer + "\n" + key.RedirectURI + "\n" + key.ScopesHash
+	return key.Issuer + "\n" + key.UpstreamID + "\n" + key.RedirectURI + "\n" + key.ScopesHash
 }
 
 // defaultUpstreamRedirectPath is the redirect path derived from the issuer
@@ -235,6 +241,7 @@ type Resolution struct {
 const (
 	dcrStepValidate         = "validate"
 	dcrStepResolveRedirect  = "resolve_redirect_uri"
+	dcrStepResolveUpstream  = "resolve_upstream_id"
 	dcrStepCacheRead        = "cache_read"
 	dcrStepMetadata         = "metadata_discovery"
 	dcrStepSelectAuthMethod = "select_auth_method"
@@ -326,9 +333,19 @@ func ResolveCredentials(
 			fmt.Errorf("resolve redirect uri: %w", err))
 	}
 
+	// Identify the upstream authorization server so two upstreams that share
+	// req.Issuer, redirectURI, and scopes — the common case within a single
+	// embedded authserver — do not collide on one cache entry (issue #5823).
+	upstreamID, err := resolveUpstreamKeyIdentity(req)
+	if err != nil {
+		return nil, newDCRStepError(dcrStepResolveUpstream, req.Issuer, redirectURI,
+			fmt.Errorf("resolve upstream identity: %w", err))
+	}
+
 	scopes := slices.Clone(req.Scopes)
 	key := Key{
 		Issuer:      req.Issuer,
+		UpstreamID:  upstreamID,
 		RedirectURI: redirectURI,
 		ScopesHash:  storage.ScopesHash(scopes),
 	}
@@ -893,6 +910,34 @@ func resolveDCREndpoints(
 
 	metadata, err := oauthproto.FetchAuthorizationServerMetadataFromURL(ctx, req.DiscoveryURL, upstreamIssuer, nil)
 	return endpointsFromMetadata(metadata, err, upstreamIssuer)
+}
+
+// resolveUpstreamKeyIdentity returns the stable identifier for the upstream
+// authorization server a registration is bound to, used as the
+// Key.UpstreamID cache component. It disambiguates upstreams that share the
+// caller's Issuer, RedirectURI, and scope set — the common case inside a
+// single embedded authserver — so they receive distinct dynamically-
+// registered clients instead of colliding on one cache entry (issue #5823).
+//
+// The identity source mirrors resolveDCREndpoints' own branch order so the
+// key names the exact server the client registers against:
+//
+//   - RegistrationEndpoint set: the registration endpoint URL itself.
+//   - DiscoveryURL set: the upstream issuer recovered from the discovery URL
+//     via deriveExpectedIssuerFromDiscoveryURL — the same value used for
+//     RFC 8414 §3.3 metadata verification.
+//
+// validateResolveInputs guarantees exactly one of the two is set, so the
+// final return is only reached on the DiscoveryURL branch. The derivation is
+// pure URL parsing (no network I/O), so computing it before the cache lookup
+// keeps the cache-hit path free of I/O; a malformed DiscoveryURL that fails
+// here could never have produced a stored entry to hit anyway, because a
+// successful registration requires the same derivation to succeed first.
+func resolveUpstreamKeyIdentity(req *Request) (string, error) {
+	if req.RegistrationEndpoint != "" {
+		return req.RegistrationEndpoint, nil
+	}
+	return deriveExpectedIssuerFromDiscoveryURL(req.DiscoveryURL)
 }
 
 // deriveExpectedIssuerFromDiscoveryURL recovers the issuer identifier the

--- a/pkg/auth/dcr/resolver_test.go
+++ b/pkg/auth/dcr/resolver_test.go
@@ -307,6 +307,65 @@ func TestResolveDCRCredentials_DistinctUpstreamsSameScopesDoNotCollide(t *testin
 	assert.Equal(t, "client-b", cachedB.ClientID)
 }
 
+// TestResolveDCRCredentials_DistinctRegistrationEndpointsDoNotCollide covers
+// the RegistrationEndpoint branch of resolveUpstreamKeyIdentity: two upstreams
+// configured with explicit (distinct) registration endpoints but the same
+// caller Issuer, RedirectURI, and scopes must still register separately. The
+// UpstreamID is the registration endpoint URL on this branch.
+func TestResolveDCRCredentials_DistinctRegistrationEndpointsDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	var regCountA, regCountB int32
+	serverA := newDCRTestServer(t, dcrTestHandlerConfig{
+		clientID:            "client-a",
+		observeRegistration: func(*http.Request, []byte) { atomic.AddInt32(&regCountA, 1) },
+	})
+	serverB := newDCRTestServer(t, dcrTestHandlerConfig{
+		clientID:            "client-b",
+		observeRegistration: func(*http.Request, []byte) { atomic.AddInt32(&regCountB, 1) },
+	})
+
+	cache := newMemoryDCRStore(t)
+	const localIssuer = "https://authserver.example.com"
+	ctx := context.Background()
+	// The RegistrationEndpoint branch performs no discovery, so the caller
+	// must supply authorization/token endpoints explicitly.
+	reqFor := func(server *httptest.Server) *Request {
+		return &Request{
+			Issuer:                localIssuer,
+			Scopes:                []string{"openid", "profile"},
+			RegistrationEndpoint:  server.URL + "/register",
+			AuthorizationEndpoint: server.URL + "/authorize",
+			TokenEndpoint:         server.URL + "/token",
+		}
+	}
+
+	resA, err := ResolveCredentials(ctx, reqFor(serverA), cache)
+	require.NoError(t, err)
+	resB, err := ResolveCredentials(ctx, reqFor(serverB), cache)
+	require.NoError(t, err)
+
+	assert.Equal(t, "client-a", resA.ClientID)
+	assert.Equal(t, "client-b", resB.ClientID,
+		"second upstream must register with its own registration endpoint, not reuse the first's cached client (#5823)")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&regCountA), "upstream A must register exactly once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&regCountB),
+		"upstream B must register exactly once; a cache collision would leave this at zero")
+
+	// The two entries coexist under keys whose only differing component is
+	// UpstreamID (the registration endpoint URL).
+	redirectURI := localIssuer + "/oauth/callback"
+	scopesHash := storage.ScopesHash([]string{"openid", "profile"})
+	_, okA, err := cache.Get(ctx,
+		Key{Issuer: localIssuer, UpstreamID: serverA.URL + "/register", RedirectURI: redirectURI, ScopesHash: scopesHash})
+	require.NoError(t, err)
+	assert.True(t, okA, "upstream A entry must be keyed by its registration endpoint")
+	_, okB, err := cache.Get(ctx,
+		Key{Issuer: localIssuer, UpstreamID: serverB.URL + "/register", RedirectURI: redirectURI, ScopesHash: scopesHash})
+	require.NoError(t, err)
+	assert.True(t, okB, "upstream B entry must be keyed by its registration endpoint")
+}
+
 func TestResolveDCRCredentials_ExplicitEndpointsOverride(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/dcr/resolver_test.go
+++ b/pkg/auth/dcr/resolver_test.go
@@ -58,6 +58,11 @@ type dcrTestHandlerConfig struct {
 	// does not expire".
 	clientIDIssuedAt      int64
 	clientSecretExpiresAt int64
+
+	// clientID overrides the client_id returned by the registration
+	// endpoint. Defaults to "test-client-id". Distinct values let a test
+	// prove two upstreams received distinct dynamically-registered clients.
+	clientID string
 }
 
 // newDCRTestServer mounts RFC 8414 metadata and a DCR endpoint on a single
@@ -107,11 +112,15 @@ func newDCRTestServer(t *testing.T, cfg dcrTestHandlerConfig) *httptest.Server {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		clientID := cfg.clientID
+		if clientID == "" {
+			clientID = "test-client-id"
+		}
 		resp := oauthproto.DynamicClientRegistrationResponse{
-			ClientID:                "test-client-id",
+			ClientID:                clientID,
 			ClientSecret:            "test-client-secret",
 			RegistrationAccessToken: "test-reg-token",
-			RegistrationClientURI:   server.URL + "/register/test-client-id",
+			RegistrationClientURI:   server.URL + "/register/" + clientID,
 			TokenEndpointAuthMethod: req.TokenEndpointAuthMethod,
 			ClientIDIssuedAt:        cfg.clientIDIssuedAt,
 			ClientSecretExpiresAt:   cfg.clientSecretExpiresAt,
@@ -145,8 +154,12 @@ func TestResolveDCRCredentials_CacheHitShortCircuits(t *testing.T) {
 	// Pre-populate the cache with a resolution matching the key we will
 	// look up.
 	redirectURI := issuer + "/oauth/callback"
+	// UpstreamID is the upstream issuer the resolver derives from the
+	// DiscoveryURL below; for a well-known discovery URL that is the issuer
+	// origin itself. The preloaded key must match it for the cache to hit.
 	key := Key{
 		Issuer:      issuer,
+		UpstreamID:  issuer,
 		RedirectURI: redirectURI,
 		ScopesHash:  storage.ScopesHash([]string{"openid", "profile"}),
 	}
@@ -213,12 +226,85 @@ func TestResolveDCRCredentials_RegistersOnCacheMiss(t *testing.T) {
 	assert.Equal(t, []string{issuer + "/oauth/callback"}, dcrReq.RedirectURIs)
 	assert.ElementsMatch(t, []string{"openid", "profile"}, []string(dcrReq.Scopes))
 
-	// Cache was populated.
+	// Cache was populated. UpstreamID is the issuer origin the resolver
+	// derives from the oauth-authorization-server discovery URL.
 	cached, ok, err := cache.Get(context.Background(),
-		Key{Issuer: issuer, RedirectURI: issuer + "/oauth/callback", ScopesHash: storage.ScopesHash([]string{"openid", "profile"})})
+		Key{Issuer: issuer, UpstreamID: issuer, RedirectURI: issuer + "/oauth/callback", ScopesHash: storage.ScopesHash([]string{"openid", "profile"})})
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "test-client-id", cached.ClientID)
+}
+
+// TestResolveDCRCredentials_DistinctUpstreamsSameScopesDoNotCollide is the
+// regression test for issue #5823. Within one embedded authserver every
+// OAuth2 upstream shares the authserver's own Issuer and the single defaulted
+// {issuer}/oauth/callback RedirectURI, so the cache key differed only by the
+// scopes hash. Two upstreams configured with equal scopes therefore collided:
+// the second read back the first's dynamically-registered client and never
+// registered with its own authorization server. The UpstreamID key component
+// disambiguates them.
+func TestResolveDCRCredentials_DistinctUpstreamsSameScopesDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	var regCountA, regCountB int32
+	serverA := newDCRTestServer(t, dcrTestHandlerConfig{
+		clientID:                          "client-a",
+		tokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+		scopesSupported:                   []string{"openid", "profile"},
+		observeRegistration:               func(*http.Request, []byte) { atomic.AddInt32(&regCountA, 1) },
+	})
+	serverB := newDCRTestServer(t, dcrTestHandlerConfig{
+		clientID:                          "client-b",
+		tokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+		scopesSupported:                   []string{"openid", "profile"},
+		observeRegistration:               func(*http.Request, []byte) { atomic.AddInt32(&regCountB, 1) },
+	})
+
+	// One shared cache, one shared local issuer, one shared scope set — the
+	// embedded-authserver shape. Only the upstream (DiscoveryURL) differs.
+	cache := newMemoryDCRStore(t)
+	const localIssuer = "https://authserver.example.com"
+	ctx := context.Background()
+	reqFor := func(discoveryHost string) *Request {
+		return &Request{
+			Issuer:       localIssuer,
+			Scopes:       []string{"openid", "profile"},
+			DiscoveryURL: discoveryHost + "/.well-known/oauth-authorization-server",
+		}
+	}
+
+	resA, err := ResolveCredentials(ctx, reqFor(serverA.URL), cache)
+	require.NoError(t, err)
+	resB, err := ResolveCredentials(ctx, reqFor(serverB.URL), cache)
+	require.NoError(t, err)
+
+	// The crux: the second upstream registered with its OWN authorization
+	// server and received its own client, rather than reading back the
+	// first's cached credentials.
+	assert.Equal(t, "client-a", resA.ClientID)
+	assert.Equal(t, "client-b", resB.ClientID,
+		"second upstream must register with its own AS, not reuse the first's cached client (#5823)")
+	assert.Equal(t, serverA.URL+"/token", resA.TokenEndpoint)
+	assert.Equal(t, serverB.URL+"/token", resB.TokenEndpoint,
+		"second upstream's endpoints must come from its own AS metadata")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&regCountA), "upstream A must register exactly once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&regCountB),
+		"upstream B must register exactly once; a cache collision would leave this at zero")
+
+	// Both resolutions coexist in the cache under keys that differ only by
+	// UpstreamID (shared Issuer, RedirectURI, and scopes hash).
+	redirectURI := localIssuer + "/oauth/callback"
+	scopesHash := storage.ScopesHash([]string{"openid", "profile"})
+	cachedA, okA, err := cache.Get(ctx,
+		Key{Issuer: localIssuer, UpstreamID: serverA.URL, RedirectURI: redirectURI, ScopesHash: scopesHash})
+	require.NoError(t, err)
+	require.True(t, okA)
+	assert.Equal(t, "client-a", cachedA.ClientID)
+	cachedB, okB, err := cache.Get(ctx,
+		Key{Issuer: localIssuer, UpstreamID: serverB.URL, RedirectURI: redirectURI, ScopesHash: scopesHash})
+	require.NoError(t, err)
+	require.True(t, okB)
+	assert.Equal(t, "client-b", cachedB.ClientID)
 }
 
 func TestResolveDCRCredentials_ExplicitEndpointsOverride(t *testing.T) {

--- a/pkg/auth/dcr/resolver_test.go
+++ b/pkg/auth/dcr/resolver_test.go
@@ -1827,6 +1827,28 @@ func TestDcrStepError(t *testing.T) {
 		require.True(t, errors.As(err, &stepErr))
 		assert.Equal(t, dcrStepValidate, stepErr.Step)
 	})
+
+	t.Run("malformed DiscoveryURL fails at dcrStepResolveUpstream", func(t *testing.T) {
+		t.Parallel()
+
+		// A DiscoveryURL with no scheme/host passes validateResolveInputs
+		// (which only checks non-emptiness) and the Issuer-based redirect
+		// derivation, then fails in resolveUpstreamKeyIdentity —
+		// deriveExpectedIssuerFromDiscoveryURL rejects the missing origin.
+		// This is a new failure mode introduced with UpstreamID: a malformed
+		// DiscoveryURL now surfaces here rather than later in
+		// resolveDCREndpoints, so the step must be dcrStepResolveUpstream.
+		req := &Request{
+			Issuer:       "https://authserver.example.com",
+			Scopes:       []string{"openid"},
+			DiscoveryURL: "not-a-url",
+		}
+		_, err := ResolveCredentials(context.Background(), req, newMemoryDCRStore(t))
+		require.Error(t, err)
+		var stepErr *dcrStepError
+		require.True(t, errors.As(err, &stepErr))
+		assert.Equal(t, dcrStepResolveUpstream, stepErr.Step)
+	})
 }
 
 func TestSanitizeErrorForLog(t *testing.T) {

--- a/pkg/auth/dcr/resolver_test.go
+++ b/pkg/auth/dcr/resolver_test.go
@@ -307,6 +307,89 @@ func TestResolveDCRCredentials_DistinctUpstreamsSameScopesDoNotCollide(t *testin
 	assert.Equal(t, "client-b", cachedB.ClientID)
 }
 
+// TestResolveDCRCredentials_ConcurrentDistinctUpstreamsBothRegister guards the
+// singleflight (flight-key) split, complementing the sequential
+// TestResolveDCRCredentials_DistinctUpstreamsSameScopesDoNotCollide which only
+// proves the persistent cache-key split. Two upstreams that share the caller's
+// Issuer, RedirectURI, and scopes but differ by UpstreamID must not coalesce
+// into one dcrFlight — each must register with its own AS. A barrier in the
+// registration handlers forces both calls to be in-flight simultaneously, so a
+// flight-key collision would surface as one call becoming the other's follower
+// (its registration count staying at zero).
+func TestResolveDCRCredentials_ConcurrentDistinctUpstreamsBothRegister(t *testing.T) {
+	t.Parallel()
+
+	// Barrier: release both registration handlers only once both have been
+	// entered, forcing genuine in-flight overlap. The timeout keeps the test
+	// fail-fast — if the two calls coalesced there would be only one handler
+	// to enter, so the sole handler proceeds after the wait and the reg-count
+	// assertions below catch the collision instead of the test hanging.
+	var regCountA, regCountB, arrivals int32
+	bothArrived := make(chan struct{})
+	barrier := func() {
+		if atomic.AddInt32(&arrivals, 1) == 2 {
+			close(bothArrived)
+		}
+		select {
+		case <-bothArrived:
+		case <-time.After(3 * time.Second):
+		}
+	}
+
+	serverA := newDCRTestServer(t, dcrTestHandlerConfig{
+		clientID:                          "client-a",
+		tokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+		scopesSupported:                   []string{"openid", "profile"},
+		observeRegistration:               func(*http.Request, []byte) { atomic.AddInt32(&regCountA, 1); barrier() },
+	})
+	serverB := newDCRTestServer(t, dcrTestHandlerConfig{
+		clientID:                          "client-b",
+		tokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+		scopesSupported:                   []string{"openid", "profile"},
+		observeRegistration:               func(*http.Request, []byte) { atomic.AddInt32(&regCountB, 1); barrier() },
+	})
+
+	cache := newMemoryDCRStore(t)
+	const localIssuer = "https://authserver.example.com"
+	reqFor := func(discoveryHost string) *Request {
+		return &Request{
+			Issuer:       localIssuer,
+			Scopes:       []string{"openid", "profile"},
+			DiscoveryURL: discoveryHost + "/.well-known/oauth-authorization-server",
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	results := make([]*Resolution, 2)
+	errs := make([]error, 2)
+	go func() {
+		defer wg.Done()
+		results[0], errs[0] = ResolveCredentials(context.Background(), reqFor(serverA.URL), cache)
+	}()
+	go func() {
+		defer wg.Done()
+		results[1], errs[1] = ResolveCredentials(context.Background(), reqFor(serverB.URL), cache)
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for concurrent ResolveCredentials calls; possible flight-key deadlock")
+	}
+
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+	assert.Equal(t, "client-a", results[0].ClientID)
+	assert.Equal(t, "client-b", results[1].ClientID,
+		"each concurrent upstream must receive its own client, not the other flight's leader result")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&regCountA), "upstream A must register exactly once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&regCountB),
+		"upstream B must register exactly once; a flight-key collision would coalesce the two calls and leave this at zero")
+}
+
 // TestResolveDCRCredentials_DistinctRegistrationEndpointsDoNotCollide covers
 // the RegistrationEndpoint branch of resolveUpstreamKeyIdentity: two upstreams
 // configured with explicit (distinct) registration endpoints but the same

--- a/pkg/auth/dcr/store.go
+++ b/pkg/auth/dcr/store.go
@@ -30,8 +30,8 @@ const dcrStaleAgeThreshold = 90 * 24 * time.Hour
 type Key = storage.DCRKey
 
 // CredentialStore caches RFC 7591 Dynamic Client Registration resolutions
-// keyed by the (Issuer, RedirectURI, ScopesHash) tuple. Implementations must
-// be safe for concurrent use.
+// keyed by the (Issuer, UpstreamID, RedirectURI, ScopesHash) tuple.
+// Implementations must be safe for concurrent use.
 //
 // This is the runner-facing interface used by the DCR resolver. It is a
 // narrow re-projection of storage.DCRCredentialStore that exchanges

--- a/pkg/auth/dcr/store_test.go
+++ b/pkg/auth/dcr/store_test.go
@@ -25,6 +25,7 @@ func TestStorageBackedStore_PutGet_RoundTrip(t *testing.T) {
 
 	key := Key{
 		Issuer:      "https://idp.example.com",
+		UpstreamID:  "https://upstream.example.com",
 		RedirectURI: "https://toolhive.example.com/oauth/callback",
 		ScopesHash:  storage.ScopesHash([]string{"openid", "profile"}),
 	}
@@ -73,23 +74,37 @@ func TestStorageBackedStore_DistinctKeysDoNotCollide(t *testing.T) {
 
 	keyA := Key{
 		Issuer:      "https://idp-a.example.com",
+		UpstreamID:  "https://upstream-a.example.com",
 		RedirectURI: "https://toolhive.example.com/oauth/callback",
 		ScopesHash:  storage.ScopesHash([]string{"openid"}),
 	}
 	keyB := Key{
 		Issuer:      "https://idp-b.example.com",
+		UpstreamID:  "https://upstream-a.example.com",
 		RedirectURI: "https://toolhive.example.com/oauth/callback",
 		ScopesHash:  storage.ScopesHash([]string{"openid"}),
 	}
 	keyC := Key{
 		Issuer:      "https://idp-a.example.com",
+		UpstreamID:  "https://upstream-a.example.com",
 		RedirectURI: "https://other.example.com/callback",
 		ScopesHash:  storage.ScopesHash([]string{"openid"}),
 	}
 	keyD := Key{
 		Issuer:      "https://idp-a.example.com",
+		UpstreamID:  "https://upstream-a.example.com",
 		RedirectURI: "https://toolhive.example.com/oauth/callback",
 		ScopesHash:  storage.ScopesHash([]string{"openid", "email"}),
+	}
+	// keyE shares Issuer, RedirectURI, and scopes with keyA and differs only
+	// by UpstreamID — the exact shape of two OAuth2 upstreams inside one
+	// embedded authserver. Before UpstreamID was part of the key these two
+	// collided (issue #5823); keyE must resolve to its own entry.
+	keyE := Key{
+		Issuer:      "https://idp-a.example.com",
+		UpstreamID:  "https://upstream-b.example.com",
+		RedirectURI: "https://toolhive.example.com/oauth/callback",
+		ScopesHash:  storage.ScopesHash([]string{"openid"}),
 	}
 
 	// The persisted *storage.DCRCredentials shape requires non-empty
@@ -108,6 +123,7 @@ func TestStorageBackedStore_DistinctKeysDoNotCollide(t *testing.T) {
 	require.NoError(t, store.Put(ctx, keyB, resolution("b")))
 	require.NoError(t, store.Put(ctx, keyC, resolution("c")))
 	require.NoError(t, store.Put(ctx, keyD, resolution("d")))
+	require.NoError(t, store.Put(ctx, keyE, resolution("e")))
 
 	for _, tc := range []struct {
 		key      Key
@@ -117,6 +133,7 @@ func TestStorageBackedStore_DistinctKeysDoNotCollide(t *testing.T) {
 		{keyB, "b"},
 		{keyC, "c"},
 		{keyD, "d"},
+		{keyE, "e"},
 	} {
 		got, ok, err := store.Get(ctx, tc.key)
 		require.NoError(t, err)
@@ -133,6 +150,7 @@ func TestStorageBackedStore_Put_OverwritesExisting(t *testing.T) {
 
 	key := Key{
 		Issuer:      "https://idp.example.com",
+		UpstreamID:  "https://upstream.example.com",
 		RedirectURI: "https://x.example.com/cb",
 		ScopesHash:  storage.ScopesHash([]string{"openid"}),
 	}
@@ -189,6 +207,7 @@ func TestStorageBackedStore_GetReturnsDefensiveCopy(t *testing.T) {
 
 	key := Key{
 		Issuer:      "https://idp.example.com",
+		UpstreamID:  "https://upstream.example.com",
 		RedirectURI: "https://x.example.com/cb",
 		ScopesHash:  storage.ScopesHash([]string{"openid"}),
 	}
@@ -241,6 +260,7 @@ func TestStorageBackedStore_ConcurrentAccess(t *testing.T) {
 	overlappingKey := func(i int) Key {
 		return Key{
 			Issuer:      "https://idp.example.com",
+			UpstreamID:  "https://upstream.example.com",
 			RedirectURI: "https://thv.example.com/oauth/callback",
 			ScopesHash:  fmt.Sprintf("overlap-%d", i%4),
 		}
@@ -248,6 +268,7 @@ func TestStorageBackedStore_ConcurrentAccess(t *testing.T) {
 	disjointKey := func(worker, i int) Key {
 		return Key{
 			Issuer:      fmt.Sprintf("https://idp-%d.example.com", worker),
+			UpstreamID:  "https://upstream.example.com",
 			RedirectURI: "https://thv.example.com/oauth/callback",
 			ScopesHash:  fmt.Sprintf("disjoint-%d", i),
 		}
@@ -329,6 +350,7 @@ func TestResolutionCredentialsRoundTrip(t *testing.T) {
 
 	key := Key{
 		Issuer:      "https://idp.example.com",
+		UpstreamID:  "https://upstream.example.com",
 		RedirectURI: "https://thv.example.com/oauth/callback",
 		ScopesHash:  storage.ScopesHash([]string{"openid", "profile"}),
 	}
@@ -476,6 +498,7 @@ func TestInMemoryStore_PutGetCloseShareBackend(t *testing.T) {
 	ctx := context.Background()
 	key := Key{
 		Issuer:      "https://idp.example.com",
+		UpstreamID:  "https://upstream.example.com",
 		RedirectURI: "https://toolhive.example.com/oauth/callback",
 		ScopesHash:  storage.ScopesHash([]string{"openid"}),
 	}

--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -707,12 +707,14 @@ func resolveDCRCredentials(
 	// dcr.Request.Issuer carries the caller's logical scope for cache
 	// keying. The CLI flow has no separate logical issuer of its own, so
 	// it deliberately reuses the upstream's issuer URL here. This is
-	// safe because the resolver's cache key is (Issuer, RedirectURI,
-	// ScopesHash) and the CLI always supplies an explicit loopback
-	// RedirectURI per RFC 8252 §7.3 — even if a future embedded-authserver
-	// upstream happened to share Issuer with a CLI invocation, the
-	// distinct RedirectURI keeps the cache keys apart. See the Issuer
-	// field doc on dcr.Request for the wider semantics.
+	// safe because the resolver's cache key is (Issuer, UpstreamID,
+	// RedirectURI, ScopesHash) and the CLI always supplies an explicit
+	// loopback RedirectURI per RFC 8252 §7.3 — even if a future
+	// embedded-authserver upstream happened to share Issuer with a CLI
+	// invocation, the distinct RedirectURI keeps the cache keys apart.
+	// UpstreamID (derived by the resolver from the RegistrationEndpoint set
+	// below, or a DiscoveryURL) further distinguishes distinct upstreams.
+	// See the Issuer field doc on dcr.Request for the wider semantics.
 	req := &dcr.Request{
 		Issuer:                issuer,
 		RedirectURI:           redirectURI,

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -1640,6 +1640,7 @@ func TestBuildUpstreamConfigs_DCR(t *testing.T) {
 		redirectURI := server.URL + "/oauth/callback"
 		key := storage.DCRKey{
 			Issuer:      server.URL,
+			UpstreamID:  server.URL,
 			RedirectURI: redirectURI,
 			ScopesHash:  storage.ScopesHash([]string{"openid", "profile"}),
 		}
@@ -1781,6 +1782,7 @@ func TestNewEmbeddedAuthServer_DCRBoot(t *testing.T) {
 	redirectURI := server.URL + "/oauth/callback"
 	key := storage.DCRKey{
 		Issuer:      server.URL,
+		UpstreamID:  server.URL,
 		RedirectURI: redirectURI,
 		ScopesHash:  storage.ScopesHash([]string{"openid", "profile"}),
 	}
@@ -1961,6 +1963,7 @@ func TestEmbeddedAuthServer_DCRStorePersistsAcrossClose(t *testing.T) {
 	redirectURI := server.URL + "/oauth/callback"
 	key := storage.DCRKey{
 		Issuer:      server.URL,
+		UpstreamID:  server.URL,
 		RedirectURI: redirectURI,
 		ScopesHash:  storage.ScopesHash([]string{"openid", "profile"}),
 	}

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -1281,6 +1281,7 @@ func (s *MemoryStorage) GetDCRCredentials(_ context.Context, key DCRKey) (*DCRCr
 	if !ok {
 		slog.Debug("dcr credentials not found",
 			"issuer", key.Issuer,
+			"upstream_id", key.UpstreamID,
 			"redirect_uri", key.RedirectURI,
 		)
 		return nil, fmt.Errorf("%w: %w", ErrNotFound, fosite.ErrNotFound.WithHint("DCR credentials not found"))

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -1871,7 +1871,7 @@ func TestMemoryStorage_DCRCredentials_NotFound(t *testing.T) {
 
 // TestMemoryStorage_DCRCredentials_StoreInvalidInputRejected pins the
 // fail-loud-on-invalid-input contract: nil creds, an unpopulated Key
-// (empty Issuer, RedirectURI, or ScopesHash), and missing RFC 7591
+// (empty Issuer, UpstreamID, RedirectURI, or ScopesHash), and missing RFC 7591
 // mandatory response fields (ClientID, AuthorizationEndpoint,
 // TokenEndpoint) must be rejected with fosite.ErrInvalidRequest rather
 // than producing a working-looking write that fails downstream at the

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -1766,6 +1766,7 @@ func TestMemoryStorage_DCRCredentials_RoundTrip(t *testing.T) {
 	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 		key := DCRKey{
 			Issuer:      "https://thv.example.com",
+			UpstreamID:  "https://idp.example.com",
 			RedirectURI: "https://thv.example.com/oauth/callback",
 			ScopesHash:  ScopesHash([]string{"openid", "profile"}),
 		}
@@ -1796,9 +1797,10 @@ func TestMemoryStorage_DCRCredentials_RoundTrip(t *testing.T) {
 
 func TestMemoryStorage_DCRCredentials_DistinctKeysDoNotCollide(t *testing.T) {
 	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
-		mkKey := func(issuer, redirect string, scopes []string) DCRKey {
+		mkKey := func(issuer, upstreamID, redirect string, scopes []string) DCRKey {
 			return DCRKey{
 				Issuer:      issuer,
+				UpstreamID:  upstreamID,
 				RedirectURI: redirect,
 				ScopesHash:  ScopesHash(scopes),
 			}
@@ -1812,10 +1814,14 @@ func TestMemoryStorage_DCRCredentials_DistinctKeysDoNotCollide(t *testing.T) {
 			}
 		}
 		entries := []*DCRCredentials{
-			mkCreds(mkKey("https://idp-a.example.com", "https://x/cb", []string{"openid"}), "a"),
-			mkCreds(mkKey("https://idp-b.example.com", "https://x/cb", []string{"openid"}), "b"),
-			mkCreds(mkKey("https://idp-a.example.com", "https://y/cb", []string{"openid"}), "c"),
-			mkCreds(mkKey("https://idp-a.example.com", "https://x/cb", []string{"openid", "email"}), "d"),
+			mkCreds(mkKey("https://idp-a.example.com", "https://up-a", "https://x/cb", []string{"openid"}), "a"),
+			mkCreds(mkKey("https://idp-b.example.com", "https://up-a", "https://x/cb", []string{"openid"}), "b"),
+			mkCreds(mkKey("https://idp-a.example.com", "https://up-a", "https://y/cb", []string{"openid"}), "c"),
+			mkCreds(mkKey("https://idp-a.example.com", "https://up-a", "https://x/cb", []string{"openid", "email"}), "d"),
+			// Differs from entry "a" only by UpstreamID — two OAuth2 upstreams
+			// inside one embedded authserver sharing issuer, redirect, and
+			// scopes. Before UpstreamID joined the key these collided (#5823).
+			mkCreds(mkKey("https://idp-a.example.com", "https://up-b", "https://x/cb", []string{"openid"}), "e"),
 		}
 		for _, e := range entries {
 			require.NoError(t, s.StoreDCRCredentials(ctx, e))
@@ -1834,6 +1840,7 @@ func TestMemoryStorage_DCRCredentials_OverwriteSemantics(t *testing.T) {
 	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 		key := DCRKey{
 			Issuer:      "https://idp.example.com",
+			UpstreamID:  "https://upstream.example.com",
 			RedirectURI: "https://x/cb",
 			ScopesHash:  ScopesHash([]string{"openid"}),
 		}
@@ -1879,6 +1886,7 @@ func TestMemoryStorage_DCRCredentials_StoreInvalidInputRejected(t *testing.T) {
 		return &DCRCredentials{
 			Key: DCRKey{
 				Issuer:      "https://idp.example.com",
+				UpstreamID:  "https://upstream.example.com",
 				RedirectURI: "https://x/cb",
 				ScopesHash:  ScopesHash([]string{"openid"}),
 			},
@@ -1900,6 +1908,13 @@ func TestMemoryStorage_DCRCredentials_StoreInvalidInputRejected(t *testing.T) {
 			name: "empty issuer",
 			mutator: func(c *DCRCredentials) *DCRCredentials {
 				c.Key.Issuer = ""
+				return c
+			},
+		},
+		{
+			name: "empty upstream_id",
+			mutator: func(c *DCRCredentials) *DCRCredentials {
+				c.Key.UpstreamID = ""
 				return c
 			},
 		},
@@ -1961,6 +1976,7 @@ func TestMemoryStorage_DCRCredentials_GetReturnsDefensiveCopy(t *testing.T) {
 	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 		key := DCRKey{
 			Issuer:      "https://idp.example.com",
+			UpstreamID:  "https://upstream.example.com",
 			RedirectURI: "https://x/cb",
 			ScopesHash:  ScopesHash([]string{"openid"}),
 		}
@@ -1988,6 +2004,7 @@ func TestMemoryStorage_DCRCredentials_StoreCopyIsolatesCaller(t *testing.T) {
 	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 		key := DCRKey{
 			Issuer:      "https://idp.example.com",
+			UpstreamID:  "https://upstream.example.com",
 			RedirectURI: "https://x/cb",
 			ScopesHash:  ScopesHash([]string{"openid"}),
 		}
@@ -2015,6 +2032,7 @@ func TestMemoryStorage_DCRCredentials_ExcludedFromCleanupExpired(t *testing.T) {
 	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 		key := DCRKey{
 			Issuer:      "https://idp.example.com",
+			UpstreamID:  "https://upstream.example.com",
 			RedirectURI: "https://x/cb",
 			ScopesHash:  ScopesHash([]string{"openid"}),
 		}
@@ -2057,6 +2075,7 @@ func TestMemoryStorage_DCRCredentials_ConcurrentAccess(t *testing.T) {
 		overlappingKey := func(i int) DCRKey {
 			return DCRKey{
 				Issuer:      "https://idp.example.com",
+				UpstreamID:  "https://upstream.example.com",
 				RedirectURI: "https://thv.example.com/oauth/callback",
 				ScopesHash:  fmt.Sprintf("overlap-%d", i%4),
 			}
@@ -2064,6 +2083,7 @@ func TestMemoryStorage_DCRCredentials_ConcurrentAccess(t *testing.T) {
 		disjointKey := func(worker, i int) DCRKey {
 			return DCRKey{
 				Issuer:      fmt.Sprintf("https://idp-%d.example.com", worker),
+				UpstreamID:  "https://upstream.example.com",
 				RedirectURI: "https://thv.example.com/oauth/callback",
 				ScopesHash:  fmt.Sprintf("disjoint-%d", i),
 			}

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1378,7 +1378,7 @@ func (s *RedisStorage) StoreDCRCredentials(ctx context.Context, creds *DCRCreden
 // Returns ErrNotFound (wrapped) when no entry exists. The returned value is a
 // fresh struct decoded from JSON, which acts as a defensive copy.
 //
-// An unpopulated key (empty Issuer, RedirectURI, or ScopesHash) cannot match
+// An unpopulated key (empty Issuer, UpstreamID, RedirectURI, or ScopesHash) cannot match
 // any stored row because StoreDCRCredentials rejects such keys, so a Get
 // against one is a normal miss — ErrNotFound — matching
 // MemoryStorage.GetDCRCredentials and the DCRCredentialStore interface contract.

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1246,6 +1246,7 @@ type storedDCRCredentials struct {
 	// Embed the canonical key so a row recovered without its lookup key
 	// (e.g. via SCAN during diagnostics) still self-identifies.
 	KeyIssuer      string `json:"key_issuer"`
+	KeyUpstreamID  string `json:"key_upstream_id"`
 	KeyRedirectURI string `json:"key_redirect_uri"`
 	KeyScopesHash  string `json:"key_scopes_hash"`
 
@@ -1282,6 +1283,7 @@ func (s *storedDCRCredentials) toDCRCredentials() *DCRCredentials {
 	return &DCRCredentials{
 		Key: DCRKey{
 			Issuer:      s.KeyIssuer,
+			UpstreamID:  s.KeyUpstreamID,
 			RedirectURI: s.KeyRedirectURI,
 			ScopesHash:  s.KeyScopesHash,
 		},
@@ -1328,6 +1330,7 @@ func (s *RedisStorage) StoreDCRCredentials(ctx context.Context, creds *DCRCreden
 
 	stored := storedDCRCredentials{
 		KeyIssuer:               creds.Key.Issuer,
+		KeyUpstreamID:           creds.Key.UpstreamID,
 		KeyRedirectURI:          creds.Key.RedirectURI,
 		KeyScopesHash:           creds.Key.ScopesHash,
 		ProviderName:            creds.ProviderName,

--- a/pkg/authserver/storage/redis_integration_test.go
+++ b/pkg/authserver/storage/redis_integration_test.go
@@ -1462,8 +1462,8 @@ func TestIntegration_DCRCredentials_RoundTrip(t *testing.T) {
 
 func TestIntegration_DCRCredentials_DistinctKeysCoexist(t *testing.T) {
 	withIntegrationStorage(t, func(ctx context.Context, s *RedisStorage) {
-		mkKey := func(issuer, redirect string, scopes []string) DCRKey {
-			return DCRKey{Issuer: issuer, RedirectURI: redirect, ScopesHash: ScopesHash(scopes)}
+		mkKey := func(issuer, upstreamID, redirect string, scopes []string) DCRKey {
+			return DCRKey{Issuer: issuer, UpstreamID: upstreamID, RedirectURI: redirect, ScopesHash: ScopesHash(scopes)}
 		}
 		mk := func(key DCRKey, clientID string) *DCRCredentials {
 			return &DCRCredentials{
@@ -1474,10 +1474,13 @@ func TestIntegration_DCRCredentials_DistinctKeysCoexist(t *testing.T) {
 			}
 		}
 		entries := []*DCRCredentials{
-			mk(mkKey("https://idp-a.example.com", "https://x/cb", []string{"openid"}), "a"),
-			mk(mkKey("https://idp-b.example.com", "https://x/cb", []string{"openid"}), "b"),
-			mk(mkKey("https://idp-a.example.com", "https://y/cb", []string{"openid"}), "c"),
-			mk(mkKey("https://idp-a.example.com", "https://x/cb", []string{"openid", "email"}), "d"),
+			mk(mkKey("https://idp-a.example.com", "https://up-a", "https://x/cb", []string{"openid"}), "a"),
+			mk(mkKey("https://idp-b.example.com", "https://up-a", "https://x/cb", []string{"openid"}), "b"),
+			mk(mkKey("https://idp-a.example.com", "https://up-a", "https://y/cb", []string{"openid"}), "c"),
+			mk(mkKey("https://idp-a.example.com", "https://up-a", "https://x/cb", []string{"openid", "email"}), "d"),
+			// Differs from entry "a" only by UpstreamID — the two-upstreams-in-
+			// one-authserver shape that collided before #5823.
+			mk(mkKey("https://idp-a.example.com", "https://up-b", "https://x/cb", []string{"openid"}), "e"),
 		}
 		for _, e := range entries {
 			require.NoError(t, s.StoreDCRCredentials(ctx, e))

--- a/pkg/authserver/storage/redis_keys.go
+++ b/pkg/authserver/storage/redis_keys.go
@@ -95,19 +95,26 @@ func redisProviderKey(prefix, providerID, providerSubject string) string {
 }
 
 // redisDCRKey generates a Redis key for a DCR credential entry, identifying the
-// (Issuer, RedirectURI, ScopesHash) tuple that DCRKey canonicalises.
+// (Issuer, UpstreamID, RedirectURI, ScopesHash) tuple that DCRKey canonicalises.
 //
-// Format: "{prefix}dcr:<len(issuer)>:<issuer>:<len(redirect_uri)>:<redirect_uri>:<scopes_hash>"
+// Format: "{prefix}dcr:<len(issuer)>:<issuer>:<len(upstream_id)>:<upstream_id>:<len(redirect_uri)>:<redirect_uri>:<scopes_hash>"
 //
-// The first two segments are length-prefixed to handle colons in RedirectURI
-// (and, for symmetry, Issuer) without ambiguity, mirroring redisProviderKey.
-// ScopesHash is expected to be a SHA-256 hex digest produced by
-// storage.ScopesHash — only [0-9a-f] and never colon-bearing — so it is
+// The first three segments are length-prefixed to handle colons in UpstreamID
+// and RedirectURI (and, for symmetry, Issuer) without ambiguity, mirroring
+// redisProviderKey. ScopesHash is expected to be a SHA-256 hex digest produced
+// by storage.ScopesHash — only [0-9a-f] and never colon-bearing — so it is
 // appended without a length prefix. The format is robust for that domain;
 // validateDCRCredentialsForStore (called by every Store path) already
 // rejects an empty ScopesHash, and callers are required to compute the hash
 // via storage.ScopesHash. Length-prefix collision-safety is preserved on
 // the leading segments either way.
+//
+// The UpstreamID segment (issue #5823) means two upstreams that share the
+// consumer's Issuer and RedirectURI but differ only by their authorization
+// server no longer map to the same Redis key. Adding it changes the key
+// format, so entries written by an older binary (without the segment) will
+// miss on lookup and be harmlessly re-registered under the new key; the
+// stale rows expire via their existing TTL or can be cleared manually.
 //
 // The public-vs-confidential client distinction is intentionally NOT
 // encoded here — see DCRKey's doc for the rationale. Today's two consumers
@@ -117,9 +124,10 @@ func redisProviderKey(prefix, providerID, providerSubject string) string {
 // add the distinguishing component back to the key format alongside an
 // explicit migration story for existing Redis-cached entries.
 func redisDCRKey(prefix string, key DCRKey) string {
-	return fmt.Sprintf("%s%s:%d:%s:%d:%s:%s",
+	return fmt.Sprintf("%s%s:%d:%s:%d:%s:%d:%s:%s",
 		prefix, KeyTypeDCR,
 		len(key.Issuer), key.Issuer,
+		len(key.UpstreamID), key.UpstreamID,
 		len(key.RedirectURI), key.RedirectURI,
 		key.ScopesHash)
 }

--- a/pkg/authserver/storage/redis_keys.go
+++ b/pkg/authserver/storage/redis_keys.go
@@ -113,8 +113,12 @@ func redisProviderKey(prefix, providerID, providerSubject string) string {
 // consumer's Issuer and RedirectURI but differ only by their authorization
 // server no longer map to the same Redis key. Adding it changes the key
 // format, so entries written by an older binary (without the segment) will
-// miss on lookup and be harmlessly re-registered under the new key; the
-// stale rows expire via their existing TTL or can be cleared manually.
+// miss on lookup and be harmlessly re-registered under the new key. Orphaned
+// old rows self-evict only when the upstream asserted an RFC 7591 §3.2.1
+// client_secret_expires_at (StoreDCRCredentials sets a matching Redis TTL for
+// those); entries for non-expiring secrets — the common §3.2.1 "never" case —
+// carry no TTL and persist indefinitely, so they require manual cleanup.
+// There is no automated one-shot migration for this key-format change today.
 //
 // The public-vs-confidential client distinction is intentionally NOT
 // encoded here — see DCRKey's doc for the rationale. Today's two consumers

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -2039,12 +2039,14 @@ func TestRedisKeyGeneration(t *testing.T) {
 		t.Parallel()
 		result := redisDCRKey("test:auth:", DCRKey{
 			Issuer:      "https://thv.example.com",
+			UpstreamID:  "https://idp.example.com",
 			RedirectURI: "https://thv.example.com/oauth/callback",
 			ScopesHash:  "abc123",
 		})
-		// 23 = len("https://thv.example.com"), 38 = len("https://thv.example.com/oauth/callback")
+		// 23 = len("https://thv.example.com"), 23 = len("https://idp.example.com"),
+		// 38 = len("https://thv.example.com/oauth/callback")
 		assert.Equal(t,
-			"test:auth:dcr:23:https://thv.example.com:38:https://thv.example.com/oauth/callback:abc123",
+			"test:auth:dcr:23:https://thv.example.com:23:https://idp.example.com:38:https://thv.example.com/oauth/callback:abc123",
 			result)
 	})
 }
@@ -2057,8 +2059,8 @@ func TestRedisKeyGeneration(t *testing.T) {
 func TestRedisDCRKey_Distinct(t *testing.T) {
 	t.Parallel()
 
-	mk := func(issuer, redirect, scopes string) DCRKey {
-		return DCRKey{Issuer: issuer, RedirectURI: redirect, ScopesHash: scopes}
+	mk := func(issuer, upstreamID, redirect, scopes string) DCRKey {
+		return DCRKey{Issuer: issuer, UpstreamID: upstreamID, RedirectURI: redirect, ScopesHash: scopes}
 	}
 
 	tests := []struct {
@@ -2067,33 +2069,48 @@ func TestRedisDCRKey_Distinct(t *testing.T) {
 	}{
 		{
 			name: "different issuer",
-			a:    mk("https://idp-a.example.com", "https://x/cb", "h1"),
-			b:    mk("https://idp-b.example.com", "https://x/cb", "h1"),
+			a:    mk("https://idp-a.example.com", "https://up", "https://x/cb", "h1"),
+			b:    mk("https://idp-b.example.com", "https://up", "https://x/cb", "h1"),
+		},
+		{
+			// Two upstreams that share the consumer's issuer, redirect, and
+			// scopes and differ only by upstream — the #5823 shape.
+			name: "different upstream_id",
+			a:    mk("https://idp.example.com", "https://up-a", "https://x/cb", "h1"),
+			b:    mk("https://idp.example.com", "https://up-b", "https://x/cb", "h1"),
 		},
 		{
 			name: "different redirect_uri",
-			a:    mk("https://idp.example.com", "https://x/cb", "h1"),
-			b:    mk("https://idp.example.com", "https://y/cb", "h1"),
+			a:    mk("https://idp.example.com", "https://up", "https://x/cb", "h1"),
+			b:    mk("https://idp.example.com", "https://up", "https://y/cb", "h1"),
 		},
 		{
 			name: "different scopes hash",
-			a:    mk("https://idp.example.com", "https://x/cb", "h1"),
-			b:    mk("https://idp.example.com", "https://x/cb", "h2"),
+			a:    mk("https://idp.example.com", "https://up", "https://x/cb", "h1"),
+			b:    mk("https://idp.example.com", "https://up", "https://x/cb", "h2"),
 		},
 		{
 			// Without length prefixing, ("ab", "cd") and ("a", "bcd") would
 			// both yield ":ab:cd:" as the issuer/redirect segment after a
 			// fmt.Sprintf collapse. The length prefix prevents that.
 			name: "redirect_uri-issuer boundary collision (length-prefix property)",
-			a:    mk("ab", "cd", "h1"),
-			b:    mk("a", "bcd", "h1"),
+			a:    mk("ab", "up", "cd", "h1"),
+			b:    mk("a", "up", "bcd", "h1"),
+		},
+		{
+			// UpstreamID legitimately contains colons and can abut the issuer
+			// boundary; the length prefix keeps ("ab","cd") and ("a","bcd")
+			// distinct across the issuer/upstream seam too.
+			name: "issuer-upstream_id boundary collision (length-prefix property)",
+			a:    mk("ab", "cd", "https://x/cb", "h1"),
+			b:    mk("a", "bcd", "https://x/cb", "h1"),
 		},
 		{
 			// RedirectURI legitimately contains colons (e.g. ":443"). A plain
 			// "%s:%s:%s" key would be ambiguous; the length prefix is not.
 			name: "colons inside redirect_uri",
-			a:    mk("https://idp.example.com", "https://x.example.com:443/cb", "h1"),
-			b:    mk("https://idp.example.com", "https://x.example.com/cb:443", "h1"),
+			a:    mk("https://idp.example.com", "https://up", "https://x.example.com:443/cb", "h1"),
+			b:    mk("https://idp.example.com", "https://up", "https://x.example.com/cb:443", "h1"),
 		},
 	}
 
@@ -2115,6 +2132,7 @@ func TestRedisDCRKey_Deterministic(t *testing.T) {
 
 	key := DCRKey{
 		Issuer:      "https://idp.example.com",
+		UpstreamID:  "https://upstream.example.com",
 		RedirectURI: "https://thv.example.com/oauth/callback",
 		ScopesHash:  ScopesHash([]string{"openid", "profile", "email"}),
 	}
@@ -2362,6 +2380,7 @@ func TestRedisStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
 func dcrFixtureKey() DCRKey {
 	return DCRKey{
 		Issuer:      "https://thv.example.com",
+		UpstreamID:  "https://idp.example.com",
 		RedirectURI: "https://thv.example.com/oauth/callback",
 		ScopesHash:  ScopesHash([]string{"openid", "profile"}),
 	}
@@ -2461,8 +2480,8 @@ func TestRedisStorage_DCRCredentials_NotFound(t *testing.T) {
 
 func TestRedisStorage_DCRCredentials_DistinctKeysCoexist(t *testing.T) {
 	withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
-		mkKey := func(issuer, redirect string, scopes []string) DCRKey {
-			return DCRKey{Issuer: issuer, RedirectURI: redirect, ScopesHash: ScopesHash(scopes)}
+		mkKey := func(issuer, upstreamID, redirect string, scopes []string) DCRKey {
+			return DCRKey{Issuer: issuer, UpstreamID: upstreamID, RedirectURI: redirect, ScopesHash: ScopesHash(scopes)}
 		}
 		mk := func(key DCRKey, clientID string) *DCRCredentials {
 			return &DCRCredentials{
@@ -2473,10 +2492,13 @@ func TestRedisStorage_DCRCredentials_DistinctKeysCoexist(t *testing.T) {
 			}
 		}
 		entries := []*DCRCredentials{
-			mk(mkKey("https://idp-a.example.com", "https://x/cb", []string{"openid"}), "a"),
-			mk(mkKey("https://idp-b.example.com", "https://x/cb", []string{"openid"}), "b"),
-			mk(mkKey("https://idp-a.example.com", "https://y/cb", []string{"openid"}), "c"),
-			mk(mkKey("https://idp-a.example.com", "https://x/cb", []string{"openid", "email"}), "d"),
+			mk(mkKey("https://idp-a.example.com", "https://up-a", "https://x/cb", []string{"openid"}), "a"),
+			mk(mkKey("https://idp-b.example.com", "https://up-a", "https://x/cb", []string{"openid"}), "b"),
+			mk(mkKey("https://idp-a.example.com", "https://up-a", "https://y/cb", []string{"openid"}), "c"),
+			mk(mkKey("https://idp-a.example.com", "https://up-a", "https://x/cb", []string{"openid", "email"}), "d"),
+			// Differs from entry "a" only by UpstreamID — the two-upstreams-in-
+			// one-authserver shape that collided before #5823.
+			mk(mkKey("https://idp-a.example.com", "https://up-b", "https://x/cb", []string{"openid"}), "e"),
 		}
 		for _, e := range entries {
 			require.NoError(t, s.StoreDCRCredentials(ctx, e))
@@ -2505,6 +2527,7 @@ func TestRedisStorage_DCRCredentials_StoreInvalidInputRejected(t *testing.T) {
 		return &DCRCredentials{
 			Key: DCRKey{
 				Issuer:      "https://idp.example.com",
+				UpstreamID:  "https://upstream.example.com",
 				RedirectURI: "https://x/cb",
 				ScopesHash:  ScopesHash([]string{"openid"}),
 			},
@@ -2526,6 +2549,13 @@ func TestRedisStorage_DCRCredentials_StoreInvalidInputRejected(t *testing.T) {
 			name: "empty issuer",
 			mutator: func(c *DCRCredentials) *DCRCredentials {
 				c.Key.Issuer = ""
+				return c
+			},
+		},
+		{
+			name: "empty upstream_id",
+			mutator: func(c *DCRCredentials) *DCRCredentials {
+				c.Key.UpstreamID = ""
 				return c
 			},
 		},
@@ -2748,6 +2778,7 @@ func runDCRConcurrentAccess(
 		case dcrConcurrentDisjointKeys:
 			return DCRKey{
 				Issuer:      fmt.Sprintf("https://idp-%d.example.com", gid),
+				UpstreamID:  "https://upstream.example.com",
 				RedirectURI: "https://x/cb",
 				ScopesHash:  ScopesHash([]string{"openid"}),
 			}

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -2106,6 +2106,14 @@ func TestRedisDCRKey_Distinct(t *testing.T) {
 			b:    mk("a", "bcd", "https://x/cb", "h1"),
 		},
 		{
+			// UpstreamID also abuts RedirectURI; the length prefix must keep
+			// ("ab","cd") and ("a","bcd") distinct across the second new seam
+			// introduced by inserting UpstreamID between Issuer and RedirectURI.
+			name: "upstream_id-redirect_uri boundary collision (length-prefix property)",
+			a:    mk("https://idp.example.com", "ab", "cd", "h1"),
+			b:    mk("https://idp.example.com", "a", "bcd", "h1"),
+		},
+		{
 			// RedirectURI legitimately contains colons (e.g. ":443"). A plain
 			// "%s:%s:%s" key would be ambiguous; the length prefix is not.
 			name: "colons inside redirect_uri",

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -161,6 +161,14 @@ type DCRKey struct {
 	// endpoint URL when the consumer configured one directly. It is derived
 	// by the dcr resolver from the Request; do not hand-build it at call
 	// sites.
+	//
+	// On the discovery-URL path this is the derived issuer, so it identifies
+	// the authorization server rather than the exact discovery URL: two
+	// configs that resolve to the same issuer intentionally share one
+	// registration. It does not fully disambiguate the nonstandard case of a
+	// single issuer exposing distinct registration endpoints under custom
+	// (non-well-known) discovery paths — see resolveUpstreamKeyIdentity in
+	// pkg/auth/dcr for the full rationale.
 	UpstreamID string
 
 	// RedirectURI is the redirect URI registered with the upstream

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -130,9 +130,9 @@ type DCRKey struct {
 	//     issuer, because the CLI has no separate local issuer of its own.
 	// The cache is keyed by this value because two different consumers
 	// registering against the same upstream are distinct OAuth clients and
-	// must not share credentials. The (Issuer, RedirectURI, ScopesHash)
-	// tuple keeps the two consumer profiles' entries apart via the
-	// RedirectURI component (the embedded authserver registers an
+	// must not share credentials. The (Issuer, UpstreamID, RedirectURI,
+	// ScopesHash) tuple keeps the two consumer profiles' entries apart via
+	// the RedirectURI component (the embedded authserver registers an
 	// AS-origin callback while the CLI registers a loopback callback per
 	// RFC 8252 §7.3 — the two address spaces are disjoint), so a collision
 	// between profiles is impossible by construction even when the
@@ -145,6 +145,23 @@ type DCRKey struct {
 	// format must gain a consumer-identifier component alongside an
 	// explicit migration story.
 	Issuer string
+
+	// UpstreamID identifies the upstream authorization server this
+	// registration is bound to, disambiguating upstreams that share the
+	// consumer's Issuer, RedirectURI, and scope set. Within a single
+	// embedded authserver every OAuth2 upstream shares the authserver's own
+	// Issuer and the one defaulted {issuer}/oauth/callback RedirectURI, so
+	// before this component existed two upstreams configured with equal
+	// scopes collided on one cache entry — the second read back the first's
+	// dynamically-registered client_id / client_secret and never registered
+	// with its own authorization server (issue #5823).
+	//
+	// The value is the upstream's registration identity: the upstream issuer
+	// recovered from the consumer's discovery URL, or the registration
+	// endpoint URL when the consumer configured one directly. It is derived
+	// by the dcr resolver from the Request; do not hand-build it at call
+	// sites.
+	UpstreamID string
 
 	// RedirectURI is the redirect URI registered with the upstream
 	// authorization server. Embedded-authserver callers register an
@@ -198,19 +215,25 @@ func ScopesHash(scopes []string) string {
 // from drifting across implementations: a record that fails loud against one
 // backend cannot silently persist against another.
 //
-// Rejected inputs: nil creds, an unpopulated Key (empty Issuer, RedirectURI,
-// or ScopesHash), and missing RFC 7591 mandatory response fields (ClientID,
-// AuthorizationEndpoint, TokenEndpoint). An empty ScopesHash is rejected
-// because the canonical digest of any scope set — including the empty-scope
-// set via ScopesHash(nil) — is non-empty, so an empty string can only be a
-// caller bug. ClientSecret is left permissive because RFC 7591 §2 public
-// clients (auth method "none") legitimately register without a secret.
+// Rejected inputs: nil creds, an unpopulated Key (empty Issuer, UpstreamID,
+// RedirectURI, or ScopesHash), and missing RFC 7591 mandatory response fields
+// (ClientID, AuthorizationEndpoint, TokenEndpoint). An empty ScopesHash is
+// rejected because the canonical digest of any scope set — including the
+// empty-scope set via ScopesHash(nil) — is non-empty, so an empty string can
+// only be a caller bug. An empty UpstreamID is rejected because the resolver
+// always derives it from the Request (issue #5823); an empty value here would
+// re-open the cross-upstream collision it was added to close. ClientSecret is
+// left permissive because RFC 7591 §2 public clients (auth method "none")
+// legitimately register without a secret.
 func validateDCRCredentialsForStore(creds *DCRCredentials) error {
 	if creds == nil {
 		return fosite.ErrInvalidRequest.WithHint("dcr credentials cannot be nil")
 	}
 	if creds.Key.Issuer == "" {
 		return fosite.ErrInvalidRequest.WithHint("dcr credentials key issuer cannot be empty")
+	}
+	if creds.Key.UpstreamID == "" {
+		return fosite.ErrInvalidRequest.WithHint("dcr credentials key upstream_id cannot be empty")
 	}
 	if creds.Key.RedirectURI == "" {
 		return fosite.ErrInvalidRequest.WithHint("dcr credentials key redirect_uri cannot be empty")
@@ -263,7 +286,7 @@ func validateDCRCredentialsForStore(creds *DCRCredentials) error {
 // TestResolutionCredentialsRoundTrip in
 // pkg/auth/dcr/store_test.go.
 type DCRCredentials struct {
-	// Key is the canonical cache key: (Issuer, RedirectURI, ScopesHash).
+	// Key is the canonical cache key: (Issuer, UpstreamID, RedirectURI, ScopesHash).
 	Key DCRKey
 
 	// ProviderName is the upstream's UpstreamRunConfig.Name. Debug / audit
@@ -340,7 +363,7 @@ type DCRCredentials struct {
 // DCRKey is embedded as DCRCredentials.Key so the persisted blob is
 // self-describing: a Redis SCAN, an admin-tool dump, or a cross-replica
 // reconciliation path can identify a record's logical cache slot
-// (Issuer, RedirectURI, ScopesHash) from the value alone, without
+// (Issuer, UpstreamID, RedirectURI, ScopesHash) from the value alone, without
 // reconstructing it from a separately-passed key. This is a deliberate
 // asymmetry with the rest of the package — callers must populate creds.Key
 // before Store, and implementations validate it (see MemoryStorage docs


### PR DESCRIPTION
## Summary

In a multi-upstream embedded authserver, the upstream-DCR (RFC 7591 Dynamic
Client Registration) credential cache key did not include the upstream's
identity. Every OAuth2 upstream inside one embedded authserver shares the
authserver's own `Issuer` and the single defaulted `{issuer}/oauth/callback`
`RedirectURI`, so the only key component that could differ was the scopes
hash. Two upstreams configured with the same scopes therefore mapped to one
cache entry: the second upstream short-circuited on the cache hit, read back
the `client_id` / `client_secret` that were dynamically registered against the
**first** upstream's authorization server, and never registered with its own.
The failure was silent — the cache hit was treated as success — and surfaced
as wrong client credentials (failed authorization or an identity belonging to
a different AS) on every same-scope upstream after the first (issue #5823).

This PR adds an `UpstreamID` component to the DCR cache key so each distinct
upstream authorization server gets its own dynamically registered client.

- **Why:** disambiguate upstreams that share the caller's issuer, redirect
  URI, and scope set — the common case within one embedded authserver — so
  they no longer collide on a single cache entry.
- **What:** added `UpstreamID` to `storage.DCRKey` and threaded it through the
  cache key, the process-global singleflight key, the Redis key format, the
  persisted JSON round-trip, and store-time validation. The resolver derives
  `UpstreamID` from the upstream's registration identity: the upstream issuer
  recovered from `DiscoveryURL` (the same value used for RFC 8414 §3.3
  metadata verification), or the `RegistrationEndpoint` URL when set directly.

Closes #5823

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

New and updated unit tests cover the collision directly and the plumbing that
enforces it:

- `pkg/auth/dcr/resolver_test.go` — `DistinctUpstreamsSameScopesDoNotCollide`
  and `DistinctRegistrationEndpointsDoNotCollide` reproduce the two-upstream
  shape (shared issuer, redirect, and scopes) and assert each upstream now
  resolves to its own registration on both the `DiscoveryURL` and
  `RegistrationEndpoint` paths.
- `pkg/authserver/storage/memory_test.go`, `redis_test.go`, and
  `redis_integration_test.go` — assert two keys differing only by `UpstreamID`
  address distinct entries, including a length-prefix boundary-collision
  property test across the issuer/upstream_id seam.
- `pkg/authserver/storage/types.go` validation — a new `empty upstream_id`
  case confirms `StoreDCRCredentials` rejects an unpopulated `UpstreamID`.
- `pkg/auth/dcr/store_test.go` — round-trip coverage for the new key field.

## Changes

| File | Change |
|------|--------|
| `pkg/authserver/storage/types.go` | Add `UpstreamID` field to `DCRKey`; reject empty `UpstreamID` in `validateDCRCredentialsForStore`; update doc comments |
| `pkg/authserver/storage/redis_keys.go` | Add length-prefixed `UpstreamID` segment to the Redis DCR key format |
| `pkg/authserver/storage/redis.go` | Persist/restore `KeyUpstreamID` in the stored-credentials JSON blob |
| `pkg/authserver/storage/memory.go` | Include `upstream_id` in the not-found debug log |
| `pkg/auth/dcr/resolver.go` | Add `resolveUpstreamKeyIdentity`; populate `Key.UpstreamID`; add `UpstreamID` to the singleflight key; new `resolve_upstream_id` step |
| `pkg/auth/dcr/store.go` | Update `CredentialStore` doc for the four-component key |
| `pkg/auth/dcr/request.go` | Document how `UpstreamID` is derived from `DiscoveryURL` / `RegistrationEndpoint` |
| `*_test.go` (6 files) | Collision, round-trip, validation, and boundary tests |

## Does this introduce a user-facing change?

Yes. Multi-upstream embedded authservers with two or more OAuth2 DCR upstreams
that request the same scopes now register a distinct client per upstream
instead of silently reusing the first upstream's credentials, fixing failed or
misattributed authorization on the affected upstreams.

## Special notes for reviewers

- **Redis DCR key format change (migration).** Adding the `UpstreamID` segment
  changes the persisted Redis key format. Entries written by an older binary
  lack the segment, so they miss on lookup and are harmlessly re-registered
  under the new key. Stale rows expire via their existing TTL or can be cleared
  manually. No action is required.
- **Residual limitation (intentional).** On the `DiscoveryURL` path the
  identity is the derived upstream *issuer*, not the raw discovery URL, so it
  names the authorization server (aligned with the RFC 8414 §3.3 verification
  issuer). Two configs that resolve to the same issuer intentionally share one
  registration. The one uncovered case — a single issuer exposing distinct
  registration endpoints under custom, non-well-known discovery paths — is
  documented on `resolveUpstreamKeyIdentity`; if two upstreams instead declared
  different issuers, at least one would fail §3.3 verification loudly rather
  than reuse credentials.
- **Layers kept aligned.** The singleflight key (`flightKeyOf`) and the
  persisted `DCRKey` both gained `UpstreamID` in the same shape, so the
  in-flight-coalescing and cache layers stay consistent.
- This change was reviewed by an automated code-review agent across two
  iterations; no CRITICAL / HIGH / MEDIUM issues remain.

Generated with [Claude Code](https://claude.com/claude-code)
