### PR TITLE
Add Bedrock compatibility flag to thv llm setup

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -76,6 +76,39 @@ func newConfigCommand() *cobra.Command {
 	return cmd
 }
 
+// addLLMConnectionFlags registers the gateway connection flags shared by
+// "config set" and "setup" so the two commands stay in sync. It binds directly
+// into the caller's SetOptions.
+func addLLMConnectionFlags(cmd *cobra.Command, opts *llm.SetOptions) {
+	cmd.Flags().StringVar(&opts.GatewayURL, "gateway-url", "", "LLM gateway base URL (must use HTTPS)")
+	cmd.Flags().StringVar(&opts.Issuer, "issuer", "", "OIDC issuer URL")
+	cmd.Flags().StringVar(&opts.ClientID, "client-id", "", "OIDC client ID")
+	cmd.Flags().StringVar(&opts.Audience, "audience", "", "OIDC audience (optional)")
+	cmd.Flags().IntVar(&opts.ProxyPort, "proxy-port", 0, "Localhost proxy listen port (omit to keep current; default: 14000)")
+	cmd.Flags().IntVar(&opts.CallbackPort, "callback-port", 0, "OIDC callback port (omit to keep current; default: ephemeral)")
+}
+
+// applyChangedLLMFlags copies the *bool / []string flag values into opts only
+// when the user actually set them, so an unset flag leaves the persisted config
+// field unchanged (nil pointer = "not provided"). Shared by "config set" and
+// "setup" so both commands treat these flags identically.
+func applyChangedLLMFlags(
+	cmd *cobra.Command, opts *llm.SetOptions, tlsSkipVerify, bedrockCompat, enable1M bool, models []string,
+) {
+	if cmd.Flags().Changed("tls-skip-verify") {
+		opts.TLSSkipVerify = &tlsSkipVerify
+	}
+	if cmd.Flags().Changed("bedrock-compat") {
+		opts.BedrockCompat = &bedrockCompat
+	}
+	if cmd.Flags().Changed("enable-1m") {
+		opts.Enable1M = &enable1M
+	}
+	if cmd.Flags().Changed("models") {
+		opts.Models = models
+	}
+}
+
 func newConfigSetCommand() *cobra.Command {
 	var (
 		opts          llm.SetOptions
@@ -97,30 +130,14 @@ Example:
     --client-id my-client-id`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if cmd.Flags().Changed("tls-skip-verify") {
-				opts.TLSSkipVerify = &tlsSkipVerify
-			}
-			if cmd.Flags().Changed("bedrock-compat") {
-				opts.BedrockCompat = &bedrockCompat
-			}
-			if cmd.Flags().Changed("enable-1m") {
-				opts.Enable1M = &enable1M
-			}
-			if cmd.Flags().Changed("models") {
-				opts.Models = models
-			}
+			applyChangedLLMFlags(cmd, &opts, tlsSkipVerify, bedrockCompat, enable1M, models)
 			return config.UpdateConfig(func(c *config.Config) error {
 				return c.LLM.SetFields(opts)
 			})
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.GatewayURL, "gateway-url", "", "LLM gateway base URL (must use HTTPS)")
-	cmd.Flags().StringVar(&opts.Issuer, "issuer", "", "OIDC issuer URL")
-	cmd.Flags().StringVar(&opts.ClientID, "client-id", "", "OIDC client ID")
-	cmd.Flags().StringVar(&opts.Audience, "audience", "", "OIDC audience (optional)")
-	cmd.Flags().IntVar(&opts.ProxyPort, "proxy-port", 0, "Localhost proxy listen port (omit to keep current; default: 14000)")
-	cmd.Flags().IntVar(&opts.CallbackPort, "callback-port", 0, "OIDC callback port (omit to keep current; default: ephemeral)")
+	addLLMConnectionFlags(cmd, &opts)
 	cmd.Flags().BoolVar(&tlsSkipVerify, "tls-skip-verify", false,
 		"Skip TLS certificate verification for the upstream gateway (local dev only; use --tls-skip-verify=false to clear)")
 	cmd.Flags().BoolVar(&bedrockCompat, "bedrock-compat", false,
@@ -129,8 +146,9 @@ Example:
 	cmd.Flags().BoolVar(&enable1M, "enable-1m", false,
 		"With Bedrock compat, opt into the 1M context window by appending [1m] to opus/sonnet model IDs.")
 	cmd.Flags().StringSliceVar(&models, "models", nil,
-		"Override the default Bedrock model IDs, comma-separated or by repeating the flag, e.g. "+
-			"--models=us.anthropic.claude-opus-4-8,us.anthropic.claude-sonnet-5. Each ID is mapped to a "+
+		"Model IDs to persist and apply during \"thv llm setup\", comma-separated or by repeating the flag, e.g. "+
+			"--models=us.anthropic.claude-opus-4-8,us.anthropic.claude-sonnet-5. Credential-helper clients "+
+			"(Claude Desktop) write these as inferenceModels; with Bedrock compat, each ID is also mapped to a "+
 			"Claude Code tier by matching 'haiku', 'opus', or 'sonnet' in the ID.")
 
 	return cmd
@@ -300,18 +318,7 @@ Re-running is idempotent and uses the cached token (no browser prompt).
 Run "thv llm teardown" to revert all changes.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if cmd.Flags().Changed("tls-skip-verify") {
-				opts.TLSSkipVerify = &tlsSkipVerify
-			}
-			if cmd.Flags().Changed("bedrock-compat") {
-				opts.BedrockCompat = &bedrockCompat
-			}
-			if cmd.Flags().Changed("enable-1m") {
-				opts.Enable1M = &enable1M
-			}
-			if cmd.Flags().Changed("models") {
-				opts.Models = models
-			}
+			applyChangedLLMFlags(cmd, &opts, tlsSkipVerify, bedrockCompat, enable1M, models)
 			cm, err := client.NewClientManager()
 			if err != nil {
 				return fmt.Errorf("initializing client manager: %w", err)
@@ -322,17 +329,12 @@ Run "thv llm teardown" to revert all changes.`,
 			return runLLMSetup(
 				cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
 				cm, config.NewDefaultProvider(), login, opts,
-				anthropicPathPrefix, cmd.Flags().Changed("anthropic-path-prefix"), targetClient, lazy, models,
+				anthropicPathPrefix, cmd.Flags().Changed("anthropic-path-prefix"), targetClient, lazy,
 			)
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.GatewayURL, "gateway-url", "", "LLM gateway base URL (must use HTTPS)")
-	cmd.Flags().StringVar(&opts.Issuer, "issuer", "", "OIDC issuer URL")
-	cmd.Flags().StringVar(&opts.ClientID, "client-id", "", "OIDC client ID")
-	cmd.Flags().StringVar(&opts.Audience, "audience", "", "OIDC audience (optional)")
-	cmd.Flags().IntVar(&opts.ProxyPort, "proxy-port", 0, "Localhost proxy listen port (omit to keep current; default: 14000)")
-	cmd.Flags().IntVar(&opts.CallbackPort, "callback-port", 0, "OIDC callback port (omit to keep current; default: ephemeral)")
+	addLLMConnectionFlags(cmd, &opts)
 	cmd.Flags().BoolVar(&tlsSkipVerify, "tls-skip-verify", false,
 		"Skip TLS certificate verification for the upstream gateway (local dev only). "+
 			"For direct-mode tools (Claude Code, Gemini CLI) this sets NODE_TLS_REJECT_UNAUTHORIZED=0, "+
@@ -382,12 +384,12 @@ func runLLMSetup(
 	ctx context.Context, out, errOut io.Writer,
 	cm *client.ClientManager, provider config.Provider, login llm.LoginFunc,
 	inlineOpts llm.SetOptions, anthropicPathPrefix string, anthropicPathPrefixSet bool, targetClient string,
-	lazy bool, models []string,
+	lazy bool,
 ) error {
 	return llm.Setup(
 		ctx, out, errOut,
 		&clientManagerAdapter{cm}, &configUpdaterAdapter{provider}, login,
-		inlineOpts, anthropicPathPrefix, anthropicPathPrefixSet, targetClient, lazy, models,
+		inlineOpts, anthropicPathPrefix, anthropicPathPrefixSet, targetClient, lazy,
 	)
 }
 

--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -80,6 +80,9 @@ func newConfigSetCommand() *cobra.Command {
 	var (
 		opts          llm.SetOptions
 		tlsSkipVerify bool
+		bedrockCompat bool
+		enable1M      bool
+		models        []string
 	)
 
 	cmd := &cobra.Command{
@@ -97,6 +100,15 @@ Example:
 			if cmd.Flags().Changed("tls-skip-verify") {
 				opts.TLSSkipVerify = &tlsSkipVerify
 			}
+			if cmd.Flags().Changed("bedrock-compat") {
+				opts.BedrockCompat = &bedrockCompat
+			}
+			if cmd.Flags().Changed("enable-1m") {
+				opts.Enable1M = &enable1M
+			}
+			if cmd.Flags().Changed("models") {
+				opts.Models = models
+			}
 			return config.UpdateConfig(func(c *config.Config) error {
 				return c.LLM.SetFields(opts)
 			})
@@ -111,6 +123,15 @@ Example:
 	cmd.Flags().IntVar(&opts.CallbackPort, "callback-port", 0, "OIDC callback port (omit to keep current; default: ephemeral)")
 	cmd.Flags().BoolVar(&tlsSkipVerify, "tls-skip-verify", false,
 		"Skip TLS certificate verification for the upstream gateway (local dev only; use --tls-skip-verify=false to clear)")
+	cmd.Flags().BoolVar(&bedrockCompat, "bedrock-compat", false,
+		"Persist Bedrock compatibility for Claude Code (CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 + per-tier "+
+			"Bedrock model IDs). Applied by \"thv llm setup\". Use --bedrock-compat=false to clear.")
+	cmd.Flags().BoolVar(&enable1M, "enable-1m", false,
+		"With Bedrock compat, opt into the 1M context window by appending [1m] to opus/sonnet model IDs.")
+	cmd.Flags().StringSliceVar(&models, "models", nil,
+		"Override the default Bedrock model IDs, comma-separated or by repeating the flag, e.g. "+
+			"--models=us.anthropic.claude-opus-4-8,us.anthropic.claude-sonnet-5. Each ID is mapped to a "+
+			"Claude Code tier by matching 'haiku', 'opus', or 'sonnet' in the ID.")
 
 	return cmd
 }
@@ -224,6 +245,8 @@ func newLLMSetupCommand() *cobra.Command {
 	var (
 		opts                llm.SetOptions
 		tlsSkipVerify       bool
+		bedrockCompat       bool
+		enable1M            bool
 		targetClient        string
 		anthropicPathPrefix string
 		lazy                bool
@@ -264,11 +287,30 @@ Inline flags (--gateway-url, --issuer, --client-id, etc.) are applied for this
 run and persisted to config only after login and tool patching succeed. This
 lets you combine "config set" and "setup" into a single command.
 
+For a gateway that forwards to AWS Bedrock, add --bedrock-compat to configure
+Claude Code with CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 and per-tier Bedrock
+model IDs (override with --models; add --enable-1m for the 1M context window on
+opus/sonnet). The setting is persisted and only affects Claude Code. To add it to
+an already-configured Claude Code, re-run:
+
+  thv llm setup --client claude-code --bedrock-compat
+
+Re-running is idempotent and uses the cached token (no browser prompt).
+
 Run "thv llm teardown" to revert all changes.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if cmd.Flags().Changed("tls-skip-verify") {
 				opts.TLSSkipVerify = &tlsSkipVerify
+			}
+			if cmd.Flags().Changed("bedrock-compat") {
+				opts.BedrockCompat = &bedrockCompat
+			}
+			if cmd.Flags().Changed("enable-1m") {
+				opts.Enable1M = &enable1M
+			}
+			if cmd.Flags().Changed("models") {
+				opts.Models = models
 			}
 			cm, err := client.NewClientManager()
 			if err != nil {
@@ -307,8 +349,20 @@ Run "thv llm teardown" to revert all changes.`,
 			"Useful for unattended provisioning (e.g. an MDM profile).")
 	cmd.Flags().BoolVar(&skipBrowser, "skip-browser", false, skipBrowserFlagUsage)
 	cmd.Flags().StringSliceVar(&models, "models", nil,
-		"Explicit model IDs to expose to credential-helper clients (Claude Desktop's inferenceModels). "+
-			"Repeat or comma-separate. Omit to rely on the gateway's own model discovery once it is available.")
+		"Model IDs to configure, comma-separated or by repeating the flag, e.g. "+
+			"--models=us.anthropic.claude-opus-4-8,us.anthropic.claude-sonnet-5. "+
+			"For credential-helper clients (Claude Desktop) these become inferenceModels. "+
+			"With --bedrock-compat, each ID is also mapped to a Claude Code tier by matching "+
+			"'haiku', 'opus', or 'sonnet' in the ID (IDs matching no tier are ignored with a "+
+			"warning). Omit to use the built-in Bedrock defaults / gateway model discovery.")
+	cmd.Flags().BoolVar(&bedrockCompat, "bedrock-compat", false,
+		"Configure Claude Code for a gateway that forwards to AWS Bedrock: write "+
+			"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 (Bedrock rejects the experimental anthropic-beta headers) "+
+			"and pin per-tier Bedrock model IDs (override with --models). Persisted, so a later plain "+
+			"\"thv llm setup\" keeps it; clear with --bedrock-compat=false. Only affects Claude Code.")
+	cmd.Flags().BoolVar(&enable1M, "enable-1m", false,
+		"With --bedrock-compat, append the [1m] suffix to the opus and sonnet model IDs to opt into the "+
+			"1M-token context window on Bedrock (never haiku, which is 200K). Off by default.")
 
 	return cmd
 }

--- a/cmd/thv/app/llm_test.go
+++ b/cmd/thv/app/llm_test.go
@@ -71,7 +71,7 @@ func TestRunLLMSetup_NotConfigured(t *testing.T) {
 	provider := llmProvider(t, llm.Config{}) // no gateway URL
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false, nil)
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
 }
@@ -98,7 +98,7 @@ func TestRunLLMSetup_NoDetectedTools(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false, nil)
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "No supported AI tools detected")
 }
@@ -142,7 +142,7 @@ func TestRunLLMSetup_PartialFailure(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false, nil)
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.NoError(t, err)
 	assert.Contains(t, stderr.String(), "Warning: failed to configure claude-code")
 	assert.Contains(t, stdout.String(), "Configured gemini-cli")
@@ -176,7 +176,7 @@ func TestRunLLMSetup_RollbackOnConfigUpdateFailure(t *testing.T) {
 	provider := &errOnUpdateProvider{cfg: c, updateErr: errors.New("disk full")}
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false, nil)
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persisting tool configuration")
 
@@ -226,7 +226,7 @@ func TestRunLLMSetup_RollbackBothToolsOnConfigUpdateFailure(t *testing.T) {
 	provider := &errOnUpdateProvider{cfg: c, updateErr: errors.New("disk full")}
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false, nil)
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persisting tool configuration")
 
@@ -273,7 +273,7 @@ func TestRunLLMSetup_LoginFailureLeavesNoState(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider,
 		func(_ context.Context, _ *llm.Config) error { return loginErr },
-		llm.SetOptions{}, "", false, "", false, nil,
+		llm.SetOptions{}, "", false, "", false,
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "OIDC login failed")
@@ -474,7 +474,7 @@ func TestRunLLMSetup_ClientFlag_ConfiguresSingleTool(t *testing.T) {
 	})
 
 	var stdout, stderr bytes.Buffer
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "claude-code", false, nil)
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "claude-code", false)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Configured claude-code")
 	assert.NotContains(t, stdout.String(), "gemini-cli")
@@ -519,7 +519,7 @@ func TestRunLLMSetup_Lazy_SkipsLoginButConfiguresTools(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	// anthropicPathPrefixSet=true skips the network probe; lazy=true.
 	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider,
-		recordingLogin, llm.SetOptions{}, "", true, "", true, nil)
+		recordingLogin, llm.SetOptions{}, "", true, "", true)
 	require.NoError(t, err)
 
 	assert.False(t, loginCalled, "lazy mode must not invoke the OIDC login")
@@ -558,7 +558,7 @@ func TestRunLLMSetup_ClientFlag_NotInstalled(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	// cursor is not installed (no dir); expect an error.
-	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "cursor", false, nil)
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "cursor", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"cursor" is not installed or not detected`)
 }

--- a/docs/cli/thv_llm_config_set.md
+++ b/docs/cli/thv_llm_config_set.md
@@ -31,11 +31,14 @@ thv llm config set [flags]
 
 ```
       --audience string      OIDC audience (optional)
+      --bedrock-compat       Persist Bedrock compatibility for Claude Code (CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 + per-tier Bedrock model IDs). Applied by "thv llm setup". Use --bedrock-compat=false to clear.
       --callback-port int    OIDC callback port (omit to keep current; default: ephemeral)
       --client-id string     OIDC client ID
+      --enable-1m            With Bedrock compat, opt into the 1M context window by appending [1m] to opus/sonnet model IDs.
       --gateway-url string   LLM gateway base URL (must use HTTPS)
   -h, --help                 help for set
       --issuer string        OIDC issuer URL
+      --models strings       Override the default Bedrock model IDs, comma-separated or by repeating the flag, e.g. --models=us.anthropic.claude-opus-4-8,us.anthropic.claude-sonnet-5. Each ID is mapped to a Claude Code tier by matching 'haiku', 'opus', or 'sonnet' in the ID.
       --proxy-port int       Localhost proxy listen port (omit to keep current; default: 14000)
       --tls-skip-verify      Skip TLS certificate verification for the upstream gateway (local dev only; use --tls-skip-verify=false to clear)
 ```

--- a/docs/cli/thv_llm_config_set.md
+++ b/docs/cli/thv_llm_config_set.md
@@ -38,7 +38,7 @@ thv llm config set [flags]
       --gateway-url string   LLM gateway base URL (must use HTTPS)
   -h, --help                 help for set
       --issuer string        OIDC issuer URL
-      --models strings       Override the default Bedrock model IDs, comma-separated or by repeating the flag, e.g. --models=us.anthropic.claude-opus-4-8,us.anthropic.claude-sonnet-5. Each ID is mapped to a Claude Code tier by matching 'haiku', 'opus', or 'sonnet' in the ID.
+      --models strings       Model IDs to persist and apply during "thv llm setup", comma-separated or by repeating the flag, e.g. --models=us.anthropic.claude-opus-4-8,us.anthropic.claude-sonnet-5. Credential-helper clients (Claude Desktop) write these as inferenceModels; with Bedrock compat, each ID is also mapped to a Claude Code tier by matching 'haiku', 'opus', or 'sonnet' in the ID.
       --proxy-port int       Localhost proxy listen port (omit to keep current; default: 14000)
       --tls-skip-verify      Skip TLS certificate verification for the upstream gateway (local dev only; use --tls-skip-verify=false to clear)
 ```

--- a/docs/cli/thv_llm_setup.md
+++ b/docs/cli/thv_llm_setup.md
@@ -45,6 +45,16 @@ Inline flags (--gateway-url, --issuer, --client-id, etc.) are applied for this
 run and persisted to config only after login and tool patching succeed. This
 lets you combine "config set" and "setup" into a single command.
 
+For a gateway that forwards to AWS Bedrock, add --bedrock-compat to configure
+Claude Code with CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 and per-tier Bedrock
+model IDs (override with --models; add --enable-1m for the 1M context window on
+opus/sonnet). The setting is persisted and only affects Claude Code. To add it to
+an already-configured Claude Code, re-run:
+
+  thv llm setup --client claude-code --bedrock-compat
+
+Re-running is idempotent and uses the cached token (no browser prompt).
+
 Run "thv llm teardown" to revert all changes.
 
 ```
@@ -56,14 +66,16 @@ thv llm setup [flags]
 ```
       --anthropic-path-prefix string   Path prefix appended to the gateway URL when writing ANTHROPIC_BASE_URL for direct-mode tools (e.g. /anthropic). When omitted, the gateway is probed automatically.
       --audience string                OIDC audience (optional)
+      --bedrock-compat                 Configure Claude Code for a gateway that forwards to AWS Bedrock: write CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 (Bedrock rejects the experimental anthropic-beta headers) and pin per-tier Bedrock model IDs (override with --models). Persisted, so a later plain "thv llm setup" keeps it; clear with --bedrock-compat=false. Only affects Claude Code.
       --callback-port int              OIDC callback port (omit to keep current; default: ephemeral)
       --client string                  Configure only this AI tool by name (e.g. claude-code, cursor, codex). Omit to configure all detected tools.
       --client-id string               OIDC client ID
+      --enable-1m                      With --bedrock-compat, append the [1m] suffix to the opus and sonnet model IDs to opt into the 1M-token context window on Bedrock (never haiku, which is 200K). Off by default.
       --gateway-url string             LLM gateway base URL (must use HTTPS)
   -h, --help                           help for setup
       --issuer string                  OIDC issuer URL
       --lazy                           Skip the interactive OIDC login and defer it until the first time a configured tool accesses the gateway. Tool config and persisted settings are written normally. Useful for unattended provisioning (e.g. an MDM profile).
-      --models strings                 Explicit model IDs to expose to credential-helper clients (Claude Desktop's inferenceModels). Repeat or comma-separate. Omit to rely on the gateway's own model discovery once it is available.
+      --models strings                 Model IDs to configure, comma-separated or by repeating the flag, e.g. --models=us.anthropic.claude-opus-4-8,us.anthropic.claude-sonnet-5. For credential-helper clients (Claude Desktop) these become inferenceModels. With --bedrock-compat, each ID is also mapped to a Claude Code tier by matching 'haiku', 'opus', or 'sonnet' in the ID (IDs matching no tier are ignored with a warning). Omit to use the built-in Bedrock defaults / gateway model discovery.
       --proxy-port int                 Localhost proxy listen port (omit to keep current; default: 14000)
       --skip-browser                   Print the OIDC authorization URL instead of opening a browser, then wait for the callback. Use in headless/SSH/CI environments where no system browser is available.
       --tls-skip-verify                Skip TLS certificate verification for the upstream gateway (local dev only). For direct-mode tools (Claude Code, Gemini CLI) this sets NODE_TLS_REJECT_UNAUTHORIZED=0, disabling TLS for ALL of that tool's outbound connections. For proxy-mode tools only the proxy-to-gateway connection is affected.

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -165,8 +165,10 @@ const (
 //   - ValueField names which ApplyConfig field to write. Valid values:
 //     "GatewayURL", "AnthropicBaseURL", "ProxyBaseURL", "ProxyOrigin",
 //     "TokenHelperCommand", "PlaceholderAPIKey", "ClaudeCodeHelperTTLMillis",
-//     "NodeTLSRejectUnauthorized". An unrecognised ValueField is a programming
-//     error and causes ConfigureLLMGateway to return an error.
+//     "NodeTLSRejectUnauthorized", "BedrockDisableExperimentalBetas",
+//     "BedrockHaikuModel", "BedrockOpusModel", "BedrockSonnetModel". An
+//     unrecognised ValueField is a programming error and causes
+//     ConfigureLLMGateway to return an error.
 //   - Literal is written verbatim into the settings key (e.g. a fixed auth
 //     type string). Use Literal instead of ValueField for constant values so
 //     that typos in ValueField are caught as errors rather than silently
@@ -180,7 +182,8 @@ type LLMGatewayKeySpec struct {
 	JSONPointer string // RFC 6901 path
 	// ValueField: "GatewayURL" | "AnthropicBaseURL" | "ProxyBaseURL" | "ProxyOrigin" |
 	// "TokenHelperCommand" | "PlaceholderAPIKey" | "ClaudeCodeHelperTTLMillis" |
-	// "NodeTLSRejectUnauthorized"
+	// "NodeTLSRejectUnauthorized" | "BedrockDisableExperimentalBetas" |
+	// "BedrockHaikuModel" | "BedrockOpusModel" | "BedrockSonnetModel"
 	ValueField     string
 	Literal        string // constant value written verbatim; mutually exclusive with ValueField
 	ClearWhenEmpty bool   // remove the key when the resolved value is empty (ignored for Literal)
@@ -555,6 +558,18 @@ var supportedClientIntegrations = []clientAppConfig{
 			// NODE_TLS_REJECT_UNAUTHORIZED is only written when --tls-skip-verify is set.
 			// ClearWhenEmpty ensures it is removed when the flag is later cleared.
 			{JSONPointer: "/env/NODE_TLS_REJECT_UNAUTHORIZED", ValueField: "NodeTLSRejectUnauthorized", ClearWhenEmpty: true},
+			// Bedrock-compat keys (written only with --bedrock-compat). Bedrock rejects
+			// Claude Code's experimental anthropic-beta headers, so betas are disabled;
+			// the per-tier model IDs pin Bedrock inference-profile IDs. All use
+			// ClearWhenEmpty so a non-Bedrock setup removes any stale keys.
+			{
+				JSONPointer:    "/env/CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
+				ValueField:     "BedrockDisableExperimentalBetas",
+				ClearWhenEmpty: true,
+			},
+			{JSONPointer: "/env/ANTHROPIC_DEFAULT_HAIKU_MODEL", ValueField: "BedrockHaikuModel", ClearWhenEmpty: true},
+			{JSONPointer: "/env/ANTHROPIC_DEFAULT_OPUS_MODEL", ValueField: "BedrockOpusModel", ClearWhenEmpty: true},
+			{JSONPointer: "/env/ANTHROPIC_DEFAULT_SONNET_MODEL", ValueField: "BedrockSonnetModel", ClearWhenEmpty: true},
 		},
 	},
 	{

--- a/pkg/client/llm_gateway.go
+++ b/pkg/client/llm_gateway.go
@@ -390,8 +390,32 @@ func resolveApplyConfigField(valueField string, cfg llmgateway.ApplyConfig) (str
 		}
 		return "", true
 	default:
+		return resolveBedrockField(valueField, cfg)
+	}
+}
+
+// resolveBedrockField resolves the Claude Code bedrock-compat ValueFields. The
+// values are written only in bedrock-compat mode; otherwise they resolve to ""
+// so their ClearWhenEmpty key specs remove the key. Returns (_, false) for any
+// non-bedrock field so the caller can report an unknown ValueField.
+func resolveBedrockField(valueField string, cfg llmgateway.ApplyConfig) (string, bool) {
+	var v string
+	switch valueField {
+	case "BedrockDisableExperimentalBetas":
+		v = "1"
+	case "BedrockHaikuModel":
+		v = cfg.BedrockHaikuModel
+	case "BedrockOpusModel":
+		v = cfg.BedrockOpusModel
+	case "BedrockSonnetModel":
+		v = cfg.BedrockSonnetModel
+	default:
 		return "", false
 	}
+	if !cfg.BedrockCompat {
+		return "", true
+	}
+	return v, true
 }
 
 // llmValueForSpec returns the config value for a settings-file key spec.

--- a/pkg/client/llm_gateway_test.go
+++ b/pkg/client/llm_gateway_test.go
@@ -171,6 +171,66 @@ func TestRealClientConfigs_ConfigureAndRevert(t *testing.T) {
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
+// TestConfigureLLMGateway_ClaudeCodeBedrock verifies that BedrockCompat writes
+// CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 and the three per-tier model IDs into
+// Claude Code's settings.json, and that without BedrockCompat those keys are
+// absent (the ClearWhenEmpty behaviour), all against the real config table.
+func TestConfigureLLMGateway_ClaudeCodeBedrock(t *testing.T) {
+	t.Parallel()
+
+	bedrockPointers := map[string]string{
+		"/env/CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+		"/env/ANTHROPIC_DEFAULT_HAIKU_MODEL":          "us.anthropic.claude-haiku-x",
+		"/env/ANTHROPIC_DEFAULT_OPUS_MODEL":           "us.anthropic.claude-opus-x[1m]",
+		"/env/ANTHROPIC_DEFAULT_SONNET_MODEL":         "us.anthropic.claude-sonnet-x[1m]",
+	}
+
+	t.Run("BedrockCompat writes keys", func(t *testing.T) {
+		t.Parallel()
+		home := t.TempDir()
+		cm := NewTestClientManager(home, nil, supportedClientIntegrations, nil)
+		require.NoError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o700))
+
+		path, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
+			GatewayURL:         "https://gw.example.com",
+			TokenHelperCommand: `"thv" llm token`,
+			BedrockCompat:      true,
+			BedrockHaikuModel:  "us.anthropic.claude-haiku-x",
+			BedrockOpusModel:   "us.anthropic.claude-opus-x[1m]",
+			BedrockSonnetModel: "us.anthropic.claude-sonnet-x[1m]",
+		})
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		for ptr, want := range bedrockPointers {
+			got, ok := jsonPointerGet(data, ptr)
+			assert.True(t, ok, "pointer %q missing", ptr)
+			assert.Equal(t, want, got, "wrong value at %q", ptr)
+		}
+	})
+
+	t.Run("without BedrockCompat keys are absent", func(t *testing.T) {
+		t.Parallel()
+		home := t.TempDir()
+		cm := NewTestClientManager(home, nil, supportedClientIntegrations, nil)
+		require.NoError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o700))
+
+		path, err := cm.ConfigureLLMGateway(ClaudeCode, llmgateway.ApplyConfig{
+			GatewayURL:         "https://gw.example.com",
+			TokenHelperCommand: `"thv" llm token`,
+		})
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		for ptr := range bedrockPointers {
+			_, ok := jsonPointerGet(data, ptr)
+			assert.False(t, ok, "pointer %q should be absent without BedrockCompat", ptr)
+		}
+	})
+}
+
 // newLLMManager builds a ClientManager with a single direct-mode LLM entry
 // whose settings dir is homeDir/<dir>.
 func newLLMManager(t *testing.T, clientType ClientApp, mode, dir string, ptrs, vals []string) (*ClientManager, string) {

--- a/pkg/llm/config.go
+++ b/pkg/llm/config.go
@@ -25,12 +25,19 @@ type OIDCConfig = pkgoidc.ClientConfig
 // Config holds all LLM gateway settings persisted under the llm: key in
 // ToolHive's config.yaml.
 type Config struct {
-	GatewayURL      string        `yaml:"gateway_url,omitempty"       json:"gateway_url,omitempty"`
-	TLSSkipVerify   bool          `yaml:"tls_skip_verify,omitempty"   json:"tls_skip_verify,omitempty"`
-	OIDC            OIDCConfig    `yaml:"oidc,omitempty"              json:"oidc,omitempty"`
-	Proxy           ProxyConfig   `yaml:"proxy,omitempty"             json:"proxy,omitempty"`
-	Bedrock         BedrockConfig `yaml:"bedrock,omitempty"           json:"bedrock,omitempty"`
-	ConfiguredTools []ToolConfig  `yaml:"configured_tools,omitempty"  json:"configured_tools,omitempty"`
+	GatewayURL    string        `yaml:"gateway_url,omitempty"       json:"gateway_url,omitempty"`
+	TLSSkipVerify bool          `yaml:"tls_skip_verify,omitempty"   json:"tls_skip_verify,omitempty"`
+	OIDC          OIDCConfig    `yaml:"oidc,omitempty"              json:"oidc,omitempty"`
+	Proxy         ProxyConfig   `yaml:"proxy,omitempty"             json:"proxy,omitempty"`
+	Bedrock       BedrockConfig `yaml:"bedrock,omitempty"           json:"bedrock,omitempty"`
+	// Models is the persisted, single source of truth for the model IDs applied
+	// during setup. It feeds two consumers: credential-helper clients (Claude
+	// Desktop) write it verbatim as inferenceModels, and — when Bedrock compat is
+	// on — each entry is also mapped to a Claude Code tier (see BedrockConfig).
+	// Persisting it here (rather than passing a transient flag value) keeps both
+	// consumers consistent on a later plain "thv llm setup".
+	Models          []string     `yaml:"models,omitempty"            json:"models,omitempty"`
+	ConfiguredTools []ToolConfig `yaml:"configured_tools,omitempty"  json:"configured_tools,omitempty"`
 }
 
 // BedrockConfig holds settings for configuring Claude Code to reach an LLM
@@ -46,10 +53,6 @@ type BedrockConfig struct {
 	// into the 1M-token context window on Bedrock (never haiku, which is 200K).
 	// Off by default: 1M-on-Bedrock is a version-dependent Claude Code behavior.
 	Enable1M bool `yaml:"enable_1m,omitempty" json:"enable_1m,omitempty"`
-	// Models are optional Bedrock model IDs that override the built-in defaults.
-	// Each entry is mapped to a tier (haiku/opus/sonnet) by matching that word as
-	// a substring of the ID; entries that match no tier are ignored with a warning.
-	Models []string `yaml:"models,omitempty" json:"models,omitempty"`
 }
 
 // ProxyConfig holds configuration for the localhost reverse proxy.

--- a/pkg/llm/config.go
+++ b/pkg/llm/config.go
@@ -25,11 +25,31 @@ type OIDCConfig = pkgoidc.ClientConfig
 // Config holds all LLM gateway settings persisted under the llm: key in
 // ToolHive's config.yaml.
 type Config struct {
-	GatewayURL      string       `yaml:"gateway_url,omitempty"       json:"gateway_url,omitempty"`
-	TLSSkipVerify   bool         `yaml:"tls_skip_verify,omitempty"   json:"tls_skip_verify,omitempty"`
-	OIDC            OIDCConfig   `yaml:"oidc,omitempty"              json:"oidc,omitempty"`
-	Proxy           ProxyConfig  `yaml:"proxy,omitempty"             json:"proxy,omitempty"`
-	ConfiguredTools []ToolConfig `yaml:"configured_tools,omitempty"  json:"configured_tools,omitempty"`
+	GatewayURL      string        `yaml:"gateway_url,omitempty"       json:"gateway_url,omitempty"`
+	TLSSkipVerify   bool          `yaml:"tls_skip_verify,omitempty"   json:"tls_skip_verify,omitempty"`
+	OIDC            OIDCConfig    `yaml:"oidc,omitempty"              json:"oidc,omitempty"`
+	Proxy           ProxyConfig   `yaml:"proxy,omitempty"             json:"proxy,omitempty"`
+	Bedrock         BedrockConfig `yaml:"bedrock,omitempty"           json:"bedrock,omitempty"`
+	ConfiguredTools []ToolConfig  `yaml:"configured_tools,omitempty"  json:"configured_tools,omitempty"`
+}
+
+// BedrockConfig holds settings for configuring Claude Code to reach an LLM
+// gateway that forwards to AWS Bedrock. It is persisted so that a later plain
+// "thv llm setup" re-applies these settings rather than silently clearing them.
+type BedrockConfig struct {
+	// Compat, when true, writes CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 and the
+	// per-tier Bedrock model IDs into Claude Code's settings.json. Bedrock rejects
+	// Claude Code's experimental anthropic-beta headers, so this is required for a
+	// Bedrock-backed gateway.
+	Compat bool `yaml:"compat,omitempty" json:"compat,omitempty"`
+	// Enable1M appends the "[1m]" suffix to the opus and sonnet model IDs to opt
+	// into the 1M-token context window on Bedrock (never haiku, which is 200K).
+	// Off by default: 1M-on-Bedrock is a version-dependent Claude Code behavior.
+	Enable1M bool `yaml:"enable_1m,omitempty" json:"enable_1m,omitempty"`
+	// Models are optional Bedrock model IDs that override the built-in defaults.
+	// Each entry is mapped to a tier (haiku/opus/sonnet) by matching that word as
+	// a substring of the ID; entries that match no tier are ignored with a warning.
+	Models []string `yaml:"models,omitempty" json:"models,omitempty"`
 }
 
 // ProxyConfig holds configuration for the localhost reverse proxy.

--- a/pkg/llm/manage.go
+++ b/pkg/llm/manage.go
@@ -45,7 +45,7 @@ func (c *Config) SetFields(opts SetOptions) error {
 		c.Bedrock.Enable1M = *opts.Enable1M
 	}
 	if opts.Models != nil {
-		c.Bedrock.Models = opts.Models
+		c.Models = opts.Models
 	}
 
 	if !c.IsConfigured() {
@@ -70,8 +70,8 @@ type SetOptions struct {
 	// "not provided" (enabling explicit clear via config set). See BedrockConfig.
 	BedrockCompat *bool
 	Enable1M      *bool
-	// Models overrides the default Bedrock model IDs. nil = not provided (leave
-	// existing config unchanged); an empty non-nil slice clears the override.
+	// Models sets the persisted model IDs (Config.Models). nil = not provided
+	// (leave existing config unchanged); an empty non-nil slice clears them.
 	Models []string
 }
 
@@ -125,12 +125,12 @@ func (c *Config) Show(w io.Writer) error {
 	if c.TLSSkipVerify {
 		writef("TLS Skip Verify: true (WARNING: certificate verification disabled)\n")
 	}
+	if len(c.Models) > 0 {
+		writef("Models:          %v\n", c.Models)
+	}
 	if c.Bedrock.Compat {
 		writef("Bedrock compat:  true (CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1)\n")
 		writef("  1M context:    %t\n", c.Bedrock.Enable1M)
-		if len(c.Bedrock.Models) > 0 {
-			writef("  Models:        %v\n", c.Bedrock.Models)
-		}
 	}
 	if len(c.ConfiguredTools) > 0 {
 		writef("Configured tools:\n")

--- a/pkg/llm/manage.go
+++ b/pkg/llm/manage.go
@@ -38,6 +38,15 @@ func (c *Config) SetFields(opts SetOptions) error {
 	if opts.TLSSkipVerify != nil {
 		c.TLSSkipVerify = *opts.TLSSkipVerify
 	}
+	if opts.BedrockCompat != nil {
+		c.Bedrock.Compat = *opts.BedrockCompat
+	}
+	if opts.Enable1M != nil {
+		c.Bedrock.Enable1M = *opts.Enable1M
+	}
+	if opts.Models != nil {
+		c.Bedrock.Models = opts.Models
+	}
 
 	if !c.IsConfigured() {
 		return c.ValidatePartial()
@@ -57,6 +66,13 @@ type SetOptions struct {
 	ProxyPort     int
 	CallbackPort  int
 	TLSSkipVerify *bool // nil = not provided; &false = explicitly disable
+	// BedrockCompat and Enable1M use pointers so false can be distinguished from
+	// "not provided" (enabling explicit clear via config set). See BedrockConfig.
+	BedrockCompat *bool
+	Enable1M      *bool
+	// Models overrides the default Bedrock model IDs. nil = not provided (leave
+	// existing config unchanged); an empty non-nil slice clears the override.
+	Models []string
 }
 
 // DeleteCachedTokens removes all cached OIDC tokens stored under the LLM
@@ -108,6 +124,13 @@ func (c *Config) Show(w io.Writer) error {
 	writef("Scopes:          %v\n", c.OIDC.EffectiveScopes())
 	if c.TLSSkipVerify {
 		writef("TLS Skip Verify: true (WARNING: certificate verification disabled)\n")
+	}
+	if c.Bedrock.Compat {
+		writef("Bedrock compat:  true (CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1)\n")
+		writef("  1M context:    %t\n", c.Bedrock.Enable1M)
+		if len(c.Bedrock.Models) > 0 {
+			writef("  Models:        %v\n", c.Bedrock.Models)
+		}
 	}
 	if len(c.ConfiguredTools) > 0 {
 		writef("Configured tools:\n")

--- a/pkg/llm/manage_test.go
+++ b/pkg/llm/manage_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/stacklok/toolhive/pkg/secrets"
@@ -159,6 +161,50 @@ func TestConfig_SetFields(t *testing.T) {
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+// ── SetFields (Bedrock) ──────────────────────────────────────────────────────
+
+func TestConfig_SetFields_Bedrock(t *testing.T) {
+	t.Parallel()
+
+	base := func() Config {
+		return Config{
+			GatewayURL: "https://gw.example.com",
+			OIDC:       OIDCConfig{Issuer: "https://auth.example.com", ClientID: "c"},
+		}
+	}
+
+	t.Run("compat, enable1M, and models are set and persisted", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		require.NoError(t, cfg.SetFields(SetOptions{
+			BedrockCompat: boolPtr(true),
+			Enable1M:      boolPtr(true),
+			Models:        []string{"us.anthropic.claude-opus-x"},
+		}))
+		assert.True(t, cfg.Bedrock.Compat)
+		assert.True(t, cfg.Bedrock.Enable1M)
+		assert.Equal(t, []string{"us.anthropic.claude-opus-x"}, cfg.Bedrock.Models)
+	})
+
+	t.Run("nil pointers leave existing bedrock values unchanged", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.Bedrock = BedrockConfig{Compat: true, Enable1M: true, Models: []string{"m"}}
+		require.NoError(t, cfg.SetFields(SetOptions{}))
+		assert.True(t, cfg.Bedrock.Compat)
+		assert.True(t, cfg.Bedrock.Enable1M)
+		assert.Equal(t, []string{"m"}, cfg.Bedrock.Models)
+	})
+
+	t.Run("false pointer clears compat", func(t *testing.T) {
+		t.Parallel()
+		cfg := base()
+		cfg.Bedrock.Compat = true
+		require.NoError(t, cfg.SetFields(SetOptions{BedrockCompat: boolPtr(false)}))
+		assert.False(t, cfg.Bedrock.Compat)
+	})
+}
 
 // ── DeleteCachedTokens ───────────────────────────────────────────────────────
 

--- a/pkg/llm/manage_test.go
+++ b/pkg/llm/manage_test.go
@@ -184,17 +184,19 @@ func TestConfig_SetFields_Bedrock(t *testing.T) {
 		}))
 		assert.True(t, cfg.Bedrock.Compat)
 		assert.True(t, cfg.Bedrock.Enable1M)
-		assert.Equal(t, []string{"us.anthropic.claude-opus-x"}, cfg.Bedrock.Models)
+		// Models is persisted at the top level (single source of truth), not under Bedrock.
+		assert.Equal(t, []string{"us.anthropic.claude-opus-x"}, cfg.Models)
 	})
 
-	t.Run("nil pointers leave existing bedrock values unchanged", func(t *testing.T) {
+	t.Run("nil pointers leave existing values unchanged", func(t *testing.T) {
 		t.Parallel()
 		cfg := base()
-		cfg.Bedrock = BedrockConfig{Compat: true, Enable1M: true, Models: []string{"m"}}
+		cfg.Bedrock = BedrockConfig{Compat: true, Enable1M: true}
+		cfg.Models = []string{"m"}
 		require.NoError(t, cfg.SetFields(SetOptions{}))
 		assert.True(t, cfg.Bedrock.Compat)
 		assert.True(t, cfg.Bedrock.Enable1M)
-		assert.Equal(t, []string{"m"}, cfg.Bedrock.Models)
+		assert.Equal(t, []string{"m"}, cfg.Models)
 	})
 
 	t.Run("false pointer clears compat", func(t *testing.T) {

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -144,11 +144,15 @@ func Setup(
 
 	configured, err := configureDetectedTools(
 		out, errOut, gm, detected, llmCfg.GatewayURL, proxyBaseURL, tokenHelperCommand,
-		tokenHelperPath, tokenHelperArgs, llmCfg.TLSSkipVerify, anthropicPrefix, models,
+		tokenHelperPath, tokenHelperArgs, llmCfg.TLSSkipVerify, anthropicPrefix, models, llmCfg.Bedrock,
 	)
 	if err != nil {
 		return err
 	}
+
+	// Bedrock-compat only affects Claude Code. If it was requested but Claude Code
+	// was not among the configured tools, the flag had no effect — say so.
+	warnBedrockNoEffect(errOut, llmCfg.Bedrock.Compat, configured)
 
 	warnTLSSkipVerify(errOut, llmCfg.TLSSkipVerify, configured)
 	warnCredentialHelperTools(out, errOut, gm, configured)
@@ -349,6 +353,58 @@ func filterDetectedClients(detected []string, targetClient string) ([]string, er
 	return nil, fmt.Errorf("client %q is not installed or not detected", targetClient)
 }
 
+// claudeCodeClient is the canonical client identifier for Claude Code. Declared
+// here as a string literal because pkg/llm does not import pkg/client (which
+// owns the ClientApp constant) to avoid an import cycle.
+const claudeCodeClient = "claude-code"
+
+// Default Bedrock inference-profile model IDs written for Claude Code in
+// bedrock-compat mode when --models does not override a tier. These track the
+// current generation and are expected to be bumped periodically; users override
+// per tier via --models.
+const (
+	defaultBedrockHaikuModel  = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+	defaultBedrockOpusModel   = "us.anthropic.claude-opus-4-8"
+	defaultBedrockSonnetModel = "us.anthropic.claude-sonnet-5"
+)
+
+// resolveBedrockModels maps optional override model IDs onto Claude Code's three
+// tiers, starting from the built-in defaults. Each override is assigned to a tier
+// by matching "haiku", "opus", or "sonnet" (case-insensitive) as a substring of
+// the ID; overrides matching no tier are returned in unmatched for the caller to
+// warn about. When enable1M is true, the "[1m]" suffix is appended to the opus
+// and sonnet IDs (never haiku, which has a 200K context window) to opt into the
+// 1M context window on Bedrock.
+func resolveBedrockModels(models []string, enable1M bool) (haiku, opus, sonnet string, unmatched []string) {
+	haiku, opus, sonnet = defaultBedrockHaikuModel, defaultBedrockOpusModel, defaultBedrockSonnetModel
+	for _, m := range models {
+		switch lower := strings.ToLower(m); {
+		case strings.Contains(lower, "haiku"):
+			haiku = m
+		case strings.Contains(lower, "opus"):
+			opus = m
+		case strings.Contains(lower, "sonnet"):
+			sonnet = m
+		default:
+			unmatched = append(unmatched, m)
+		}
+	}
+	if enable1M {
+		opus += "[1m]"
+		sonnet += "[1m]"
+	}
+	return haiku, opus, sonnet, unmatched
+}
+
+// warnBedrockNoEffect warns when bedrock-compat was requested but Claude Code
+// was not among the configured tools, so the flag had no effect.
+func warnBedrockNoEffect(errOut io.Writer, compat bool, configured []ToolConfig) {
+	if compat && !isTarget(configured, claudeCodeClient) {
+		_, _ = fmt.Fprintln(errOut,
+			"Warning: --bedrock-compat was set but Claude Code was not configured; the flag had no effect.")
+	}
+}
+
 // configureDetectedTools patches each detected tool's config file and returns
 // the list of successfully configured tools. An error is returned only when no
 // tool was configured successfully.
@@ -361,6 +417,7 @@ func configureDetectedTools(
 	tlsSkipVerify bool,
 	anthropicPathPrefix string,
 	models []string,
+	bedrock BedrockConfig,
 ) ([]ToolConfig, error) {
 	var configured []ToolConfig
 	for _, clientType := range detected {
@@ -389,6 +446,23 @@ func configureDetectedTools(
 			TLSSkipVerify:      tlsSkipVerify,
 			Models:             models,
 		}
+
+		// Bedrock-compat applies only to Claude Code: it disables the experimental
+		// anthropic-beta headers Bedrock rejects and pins per-tier Bedrock model
+		// IDs. Resolve defaults, tier mapping, and the optional [1m] suffix here so
+		// pkg/client only writes the resolved values.
+		if bedrock.Compat && clientType == claudeCodeClient {
+			haiku, opus, sonnet, unmatched := resolveBedrockModels(bedrock.Models, bedrock.Enable1M)
+			applyCfg.BedrockCompat = true
+			applyCfg.BedrockHaikuModel = haiku
+			applyCfg.BedrockOpusModel = opus
+			applyCfg.BedrockSonnetModel = sonnet
+			for _, m := range unmatched {
+				_, _ = fmt.Fprintf(errOut,
+					"Warning: --models entry %q did not match a tier (expected haiku/opus/sonnet in the ID); ignored\n", m)
+			}
+		}
+
 		configPath, err := gm.ConfigureLLMGateway(clientType, applyCfg)
 		if err != nil {
 			_, _ = fmt.Fprintf(errOut, "Warning: failed to configure %s: %v\n", clientType, err)

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -72,7 +72,7 @@ func Setup(
 	ctx context.Context, out, errOut io.Writer,
 	gm GatewayManager, provider ConfigUpdater, login LoginFunc,
 	inlineOpts SetOptions, anthropicPathPrefix string, anthropicPathPrefixSet bool, targetClient string,
-	lazy bool, models []string,
+	lazy bool,
 ) error {
 	llmCfg := provider.GetLLMConfig()
 
@@ -144,15 +144,19 @@ func Setup(
 
 	configured, err := configureDetectedTools(
 		out, errOut, gm, detected, llmCfg.GatewayURL, proxyBaseURL, tokenHelperCommand,
-		tokenHelperPath, tokenHelperArgs, llmCfg.TLSSkipVerify, anthropicPrefix, models, llmCfg.Bedrock,
+		tokenHelperPath, tokenHelperArgs, llmCfg.TLSSkipVerify, anthropicPrefix, llmCfg.Models, llmCfg.Bedrock,
 	)
 	if err != nil {
 		return err
 	}
 
-	// Bedrock-compat only affects Claude Code. If it was requested but Claude Code
-	// was not among the configured tools, the flag had no effect — say so.
-	warnBedrockNoEffect(errOut, llmCfg.Bedrock.Compat, configured)
+	// Warn about bedrock flags the user passed THIS run that had no effect:
+	// --bedrock-compat when Claude Code was not configured, and --enable-1m when
+	// bedrock-compat is off. Keyed off inlineOpts (not the merged config) because
+	// bedrock-compat is persisted — gating on llmCfg.Bedrock would nag on every
+	// later setup that omits claude-code. llmCfg.Bedrock.Compat is the effective
+	// (persisted + inline) compat state used for the --enable-1m check.
+	warnBedrockNoEffect(errOut, inlineOpts, llmCfg.Bedrock.Compat, configured)
 
 	warnTLSSkipVerify(errOut, llmCfg.TLSSkipVerify, configured)
 	warnCredentialHelperTools(out, errOut, gm, configured)
@@ -368,40 +372,84 @@ const (
 	defaultBedrockSonnetModel = "us.anthropic.claude-sonnet-5"
 )
 
+// oneMSuffix is the model-ID suffix that opts Bedrock opus/sonnet into the
+// 1M-token context window.
+const oneMSuffix = "[1m]"
+
 // resolveBedrockModels maps optional override model IDs onto Claude Code's three
 // tiers, starting from the built-in defaults. Each override is assigned to a tier
 // by matching "haiku", "opus", or "sonnet" (case-insensitive) as a substring of
-// the ID; overrides matching no tier are returned in unmatched for the caller to
-// warn about. When enable1M is true, the "[1m]" suffix is appended to the opus
-// and sonnet IDs (never haiku, which has a 200K context window) to opt into the
-// 1M context window on Bedrock.
-func resolveBedrockModels(models []string, enable1M bool) (haiku, opus, sonnet string, unmatched []string) {
+// the ID. When enable1M is true, the "[1m]" suffix is appended to the opus and
+// sonnet IDs (never haiku, which has a 200K context window) to opt into the 1M
+// context window on Bedrock; an override that already carries the suffix is left
+// as-is so it is not doubled.
+//
+// warnings collects the human-readable diagnostics for overrides that had no
+// (or a surprising) effect — an ID matching no tier, and a second ID clobbering
+// a tier an earlier ID already set — so the caller can surface them.
+func resolveBedrockModels(models []string, enable1M bool) (haiku, opus, sonnet string, warnings []string) {
 	haiku, opus, sonnet = defaultBedrockHaikuModel, defaultBedrockOpusModel, defaultBedrockSonnetModel
+	// Track which tiers an override has already claimed so a second override for
+	// the same tier is reported rather than silently winning last-write.
+	assigned := make(map[string]string, 3)
+	assign := func(tier string, dst *string, id string) {
+		if prev, ok := assigned[tier]; ok {
+			warnings = append(warnings, fmt.Sprintf(
+				"--models entry %q overrides %q for the %s tier; only the last is used", id, prev, tier))
+		}
+		assigned[tier] = id
+		*dst = id
+	}
 	for _, m := range models {
 		switch lower := strings.ToLower(m); {
 		case strings.Contains(lower, "haiku"):
-			haiku = m
+			assign("haiku", &haiku, m)
 		case strings.Contains(lower, "opus"):
-			opus = m
+			assign("opus", &opus, m)
 		case strings.Contains(lower, "sonnet"):
-			sonnet = m
+			assign("sonnet", &sonnet, m)
 		default:
-			unmatched = append(unmatched, m)
+			warnings = append(warnings, fmt.Sprintf(
+				"--models entry %q did not match a tier (expected haiku/opus/sonnet in the ID); ignored", m))
 		}
 	}
 	if enable1M {
-		opus += "[1m]"
-		sonnet += "[1m]"
+		opus = withOneMSuffix(opus)
+		sonnet = withOneMSuffix(sonnet)
 	}
-	return haiku, opus, sonnet, unmatched
+	return haiku, opus, sonnet, warnings
 }
 
-// warnBedrockNoEffect warns when bedrock-compat was requested but Claude Code
-// was not among the configured tools, so the flag had no effect.
-func warnBedrockNoEffect(errOut io.Writer, compat bool, configured []ToolConfig) {
-	if compat && !isTarget(configured, claudeCodeClient) {
+// withOneMSuffix appends the "[1m]" suffix unless id already ends with it, so a
+// user-supplied ID that already carries the suffix is not doubled into "[1m][1m]".
+func withOneMSuffix(id string) string {
+	if strings.HasSuffix(id, oneMSuffix) {
+		return id
+	}
+	return id + oneMSuffix
+}
+
+// warnBedrockNoEffect warns about Bedrock flags the user passed on THIS run that
+// had no effect. It keys off opts (the inline flags for this invocation), not the
+// persisted config, because bedrock-compat is sticky: warning off the merged state
+// would nag on every later setup that omits claude-code even though the flag was
+// not passed. effectiveCompat is the merged (persisted + inline) compat state, used
+// to decide whether an inline --enable-1m is inert.
+//
+// Two cases:
+//   - --bedrock-compat passed this run but Claude Code was not among the configured
+//     tools (the keys only attach to Claude Code), and
+//   - --enable-1m passed this run while compat is off (the 1M suffix rides the
+//     Bedrock model-ID path, so it is inert without compat) — otherwise a silent
+//     no-op.
+func warnBedrockNoEffect(errOut io.Writer, opts SetOptions, effectiveCompat bool, configured []ToolConfig) {
+	if opts.BedrockCompat != nil && *opts.BedrockCompat && !isTarget(configured, claudeCodeClient) {
 		_, _ = fmt.Fprintln(errOut,
 			"Warning: --bedrock-compat was set but Claude Code was not configured; the flag had no effect.")
+	}
+	if opts.Enable1M != nil && *opts.Enable1M && !effectiveCompat {
+		_, _ = fmt.Fprintln(errOut,
+			"Warning: --enable-1m has no effect without --bedrock-compat; it is ignored.")
 	}
 }
 
@@ -452,14 +500,13 @@ func configureDetectedTools(
 		// IDs. Resolve defaults, tier mapping, and the optional [1m] suffix here so
 		// pkg/client only writes the resolved values.
 		if bedrock.Compat && clientType == claudeCodeClient {
-			haiku, opus, sonnet, unmatched := resolveBedrockModels(bedrock.Models, bedrock.Enable1M)
+			haiku, opus, sonnet, warnings := resolveBedrockModels(models, bedrock.Enable1M)
 			applyCfg.BedrockCompat = true
 			applyCfg.BedrockHaikuModel = haiku
 			applyCfg.BedrockOpusModel = opus
 			applyCfg.BedrockSonnetModel = sonnet
-			for _, m := range unmatched {
-				_, _ = fmt.Fprintf(errOut,
-					"Warning: --models entry %q did not match a tier (expected haiku/opus/sonnet in the ID); ignored\n", m)
+			for _, w := range warnings {
+				_, _ = fmt.Fprintf(errOut, "Warning: %s\n", w)
 			}
 		}
 

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -26,13 +26,13 @@ func TestResolveBedrockModels(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		models        []string
-		enable1M      bool
-		wantHaiku     string
-		wantOpus      string
-		wantSonnet    string
-		wantUnmatched []string
+		name         string
+		models       []string
+		enable1M     bool
+		wantHaiku    string
+		wantOpus     string
+		wantSonnet   string
+		wantWarnings []string
 	}{
 		{
 			name:       "defaults when no overrides",
@@ -55,12 +55,12 @@ func TestResolveBedrockModels(t *testing.T) {
 			wantSonnet: defaultBedrockSonnetModel + "[1m]",
 		},
 		{
-			name:          "unmatched entry is reported and ignored",
-			models:        []string{"us.anthropic.claude-opus-x", "some-random-model"},
-			wantHaiku:     defaultBedrockHaikuModel,
-			wantOpus:      "us.anthropic.claude-opus-x",
-			wantSonnet:    defaultBedrockSonnetModel,
-			wantUnmatched: []string{"some-random-model"},
+			name:         "unmatched entry is reported and ignored",
+			models:       []string{"us.anthropic.claude-opus-x", "some-random-model"},
+			wantHaiku:    defaultBedrockHaikuModel,
+			wantOpus:     "us.anthropic.claude-opus-x",
+			wantSonnet:   defaultBedrockSonnetModel,
+			wantWarnings: []string{`--models entry "some-random-model" did not match a tier (expected haiku/opus/sonnet in the ID); ignored`},
 		},
 		{
 			name:       "matching is case-insensitive",
@@ -69,16 +69,104 @@ func TestResolveBedrockModels(t *testing.T) {
 			wantOpus:   "US.ANTHROPIC.CLAUDE-OPUS-X",
 			wantSonnet: defaultBedrockSonnetModel,
 		},
+		{
+			name:       "duplicate-tier override reports the clobbered entry and last wins",
+			models:     []string{"us.anthropic.claude-sonnet-5", "us.anthropic.claude-sonnet-4-6"},
+			wantHaiku:  defaultBedrockHaikuModel,
+			wantOpus:   defaultBedrockOpusModel,
+			wantSonnet: "us.anthropic.claude-sonnet-4-6",
+			wantWarnings: []string{
+				`--models entry "us.anthropic.claude-sonnet-4-6" overrides "us.anthropic.claude-sonnet-5" for the sonnet tier; only the last is used`,
+			},
+		},
+		{
+			name:       "already-suffixed override is not doubled with enable1M",
+			models:     []string{"us.anthropic.claude-opus-4-8[1m]"},
+			enable1M:   true,
+			wantHaiku:  defaultBedrockHaikuModel,
+			wantOpus:   "us.anthropic.claude-opus-4-8[1m]",
+			wantSonnet: defaultBedrockSonnetModel + "[1m]",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			haiku, opus, sonnet, unmatched := resolveBedrockModels(tt.models, tt.enable1M)
+			haiku, opus, sonnet, warnings := resolveBedrockModels(tt.models, tt.enable1M)
 			assert.Equal(t, tt.wantHaiku, haiku)
 			assert.Equal(t, tt.wantOpus, opus)
 			assert.Equal(t, tt.wantSonnet, sonnet)
-			assert.Equal(t, tt.wantUnmatched, unmatched)
+			assert.Equal(t, tt.wantWarnings, warnings)
+		})
+	}
+}
+
+// ── warnBedrockNoEffect ───────────────────────────────────────────────────────
+
+func TestWarnBedrockNoEffect(t *testing.T) {
+	t.Parallel()
+
+	claudeCode := []ToolConfig{{Tool: claudeCodeClient}}
+	cursorOnly := []ToolConfig{{Tool: "cursor"}}
+
+	tests := []struct {
+		name            string
+		opts            SetOptions // flags passed THIS run
+		effectiveCompat bool       // merged persisted + inline compat
+		configured      []ToolConfig
+		wantWarn        string // substring expected on stderr; "" means no output
+	}{
+		{
+			name:            "compat passed this run with claude-code configured is silent",
+			opts:            SetOptions{BedrockCompat: boolPtr(true)},
+			effectiveCompat: true,
+			configured:      claudeCode,
+		},
+		{
+			name:            "compat passed this run without claude-code warns",
+			opts:            SetOptions{BedrockCompat: boolPtr(true)},
+			effectiveCompat: true,
+			configured:      cursorOnly,
+			wantWarn:        "--bedrock-compat was set but Claude Code was not configured",
+		},
+		{
+			// Regression: bedrock-compat is persisted, so a later run that omits the
+			// flag must NOT warn even though effective compat is on and claude-code
+			// is not among the configured tools.
+			name:            "persisted compat, flag not passed this run, is silent",
+			opts:            SetOptions{},
+			effectiveCompat: true,
+			configured:      cursorOnly,
+		},
+		{
+			name:       "enable1M passed this run without compat warns",
+			opts:       SetOptions{Enable1M: boolPtr(true)},
+			configured: claudeCode,
+			wantWarn:   "--enable-1m has no effect without --bedrock-compat",
+		},
+		{
+			name:            "enable1M passed this run with effective compat is silent",
+			opts:            SetOptions{Enable1M: boolPtr(true)},
+			effectiveCompat: true,
+			configured:      claudeCode,
+		},
+		{
+			name:       "no bedrock flags this run is silent",
+			opts:       SetOptions{},
+			configured: claudeCode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var errOut bytes.Buffer
+			warnBedrockNoEffect(&errOut, tt.opts, tt.effectiveCompat, tt.configured)
+			if tt.wantWarn == "" {
+				assert.Empty(t, errOut.String())
+				return
+			}
+			assert.Contains(t, errOut.String(), tt.wantWarn)
 		})
 	}
 }
@@ -339,7 +427,7 @@ func TestSetup_Lazy_SkipsLoginAndPersistsTools(t *testing.T) {
 	// anthropicPathPrefixSet=true skips the network probe; lazy=true.
 	err := Setup(
 		context.Background(), &stdout, &stderr, gm, provider, login,
-		SetOptions{}, "", true, "", true, nil,
+		SetOptions{}, "", true, "", true,
 	)
 	require.NoError(t, err)
 
@@ -367,7 +455,7 @@ func TestSetup_NonLazy_InvokesLogin(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := Setup(
 		context.Background(), &stdout, &stderr, gm, provider, login,
-		SetOptions{}, "", true, "", false, nil,
+		SetOptions{}, "", true, "", false,
 	)
 	require.NoError(t, err)
 

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -20,6 +20,116 @@ import (
 	secretsmocks "github.com/stacklok/toolhive/pkg/secrets/mocks"
 )
 
+// ── resolveBedrockModels ──────────────────────────────────────────────────────
+
+func TestResolveBedrockModels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		models        []string
+		enable1M      bool
+		wantHaiku     string
+		wantOpus      string
+		wantSonnet    string
+		wantUnmatched []string
+	}{
+		{
+			name:       "defaults when no overrides",
+			wantHaiku:  defaultBedrockHaikuModel,
+			wantOpus:   defaultBedrockOpusModel,
+			wantSonnet: defaultBedrockSonnetModel,
+		},
+		{
+			name:       "override each tier by substring",
+			models:     []string{"us.anthropic.claude-haiku-x", "us.anthropic.claude-opus-x", "us.anthropic.claude-sonnet-x"},
+			wantHaiku:  "us.anthropic.claude-haiku-x",
+			wantOpus:   "us.anthropic.claude-opus-x",
+			wantSonnet: "us.anthropic.claude-sonnet-x",
+		},
+		{
+			name:       "enable1M appends [1m] to opus and sonnet only",
+			enable1M:   true,
+			wantHaiku:  defaultBedrockHaikuModel,
+			wantOpus:   defaultBedrockOpusModel + "[1m]",
+			wantSonnet: defaultBedrockSonnetModel + "[1m]",
+		},
+		{
+			name:          "unmatched entry is reported and ignored",
+			models:        []string{"us.anthropic.claude-opus-x", "some-random-model"},
+			wantHaiku:     defaultBedrockHaikuModel,
+			wantOpus:      "us.anthropic.claude-opus-x",
+			wantSonnet:    defaultBedrockSonnetModel,
+			wantUnmatched: []string{"some-random-model"},
+		},
+		{
+			name:       "matching is case-insensitive",
+			models:     []string{"US.ANTHROPIC.CLAUDE-OPUS-X"},
+			wantHaiku:  defaultBedrockHaikuModel,
+			wantOpus:   "US.ANTHROPIC.CLAUDE-OPUS-X",
+			wantSonnet: defaultBedrockSonnetModel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			haiku, opus, sonnet, unmatched := resolveBedrockModels(tt.models, tt.enable1M)
+			assert.Equal(t, tt.wantHaiku, haiku)
+			assert.Equal(t, tt.wantOpus, opus)
+			assert.Equal(t, tt.wantSonnet, sonnet)
+			assert.Equal(t, tt.wantUnmatched, unmatched)
+		})
+	}
+}
+
+// TestConfigureDetectedTools_BedrockClaudeCode verifies that bedrock-compat
+// populates the ApplyConfig bedrock fields for claude-code (with defaults) and
+// leaves them untouched for a non-claude-code client.
+func TestConfigureDetectedTools_BedrockClaudeCode(t *testing.T) {
+	t.Parallel()
+
+	gm := &capturingGatewayManager{mode: "direct"}
+	var out, errOut bytes.Buffer
+
+	_, err := configureDetectedTools(
+		&out, &errOut, gm,
+		[]string{"claude-code"},
+		"https://gw.example.com", "http://localhost:14000/v1", `"thv" llm token`,
+		"/usr/local/bin/thv", []string{"llm", "token", "--skip-browser"},
+		false, "/anthropic", nil,
+		BedrockConfig{Compat: true, Enable1M: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, gm.applied, 1)
+
+	got := gm.applied[0]
+	assert.True(t, got.BedrockCompat)
+	assert.Equal(t, defaultBedrockHaikuModel, got.BedrockHaikuModel)
+	assert.Equal(t, defaultBedrockOpusModel+"[1m]", got.BedrockOpusModel)
+	assert.Equal(t, defaultBedrockSonnetModel+"[1m]", got.BedrockSonnetModel)
+}
+
+func TestConfigureDetectedTools_BedrockSkippedForNonClaudeCode(t *testing.T) {
+	t.Parallel()
+
+	gm := &capturingGatewayManager{mode: "proxy"}
+	var out, errOut bytes.Buffer
+
+	_, err := configureDetectedTools(
+		&out, &errOut, gm,
+		[]string{"cursor"},
+		"https://gw.example.com", "http://localhost:14000/v1", `"thv" llm token`,
+		"/usr/local/bin/thv", []string{"llm", "token", "--skip-browser"},
+		false, "", nil,
+		BedrockConfig{Compat: true},
+	)
+	require.NoError(t, err)
+	require.Len(t, gm.applied, 1)
+	assert.False(t, gm.applied[0].BedrockCompat)
+	assert.Empty(t, gm.applied[0].BedrockOpusModel)
+}
+
 // ── mergeToolConfigs ──────────────────────────────────────────────────────────
 
 func TestMergeToolConfigs_EmptyExisting(t *testing.T) {
@@ -299,6 +409,7 @@ func TestConfigureDetectedTools_PathPrefixAppendedForDirectMode(t *testing.T) {
 		"https://gw.example.com", "http://localhost:14000/v1", `"thv" llm token`,
 		"/usr/local/bin/thv", []string{"llm", "token", "--skip-browser"},
 		false, "/anthropic", nil,
+		BedrockConfig{},
 	)
 	require.NoError(t, err)
 	require.Len(t, gm.applied, 1)
@@ -320,6 +431,7 @@ func TestConfigureDetectedTools_NoPrefixWhenEmpty(t *testing.T) {
 		"https://gw.example.com", "http://localhost:14000/v1", `"thv" llm token`,
 		"/usr/local/bin/thv", []string{"llm", "token", "--skip-browser"},
 		false, "", nil, // no prefix
+		BedrockConfig{},
 	)
 	require.NoError(t, err)
 	require.Len(t, gm.applied, 1)
@@ -340,6 +452,7 @@ func TestConfigureDetectedTools_PrefixNotAppliedForProxyMode(t *testing.T) {
 		"https://gw.example.com", "http://localhost:14000/v1", `"thv" llm token`,
 		"/usr/local/bin/thv", []string{"llm", "token", "--skip-browser"},
 		false, "/anthropic", nil,
+		BedrockConfig{},
 	)
 	require.NoError(t, err)
 	require.Len(t, gm.applied, 1)

--- a/pkg/llmgateway/config.go
+++ b/pkg/llmgateway/config.go
@@ -108,4 +108,15 @@ type ApplyConfig struct {
 	// a model override (e.g. Claude Desktop's inferenceModels). Empty means the
 	// client falls back to gateway-side model auto-discovery.
 	Models []string
+	// BedrockCompat and the per-tier Bedrock model IDs configure Claude Code for a
+	// gateway that forwards to AWS Bedrock. When BedrockCompat is true, Claude Code
+	// is configured with CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 (Bedrock rejects
+	// the experimental anthropic-beta headers) and the three per-tier model IDs.
+	// The caller (pkg/llm) resolves defaults, tier mapping, and the optional "[1m]"
+	// suffix; pkg/client only writes the resolved values. All are empty/false for
+	// non-Bedrock setups.
+	BedrockCompat      bool
+	BedrockHaikuModel  string
+	BedrockOpusModel   string
+	BedrockSonnetModel string
 }


### PR DESCRIPTION
## Summary

Configuring Claude Code against an LLM gateway that forwards to AWS Bedrock previously required hand-editing `~/.claude/settings.json`. Bedrock rejects Claude Code's experimental `anthropic-beta` headers (requests fail with "Unexpected value(s) for the anthropic-beta header"), and Bedrock-style model IDs must be pinned per tier. There was no supported way to configure this through `thv`.

This adds a `--bedrock-compat` flag that encodes that knowledge so users don't have to.

- New `--bedrock-compat` flag on `thv llm setup` and `thv llm config set`: writes `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` and the three per-tier model IDs (`ANTHROPIC_DEFAULT_{HAIKU,OPUS,SONNET}_MODEL`) into `settings.json`.
- Reuses the existing `ClearWhenEmpty` key-spec mechanism (same pattern as `NODE_TLS_REJECT_UNAUTHORIZED`), so teardown, revert, and idempotent re-runs work with no new writer.
- The setting is **persisted** in `config.yaml`, so a later plain `thv llm setup` keeps Bedrock on instead of silently stripping it.
- `--models` overrides the default `us.anthropic.*` IDs (each mapped to a tier by matching `haiku`/`opus`/`sonnet` in the ID; unmatched IDs warn and are ignored).
- `--enable-1m` appends the `[1m]` suffix to the opus/sonnet IDs to opt into the 1M-token context window on Bedrock (never haiku, which is 200K). Off by default because 1M-on-Bedrock is a version-dependent Claude Code behavior.
- Bedrock keys only attach to Claude Code; the flag is a no-op for other clients and warns when Claude Code is not among the configured tools.

Chose a flag over a separate `claude-code-bedrock` client entry because such an entry can't be auto-detected (it shares the `claude` binary and `settings.json` with `claude-code`) and would bake in stale model IDs.

Fixes #

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Unit tests cover `resolveBedrockModels` (defaults, substring tier-mapping, case-insensitivity, `[1m]` on opus/sonnet only, unmatched warnings), `SetFields` persistence (set / nil-leaves-unchanged / false-clears), the per-client key writes against the real config table, and that bedrock is skipped for non-claude-code clients. Manually verified the generated keys land in `~/.claude/settings.json` and that a plain re-run preserves the existing `ANTHROPIC_BASE_URL` / `apiKeyHelper` keys.

Note: two unrelated failures exist on `origin/main` independent of this PR (`pkg/plugins/pluginsvc` `TestParseGitReference_RefAndSubdir`, and a gosec G115 in `cmd/thv/app/upgrade.go`); neither file is touched here.

## Does this introduce a user-facing change?

Yes. New flags on `thv llm setup` and `thv llm config set`:

- `--bedrock-compat` — configure Claude Code for a Bedrock-backed gateway.
- `--enable-1m` — opt into the 1M context window on opus/sonnet (requires `--bedrock-compat`).
- `--models` — now also maps IDs to Claude Code tiers when `--bedrock-compat` is set.

Example commands:

\`\`\`bash
# First-time setup for a Bedrock-backed gateway
thv llm setup --client claude-code --bedrock-compat

# Add Bedrock to an already-configured Claude Code (idempotent, uses cached token)
thv llm setup --client claude-code --bedrock-compat

# With the 1M context window
thv llm setup --client claude-code --bedrock-compat --enable-1m

# With custom Bedrock model IDs
thv llm setup --client claude-code --bedrock-compat \
  --models=us.anthropic.claude-opus-4-8,us.anthropic.claude-sonnet-5

# Turn it back off (clears the keys)
thv llm setup --client claude-code --bedrock-compat=false
\`\`\`

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Flag-based design over a static `claude-code-bedrock` client entry (which can't be auto-detected and would bake in stale model IDs). Two orthogonal capabilities kept separate: the provider-compat toggle (disable experimental betas) and model pinning (per-tier Bedrock IDs).

Decisions:
1. Hardcoded `us.anthropic.*` defaults, overridable per-tier via `--models` (substring tier-mapping).
2. Persisted in `config.yaml` (sticky, like `tls-skip-verify`).
3. `[1m]` handled via opt-in `--enable-1m` (opus/sonnet only).
4. No `--client`: bedrock keys apply only to `claude-code`; warn if absent.

Changes:
- `pkg/llm/config.go` — persisted `BedrockConfig{Compat, Enable1M, Models}`.
- `pkg/llm/manage.go` — `SetOptions` fields, merged in `SetFields`, shown in `Show`.
- `pkg/llmgateway/config.go` — `ApplyConfig` bedrock fields (policy filled by pkg/llm, written by pkg/client).
- `pkg/client/llm_gateway.go` — `resolveBedrockField` helper for the four ValueFields.
- `pkg/client/config.go` — four `ClearWhenEmpty` keys on the ClaudeCode entry.
- `pkg/llm/setup.go` — default constants, `resolveBedrockModels`, orchestration, `warnBedrockNoEffect`.
- `cmd/thv/app/llm.go` — flags on `setup` and `config set`, help text.

Note on 1M + betas: on Bedrock these are independent — `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` does not strip the 1M window (Claude Code never populates the SDK betas array for Bedrock; 1M rides the `[1m]` model-ID path instead).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)