### PR TITLE
Add stateless routing to streamable MCP proxy

### DIFF
--- a/pkg/mcp/parser.go
+++ b/pkg/mcp/parser.go
@@ -252,13 +252,7 @@ func extractResourceAndArguments(method string, params json.RawMessage) (string,
 		return getStaticResourceID(method), nil, nil
 	}
 
-	// Extract _meta field if present
-	var meta map[string]interface{}
-	if metaRaw, ok := paramsMap["_meta"]; ok {
-		if metaMap, ok := metaRaw.(map[string]interface{}); ok {
-			meta = metaMap
-		}
-	}
+	meta := metaFromParamsMap(paramsMap)
 
 	resourceID, arguments := processMethodWithHandler(method, paramsMap)
 	return resourceID, arguments, meta

--- a/pkg/mcp/revision.go
+++ b/pkg/mcp/revision.go
@@ -3,7 +3,10 @@
 
 package mcp
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Revision identifies which MCP protocol era a request belongs to.
 type Revision int
@@ -242,6 +245,33 @@ func ClassifyRevision(method string, meta map[string]any, protoHeader string) (R
 	}
 
 	return RevisionModern, nil
+}
+
+// ExtractMeta pulls the "_meta" object out of raw JSON-RPC request params, for
+// use with ClassifyRevision. It is deliberately tolerant: absent params, params
+// that don't decode as a JSON object, or a "_meta" value that isn't itself an
+// object all yield a nil map rather than an error. Only a well-formed object
+// "_meta" is returned.
+func ExtractMeta(params json.RawMessage) map[string]any {
+	if len(params) == 0 {
+		return nil
+	}
+	var paramsMap map[string]any
+	if err := json.Unmarshal(params, &paramsMap); err != nil {
+		return nil
+	}
+	return metaFromParamsMap(paramsMap)
+}
+
+// metaFromParamsMap reports the "_meta" value of an already-decoded JSON-RPC
+// params map, if it decodes as a JSON object. A missing key or a wrong-typed
+// value (e.g. a string or number) both yield nil.
+func metaFromParamsMap(paramsMap map[string]any) map[string]any {
+	meta, ok := paramsMap["_meta"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return meta
 }
 
 // hasModernSignal reports whether the request signals the Modern revision:

--- a/pkg/mcp/revision_test.go
+++ b/pkg/mcp/revision_test.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -316,6 +317,79 @@ func TestClassifyRevision(t *testing.T) {
 
 			assert.Equal(t, tt.expectedRev, rev)
 			tt.checkErr(t, err)
+		})
+	}
+}
+
+func TestExtractMeta(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params json.RawMessage
+		want   map[string]any
+	}{
+		{
+			name:   "well-formed object _meta is returned",
+			params: json.RawMessage(`{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}`),
+			want:   map[string]any{"io.modelcontextprotocol/protocolVersion": "2026-07-28"},
+		},
+		{
+			name:   "empty object _meta is returned",
+			params: json.RawMessage(`{"_meta":{}}`),
+			want:   map[string]any{},
+		},
+		{
+			name:   "nil params yields nil",
+			params: nil,
+			want:   nil,
+		},
+		{
+			name:   "empty params yields nil",
+			params: json.RawMessage(``),
+			want:   nil,
+		},
+		{
+			name:   "params without _meta yields nil",
+			params: json.RawMessage(`{"other":"value"}`),
+			want:   nil,
+		},
+		{
+			name:   "params as JSON array yields nil",
+			params: json.RawMessage(`["_meta"]`),
+			want:   nil,
+		},
+		{
+			name:   "params as JSON scalar yields nil",
+			params: json.RawMessage(`42`),
+			want:   nil,
+		},
+		{
+			name:   "malformed params bytes yield nil",
+			params: json.RawMessage(`{not json`),
+			want:   nil,
+		},
+		{
+			name:   "_meta as string yields nil",
+			params: json.RawMessage(`{"_meta":"not-an-object"}`),
+			want:   nil,
+		},
+		{
+			name:   "_meta as number yields nil",
+			params: json.RawMessage(`{"_meta":42}`),
+			want:   nil,
+		},
+		{
+			name:   "_meta as array yields nil",
+			params: json.RawMessage(`{"_meta":[1,2,3]}`),
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ExtractMeta(tt.params))
 		})
 	}
 }

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/bodylimit"
 	"github.com/stacklok/toolhive/pkg/healthcheck"
+	"github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
@@ -719,6 +720,10 @@ func (p *HTTPProxy) ensureSession(id string) error {
 // resolveSessionForBatch resolves the session for batch POSTs.
 // Writes appropriate HTTP errors and returns an error when handling should stop.
 //
+// Batches don't exist under the Modern revision, so this path is Legacy-only
+// by construction; Modern message-shape enforcement (rejecting a batch outright)
+// is deferred.
+//
 // Sessionless POSTs receive a per-request UUID used solely as an in-process
 // routing token. Sessionless routing tokens MUST be unique per request:
 // sharing one (e.g. the empty string) across concurrent sessionless requests
@@ -745,17 +750,26 @@ func (p *HTTPProxy) resolveSessionForBatch(w http.ResponseWriter, r *http.Reques
 }
 
 // resolveSessionForRequest resolves session rules for a single JSON-RPC request.
-// On initialize, assigns a new session ID if none is provided and returns setSessionHeader=true.
-// A provided but unknown session ID returns 404.
 //
-// Sessionless non-initialize requests receive a per-request UUID used solely as
-// an in-process routing token (not registered with sessionManager). Sessionless
-// routing tokens MUST be unique per request: sharing one (e.g. the empty string)
-// across concurrent sessionless requests with the same JSON-RPC id collapses
-// them onto the same compositeKey(sessID, idKey) and overwrites entries in the
-// waiters / idRestore sync.Maps, leaking one client's response payload to
-// another. This is a confidentiality bug, not a performance issue -- do not
-// collapse the token.
+// It first classifies the request as Modern or Legacy MCP (mcp.ClassifyRevision).
+// A classification error is rejected outright with an HTTP 400 JSON-RPC error
+// response. A Modern request is always sessionless: it gets a fresh per-request
+// routing token and never touches sessionManager, regardless of any
+// Mcp-Session-Id header it carries (see the confidentiality note below). A
+// Legacy request falls through to the existing session rules: on initialize,
+// assigns a new session ID if none is provided and returns setSessionHeader=true;
+// a provided but unknown session ID returns 404.
+//
+// Sessionless requests (both the Modern branch and Legacy's sessionless
+// non-initialize branch) receive a per-request UUID used solely as an
+// in-process routing token (not registered with sessionManager). Sessionless
+// routing tokens MUST be unique per request: sharing one (e.g. the empty string,
+// or a stale/foreign Mcp-Session-Id) across concurrent sessionless requests with
+// the same JSON-RPC id collapses them onto the same compositeKey(sessID, idKey)
+// and overwrites entries in the waiters / idRestore sync.Maps, leaking one
+// client's response payload to another. This is a confidentiality bug, not a
+// performance issue -- do not collapse the token, and do not let a Modern
+// request fall through to the session-lookup path below.
 //
 // Writes HTTP errors on failure and returns error to stop handling.
 func (p *HTTPProxy) resolveSessionForRequest(
@@ -763,6 +777,30 @@ func (p *HTTPProxy) resolveSessionForRequest(
 	r *http.Request,
 	req *jsonrpc2.Request,
 ) (string, bool, error) {
+	// Classification/routing here applies only to the single id-bearing request
+	// path; the batch and notification/client-response paths are Legacy-only by
+	// construction, with Modern message-shape enforcement deferred.
+	meta := mcp.ExtractMeta(req.Params)
+	protoHeader := r.Header.Get("MCP-Protocol-Version")
+	rev, err := mcp.ClassifyRevision(req.Method, meta, protoHeader)
+	if err != nil {
+		writeClassificationError(w, req.ID.Raw(), err)
+		return "", false, err
+	}
+
+	if rev == mcp.RevisionModern {
+		// Modern is stateless: mint a fresh routing token unconditionally and
+		// ignore any client-supplied Mcp-Session-Id. Never fall through to the
+		// session-lookup path below with it -- see the confidentiality note
+		// in this function's doc comment.
+		token, err := uuid.NewRandom()
+		if err != nil {
+			writeHTTPError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to generate routing token: %v", err))
+			return "", false, fmt.Errorf("generate routing token: %w", err)
+		}
+		return token.String(), false, nil
+	}
+
 	var setSessionHeader bool
 	sessID := r.Header.Get("Mcp-Session-Id")
 
@@ -803,6 +841,49 @@ func (p *HTTPProxy) resolveSessionForRequest(
 	return sessID, false, nil
 }
 
+// writeClassificationError renders an mcp.ClassifyRevision error as an HTTP 400
+// JSON-RPC error response, modeled on session.NotFoundBody/WriteNotFound: the
+// body is marshaled first (with a hand-crafted fallback on marshal failure) so
+// headers and status are only written once a valid body is ready.
+// It uses the error's Code(), Error() message, and Data() (when non-empty) if
+// the error implements mcp.CodedError, falling back to the standard JSON-RPC
+// Invalid Params code otherwise -- a fallback that is currently unreachable,
+// since every error ClassifyRevision returns implements mcp.CodedError.
+func writeClassificationError(w http.ResponseWriter, requestID any, err error) {
+	code := mcp.CodeInvalidParams
+	var coded mcp.CodedError
+	var data map[string]any
+	if errors.As(err, &coded) {
+		code = coded.Code()
+		data = coded.Data()
+	}
+
+	errBody := map[string]any{
+		"code":    code,
+		"message": err.Error(),
+	}
+	if len(data) > 0 {
+		errBody["data"] = data
+	}
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"error":   errBody,
+		"id":      requestID,
+	}
+
+	body, marshalErr := json.Marshal(resp)
+	if marshalErr != nil {
+		// This should never happen with simple map types, but return a
+		// hand-crafted fallback to guarantee a valid JSON-RPC error.
+		body = []byte(`{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"},"id":null}`)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	//nolint:gosec // G104: writing a JSON-RPC error response to an HTTP client
+	_, _ = w.Write(body)
+}
+
 func isBatch(body []byte) bool {
 	t := bytes.TrimSpace(body)
 	return len(t) > 0 && t[0] == '['
@@ -831,6 +912,8 @@ func decodeJSONRPCMessage(w http.ResponseWriter, body []byte) (jsonrpc2.Message,
 	return msg, true
 }
 
+// handleNotificationOrClientResponse handles notifications and client responses
+// as Legacy today; Modern-aware handling of this path is deferred.
 func (p *HTTPProxy) handleNotificationOrClientResponse(w http.ResponseWriter, sessID string, msg jsonrpc2.Message) bool {
 	if isNotification(msg) || (func() bool { _, ok := msg.(*jsonrpc2.Response); return ok })() {
 		// Refresh TTL so a client sending only notifications doesn't get evicted.

--- a/pkg/transport/proxy/streamable/streamable_proxy_modern_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_modern_test.go
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package streamable
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive/pkg/mcp"
+)
+
+// modernBodyWithVersion builds a single Modern JSON-RPC request body carrying the
+// reserved io.modelcontextprotocol/* _meta keys ClassifyRevision inspects.
+func modernBodyWithVersion(id int, method, version string) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":%d,"method":%q,"params":{"_meta":{`+
+			`"io.modelcontextprotocol/protocolVersion":%q,`+
+			`"io.modelcontextprotocol/clientCapabilities":{}}}}`,
+		id, method, version)
+}
+
+// modernBody builds a well-formed Modern request for the version this build supports.
+func modernBody(id int, method string) string {
+	return modernBodyWithVersion(id, method, "2026-07-28")
+}
+
+// TestModernConcurrentRequestsAreNotMixed is the Modern analogue of
+// TestSessionlessConcurrentRequestsAreNotMixed, and the critical confidentiality
+// guard for the stateless routing path: two concurrent Modern POSTs sharing
+// JSON-RPC id 1 must each receive their own payload. One request additionally
+// carries a foreign Mcp-Session-Id header — it must NOT fall through to the
+// shared-key session path (which would collapse both requests onto
+// compositeKey(sessID, idKey) and leak one client's response to the other).
+//
+// t.Setenv requires a non-parallel test; the short proxy timeout makes a
+// regression fail fast rather than hanging on the 60s default.
+func TestModernConcurrentRequestsAreNotMixed(t *testing.T) {
+	t.Setenv(proxyRequestTimeoutEnv, "3s")
+
+	port := pickFreePort(t)
+	proxy := NewHTTPProxy("127.0.0.1", port, nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, proxy.Start(ctx))
+	t.Cleanup(func() { _ = proxy.Stop(ctx) })
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Barrier backend: buffer both requests before responding, so both proxy
+	// waiters are registered first — the precondition under which a shared
+	// routing token would overwrite one waiter. Echo req.Method to prove each
+	// client got its own payload.
+	go func() {
+		buffered := make([]*jsonrpc2.Request, 0, 2)
+		for len(buffered) < 2 {
+			select {
+			case msg := <-proxy.GetMessageChannel():
+				if req, ok := msg.(*jsonrpc2.Request); ok && req.ID.IsValid() {
+					buffered = append(buffered, req)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+		for _, req := range buffered {
+			result := map[string]any{"echoed_method": req.Method}
+			resp, _ := jsonrpc2.NewResponse(req.ID, result, nil)
+			_ = proxy.ForwardResponseToClients(ctx, resp)
+		}
+	}()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, StreamableHTTPEndpoint)
+
+	type result struct {
+		method string
+		status int
+		body   map[string]any
+		err    error
+	}
+
+	// Both POSTs are Modern and share JSON-RPC id 1. sessionID is a foreign
+	// Mcp-Session-Id header the Modern path must ignore; empty means no header.
+	fire := func(method, sessionID string) result {
+		req, err := http.NewRequest(
+			http.MethodPost, url, bytes.NewReader([]byte(modernBody(1, method))))
+		if err != nil {
+			return result{method: method, err: err}
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if sessionID != "" {
+			req.Header.Set("Mcp-Session-Id", sessionID)
+		}
+		client := &http.Client{Timeout: 8 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return result{method: method, err: err}
+		}
+		defer func() {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+		var decoded map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&decoded)
+		return result{method: method, status: resp.StatusCode, body: decoded}
+	}
+
+	resCh := make(chan result, 2)
+	go func() { resCh <- fire("tools/list", "foreign-session-id") }()
+	go func() { resCh <- fire("resources/list", "") }()
+
+	received := map[string]result{}
+	for i := 0; i < 2; i++ {
+		select {
+		case r := <-resCh:
+			received[r.method] = r
+		case <-time.After(15 * time.Second):
+			t.Fatalf("timeout waiting for concurrent Modern responses; received so far: %v", received)
+		}
+	}
+
+	for _, method := range []string{"tools/list", "resources/list"} {
+		r := received[method]
+		require.NoError(t, r.err, "client %q HTTP error", method)
+		require.Equal(t, http.StatusOK, r.status, "client %q HTTP status", method)
+		require.NotNil(t, r.body, "client %q empty body", method)
+		res, ok := r.body["result"].(map[string]any)
+		require.True(t, ok, "client %q missing result: %v", method, r.body)
+		assert.Equal(t, method, res["echoed_method"],
+			"client %q received the other client's payload (response cross-talk)", method)
+	}
+}
+
+// TestModernRequestIgnoresClientSessionID verifies that a Modern POST carrying a
+// bogus Mcp-Session-Id is served statelessly: it returns 200 (a Legacy request
+// with an unknown session id returns 404, so status discriminates the paths),
+// sets no Mcp-Session-Id response header, and never registers the foreign id
+// with the session manager.
+func TestModernRequestIgnoresClientSessionID(t *testing.T) {
+	t.Parallel()
+
+	port := pickFreePort(t)
+	proxy, ctx, cancel := startProxyWithBackend(t, port)
+	t.Cleanup(cancel)
+	t.Cleanup(func() { _ = proxy.Stop(ctx) })
+
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, StreamableHTTPEndpoint)
+
+	const bogusSession = "bogus-session-id"
+	req, err := http.NewRequest(
+		http.MethodPost, url, bytes.NewReader([]byte(modernBody(1, "tools/list"))))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Mcp-Session-Id", bogusSession)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Mcp-Session-Id"),
+		"Modern response must not set a session header")
+
+	_, ok := proxy.sessionManager.Get(bogusSession)
+	assert.False(t, ok, "Modern path must not register the foreign session id")
+}
+
+// TestModernClassificationErrorsReturn400 verifies that ClassifyRevision errors
+// on the single-request path are rendered as HTTP 400 JSON-RPC error responses
+// with the spec-defined error code.
+func TestModernClassificationErrorsReturn400(t *testing.T) {
+	t.Parallel()
+
+	port := pickFreePort(t)
+	proxy, ctx, cancel := startProxyWithBackend(t, port)
+	t.Cleanup(cancel)
+	t.Cleanup(func() { _ = proxy.Stop(ctx) })
+
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, StreamableHTTPEndpoint)
+
+	tests := []struct {
+		name        string
+		body        string
+		protoHeader string
+		wantCode    int64
+	}{
+		{
+			name:        "header/body version mismatch",
+			body:        modernBodyWithVersion(1, "tools/list", "2026-07-28"),
+			protoHeader: "2025-11-25",
+			wantCode:    mcp.CodeHeaderMismatch,
+		},
+		{
+			name:     "unsupported body version",
+			body:     modernBodyWithVersion(1, "tools/list", "1999-01-01"),
+			wantCode: mcp.CodeUnsupportedProtocolVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(tt.body)))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			if tt.protoHeader != "" {
+				req.Header.Set("MCP-Protocol-Version", tt.protoHeader)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+			var decoded struct {
+				Error struct {
+					Code int64 `json:"code"`
+				} `json:"error"`
+			}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&decoded))
+			assert.Equal(t, tt.wantCode, decoded.Error.Code)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The MCP 2026-07-28 (Modern) revision is **stateless** — requests carry protocol metadata per-request in `_meta` and there is no `Mcp-Session-Id`. The streamable proxy multiplexes every concurrent request onto a single stdio pipe and demuxes backend responses by `compositeKey(sessID, idKey)`. A Modern request that carried a client-supplied session id would otherwise fall through to the session-lookup path and could collide with a concurrent request on the same key, **cross-delivering one client's response to another** — a confidentiality bug.

This wires per-request revision classification into the streamable proxy's routing:

- Classify each single POST via `mcp.ClassifyRevision`.
- **Modern** requests get a fresh per-request routing token, **ignore any `Mcp-Session-Id`**, and never touch the session manager.
- Classification errors are rejected with an HTTP 400 JSON-RPC error.
- **Legacy behavior is unchanged.**
- Adds `mcp.ExtractMeta` to pull `_meta` from raw params, deduped with the parser's existing extraction via a shared helper.

Message-shape enforcement (batches, client-sent responses, GET/DELETE → 405) is **deferred** — those paths remain Legacy-only by construction. Tracked as a follow-up.

> **Stacked on #5834** (the classifier/parser/authz foundation). Base will retarget to `main` once #5834 merges.

Part of #5830. Design: RFC THV-0081 + arch doc (#5808).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test plan

- [x] Unit tests

New tests:
- `TestModernConcurrentRequestsAreNotMixed` — **the security case**: two concurrent Modern POSTs sharing JSON-RPC id `1`, one carrying a foreign `Mcp-Session-Id`, must not cross-deliver responses.
- `TestModernRequestIgnoresClientSessionID` — a Modern request with a bogus session id is served statelessly (200, no session header, session manager untouched) rather than 404'd.
- `TestModernClassificationErrorsReturn400` — header/body mismatch → `-32020`, unsupported version → `-32022`, both HTTP 400.
- `TestExtractMeta` — tolerant `_meta` extraction across malformed/absent/wrong-typed inputs.

## Special notes for reviewers

- The load-bearing invariant is that the Modern branch returns **before** any `Mcp-Session-Id` read or `sessionManager` access. Reviewed by an independent security pass which confirmed it holds and that routing tokens are crypto-random (no collision).
- `task lint-fix` has not been run locally; relying on CI lint.

Generated with [Claude Code](https://claude.com/claude-code)