### PR TITLE
Promote stacklok.component/product to per-series metric labels

### DIFF
--- a/pkg/telemetry/config.go
+++ b/pkg/telemetry/config.go
@@ -235,6 +235,39 @@ func ResolveServiceName(config *Config, serverName string) {
 	}
 }
 
+// Option customizes provider construction beyond the serialized Config. It
+// carries runtime-only settings that must not be part of the CRD/config surface
+// (e.g. the emitter-ownership component identity, determined by which surface is
+// running rather than by user configuration).
+type Option func(*providerOptions)
+
+// providerOptions holds resolved Option values consumed by NewProvider.
+type providerOptions struct {
+	// stacklokComponent overrides the RFC D8 stacklok.component value. Empty means
+	// default to the ToolHive proxy/API identity (providers.ComponentToolhive).
+	stacklokComponent string
+	// extraProcessors are additional OTEL span processors (e.g. a Sentry bridge)
+	// registered alongside the globally-registered ones.
+	extraProcessors []sdktrace.SpanProcessor
+}
+
+// WithStacklokComponent sets the RFC D8 emitter-ownership component identity.
+// vMCP surfaces pass providers.ComponentVMCP; proxy/API surfaces omit it and
+// default to providers.ComponentToolhive.
+func WithStacklokComponent(component string) Option {
+	return func(o *providerOptions) {
+		o.stacklokComponent = component
+	}
+}
+
+// WithSpanProcessors registers additional OTEL span processors (e.g. a Sentry
+// bridge) alongside any globally-registered processors.
+func WithSpanProcessors(processors ...sdktrace.SpanProcessor) Option {
+	return func(o *providerOptions) {
+		o.extraProcessors = append(o.extraProcessors, processors...)
+	}
+}
+
 // Provider encapsulates OpenTelemetry providers and configuration.
 type Provider struct {
 	config            Config
@@ -245,11 +278,18 @@ type Provider struct {
 }
 
 // NewProvider creates a new OpenTelemetry provider with the given configuration.
-// Optional extra span processors (e.g. a Sentry bridge) can be registered via extraProcessors.
-func NewProvider(ctx context.Context, config Config, extraProcessors ...sdktrace.SpanProcessor) (*Provider, error) {
+// Optional Options customize runtime-only settings not carried on Config, such as
+// the RFC D8 emitter-ownership component (WithStacklokComponent) and extra span
+// processors (WithSpanProcessors, e.g. a Sentry bridge).
+func NewProvider(ctx context.Context, config Config, opts ...Option) (*Provider, error) {
 	// Validate configuration
 	if err := validateOtelConfig(config); err != nil {
 		return nil, err
+	}
+
+	options := providerOptions{}
+	for _, opt := range opts {
+		opt(&options)
 	}
 
 	// Always use the current binary version so that restarts and exports
@@ -263,6 +303,7 @@ func NewProvider(ctx context.Context, config Config, extraProcessors ...sdktrace
 	telemetryOptions := []providers.ProviderOption{
 		providers.WithServiceName(config.ServiceName),
 		providers.WithServiceVersion(serviceVersion),
+		providers.WithStacklokComponent(options.stacklokComponent),
 		providers.WithOTLPEndpoint(config.Endpoint),
 		providers.WithHeaders(config.Headers),
 		providers.WithInsecure(config.Insecure),
@@ -276,7 +317,7 @@ func NewProvider(ctx context.Context, config Config, extraProcessors ...sdktrace
 
 	// Merge globally registered processors (self-registered by integrations such
 	// as a Sentry bridge) with any explicitly passed ones.
-	allProcessors := append(registeredSpanProcessors(), extraProcessors...)
+	allProcessors := append(registeredSpanProcessors(), options.extraProcessors...)
 	if len(allProcessors) > 0 {
 		telemetryOptions = append(telemetryOptions, providers.WithExtraSpanProcessors(allProcessors...))
 	}

--- a/pkg/telemetry/config.go
+++ b/pkg/telemetry/config.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/stacklok/toolhive/pkg/telemetry/providers"
@@ -246,9 +245,6 @@ type providerOptions struct {
 	// stacklokComponent overrides the RFC D8 stacklok.component value. Empty means
 	// default to the ToolHive proxy/API identity (providers.ComponentToolhive).
 	stacklokComponent string
-	// extraProcessors are additional OTEL span processors (e.g. a Sentry bridge)
-	// registered alongside the globally-registered ones.
-	extraProcessors []sdktrace.SpanProcessor
 }
 
 // WithStacklokComponent sets the RFC D8 emitter-ownership component identity.
@@ -257,14 +253,6 @@ type providerOptions struct {
 func WithStacklokComponent(component string) Option {
 	return func(o *providerOptions) {
 		o.stacklokComponent = component
-	}
-}
-
-// WithSpanProcessors registers additional OTEL span processors (e.g. a Sentry
-// bridge) alongside any globally-registered processors.
-func WithSpanProcessors(processors ...sdktrace.SpanProcessor) Option {
-	return func(o *providerOptions) {
-		o.extraProcessors = append(o.extraProcessors, processors...)
 	}
 }
 
@@ -279,8 +267,7 @@ type Provider struct {
 
 // NewProvider creates a new OpenTelemetry provider with the given configuration.
 // Optional Options customize runtime-only settings not carried on Config, such as
-// the RFC D8 emitter-ownership component (WithStacklokComponent) and extra span
-// processors (WithSpanProcessors, e.g. a Sentry bridge).
+// the RFC D8 emitter-ownership component (WithStacklokComponent).
 func NewProvider(ctx context.Context, config Config, opts ...Option) (*Provider, error) {
 	// Validate configuration
 	if err := validateOtelConfig(config); err != nil {
@@ -315,10 +302,9 @@ func NewProvider(ctx context.Context, config Config, opts ...Option) (*Provider,
 		providers.WithCustomAttributes(config.CustomAttributes),
 	}
 
-	// Merge globally registered processors (self-registered by integrations such
-	// as a Sentry bridge) with any explicitly passed ones.
-	allProcessors := append(registeredSpanProcessors(), options.extraProcessors...)
-	if len(allProcessors) > 0 {
+	// Include globally registered span processors (self-registered by integrations
+	// such as a Sentry bridge).
+	if allProcessors := registeredSpanProcessors(); len(allProcessors) > 0 {
 		telemetryOptions = append(telemetryOptions, providers.WithExtraSpanProcessors(allProcessors...))
 	}
 

--- a/pkg/telemetry/config_test.go
+++ b/pkg/telemetry/config_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -270,6 +271,62 @@ func TestProvider_Middleware(t *testing.T) {
 
 	wrappedHandler := middleware(testHandler)
 	assert.NotNil(t, wrappedHandler)
+}
+
+// TestNewProvider_StacklokComponentLabel verifies WithStacklokComponent threads
+// through NewProvider so the emitted series carry the RFC D8 ownership labels,
+// defaulting to "toolhive" when the option is omitted.
+func TestNewProvider_StacklokComponentLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		opts          []Option
+		wantComponent string
+	}{
+		{name: "default is toolhive", opts: nil, wantComponent: "toolhive"},
+		{name: "vmcp override", opts: []Option{WithStacklokComponent("vmcp")}, wantComponent: "vmcp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			config := Config{
+				ServiceName:                 "test-service",
+				ServiceVersion:              "1.0.0",
+				SamplingRate:                "0.1",
+				Headers:                     make(map[string]string),
+				EnablePrometheusMetricsPath: true,
+			}
+
+			provider, err := NewProvider(ctx, config, tt.opts...)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = provider.Shutdown(ctx) })
+
+			counter, err := provider.MeterProvider().Meter("test").Int64Counter("component_label_test")
+			require.NoError(t, err)
+			counter.Add(ctx, 1)
+
+			handler := provider.PrometheusHandler()
+			require.NotNil(t, handler)
+			req := httptest.NewRequest("GET", "/metrics", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var line string
+			for l := range strings.SplitSeq(rec.Body.String(), "\n") {
+				if strings.HasPrefix(l, "component_label_test_total") {
+					line = l
+					break
+				}
+			}
+			require.NotEmpty(t, line, "expected component_label_test_total series")
+			assert.Contains(t, line, `stacklok_component="`+tt.wantComponent+`"`)
+			assert.Contains(t, line, `stacklok_product="stacklok-enterprise"`)
+		})
+	}
 }
 
 // TestProvider_ShutdownTimeout tests provider shutdown with timeout

--- a/pkg/telemetry/providers/prometheus/prometheus.go
+++ b/pkg/telemetry/providers/prometheus/prometheus.go
@@ -11,6 +11,7 @@ import (
 	promclient "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
@@ -21,6 +22,11 @@ type Config struct {
 	EnableMetricsPath bool
 	// IncludeRuntimeMetrics adds Go runtime metrics to the registry
 	IncludeRuntimeMetrics bool
+	// ResourceAsConstantLabels, when non-nil, promotes the resource attributes it
+	// admits to constant per-series labels (RFC D8). Use an allow-keys filter so
+	// only the intended keys are promoted — promoting the whole resource would pull
+	// host.*/process.*/env attributes onto every series and blow up cardinality.
+	ResourceAsConstantLabels attribute.Filter
 }
 
 // NewReader creates a Prometheus metric reader and HTTP handler for use in a unified meter provider
@@ -39,7 +45,11 @@ func NewReader(config Config) (sdkmetric.Reader, http.Handler, error) {
 	}
 
 	// Create the Prometheus exporter (which is also a Reader)
-	exporter, err := prometheus.New(prometheus.WithRegisterer(registry))
+	opts := []prometheus.Option{prometheus.WithRegisterer(registry)}
+	if config.ResourceAsConstantLabels != nil {
+		opts = append(opts, prometheus.WithResourceAsConstantLabels(config.ResourceAsConstantLabels))
+	}
+	exporter, err := prometheus.New(opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create prometheus exporter: %w", err)
 	}

--- a/pkg/telemetry/providers/providers.go
+++ b/pkg/telemetry/providers/providers.go
@@ -28,6 +28,11 @@ type Config struct {
 	ServiceName    string // ServiceName identifies the service for telemetry data
 	ServiceVersion string // ServiceVersion identifies the service version for telemetry data
 
+	// StacklokComponent is the emitter-ownership component identity (RFC D8),
+	// set on the OTel resource as stacklok.component and promoted to the
+	// stacklok_component per-series label. Defaults to ComponentToolhive when empty.
+	StacklokComponent string
+
 	// OTLP configuration
 	OTLPEndpoint   string            // OTLPEndpoint is the OTLP collector endpoint (e.g., "localhost:4318")
 	Headers        map[string]string // Headers are additional headers to send with OTLP requests
@@ -72,6 +77,15 @@ func WithServiceVersion(serviceVersion string) ProviderOption {
 			return fmt.Errorf("service version cannot be empty")
 		}
 		config.ServiceVersion = serviceVersion
+		return nil
+	}
+}
+
+// WithStacklokComponent sets the emitter-ownership component identity (RFC D8).
+// When empty, NewCompositeProvider defaults it to ComponentToolhive.
+func WithStacklokComponent(component string) ProviderOption {
+	return func(config *Config) error {
+		config.StacklokComponent = component
 		return nil
 	}
 }
@@ -183,6 +197,19 @@ func NewCompositeProvider(
 		semconv.ServiceName(config.ServiceName),
 		semconv.ServiceVersion(config.ServiceVersion),
 	}
+
+	// Emitter-ownership attributes (RFC D8). These land in the target_info gauge
+	// by default; the Prometheus exporter promotes them to per-series labels via
+	// WithResourceAsConstantLabels. product is constant across services; component
+	// defaults to the ToolHive proxy/API identity unless a caller (e.g. vMCP) overrides it.
+	component := config.StacklokComponent
+	if component == "" {
+		component = ComponentToolhive
+	}
+	baseAttrs = append(baseAttrs,
+		attribute.String(AttrStacklokComponent, component),
+		attribute.String(AttrStacklokProduct, ProductStacklokEnterprise),
+	)
 
 	// Add custom attributes from CLI flags
 	if len(config.CustomAttributes) > 0 {

--- a/pkg/telemetry/providers/providers_strategy.go
+++ b/pkg/telemetry/providers/providers_strategy.go
@@ -146,6 +146,10 @@ func (s *UnifiedMeterStrategy) CreateMeterProvider(
 		promConfig := prometheus.Config{
 			EnableMetricsPath:     true,
 			IncludeRuntimeMetrics: true,
+			// Promote only the two emitter-ownership attributes to per-series labels
+			// (RFC D8); never the whole resource — that would leak host.*/process.*/env
+			// attributes onto every series and blow up cardinality.
+			ResourceAsConstantLabels: stacklokResourceLabelFilter(),
 		}
 		reader, handler, err := prometheus.NewReader(promConfig)
 		if err != nil {

--- a/pkg/telemetry/providers/stacklok.go
+++ b/pkg/telemetry/providers/stacklok.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import "go.opentelemetry.io/otel/attribute"
+
+// Emitter-ownership resource attributes (RFC metrics-standardization, D8).
+//
+// Each ToolHive service tags its OTel resource with a vendor-owned component
+// identity and the shared product marker. The Prometheus exporter promotes
+// these two attributes to per-series labels (see the Prometheus reader's
+// WithResourceAsConstantLabels) so a single selector,
+// stacklok_product="stacklok-enterprise", matches both our stacklok.* metrics
+// and the unprefixed semconv (mcp.*, http.*) ones.
+//
+// These live here, not in the OSS toolhive-core shared metrics package: the
+// product marker names the enterprise product and the component values are the
+// internal service roster, neither of which belongs in a public shared library.
+// toolhive-core exports only vendor-neutral primitives (bucket presets, canonical
+// per-series label keys). Each consuming service (proxy, vMCP, registry) owns
+// its own copy of these ownership attributes.
+const (
+	// AttrStacklokComponent is the resource-attribute key identifying the emitting
+	// component. The Prometheus exporter renders it as the stacklok_component label.
+	AttrStacklokComponent = "stacklok.component"
+
+	// AttrStacklokProduct is the resource-attribute key identifying the product.
+	// The Prometheus exporter renders it as the stacklok_product label.
+	AttrStacklokProduct = "stacklok.product"
+
+	// ProductStacklokEnterprise is the shared value for AttrStacklokProduct across
+	// every in-scope service. It is the cross-component selector value.
+	ProductStacklokEnterprise = "stacklok-enterprise"
+
+	// ComponentToolhive is the AttrStacklokComponent value for the ToolHive proxy
+	// and API server.
+	ComponentToolhive = "toolhive"
+
+	// ComponentVMCP is the AttrStacklokComponent value for the Virtual MCP server.
+	ComponentVMCP = "vmcp"
+)
+
+// stacklokResourceLabelFilter admits exactly the two emitter-ownership attribute
+// keys for promotion to per-series Prometheus labels (RFC D8). It deliberately
+// excludes every other resource attribute (host.*, process.*, env-provided) to
+// keep series cardinality bounded.
+func stacklokResourceLabelFilter() attribute.Filter {
+	return attribute.NewAllowKeysFilter(AttrStacklokComponent, AttrStacklokProduct)
+}

--- a/pkg/telemetry/providers/stacklok_test.go
+++ b/pkg/telemetry/providers/stacklok_test.go
@@ -96,17 +96,23 @@ func TestStacklokLabels_DoNotLeakUnrelatedResourceAttrs(t *testing.T) {
 
 	body := scrapePrometheus(t)
 
+	var counterLine string
 	for line := range strings.SplitSeq(body, "\n") {
-		if !strings.HasPrefix(line, "d8_test_counter_total") {
-			continue
+		if strings.HasPrefix(line, "d8_test_counter_total") {
+			counterLine = line
+			break
 		}
-		// The env-provided attribute must not have been promoted onto the series.
-		assert.NotContains(t, line, "leak-canary", "env resource attr leaked onto series")
-		assert.NotContains(t, line, "deployment_environment", "env resource attr key leaked onto series")
-		// Host/process attributes must not be promoted either.
-		assert.NotContains(t, line, "host_name")
-		assert.NotContains(t, line, "process_pid")
 	}
+	// Assert the inspected series exists so the guard below cannot pass vacuously
+	// if the metric is ever renamed or suppressed.
+	require.NotEmpty(t, counterLine, "expected d8_test_counter_total series in:\n%s", body)
+
+	// The env-provided attribute must not have been promoted onto the series.
+	assert.NotContains(t, counterLine, "leak-canary", "env resource attr leaked onto series")
+	assert.NotContains(t, counterLine, "deployment_environment", "env resource attr key leaked onto series")
+	// Host/process attributes must not be promoted either.
+	assert.NotContains(t, counterLine, "host_name")
+	assert.NotContains(t, counterLine, "process_pid")
 }
 
 func TestStacklokResourceLabelFilter_AdmitsExactlyTwoKeys(t *testing.T) {

--- a/pkg/telemetry/providers/stacklok_test.go
+++ b/pkg/telemetry/providers/stacklok_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package providers
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// scrapePrometheus builds a Prometheus-only provider, records one metric, and
+// returns the scraped /metrics body.
+func scrapePrometheus(t *testing.T, extraOpts ...ProviderOption) string {
+	t.Helper()
+	ctx := context.Background()
+	options := append([]ProviderOption{
+		WithServiceName("test-service"),
+		WithServiceVersion("1.0.0"),
+		WithEnablePrometheusMetricsPath(true),
+	}, extraOpts...)
+
+	provider, err := NewCompositeProvider(ctx, options...)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	t.Cleanup(func() { _ = provider.Shutdown(ctx) })
+
+	counter, err := provider.MeterProvider().Meter("test").Int64Counter("d8_test_counter")
+	require.NoError(t, err)
+	counter.Add(ctx, 1)
+
+	require.NotNil(t, provider.PrometheusHandler())
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	rec := httptest.NewRecorder()
+	provider.PrometheusHandler().ServeHTTP(rec, req)
+	require.Equal(t, 200, rec.Code)
+	return rec.Body.String()
+}
+
+func TestStacklokComponent_PromotedToPerSeriesLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		opts          []ProviderOption
+		wantComponent string
+	}{
+		{
+			name:          "defaults to toolhive when unset",
+			opts:          nil,
+			wantComponent: ComponentToolhive,
+		},
+		{
+			name:          "empty component defaults to toolhive",
+			opts:          []ProviderOption{WithStacklokComponent("")},
+			wantComponent: ComponentToolhive,
+		},
+		{
+			name:          "vmcp component honored",
+			opts:          []ProviderOption{WithStacklokComponent(ComponentVMCP)},
+			wantComponent: ComponentVMCP,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body := scrapePrometheus(t, tt.opts...)
+
+			// The emitted counter series (not only target_info) carries both labels.
+			var counterLine string
+			for line := range strings.SplitSeq(body, "\n") {
+				if strings.HasPrefix(line, "d8_test_counter_total") {
+					counterLine = line
+					break
+				}
+			}
+			require.NotEmpty(t, counterLine, "expected d8_test_counter_total series in:\n%s", body)
+			assert.Contains(t, counterLine, `stacklok_component="`+tt.wantComponent+`"`)
+			assert.Contains(t, counterLine, `stacklok_product="`+ProductStacklokEnterprise+`"`)
+		})
+	}
+}
+
+// TestStacklokLabels_DoNotLeakUnrelatedResourceAttrs is the cardinality guard:
+// the promotion filter must admit ONLY the two stacklok.* keys, never host.*,
+// process.*, or the OTEL_RESOURCE_ATTRIBUTES-provided attributes.
+func TestStacklokLabels_DoNotLeakUnrelatedResourceAttrs(t *testing.T) {
+	// Not parallel: sets a process-wide env var consumed by resource.WithFromEnv.
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=leak-canary")
+
+	body := scrapePrometheus(t)
+
+	for line := range strings.SplitSeq(body, "\n") {
+		if !strings.HasPrefix(line, "d8_test_counter_total") {
+			continue
+		}
+		// The env-provided attribute must not have been promoted onto the series.
+		assert.NotContains(t, line, "leak-canary", "env resource attr leaked onto series")
+		assert.NotContains(t, line, "deployment_environment", "env resource attr key leaked onto series")
+		// Host/process attributes must not be promoted either.
+		assert.NotContains(t, line, "host_name")
+		assert.NotContains(t, line, "process_pid")
+	}
+}
+
+func TestStacklokResourceLabelFilter_AdmitsExactlyTwoKeys(t *testing.T) {
+	t.Parallel()
+
+	filter := stacklokResourceLabelFilter()
+
+	admitted := []attribute.KeyValue{
+		attribute.String(AttrStacklokComponent, ComponentToolhive),
+		attribute.String(AttrStacklokProduct, ProductStacklokEnterprise),
+	}
+	for _, kv := range admitted {
+		assert.True(t, filter(kv), "filter should admit %q", kv.Key)
+	}
+
+	excluded := []attribute.KeyValue{
+		attribute.String("service.name", "thv-api"),
+		attribute.String("host.name", "node-1"),
+		attribute.Int("process.pid", 42),
+		attribute.String("deployment.environment", "prod"),
+	}
+	for _, kv := range excluded {
+		assert.False(t, filter(kv), "filter should exclude %q", kv.Key)
+	}
+}

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/groups"
 	"github.com/stacklok/toolhive/pkg/migration"
 	"github.com/stacklok/toolhive/pkg/telemetry"
+	"github.com/stacklok/toolhive/pkg/telemetry/providers"
 	"github.com/stacklok/toolhive/pkg/versions"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
@@ -190,7 +191,8 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 	// If telemetry is configured, create the provider early so aggregator can use it.
 	var telemetryProvider *telemetry.Provider
 	if vmcpCfg.Telemetry != nil {
-		telemetryProvider, err = telemetry.NewProvider(ctx, *vmcpCfg.Telemetry)
+		telemetryProvider, err = telemetry.NewProvider(ctx, *vmcpCfg.Telemetry,
+			telemetry.WithStacklokComponent(providers.ComponentVMCP))
 		if err != nil {
 			return fmt.Errorf("failed to create telemetry provider: %w", err)
 		}


### PR DESCRIPTION
## Summary

RFC D8 (metrics standardization) requires emitter-ownership to ride on vendor-owned resource attributes so that a single Prometheus selector — `stacklok_product="stacklok-enterprise"` — matches both our `stacklok.*` series and the unprefixed semconv series (`mcp.*`, `http.*`). Today the ToolHive proxy/API and vMCP set neither `stacklok.component` nor `stacklok.product`, and their Prometheus exporter does not promote resource attributes to labels, so no such selector works. This PR wires both attributes into the OTel resource and promotes exactly those two keys to per-series labels.

This is **PR 2 of 3** for the tracking issue, covering the **ToolHive proxy + vMCP** portion only. The LLM Gateway (PR 1) and registry (PR 3) portions land in their own repositories and are out of scope here.

- **Why:** without these attributes and label promotion, the standardized dashboards' `stacklok_product` selector cannot match ToolHive/vMCP series — the attributes only ever appear in the default `target_info` gauge, not on the emitted series.
- **What:** set `stacklok.component` (`toolhive` for proxy/API, `vmcp` for vMCP) and `stacklok.product=stacklok-enterprise` on the OTel resource, and construct the Prometheus exporter with `WithResourceAsConstantLabels` using an allow-keys filter that admits exactly those two keys.

Part of stacklok/stacklok-enterprise-platform#2300 (PR 2 of 3).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- `go build ./...` — clean.
- `task test` on `pkg/telemetry/...` and `pkg/sentry/...` — pass.
- `task lint-fix` — 0 issues.
- `task license-check` — pass.
- New unit tests cover per-series label promotion for both `toolhive` and `vmcp`, the cardinality guard (whole resource is never promoted), the filter admitting exactly the two keys, and `WithStacklokComponent` threading through `NewProvider`.
- Two rounds of automated code review; all findings addressed.

## Changes

| File | Change |
|------|--------|
| `pkg/telemetry/providers/stacklok.go` | New. Local constants for the two dotted keys (`stacklok.component`, `stacklok.product`), the shared product value (`stacklok-enterprise`), the component values (`toolhive`, `vmcp`), and an allow-keys filter helper. |
| `pkg/telemetry/providers/providers.go` | Merge `stacklok.component` (defaulting to `toolhive`) and `stacklok.product=stacklok-enterprise` into the OTel resource; add `WithStacklokComponent` provider option and `StacklokComponent` config field. |
| `pkg/telemetry/providers/prometheus/prometheus.go` | Construct the Prometheus exporter with `WithResourceAsConstantLabels` when a `ResourceAsConstantLabels` filter is supplied. |
| `pkg/telemetry/providers/providers_strategy.go` | Pass the allow-keys filter (exactly the two ownership keys) into the Prometheus reader config. |
| `pkg/telemetry/config.go` | Add an Option pattern to `NewProvider` (`WithStacklokComponent`); change the signature from a trailing `extraProcessors` variadic to `opts ...Option`. |
| `pkg/vmcp/cli/serve.go` | vMCP passes `WithStacklokComponent(ComponentVMCP)` at its single `NewProvider` call site. |
| `pkg/telemetry/providers/stacklok_test.go` | New. Per-series label promotion for `toolhive`/`vmcp`, cardinality guard, filter admits exactly two keys. |
| `pkg/telemetry/config_test.go` | `WithStacklokComponent` threads through `NewProvider`. |

## Does this introduce a user-facing change?

Yes. Metrics scraped from the ToolHive proxy/API and vMCP `/metrics` endpoints now carry `stacklok_component` and `stacklok_product` labels on every emitted series (not just in `target_info`), enabling the `stacklok_product="stacklok-enterprise"` selector across both `stacklok.*` and semconv series.

## Special notes for reviewers

**Deliberate deviation from an acceptance criterion — needs RFC-author (ITEM-007) sign-off before the issue checklist is ticked.**

The issue's acceptance criteria state: *"Label keys/values come from the shared toolhive-core constants (ITEM-007)."* This PR **intentionally defines the constants locally** in `pkg/telemetry/providers/stacklok.go` rather than in the OSS `toolhive-core` metrics package. Rationale:

- The product marker names the enterprise product (`stacklok-enterprise`), and the component values are the internal service roster (`toolhive`/`vmcp`/`registry`/`ai_gateway`). Neither should be published in the public, Apache-2.0 `toolhive-core` shared library.
- `toolhive-core/metrics` is scoped to vendor-neutral primitives only (bucket presets, canonical per-series label keys). Each consuming service owns its own copy of these ownership attributes.

Please flag this for the RFC author explicitly — the issue's ITEM-007 acceptance item should not be checked until this ownership-boundary decision is signed off.

Other notes:
- The single `NewProvider` call in `pkg/vmcp/cli/serve.go` covers the standalone `vmcp` binary, `thv vmcp`, and operator-deployed vMCP. Proxy/API paths default to `toolhive` with no call-site change.
- The `NewProvider` signature change (trailing `extraProcessors ...sdktrace.SpanProcessor` → `opts ...Option`) is caller-safe: no caller passed processors positionally; they flow through the global registry.

Generated with [Claude Code](https://claude.com/claude-code)
