### PR TITLE
Return HTTP 403 for authz-denied vMCP calls (#5827)

### DIFF
--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -247,6 +247,9 @@ Middleware is applied by wrapping handlers, so execution order is outer-to-inner
 | 9 | Backend Enrichment | Optional | Adds backend name to audit context (only when Audit is configured) |
 | 10 | MCP Parsing | Always | Second application is a no-op when auth already parsed; ensures telemetry can label metrics with `mcp_method` when auth is nil |
 | 11 | Telemetry | Optional | OpenTelemetry instrumentation |
+| 12 | Pre-dispatch authorization gate | Optional | Innermost: runs inside the Streamable HTTP transport before session validation and SDK dispatch. Rejects a Cedar-denied `tools/call` / `resources/read` / `prompts/get` with HTTP 403 + JSON-RPC code 403, reusing the core admission decision. Installed only when Authorization is configured. See "Authorization Enforcement" below. |
+
+> On the New/Serve path, authorization is enforced by the **core admission seam**, not by rows 6–8 as standalone HTTP middleware; row 12 is the transport-level projection of that decision. See [Authorization Enforcement](#authorization-enforcement-core-admission-seam--pre-dispatch-gate).
 
 ### Discovery Middleware
 
@@ -288,6 +291,50 @@ Authentication → MCP Parsing → Audit → Discovery → Annotation Enrichment
 ```
 
 **Implementation**: `pkg/vmcp/server/server.go`, `pkg/vmcp/discovery/middleware.go`, `pkg/vmcp/auth/factory/`
+
+### Authorization Enforcement (core admission seam + pre-dispatch gate)
+
+On the New/Serve path, authorization is enforced by the **core admission seam**
+(`pkg/vmcp/core`), not by HTTP middleware. The seam applies one Cedar decision to both
+the list side (`ListTools`/`ListResources`/`ListPrompts` filter the advertised set) and
+the call side (`CallTool`/`ReadResource`/`GetPrompt` deny before dispatch), closing the
+"list says yes / call says no" gap.
+
+Because the SDK maps a call-side deny to a tool result, a raw denied `tools/call` would
+otherwise return **HTTP 200** (either the SDK's `-32602 "not found"` for a list-filtered
+tool, or a `200 + IsError` tool result for an argument-gated deny). To make a denial a
+first-class wire rejection, Serve installs a **pre-dispatch authorization gate**
+(`pkg/vmcp/server/call_gate.go`) on the Streamable HTTP transport, but only when Cedar
+policies are configured:
+
+- The gate re-runs the core admission decision for `tools/call`, `resources/read`, and
+  `prompts/get` via `core.CheckToolCall` / `CheckResourceRead` / `CheckPromptGet` — the
+  same helpers the call path uses, so a pre-check and the call can never drift. Non-gated
+  methods (e.g. `initialize`, `tools/list`) are admitted untouched.
+- A denial is rejected as **HTTP 403 + JSON-RPC error code 403** (`pkg/mcp.JSONRPCCodeDenied`)
+  with a kind-only message (`"call denied by authorization policy"`,
+  `"read denied by authorization policy"`, `"prompt denied by authorization policy"`) —
+  identical to the single-server `thv run` authorization response. The message never
+  names the capability or reveals advertised-vs-nonexistent, so a denial is not an
+  **enumeration oracle**: a filtered tool, an argument-gated deny, and a nonexistent tool
+  under a default-deny policy all converge on the same 403.
+- The gate runs **before session validation** (403-before-404): a denial is determinable
+  from the caller's own identity without session state.
+- It sits **inside the audit middleware**, so a denied call is audited with outcome
+  `denied` (403 → `OutcomeDenied`) with no audit-layer changes.
+- An authorizer error fails **closed** (treated as a denial); a non-authorization
+  (infrastructure) error admits, so the call path surfaces it through existing mapping —
+  the gate never converts a plumbing fault into a 403.
+- **Code mode carve-out**: `execute_tool_script` is not in the admission seam (the feature
+  flag is the grant, and each inner tool call the script makes is re-authorized by its real
+  name), so the codemode decorator's `CheckToolCall` admits it while delegating every other
+  name to the inner core.
+
+The `Call*` methods keep their internal admission checks as defense-in-depth for other
+embedders and misconfigured gates.
+
+**Implementation**: `pkg/vmcp/core/core_checks.go`, `pkg/vmcp/server/call_gate.go`,
+`pkg/vmcp/codemode/decorator.go`, `pkg/mcp/errors.go`
 
 ## Health Monitoring
 

--- a/docs/authz.md
+++ b/docs/authz.md
@@ -51,6 +51,18 @@ occurs:
 4. If the request is authorized, it is passed to the next handler. Otherwise, a
    403 Forbidden response is returned.
 
+### Virtual MCP parity
+
+Virtual MCP (`vmcp`) enforces the same Cedar policies through its core admission
+seam rather than HTTP middleware, but the client-facing behavior matches a
+single-server `thv run`: a denied `tools/call`, `resources/read`, or `prompts/get`
+is rejected with **HTTP 403** and a JSON-RPC error whose code is `403`, and the
+denied request is audited with outcome `denied`. The denial message is kind-only
+(for example, `call denied by authorization policy`) and never reveals the
+capability name or whether it exists, so it cannot be used to enumerate the
+server. See the [Virtual MCP architecture](arch/10-virtual-mcp-architecture.md#authorization-enforcement-core-admission-seam--pre-dispatch-gate)
+for details.
+
 ## Configure authorization
 
 To set up authorization for an MCP server managed by ToolHive, follow these

--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -124,7 +124,7 @@ func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
 
 	errorResponse := &jsonrpc2.Response{
 		ID:    id,
-		Error: jsonrpc2.NewError(403, errorMsg),
+		Error: jsonrpc2.NewError(mcp.JSONRPCCodeDenied, errorMsg),
 	}
 
 	// Set the response headers

--- a/pkg/mcp/errors.go
+++ b/pkg/mcp/errors.go
@@ -3,6 +3,15 @@
 
 package mcp
 
+// JSONRPCCodeDenied is the application-space JSON-RPC error code ToolHive uses
+// when a policy denies a call, alongside HTTP 403. Both denial paths reference
+// this constant — the single-server authorization middleware
+// (pkg/authz.handleUnauthorized) and the vMCP Serve-path call gate — so a denial
+// is represented by one code across `thv run` and vMCP, by reference rather than
+// by two copies of the literal. It is deliberately outside the reserved
+// -32768..-32000 JSON-RPC range so it never collides with an SDK-generated code.
+const JSONRPCCodeDenied = 403
+
 // CodedError is implemented by domain errors that should surface a stable error
 // code and optional structured data in an MCP tool result.
 //

--- a/pkg/vmcp/codemode/decorator.go
+++ b/pkg/vmcp/codemode/decorator.go
@@ -204,6 +204,24 @@ func (d *decorator) CallTool(
 	return fromMCPResult(result), nil
 }
 
+// CheckToolCall admits execute_tool_script without consulting inner admission and
+// delegates every other name to inner. This mirrors the CallTool override's guard:
+// execute_tool_script is NOT represented in the core admission seam (a Cedar policy
+// cannot allow/deny code mode per-principal — see the decorator's authorization
+// contract), so a promoted CheckToolCall would hit inner, find the name absent from
+// the advertised set, and fail the stub-tool admission under any permit-list policy —
+// causing a pre-dispatch gate to 403 every code-mode call. Admitting it here is safe
+// precisely because the feature flag is the grant and each inner tool call the script
+// makes is re-authorized by its real name through inner.CallTool.
+func (d *decorator) CheckToolCall(
+	ctx context.Context, identity *auth.Identity, name string, args map[string]any,
+) error {
+	if name == script.ExecuteToolScriptName {
+		return nil
+	}
+	return d.VMCP.CheckToolCall(ctx, identity, name, args)
+}
+
 // virtualTool builds the execute_tool_script definition whose description enumerates the
 // callable tools (everything in innerTools except the virtual tool itself).
 func virtualTool(innerTools []vmcp.Tool) vmcp.Tool {
@@ -251,7 +269,7 @@ func (d *decorator) bindTools(identity *auth.Identity, tools []vmcp.Tool) []scri
 					// which are denied. (The admission filter already excludes denied tools
 					// from the bound set; this guards the narrower allow-list/deny-call gap.)
 					if errors.Is(err, vmcp.ErrAuthorizationFailed) {
-						return nil, errors.New("tool call denied by authorization policy")
+						return nil, errors.New(vmcp.DenyMessageToolCall)
 					}
 					return nil, err
 				}

--- a/pkg/vmcp/codemode/decorator_test.go
+++ b/pkg/vmcp/codemode/decorator_test.go
@@ -27,6 +27,11 @@ type fakeCore struct {
 	lookupTool func(ctx context.Context, id *auth.Identity, name string) (*vmcp.Tool, error)
 	callTool   func(ctx context.Context, id *auth.Identity, name string,
 		args, meta map[string]any) (*vmcp.ToolCallResult, error)
+	checkTool func(ctx context.Context, id *auth.Identity, name string, args map[string]any) error
+}
+
+func (f *fakeCore) CheckToolCall(ctx context.Context, id *auth.Identity, name string, args map[string]any) error {
+	return f.checkTool(ctx, id, name, args)
 }
 
 func (f *fakeCore) ListTools(ctx context.Context, id *auth.Identity) ([]vmcp.Tool, error) {
@@ -352,4 +357,27 @@ func TestCallTool_ToolCallTimeout(t *testing.T) {
 	res, err := d.CallTool(context.Background(), nil, script.ExecuteToolScriptName, args, nil)
 	require.NoError(t, err)
 	assert.True(t, res.IsError, "a tool call exceeding ToolCallTimeout must fail the script")
+}
+
+// TestCheckToolCall_AdmitsScriptTool_DelegatesRest verifies the pre-flight gate
+// override: execute_tool_script is admitted WITHOUT consulting inner admission
+// (even under a deny-all inner), so a pre-dispatch gate never 403s a code-mode call;
+// every other name delegates to inner, so a denied tool stays denied.
+func TestCheckToolCall_AdmitsScriptTool_DelegatesRest(t *testing.T) {
+	t.Parallel()
+
+	denyAll := errors.New("denied by policy")
+	inner := echoBackend()
+	inner.checkTool = func(_ context.Context, _ *auth.Identity, _ string, _ map[string]any) error {
+		return denyAll
+	}
+	d := NewDecorator(inner, nil)
+
+	// execute_tool_script is admitted despite the deny-all inner.
+	require.NoError(t, d.CheckToolCall(context.Background(), nil, script.ExecuteToolScriptName, nil),
+		"the code-mode meta-tool must be admitted by the pre-flight gate (feature flag is the grant)")
+
+	// Every other name delegates to inner, so the deny is preserved.
+	err := d.CheckToolCall(context.Background(), nil, "echo", nil)
+	assert.ErrorIs(t, err, denyAll, "a non-meta tool must delegate to inner admission")
 }

--- a/pkg/vmcp/conversion/errors.go
+++ b/pkg/vmcp/conversion/errors.go
@@ -22,7 +22,7 @@ func ErrorToToolResult(err error) *sdkmcp.CallToolResult {
 		return CodedErrorResult(err, coded)
 	}
 	if errors.Is(err, vmcp.ErrAuthorizationFailed) {
-		return sdkmcp.NewToolResultError("call denied by authorization policy")
+		return sdkmcp.NewToolResultError(vmcp.DenyMessageToolCall)
 	}
 	return sdkmcp.NewToolResultError(err.Error())
 }

--- a/pkg/vmcp/core/core.go
+++ b/pkg/vmcp/core/core.go
@@ -106,6 +106,29 @@ type VMCP interface {
 	// unadvertised name. Applies the same admission filter as ListPrompts.
 	LookupPrompt(ctx context.Context, identity *auth.Identity, name string) (*vmcp.Prompt, error)
 
+	// CheckToolCall runs the CALL-side admission decision for the named tool
+	// WITHOUT invoking it: it returns nil when identity is allowed to call name
+	// with args, and an error wrapping [vmcp.ErrAuthorizationFailed] on deny AND on
+	// an authorizer error (fail closed). It shares the exact admission block CallTool
+	// runs, so a pre-flight check and the call can never drift.
+	//
+	// Unlike LookupTool (list-side, no args), this is the call-side decision: it
+	// evaluates argument-conditional policies with the real args. identity is never
+	// logged. See ListTools for the nil/anonymous semantics.
+	CheckToolCall(ctx context.Context, identity *auth.Identity, name string, args map[string]any) error
+
+	// CheckResourceRead runs the read-side admission decision for uri WITHOUT
+	// reading it. Same contract as CheckToolCall: nil when allowed, an error
+	// wrapping [vmcp.ErrAuthorizationFailed] on deny or authorizer error (fail
+	// closed). Shares ReadResource's admission block.
+	CheckResourceRead(ctx context.Context, identity *auth.Identity, uri string) error
+
+	// CheckPromptGet runs the get-side admission decision for the named prompt
+	// WITHOUT retrieving it. Same contract as CheckToolCall: nil when allowed, an
+	// error wrapping [vmcp.ErrAuthorizationFailed] on deny or authorizer error (fail
+	// closed). Shares GetPrompt's admission block.
+	CheckPromptGet(ctx context.Context, identity *auth.Identity, name string) error
+
 	// ListBackends returns the backends visible to identity, scoped to the gateway's
 	// group (groupRef always applies; the BackendRegistry is the group-scoped source).
 	//

--- a/pkg/vmcp/core/core_calls.go
+++ b/pkg/vmcp/core/core_calls.go
@@ -42,28 +42,8 @@ func (c *coreVMCP) CallTool(
 		return nil, err
 	}
 
-	// Admission deny: enforce the same decision ListTools filters on, sourcing the
-	// tool's annotations from the advertised set (mirroring the annotation cache the
-	// HTTP middleware populates from tools/list) so annotation-gated policies
-	// evaluate. advertisedTools includes composites, so their annotations are sourced
-	// too. A name absent from the advertised set carries no annotations, so an
-	// annotation-gated decision evaluates with no hints (and may deny). In normal
-	// operation the advertised set and the routing table are derived from the same
-	// aggregation, so this only arises if they diverge.
-	tool := findAdvertisedTool(c.advertisedTools(agg), name)
-	if tool == nil {
-		tool = &vmcp.Tool{Name: name}
-	}
-	// An authorizer ERROR is treated as a denial (fail closed), classified as
-	// ErrAuthorizationFailed so the Serve adapter can distinguish it from a transport
-	// failure via errors.Is — mirroring the live authorizeAndServe, which routes both
-	// err and !authorized to the unauthorized response. The underlying error is
-	// preserved in the chain for server-side diagnostics; Serve decides what reaches
-	// the client.
-	if allowed, err := c.admission.AllowToolCall(ctx, identity, tool, argsCopy); err != nil {
-		return nil, fmt.Errorf("%w: tool %q: %w", vmcp.ErrAuthorizationFailed, name, err)
-	} else if !allowed {
-		return nil, fmt.Errorf("%w: tool %q", vmcp.ErrAuthorizationFailed, name)
+	if err := c.authorizeToolCall(ctx, identity, name, argsCopy, agg); err != nil {
+		return nil, err
 	}
 
 	// Composite tool: execute only when the workflow is actually advertised in the
@@ -102,13 +82,8 @@ func (c *coreVMCP) ReadResource(
 		return nil, err
 	}
 
-	// Admission deny: mirror ListResources' filter for the single read. Resources
-	// carry no annotations, so the URI alone identifies the decision. An authorizer
-	// error fails closed, classified as ErrAuthorizationFailed (see CallTool).
-	if allowed, err := c.admission.AllowResourceRead(ctx, identity, &vmcp.Resource{URI: uri}); err != nil {
-		return nil, fmt.Errorf("%w: resource %q: %w", vmcp.ErrAuthorizationFailed, uri, err)
-	} else if !allowed {
-		return nil, fmt.Errorf("%w: resource %q", vmcp.ErrAuthorizationFailed, uri)
+	if err := c.authorizeResourceRead(ctx, identity, uri); err != nil {
+		return nil, err
 	}
 
 	target, err := router.NewSessionRouter(agg.RoutingTable).RouteResource(ctx, uri)
@@ -138,13 +113,8 @@ func (c *coreVMCP) GetPrompt(
 		return nil, err
 	}
 
-	// Admission deny: mirror ListPrompts' filter for the single get. Prompts carry
-	// no annotations, so the name alone identifies the decision. An authorizer error
-	// fails closed, classified as ErrAuthorizationFailed (see CallTool).
-	if allowed, err := c.admission.AllowPromptGet(ctx, identity, &vmcp.Prompt{Name: name}); err != nil {
-		return nil, fmt.Errorf("%w: prompt %q: %w", vmcp.ErrAuthorizationFailed, name, err)
-	} else if !allowed {
-		return nil, fmt.Errorf("%w: prompt %q", vmcp.ErrAuthorizationFailed, name)
+	if err := c.authorizePromptGet(ctx, identity, name); err != nil {
+		return nil, err
 	}
 
 	target, err := router.NewSessionRouter(agg.RoutingTable).RoutePrompt(ctx, name)

--- a/pkg/vmcp/core/core_checks.go
+++ b/pkg/vmcp/core/core_checks.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+)
+
+// CheckToolCall runs the CallTool admission decision without invoking the tool.
+// It fetches its own aggregated view (the tool decision sources annotations from
+// the advertised set, and composites must be included) and delegates to the shared
+// authorizeToolCall helper, so a pre-flight gate and the call path enforce the same
+// decision from one source.
+//
+// The gated allowed-call flow thus aggregates twice (once here, once in CallTool);
+// this is intentional and cheap in practice — the Serve-layer CachingAggregator
+// (30s TTL) turns the second view into a cache hit (vmcp anti-patterns #8/#9: the
+// core does not cache, Serve does). identity is never logged.
+func (c *coreVMCP) CheckToolCall(ctx context.Context, identity *auth.Identity, name string, args map[string]any) error {
+	// Clone args before handing them to the admission seam, matching CallTool's
+	// copy-before-mutating-caller-input discipline (the caller's map — here the
+	// parsed request's Arguments, shared via context — must not be mutated).
+	args = maps.Clone(args)
+	agg, err := c.aggregatedView(ctx)
+	if err != nil {
+		// An aggregation failure is a transport/plumbing error, NOT an authorization
+		// denial — return it unwrapped so the gate admits and the call path surfaces
+		// it through existing mapping, rather than converting infra faults into 403s.
+		return err
+	}
+	return c.authorizeToolCall(ctx, identity, name, args, agg)
+}
+
+// CheckResourceRead runs the ReadResource admission decision without reading the
+// resource. It needs no aggregated view (the URI alone identifies the decision),
+// so it works even when the aggregator is failing. identity is never logged.
+func (c *coreVMCP) CheckResourceRead(ctx context.Context, identity *auth.Identity, uri string) error {
+	return c.authorizeResourceRead(ctx, identity, uri)
+}
+
+// CheckPromptGet runs the GetPrompt admission decision without retrieving the
+// prompt. It needs no aggregated view (the name alone identifies the decision),
+// so it works even when the aggregator is failing. identity is never logged.
+func (c *coreVMCP) CheckPromptGet(ctx context.Context, identity *auth.Identity, name string) error {
+	return c.authorizePromptGet(ctx, identity, name)
+}
+
+// authorizeToolCall runs the CALL-side admission decision for name with args,
+// sourcing the tool's annotations from the caller-supplied advertised view (agg)
+// so annotation-gated policies evaluate. It returns nil when allowed and an error
+// wrapping vmcp.ErrAuthorizationFailed on deny AND on an authorizer error (fail
+// closed), classified so the Serve adapter can distinguish it from a transport
+// failure via errors.Is — mirroring the live authorizeAndServe. The underlying
+// error is preserved in the chain for server-side diagnostics.
+//
+// This is the single source of truth for the tool-call decision: both CallTool
+// (before dispatch) and CheckToolCall (pre-flight) call it with the same agg, so
+// the two can never drift. args is treated as read-only.
+//
+// A name absent from the advertised set carries no annotations, so an
+// annotation-gated decision evaluates with no hints (and may deny). In normal
+// operation the advertised set and the routing table are derived from the same
+// aggregation, so this only arises if they diverge. advertisedTools includes
+// composites, so their annotations are sourced too.
+func (c *coreVMCP) authorizeToolCall(
+	ctx context.Context,
+	identity *auth.Identity,
+	name string,
+	args map[string]any,
+	agg *aggregator.AggregatedCapabilities,
+) error {
+	tool := findAdvertisedTool(c.advertisedTools(agg), name)
+	if tool == nil {
+		tool = &vmcp.Tool{Name: name}
+	}
+	if allowed, err := c.admission.AllowToolCall(ctx, identity, tool, args); err != nil {
+		return fmt.Errorf("%w: tool %q: %w", vmcp.ErrAuthorizationFailed, name, err)
+	} else if !allowed {
+		return fmt.Errorf("%w: tool %q", vmcp.ErrAuthorizationFailed, name)
+	}
+	return nil
+}
+
+// authorizeResourceRead runs the read-side admission decision for uri, mirroring
+// ListResources' filter for the single read. Resources carry no annotations, so
+// the URI alone identifies the decision — it needs no aggregated view. An
+// authorizer error fails closed, classified as ErrAuthorizationFailed (see
+// authorizeToolCall). Shared by ReadResource and CheckResourceRead.
+func (c *coreVMCP) authorizeResourceRead(ctx context.Context, identity *auth.Identity, uri string) error {
+	if allowed, err := c.admission.AllowResourceRead(ctx, identity, &vmcp.Resource{URI: uri}); err != nil {
+		return fmt.Errorf("%w: resource %q: %w", vmcp.ErrAuthorizationFailed, uri, err)
+	} else if !allowed {
+		return fmt.Errorf("%w: resource %q", vmcp.ErrAuthorizationFailed, uri)
+	}
+	return nil
+}
+
+// authorizePromptGet runs the get-side admission decision for name, mirroring
+// ListPrompts' filter for the single get. Prompts carry no annotations, so the
+// name alone identifies the decision — it needs no aggregated view. An authorizer
+// error fails closed, classified as ErrAuthorizationFailed (see authorizeToolCall).
+// Shared by GetPrompt and CheckPromptGet.
+func (c *coreVMCP) authorizePromptGet(ctx context.Context, identity *auth.Identity, name string) error {
+	if allowed, err := c.admission.AllowPromptGet(ctx, identity, &vmcp.Prompt{Name: name}); err != nil {
+		return fmt.Errorf("%w: prompt %q: %w", vmcp.ErrAuthorizationFailed, name, err)
+	} else if !allowed {
+		return fmt.Errorf("%w: prompt %q", vmcp.ErrAuthorizationFailed, name)
+	}
+	return nil
+}

--- a/pkg/vmcp/core/core_checks_test.go
+++ b/pkg/vmcp/core/core_checks_test.go
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+)
+
+// checkCore builds a *coreVMCP wired with the given admission and the base mocks,
+// bypassing New so tests can inject a specific admission seam directly. The tool
+// checks call aggregatedView; resource/prompt checks do not.
+func checkCore(m *coreMocks, adm Admission) *coreVMCP {
+	return &coreVMCP{
+		aggregator:      m.agg,
+		backendRegistry: m.reg,
+		backendClient:   m.client,
+		admission:       adm,
+	}
+}
+
+// expectAggregationAnyTimes wires reg.List + agg.AggregateCapabilities to return
+// agg on every call (the check/call pairing aggregates more than once).
+func expectAggregationAnyTimes(m *coreMocks, agg *aggregator.AggregatedCapabilities) {
+	m.reg.EXPECT().List(gomock.Any()).
+		Return([]vmcp.Backend{{ID: testBackendID, HealthStatus: vmcp.BackendHealthy}}).AnyTimes()
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(agg, nil).AnyTimes()
+}
+
+// isAuthErr reports whether err is an authorization denial (nil is not).
+func isAuthErr(err error) bool { return errors.Is(err, vmcp.ErrAuthorizationFailed) }
+
+func TestCheckToolCall_AllowDenyFailClosed(t *testing.T) {
+	t.Parallel()
+	_, m := baseConfig(t)
+
+	authorizer := &mockAuthorizer{results: map[string]mockResult{
+		"echo":   {authorized: true},
+		"boom":   {err: errors.New("authorizer exploded")},
+		"denied": {authorized: false},
+	}}
+	c := checkCore(m, newCedarAdmission(authorizer))
+	expectAggregationAnyTimes(m, &aggregator.AggregatedCapabilities{
+		Tools:        []vmcp.Tool{backendTool("echo"), backendTool("boom"), backendTool("denied")},
+		RoutingTable: &vmcp.RoutingTable{},
+	})
+
+	require.NoError(t, c.CheckToolCall(t.Context(), cedarIdentity(), "echo", nil),
+		"an allowed tool call must pass the pre-flight check")
+
+	err := c.CheckToolCall(t.Context(), cedarIdentity(), "denied", nil)
+	assert.ErrorIs(t, err, vmcp.ErrAuthorizationFailed, "a denied tool call must fail the check")
+
+	err = c.CheckToolCall(t.Context(), cedarIdentity(), "boom", nil)
+	assert.ErrorIs(t, err, vmcp.ErrAuthorizationFailed, "an authorizer error must fail closed as an authz denial")
+}
+
+// TestCheckToolCall_AggregationError_NotAuthzDenial pins the infra-error branch:
+// when aggregatedView fails (a transport/plumbing fault, e.g. the backend registry
+// or aggregator is unavailable), CheckToolCall must return that error UNWRAPPED —
+// not classified as ErrAuthorizationFailed. The gate admits on a non-authz error,
+// so wrapping a transient aggregation failure as an authz denial would silently
+// turn it into a hard HTTP 403 (fail-open infra handling must not become fail-closed
+// authz). This is the classification the fake-core gate test cannot exercise.
+func TestCheckToolCall_AggregationError_NotAuthzDenial(t *testing.T) {
+	t.Parallel()
+	_, m := baseConfig(t)
+
+	// Admission is never reached; the aggregation failure short-circuits first.
+	c := checkCore(m, newCedarAdmission(&mockAuthorizer{results: map[string]mockResult{}}))
+
+	infraErr := errors.New("aggregator unavailable")
+	m.reg.EXPECT().List(gomock.Any()).
+		Return([]vmcp.Backend{{ID: testBackendID, HealthStatus: vmcp.BackendHealthy}}).AnyTimes()
+	m.agg.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).Return(nil, infraErr).AnyTimes()
+
+	err := c.CheckToolCall(t.Context(), cedarIdentity(), "echo", nil)
+	require.Error(t, err, "an aggregation failure must surface as an error")
+	assert.False(t, isAuthErr(err),
+		"a transient aggregation failure must NOT be classified as ErrAuthorizationFailed "+
+			"(the gate would otherwise convert an infra fault into a 403)")
+}
+
+func TestCheckResourceRead_AllowDenyFailClosed_NoAggregation(t *testing.T) {
+	t.Parallel()
+	// No aggregation expectations are set: if CheckResourceRead ever aggregated, the
+	// gomock controller would fail on the unexpected reg.List/AggregateCapabilities
+	// call. This proves the read check has no aggregation dependency.
+	_, m := baseConfig(t)
+
+	authorizer := &mockAuthorizer{results: map[string]mockResult{
+		"res://ok":   {authorized: true},
+		"res://boom": {err: errors.New("authorizer exploded")},
+	}}
+	c := checkCore(m, newCedarAdmission(authorizer))
+
+	require.NoError(t, c.CheckResourceRead(t.Context(), cedarIdentity(), "res://ok"))
+	assert.ErrorIs(t, c.CheckResourceRead(t.Context(), cedarIdentity(), "res://denied"),
+		vmcp.ErrAuthorizationFailed)
+	assert.ErrorIs(t, c.CheckResourceRead(t.Context(), cedarIdentity(), "res://boom"),
+		vmcp.ErrAuthorizationFailed, "authorizer error must fail closed")
+}
+
+func TestCheckPromptGet_AllowDenyFailClosed_NoAggregation(t *testing.T) {
+	t.Parallel()
+	_, m := baseConfig(t)
+
+	authorizer := &mockAuthorizer{results: map[string]mockResult{
+		"greet": {authorized: true},
+		"boom":  {err: errors.New("authorizer exploded")},
+	}}
+	c := checkCore(m, newCedarAdmission(authorizer))
+
+	require.NoError(t, c.CheckPromptGet(t.Context(), cedarIdentity(), "greet"))
+	assert.ErrorIs(t, c.CheckPromptGet(t.Context(), cedarIdentity(), "secret"),
+		vmcp.ErrAuthorizationFailed)
+	assert.ErrorIs(t, c.CheckPromptGet(t.Context(), cedarIdentity(), "boom"),
+		vmcp.ErrAuthorizationFailed, "authorizer error must fail closed")
+}
+
+// TestCheckToolCall_AntiDrift is the invariant guard: for the same (policy, identity,
+// name, args), CheckToolCall must fail with ErrAuthorizationFailed if and only if
+// CallTool does. The shared authorizeToolCall helper makes this structural, but the
+// test pins it — including an argument-conditional Cedar policy so the args flow
+// through both routes is proven. An allowed call falls through to routing, which
+// returns ErrNotFound (empty routing table) — NOT an authz error — so the invariant
+// compares only the authorization outcome, not the transport outcome.
+func TestCheckToolCall_AntiDrift(t *testing.T) {
+	t.Parallel()
+
+	const permitEcho = `permit(principal, action == Action::"call_tool", resource == Tool::"echo");`
+	const forbidBlocked = `forbid(principal, action == Action::"call_tool", resource == Tool::"echo") ` +
+		`when { context has arg_input && context.arg_input == "blocked" };`
+
+	tests := []struct {
+		name     string
+		policies []string
+		toolName string
+		args     map[string]any
+		// wantAuthzDenied is the ABSOLUTE expected outcome. Asserting it (not just that
+		// both paths agree) is what proves the args/name are actually consulted: an
+		// agreement-only check would still pass if BOTH paths dropped args entirely.
+		wantAuthzDenied bool
+	}{
+		{"unconditional permit", []string{permitEcho}, "echo", nil, false},
+		{"default deny unpermitted name", []string{permitEcho}, "other", nil, true},
+		{"arg-gated allow", []string{permitEcho, forbidBlocked}, "echo", map[string]any{"input": "hello"}, false},
+		{"arg-gated deny", []string{permitEcho, forbidBlocked}, "echo", map[string]any{"input": "blocked"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, m := baseConfig(t)
+			c := checkCore(m, cedarAdmissionWith(t, tt.policies...))
+			expectAggregationAnyTimes(m, &aggregator.AggregatedCapabilities{
+				Tools:        []vmcp.Tool{backendTool("echo")},
+				RoutingTable: &vmcp.RoutingTable{},
+			})
+
+			checkErr := c.CheckToolCall(t.Context(), cedarIdentity(), tt.toolName, tt.args)
+			_, callErr := c.CallTool(t.Context(), cedarIdentity(), tt.toolName, tt.args, nil)
+
+			// Absolute outcome: proves args are consulted (arg-gated deny/allow differ
+			// only by the "input" value), not merely that the two paths agree.
+			assert.Equal(t, tt.wantAuthzDenied, isAuthErr(checkErr),
+				"CheckToolCall authz outcome mismatch (err=%v)", checkErr)
+			// Agreement: the shared helper keeps the two routes from drifting.
+			assert.Equal(t, isAuthErr(checkErr), isAuthErr(callErr),
+				"CheckToolCall and CallTool must agree on the authorization outcome (check=%v call=%v)",
+				checkErr, callErr)
+		})
+	}
+}
+
+// TestCheckResourceRead_AntiDrift pairs CheckResourceRead with ReadResource: the
+// check errors with ErrAuthorizationFailed iff the read does. ReadResource
+// aggregates before authorizing (allowed reads fall through to routing →
+// ErrNotFound); the check does not aggregate, so aggregation is wired AnyTimes.
+func TestCheckResourceRead_AntiDrift(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		uri             string
+		wantAuthzDenied bool
+	}{
+		{"res://ok", false},
+		{"res://denied", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.uri, func(t *testing.T) {
+			t.Parallel()
+			// A fresh authorizer per subtest: mockAuthorizer records calls into a shared
+			// slice, so a single instance shared across parallel subtests would race.
+			authorizer := &mockAuthorizer{results: map[string]mockResult{"res://ok": {authorized: true}}}
+			_, m := baseConfig(t)
+			c := checkCore(m, newCedarAdmission(authorizer))
+			expectAggregationAnyTimes(m, &aggregator.AggregatedCapabilities{RoutingTable: &vmcp.RoutingTable{}})
+
+			checkErr := c.CheckResourceRead(t.Context(), cedarIdentity(), tc.uri)
+			_, readErr := c.ReadResource(t.Context(), cedarIdentity(), tc.uri)
+
+			// Absolute outcome (proves the URI is consulted) plus agreement (no drift).
+			assert.Equal(t, tc.wantAuthzDenied, isAuthErr(checkErr),
+				"CheckResourceRead authz outcome mismatch (err=%v)", checkErr)
+			assert.Equal(t, isAuthErr(checkErr), isAuthErr(readErr),
+				"CheckResourceRead and ReadResource must agree (check=%v read=%v)", checkErr, readErr)
+		})
+	}
+}
+
+// TestCheckPromptGet_AntiDrift pairs CheckPromptGet with GetPrompt (same invariant).
+func TestCheckPromptGet_AntiDrift(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		wantAuthzDenied bool
+	}{
+		{"greet", false},
+		{"secret", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Fresh authorizer per subtest (shared mockAuthorizer records calls → would race).
+			authorizer := &mockAuthorizer{results: map[string]mockResult{"greet": {authorized: true}}}
+			_, m := baseConfig(t)
+			c := checkCore(m, newCedarAdmission(authorizer))
+			expectAggregationAnyTimes(m, &aggregator.AggregatedCapabilities{RoutingTable: &vmcp.RoutingTable{}})
+
+			checkErr := c.CheckPromptGet(t.Context(), cedarIdentity(), tc.name)
+			_, getErr := c.GetPrompt(t.Context(), cedarIdentity(), tc.name, nil)
+
+			// Absolute outcome (proves the name is consulted) plus agreement (no drift).
+			assert.Equal(t, tc.wantAuthzDenied, isAuthErr(checkErr),
+				"CheckPromptGet authz outcome mismatch (err=%v)", checkErr)
+			assert.Equal(t, isAuthErr(checkErr), isAuthErr(getErr),
+				"CheckPromptGet and GetPrompt must agree (check=%v get=%v)", checkErr, getErr)
+		})
+	}
+}

--- a/pkg/vmcp/errors.go
+++ b/pkg/vmcp/errors.go
@@ -68,6 +68,25 @@ var (
 	ErrToolNameConflict = errors.New("tool name conflict")
 )
 
+// Authorization-denial messages, one per admission kind.
+//
+// These are kind-only: each names the capability class, never the specific
+// tool/resource/prompt or whether it is advertised vs. nonexistent, so a denial
+// can never be used to enumerate what exists (the "no oracle" property). They
+// live here at the domain root and are referenced by every site that emits a
+// denial — conversion.ErrorToToolResult, the Serve resources/read handler, the
+// codemode script closure, and the pre-dispatch call gate — so a denial has one
+// wording per kind by reference, not by copied literals that can silently drift
+// apart. Test assertions deliberately keep the literal to pin the exact wording.
+const (
+	// DenyMessageToolCall is emitted when a tools/call is denied by policy.
+	DenyMessageToolCall = "call denied by authorization policy"
+	// DenyMessageResourceRead is emitted when a resources/read is denied by policy.
+	DenyMessageResourceRead = "read denied by authorization policy"
+	// DenyMessagePromptGet is emitted when a prompts/get is denied by policy.
+	DenyMessagePromptGet = "prompt denied by authorization policy"
+)
+
 // Error Categorization Helpers
 //
 // These functions categorize errors by examining error message strings.

--- a/pkg/vmcp/ratelimit/decorator.go
+++ b/pkg/vmcp/ratelimit/decorator.go
@@ -18,6 +18,10 @@ import (
 // decorator wraps a [core.VMCP] to rate-limit tool calls. Every method except
 // CallTool is promoted from the embedded inner core unchanged. The decorator sits
 // below the session optimizer, so name is already the resolved backend tool name.
+//
+// CheckToolCall is deliberately NOT overridden: promoting it to inner is correct
+// because a pre-flight admission check must not consume a rate-limit token — the
+// limiter applies only when the call is actually dispatched via CallTool.
 type decorator struct {
 	core.VMCP
 	limiter baseratelimit.Limiter

--- a/pkg/vmcp/ratelimit/decorator_test.go
+++ b/pkg/vmcp/ratelimit/decorator_test.go
@@ -39,13 +39,19 @@ func (l *recordingLimiter) Allow(_ context.Context, toolName, userID string) (*b
 
 type recordingCore struct {
 	core.VMCP
-	called   bool
-	identity *auth.Identity
-	name     string
-	args     map[string]any
-	meta     map[string]any
-	result   *vmcp.ToolCallResult
-	err      error
+	called      bool
+	checkCalled bool
+	identity    *auth.Identity
+	name        string
+	args        map[string]any
+	meta        map[string]any
+	result      *vmcp.ToolCallResult
+	err         error
+}
+
+func (c *recordingCore) CheckToolCall(_ context.Context, _ *auth.Identity, _ string, _ map[string]any) error {
+	c.checkCalled = true
+	return nil
 }
 
 func (c *recordingCore) CallTool(
@@ -156,4 +162,22 @@ func TestCallToolNilIdentityUsesEmptyUserID(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, inner.called)
 	assert.Empty(t, limiter.userID)
+}
+
+// TestCheckToolCallConsumesNoTokens verifies the deliberate non-override of
+// CheckToolCall: a pre-flight admission check promotes straight to inner without
+// touching the limiter, so it never consumes a rate-limit token (the limiter
+// applies only at CallTool dispatch).
+func TestCheckToolCallConsumesNoTokens(t *testing.T) {
+	t.Parallel()
+
+	limiter := &recordingLimiter{}
+	inner := &recordingCore{}
+	decorated := NewDecorator(inner, limiter)
+
+	err := decorated.CheckToolCall(t.Context(), nil, "backend_a_echo", nil)
+
+	require.NoError(t, err)
+	assert.True(t, inner.checkCalled, "the check must promote to inner")
+	assert.Empty(t, limiter.toolName, "a pre-flight check must not consume a rate-limit token")
 }

--- a/pkg/vmcp/server/authz_integration_test.go
+++ b/pkg/vmcp/server/authz_integration_test.go
@@ -4,8 +4,8 @@
 package server_test
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -19,17 +19,43 @@ import (
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
 	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
 	"github.com/stacklok/toolhive/pkg/vmcp/auth/strategies"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 	vmcpclient "github.com/stacklok/toolhive/pkg/vmcp/client"
+	"github.com/stacklok/toolhive/pkg/vmcp/codemode"
 	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
 	"github.com/stacklok/toolhive/pkg/vmcp/router"
 	"github.com/stacklok/toolhive/pkg/vmcp/server"
 	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
 )
+
+// rpcErrorFields is the subset of a JSON-RPC error envelope the authz tests assert on.
+type rpcErrorFields struct {
+	code    int
+	message string
+	present bool
+}
+
+// parseRPCError extracts the JSON-RPC error code/message from a response body. It
+// reports present=false when the body carries no top-level "error" object (e.g. a
+// successful result).
+func parseRPCError(t *testing.T, body []byte) rpcErrorFields {
+	t.Helper()
+	var env struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil || env.Error == nil {
+		return rpcErrorFields{}
+	}
+	return rpcErrorFields{code: env.Error.Code, message: env.Error.Message, present: true}
+}
 
 // newCedarAuthzTestServer builds a vMCP server via the rerouted server.New (→ core.New +
 // Serve) backed by the real "echo" MCP backend at backendURL. An AuthMiddleware injects a
@@ -38,6 +64,25 @@ import (
 // via Config.Authz. This exercises the full Config.Authz → deriveCoreConfig → core admission
 // chain that replaced the legacy HTTP authz middleware on the Serve path.
 func newCedarAuthzTestServer(t *testing.T, backendURL string, policies ...string) *httptest.Server {
+	t.Helper()
+	return buildCedarAuthzServer(t, backendURL, nil, policies...)
+}
+
+// newCedarAuthzCodeModeServer is newCedarAuthzTestServer with code mode enabled, so
+// the core is wrapped by the codemode decorator. It proves the pre-dispatch gate's
+// codemode carve-out: execute_tool_script is admitted (the feature flag is the grant)
+// while a directly-denied tool still 403s.
+func newCedarAuthzCodeModeServer(t *testing.T, backendURL string, policies ...string) *httptest.Server {
+	t.Helper()
+	return buildCedarAuthzServer(t, backendURL, &codemode.Config{}, policies...)
+}
+
+// buildCedarAuthzServer builds the vMCP test server. A non-nil codeModeCfg enables
+// the codemode decorator; a nil policies slice leaves Authz unset (allow-all, gate
+// not installed) — used by the no-Authz parity guard.
+func buildCedarAuthzServer(
+	t *testing.T, backendURL string, codeModeCfg *codemode.Config, policies ...string,
+) *httptest.Server {
 	t.Helper()
 
 	ctrl := gomock.NewController(t)
@@ -82,12 +127,18 @@ func newCedarAuthzTestServer(t *testing.T, backendURL string, policies ...string
 		})
 	}
 
-	authzCfg, err := authorizers.NewConfig(cedar.Config{
-		Version: "1.0",
-		Type:    cedar.ConfigType,
-		Options: &cedar.ConfigOptions{Policies: policies, EntitiesJSON: "[]"},
-	})
-	require.NoError(t, err)
+	// A nil policies slice means "no authz": leave Config.Authz nil so the gate is not
+	// installed (the no-Authz parity guard exercises this). Otherwise compile the Cedar
+	// policies into the config the core admission seam consumes.
+	var authzCfg *authorizers.Config
+	if policies != nil {
+		authzCfg, err = authorizers.NewConfig(cedar.Config{
+			Version: "1.0",
+			Type:    cedar.ConfigType,
+			Options: &cedar.ConfigOptions{Policies: policies, EntitiesJSON: "[]"},
+		})
+		require.NoError(t, err)
+	}
 
 	srv, err := server.New(
 		context.Background(),
@@ -103,6 +154,7 @@ func newCedarAuthzTestServer(t *testing.T, backendURL string, policies ...string
 			Aggregator:     agg,
 			AuthMiddleware: identityMiddleware,
 			Authz:          authzCfg,
+			CodeModeConfig: codeModeCfg,
 		},
 		router.NewSessionRouter(&vmcp.RoutingTable{}),
 		backendClient,
@@ -139,19 +191,21 @@ func TestIntegration_RealBackend_CedarAuthzGatesToolCall(t *testing.T) {
 		client := NewMCPTestClient(t, ts.URL)
 		client.InitializeSession()
 
-		// "echo" is filtered out, so there is no list signal to wait on; poll the call until
-		// the session is established and the SDK rejects the unregistered tool (transient
-		// pre-registration 404s are tolerated and retried).
-		var lastBody string
-		require.Eventually(t, func() bool {
-			resp := client.CallTool("echo", map[string]any{"input": "hello"})
-			defer resp.Body.Close()
-			b, _ := io.ReadAll(resp.Body)
-			lastBody = string(b)
-			return resp.StatusCode == http.StatusOK && bytes.Contains(b, []byte("not found"))
-		}, 5*time.Second, 50*time.Millisecond,
-			"a tool filtered out by the Cedar policy must be rejected as an unknown tool")
-		assert.NotContains(t, lastBody, "hello", "a filtered tool must never reach the backend")
+		// #5827: a policy-denied direct tools/call is now rejected by the pre-dispatch
+		// gate as HTTP 403 + JSON-RPC error code 403 — NOT the old 200 + SDK "not found"
+		// that leaked filtered-vs-nonexistent. The gate decision is deterministic (it
+		// re-runs core admission), so no polling is needed.
+		resp := client.CallTool("echo", map[string]any{"input": "hello"})
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"a tool denied by policy must be rejected with HTTP 403, body: %s", string(body))
+		rpcErr := parseRPCError(t, body)
+		require.True(t, rpcErr.present, "the 403 must carry a JSON-RPC error envelope, body: %s", string(body))
+		assert.Equal(t, mcpparser.JSONRPCCodeDenied, rpcErr.code, "the JSON-RPC error code must be 403")
+		assert.Equal(t, "call denied by authorization policy", rpcErr.message)
+		assert.NotContains(t, string(body), "hello", "a filtered tool must never reach the backend")
 
 		// And it must be absent from tools/list.
 		listResp := client.ListTools()
@@ -187,16 +241,193 @@ func TestIntegration_RealBackend_CedarAuthzGatesToolCall(t *testing.T) {
 		require.Equal(t, http.StatusOK, okResp.StatusCode, "body: %s", string(okBody))
 		assert.Contains(t, string(okBody), "hello", "a permitted call must return the backend result")
 
-		// Denied call: the core admission seam rejects it with a generic message that never
-		// leaks the underlying authorizer/policy detail.
+		// Denied call: #5827 — the pre-dispatch gate rejects the arg-gated denial as
+		// HTTP 403 + JSON-RPC error code 403 (NOT the old 200 + IsError), with a generic
+		// message that never leaks the authorizer/policy detail.
 		denyResp := client.CallTool("echo", map[string]any{"input": "blocked"})
 		defer denyResp.Body.Close()
 		denyBody, err := io.ReadAll(denyResp.Body)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, denyResp.StatusCode, "body: %s", string(denyBody))
-		assert.Contains(t, string(denyBody), "call denied by authorization policy",
+		require.Equal(t, http.StatusForbidden, denyResp.StatusCode, "body: %s", string(denyBody))
+		rpcErr := parseRPCError(t, denyBody)
+		require.True(t, rpcErr.present, "the 403 must carry a JSON-RPC error envelope, body: %s", string(denyBody))
+		assert.Equal(t, mcpparser.JSONRPCCodeDenied, rpcErr.code, "the JSON-RPC error code must be 403")
+		assert.Equal(t, "call denied by authorization policy", rpcErr.message,
 			"an arg-gated policy denial must surface the genericized authorization message")
 		assert.NotContains(t, string(denyBody), "cedar", "the authorizer implementation detail must not leak")
 		assert.NotContains(t, string(denyBody), "forbid", "the policy text must not leak")
 	})
+}
+
+// TestIntegration_RealBackend_CedarAuthz_NoEnumerationOracle proves the denial carries
+// no information about whether the named tool exists: under a default-deny policy a
+// nonexistent tool is rejected with the SAME 403 + message as a real-but-denied tool.
+// A separate permissive policy documents the flip side — when the name IS permitted,
+// the gate admits and the SDK's own -32602 "not found" surfaces at 200, so authz never
+// masks nonexistence for an allowed name.
+func TestIntegration_RealBackend_CedarAuthz_NoEnumerationOracle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nonexistent tool under default-deny is an identical 403", func(t *testing.T) {
+		t.Parallel()
+
+		backendURL := startRealMCPBackend(t)
+		ts := newCedarAuthzTestServer(t, backendURL,
+			`permit(principal, action == Action::"call_tool", resource == Tool::"unrelated");`)
+
+		client := NewMCPTestClient(t, ts.URL)
+		client.InitializeSession()
+
+		resp := client.CallTool("does-not-exist", map[string]any{"input": "x"})
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "body: %s", string(body))
+		rpcErr := parseRPCError(t, body)
+		require.True(t, rpcErr.present, "body: %s", string(body))
+		assert.Equal(t, mcpparser.JSONRPCCodeDenied, rpcErr.code)
+		assert.Equal(t, "call denied by authorization policy", rpcErr.message,
+			"a nonexistent tool must be denied identically to a real one (no enumeration oracle)")
+		assert.NotContains(t, string(body), "does-not-exist", "the tool name must not leak in the denial")
+	})
+
+	t.Run("permitted nonexistent name yields the SDK's -32602 at 200", func(t *testing.T) {
+		t.Parallel()
+
+		backendURL := startRealMCPBackend(t)
+		// Permit call_tool on any resource: the gate admits, so a nonexistent name reaches
+		// the SDK and gets the standard invalid-params "not found" — authz does not mask it.
+		ts := newCedarAuthzTestServer(t, backendURL,
+			`permit(principal, action == Action::"call_tool", resource);`)
+
+		client := NewMCPTestClient(t, ts.URL)
+		client.InitializeSession()
+
+		resp := client.CallTool("ghost-tool", map[string]any{"input": "x"})
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"a permitted-but-nonexistent name must not be gated, body: %s", string(body))
+		rpcErr := parseRPCError(t, body)
+		require.True(t, rpcErr.present, "body: %s", string(body))
+		assert.Equal(t, -32602, rpcErr.code, "the SDK's INVALID_PARAMS code must surface for an unknown tool")
+	})
+}
+
+// TestIntegration_RealBackend_CedarAuthz_ResourceAndPromptDenied proves the gate covers
+// resources/read and prompts/get, not just tools/call: a denied read/get is rejected as
+// HTTP 403 + JSON-RPC 403 with the kind-specific message.
+func TestIntegration_RealBackend_CedarAuthz_ResourceAndPromptDenied(t *testing.T) {
+	t.Parallel()
+
+	// Permit only an unrelated tool so every resource/prompt is default-denied.
+	const denyAllReadsAndPrompts = `permit(principal, action == Action::"call_tool", resource == Tool::"unrelated");`
+
+	t.Run("resources/read denied", func(t *testing.T) {
+		t.Parallel()
+
+		backendURL := startRealMCPBackend(t)
+		ts := newCedarAuthzTestServer(t, backendURL, denyAllReadsAndPrompts)
+
+		client := NewMCPTestClient(t, ts.URL)
+		client.InitializeSession()
+
+		resp := client.ReadResource("file://secret")
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "body: %s", string(body))
+		rpcErr := parseRPCError(t, body)
+		require.True(t, rpcErr.present, "body: %s", string(body))
+		assert.Equal(t, mcpparser.JSONRPCCodeDenied, rpcErr.code)
+		assert.Equal(t, "read denied by authorization policy", rpcErr.message)
+	})
+
+	t.Run("prompts/get denied", func(t *testing.T) {
+		t.Parallel()
+
+		backendURL := startRealMCPBackend(t)
+		ts := newCedarAuthzTestServer(t, backendURL, denyAllReadsAndPrompts)
+
+		client := NewMCPTestClient(t, ts.URL)
+		client.InitializeSession()
+
+		resp := client.GetPrompt("secret-prompt")
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "body: %s", string(body))
+		rpcErr := parseRPCError(t, body)
+		require.True(t, rpcErr.present, "body: %s", string(body))
+		assert.Equal(t, mcpparser.JSONRPCCodeDenied, rpcErr.code)
+		assert.Equal(t, "prompt denied by authorization policy", rpcErr.message)
+	})
+}
+
+// TestIntegration_RealBackend_NoAuthz_UnknownToolIsSDKError is the byte-parity guard:
+// with no Authz configured the gate is NOT installed, so an unknown tool falls through
+// to the SDK and gets -32602 at 200 — exactly today's behavior, unchanged by the gate.
+func TestIntegration_RealBackend_NoAuthz_UnknownToolIsSDKError(t *testing.T) {
+	t.Parallel()
+
+	backendURL := startRealMCPBackend(t)
+	// nil policies (no variadic args) ⇒ Config.Authz stays nil ⇒ no gate.
+	ts := newCedarAuthzTestServer(t, backendURL)
+
+	client := NewMCPTestClient(t, ts.URL)
+	client.InitializeSession()
+
+	resp := client.CallTool("unknown-tool", map[string]any{"input": "x"})
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"without Authz the gate is absent; the SDK handles unknown tools at 200, body: %s", string(body))
+	rpcErr := parseRPCError(t, body)
+	require.True(t, rpcErr.present, "body: %s", string(body))
+	assert.Equal(t, -32602, rpcErr.code, "the SDK's INVALID_PARAMS code must surface unchanged")
+}
+
+// TestIntegration_RealBackend_CodeMode_Authz is the regression guard for the codemode
+// carve-out: with both code mode and Authz enabled, the execute_tool_script meta-tool is
+// admitted by the gate (200) — it is not in the admission seam and would otherwise be
+// denied under a permit-list policy — while a directly-called denied tool still 403s.
+func TestIntegration_RealBackend_CodeMode_Authz(t *testing.T) {
+	t.Parallel()
+
+	backendURL := startRealMCPBackend(t)
+	// Permit "echo" (so a script can call it) but nothing grants the execute_tool_script
+	// meta-tool itself — the gate must admit it via the codemode carve-out, not policy.
+	ts := newCedarAuthzCodeModeServer(t, backendURL,
+		`permit(principal, action == Action::"call_tool", resource == Tool::"echo");`)
+
+	client := NewMCPTestClient(t, ts.URL)
+	client.InitializeSession()
+	waitForEchoTool(t, ts.URL, client.SessionID())
+
+	// execute_tool_script is admitted by the gate and runs the script (which calls the
+	// permitted "echo"), returning 200 — NOT a 403.
+	scriptResp := client.CallTool("execute_tool_script", map[string]any{
+		"script": `return echo(input="hi from script")`,
+	})
+	defer scriptResp.Body.Close()
+	scriptBody, err := io.ReadAll(scriptResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, scriptResp.StatusCode,
+		"execute_tool_script must be admitted by the gate's codemode carve-out, body: %s", string(scriptBody))
+	assert.NotEqual(t, mcpparser.JSONRPCCodeDenied, parseRPCError(t, scriptBody).code,
+		"the code-mode meta-tool must never be 403'd")
+	// Prove the script actually RAN (not a 200 + IsError): the echo backend returns its
+	// input verbatim, so the script's return value must carry "hi from script".
+	assert.Contains(t, string(scriptBody), "hi from script",
+		"the admitted script must execute and return the permitted tool's output")
+
+	// A directly-called denied tool is still gated to 403.
+	denyResp := client.CallTool("unrelated", map[string]any{"input": "x"})
+	defer denyResp.Body.Close()
+	denyBody, err := io.ReadAll(denyResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, denyResp.StatusCode, "body: %s", string(denyBody))
+	assert.Equal(t, mcpparser.JSONRPCCodeDenied, parseRPCError(t, denyBody).code)
 }

--- a/pkg/vmcp/server/call_gate.go
+++ b/pkg/vmcp/server/call_gate.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/server"
+	"github.com/stacklok/toolhive/pkg/auth"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// authzCallGate builds the pre-dispatch CallGate consulted once per POST on the
+// Streamable HTTP transport, BEFORE session validation and BEFORE the message
+// reaches the SDK. It re-runs the core admission decision for the gated methods so
+// a Cedar-denied direct tools/call, resources/read, or prompts/get is rejected on
+// the wire as HTTP 403 + JSON-RPC error code 403 — instead of the SDK's 200/"not
+// found" (a filtered tool) or the tool-result 200/IsError fallback.
+//
+// It reads only context the host middleware already populated (the parsed request
+// and the authenticated identity), matching the seam's contract; it never mutates
+// context and never logs the identity. The gate is installed only when authz is
+// configured (see Handler), so this closure runs solely on authorized deployments.
+//
+// The gate and the subsequent dispatch (core.CallTool/ReadResource/GetPrompt) both
+// authorize, and they invoke the SAME core admission helper (Check* and Call*/Read*/
+// Get* share one extracted decision — see pkg/vmcp/core), so the DECISION LOGIC
+// cannot diverge. The gate is the wire-level representation of that decision (it
+// turns a denial into 403 before dispatch); the call-path check remains as
+// defense-in-depth for embedders that bypass this transport.
+//
+// One caveat for argument-conditional policies (tools/call): the gate authorizes on
+// parsed.Arguments (decoded by pkg/mcp's parser) while dispatch re-authorizes on the
+// SDK's decode of the same request bytes. Both are encoding/json over identical
+// bytes, so they agree for plain JSON today. If the two decoders ever diverge
+// (json.Number vs float64, a future typed-params path, duplicate-key handling), the
+// gate could ALLOW while the call path DENIES (re-introducing the 200/IsError this
+// closure exists to remove) or vice-versa. The invariant is that the gated decision
+// and the enforced decision must derive from the same parse; unifying the source is
+// tracked as a follow-up (see #5845).
+func (s *Server) authzCallGate() server.CallGate {
+	return func(ctx context.Context, _ *http.Request) *server.Denial {
+		// An unparsable body or a batch leaves no ParsedMCPRequest: admit and let the
+		// SDK handle it. The batch blind spot matches the pre-existing single-server
+		// parity gap (cross-ref #5745); it is not widened here.
+		parsed := mcpparser.GetParsedMCPRequest(ctx)
+		if parsed == nil {
+			return nil
+		}
+
+		// Sanctioned transport-boundary identity read (same as the Serve handlers):
+		// the core takes identity as an explicit parameter, so the gate resolves it
+		// once here from the context the auth middleware populated. A nil identity is
+		// anonymous — the core admission seam decides what that may do.
+		identity, _ := auth.IdentityFromContext(ctx)
+
+		var err error
+		var message string
+		switch parsed.Method {
+		case "tools/call":
+			err = s.core.CheckToolCall(ctx, identity, parsed.ResourceID, parsed.Arguments)
+			message = vmcp.DenyMessageToolCall
+		case "resources/read":
+			err = s.core.CheckResourceRead(ctx, identity, parsed.ResourceID)
+			message = vmcp.DenyMessageResourceRead
+		case "prompts/get":
+			err = s.core.CheckPromptGet(ctx, identity, parsed.ResourceID)
+			message = vmcp.DenyMessagePromptGet
+		default:
+			// Non-gated method (initialize, tools/list, ping, ...): admit unchanged.
+			//
+			// This default is deliberately fail-OPEN, unlike pkg/authz's
+			// MCPMethodToFeatureOperation ("methods not in this map are denied by
+			// default"). The gate mirrors the core admission seam, which only
+			// authorizes tools/resources/prompts today; elicitation/create,
+			// sampling/createMessage, and tasks/* have no admission decision yet, so
+			// denying them here would diverge from the core rather than enforce a
+			// real policy. To gate a NEW verb: add a Check* method on core.VMCP for
+			// it and a case above — do NOT flip this default to deny, which would
+			// reject protocol methods (initialize/ping/list/notifications) that must
+			// always pass.
+			return nil
+		}
+
+		if err == nil {
+			return nil
+		}
+
+		// Only an authorization denial (or a fail-closed authorizer error, already
+		// classified as ErrAuthorizationFailed inside Check*) becomes a 403. Any other
+		// error is infrastructure (aggregation/backend plumbing): admit so the call
+		// path hits the same failure and surfaces it through the existing mapping —
+		// the gate must not convert infra faults into 403s.
+		if !errors.Is(err, vmcp.ErrAuthorizationFailed) {
+			slog.WarnContext(ctx, "vmcp authz gate: non-authorization error, admitting request",
+				"method", parsed.Method, "error", err)
+			return nil
+		}
+
+		// HTTPStatus left zero ⇒ the shim writes HTTP 403 (see server.Denial).
+		return &server.Denial{Code: mcpparser.JSONRPCCodeDenied, Message: message}
+	}
+}

--- a/pkg/vmcp/server/call_gate_test.go
+++ b/pkg/vmcp/server/call_gate_test.go
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/core"
+)
+
+// gateFakeCore is a core.VMCP whose only exercised methods are the Check* triple.
+// The embedded nil interface satisfies the rest and panics if the gate ever calls
+// a method it should not.
+type gateFakeCore struct {
+	core.VMCP
+	toolErr   error
+	resErr    error
+	promptErr error
+
+	gotMethod     string
+	gotResourceID string
+	gotArgs       map[string]any
+}
+
+func (f *gateFakeCore) CheckToolCall(_ context.Context, _ *auth.Identity, name string, args map[string]any) error {
+	f.gotMethod = "tools/call"
+	f.gotResourceID = name
+	f.gotArgs = args
+	return f.toolErr
+}
+
+func (f *gateFakeCore) CheckResourceRead(_ context.Context, _ *auth.Identity, uri string) error {
+	f.gotMethod = "resources/read"
+	f.gotResourceID = uri
+	return f.resErr
+}
+
+func (f *gateFakeCore) CheckPromptGet(_ context.Context, _ *auth.Identity, name string) error {
+	f.gotMethod = "prompts/get"
+	f.gotResourceID = name
+	return f.promptErr
+}
+
+func TestAuthzCallGate(t *testing.T) {
+	t.Parallel()
+
+	deny := fmt.Errorf("%w: policy said no", vmcp.ErrAuthorizationFailed)
+	infra := errors.New("aggregation exploded")
+
+	tests := []struct {
+		name string
+		// parsed is the request the parsing middleware would have populated; nil means
+		// no ParsedMCPRequest in context (unparsable body / batch).
+		parsed       *mcpparser.ParsedMCPRequest
+		core         *gateFakeCore
+		wantDenial   bool
+		wantMessage  string
+		wantMethod   string // Check* method the gate must have invoked ("" = none)
+		wantResource string
+		wantArgs     map[string]any
+		forbidInMsg  string // substring that must NOT appear in the denial message
+	}{
+		{
+			name: "no parsed request admits",
+			core: &gateFakeCore{},
+		},
+		{
+			name:   "non-gated method admits",
+			parsed: &mcpparser.ParsedMCPRequest{Method: "tools/list"},
+			core:   &gateFakeCore{},
+		},
+		{
+			name: "tools/call allowed admits and forwards name+args",
+			parsed: &mcpparser.ParsedMCPRequest{
+				Method: "tools/call", ResourceID: "echo", Arguments: map[string]any{"input": "hi"},
+			},
+			core:         &gateFakeCore{},
+			wantMethod:   "tools/call",
+			wantResource: "echo",
+			wantArgs:     map[string]any{"input": "hi"},
+		},
+		{
+			name: "tools/call denied returns 403 denial",
+			parsed: &mcpparser.ParsedMCPRequest{
+				Method: "tools/call", ResourceID: "secret-tool", Arguments: map[string]any{"input": "hi"},
+			},
+			core:         &gateFakeCore{toolErr: deny},
+			wantDenial:   true,
+			wantMessage:  vmcp.DenyMessageToolCall,
+			wantMethod:   "tools/call",
+			wantResource: "secret-tool",
+			forbidInMsg:  "secret-tool",
+		},
+		{
+			name: "tools/call non-authz error admits (no 403 for infra faults)",
+			parsed: &mcpparser.ParsedMCPRequest{
+				Method: "tools/call", ResourceID: "echo",
+			},
+			core:       &gateFakeCore{toolErr: infra},
+			wantMethod: "tools/call",
+		},
+		{
+			name: "resources/read denied returns 403 denial",
+			parsed: &mcpparser.ParsedMCPRequest{
+				Method: "resources/read", ResourceID: "file://secret",
+			},
+			core:         &gateFakeCore{resErr: deny},
+			wantDenial:   true,
+			wantMessage:  vmcp.DenyMessageResourceRead,
+			wantMethod:   "resources/read",
+			wantResource: "file://secret",
+			forbidInMsg:  "file://secret",
+		},
+		{
+			name: "prompts/get denied returns 403 denial",
+			parsed: &mcpparser.ParsedMCPRequest{
+				Method: "prompts/get", ResourceID: "secret-prompt",
+			},
+			core:         &gateFakeCore{promptErr: deny},
+			wantDenial:   true,
+			wantMessage:  vmcp.DenyMessagePromptGet,
+			wantMethod:   "prompts/get",
+			wantResource: "secret-prompt",
+			forbidInMsg:  "secret-prompt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Build the context per-subtest from t.Context() (our test convention),
+			// injecting the parsed request as the parsing middleware would.
+			ctx := t.Context()
+			if tt.parsed != nil {
+				ctx = context.WithValue(ctx, mcpparser.MCPRequestContextKey, tt.parsed)
+			}
+
+			s := &Server{core: tt.core}
+			gate := s.authzCallGate()
+
+			denial := gate(ctx, nil)
+
+			if tt.wantDenial {
+				require.NotNil(t, denial, "expected a denial")
+				assert.Equal(t, mcpparser.JSONRPCCodeDenied, denial.Code, "denial code must be 403")
+				assert.Equal(t, 0, denial.HTTPStatus, "HTTPStatus must be zero so the shim writes 403")
+				assert.Equal(t, tt.wantMessage, denial.Message)
+				if tt.forbidInMsg != "" {
+					assert.NotContains(t, denial.Message, tt.forbidInMsg,
+						"the denial message must not leak the capability name (no enumeration oracle)")
+				}
+			} else {
+				assert.Nil(t, denial, "expected the request to be admitted")
+			}
+
+			assert.Equal(t, tt.wantMethod, tt.core.gotMethod, "unexpected Check* method invoked")
+			if tt.wantResource != "" {
+				assert.Equal(t, tt.wantResource, tt.core.gotResourceID)
+			}
+			if tt.wantArgs != nil {
+				assert.Equal(t, tt.wantArgs, tt.core.gotArgs)
+			}
+		})
+	}
+}

--- a/pkg/vmcp/server/serve_handlers.go
+++ b/pkg/vmcp/server/serve_handlers.go
@@ -225,7 +225,7 @@ func (s *Server) coreResourceHandler(
 		result, err := s.core.ReadResource(ctx, caller, uri)
 		if err != nil {
 			if errors.Is(err, vmcp.ErrAuthorizationFailed) {
-				return nil, errors.New("read denied by authorization policy")
+				return nil, errors.New(vmcp.DenyMessageResourceRead)
 			}
 			return nil, err
 		}

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -188,6 +188,18 @@ func (*fakeCore) LookupPrompt(context.Context, *auth.Identity, string) (*vmcp.Pr
 	return nil, vmcp.ErrNotFound
 }
 
+// Check* mirror the Call*/Read* error injection so a pre-flight gate over this fake
+// sees the same allow/deny the call path would.
+func (f *fakeCore) CheckToolCall(context.Context, *auth.Identity, string, map[string]any) error {
+	return f.callErr
+}
+
+func (f *fakeCore) CheckResourceRead(context.Context, *auth.Identity, string) error {
+	return f.readErr
+}
+
+func (*fakeCore) CheckPromptGet(context.Context, *auth.Identity, string) error { return nil }
+
 func (*fakeCore) ListBackends(context.Context, *auth.Identity, bool) ([]vmcp.Backend, error) {
 	return nil, nil
 }

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -63,6 +63,11 @@ func (*stubVMCP) LookupResource(context.Context, *auth.Identity, string) (*vmcp.
 func (*stubVMCP) LookupPrompt(context.Context, *auth.Identity, string) (*vmcp.Prompt, error) {
 	return nil, nil
 }
+func (*stubVMCP) CheckToolCall(context.Context, *auth.Identity, string, map[string]any) error {
+	return nil
+}
+func (*stubVMCP) CheckResourceRead(context.Context, *auth.Identity, string) error { return nil }
+func (*stubVMCP) CheckPromptGet(context.Context, *auth.Identity, string) error    { return nil }
 func (*stubVMCP) ListBackends(context.Context, *auth.Identity, bool) ([]vmcp.Backend, error) {
 	return nil, nil
 }

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -276,6 +276,14 @@ type Server struct {
 	// server (BackendHealth keeps a defensive nil guard regardless).
 	core core.VMCP
 
+	// authzGateEnabled installs the pre-dispatch authorization CallGate in Handler.
+	// Authz is core-owned and stripped from the transport ServerConfig (see
+	// deriveServerConfig / buildServeConfig), so it never reaches s.config; New —
+	// the only composition path that knows the authz config — sets this flag from
+	// cfg.Authz != nil after Serve builds the Server. It stays false for direct-Serve
+	// callers, which have no way to configure authorization and run allow-all cores.
+	authzGateEnabled bool
+
 	// optimizerFactory builds a per-session optimizer over the core's advertised
 	// tools. Set only when the optimizer is enabled (nil otherwise). When non-nil,
 	// session registration advertises find_tool/
@@ -497,6 +505,11 @@ func New(
 		return nil, err
 	}
 
+	// Enable the pre-dispatch authorization gate when Cedar policies are configured.
+	// Authz is core-owned and not carried on the transport ServerConfig Serve builds
+	// from, so New — which holds cfg.Authz — sets the flag here (see Server.authzGateEnabled).
+	srv.authzGateEnabled = cfg.Authz != nil
+
 	// Bind the elicitation adapter to the SDK server Serve built so composite-workflow
 	// elicitation reaches the same mcp-go server that serves client traffic.
 	elicitation.bind(NewSDKElicitationAdapter(srv.MCPServer()))
@@ -516,13 +529,21 @@ func New(
 // All returned handlers share the same underlying MCPServer and SessionManager,
 // so callers should not serve concurrent traffic through multiple handlers.
 func (s *Server) Handler(_ context.Context) (http.Handler, error) {
-	// Create Streamable HTTP server with ToolHive session management
-	streamableServer := server.NewStreamableHTTPServer(
-		s.mcpServer,
+	// Create Streamable HTTP server with ToolHive session management.
+	streamableOpts := []server.StreamableHTTPOption{
 		server.WithEndpointPath(s.config.EndpointPath),
 		server.WithSessionIdManager(s.vmcpSessionMgr),
 		server.WithHeartbeatInterval(heartbeatInterval(s.config.HeartbeatInterval)),
-	)
+	}
+	// Install the pre-dispatch authorization gate only when authz is configured
+	// (allow-all otherwise, matching the core admission seam's guard). The gate
+	// re-runs the core admission decision for gated methods so a denied tools/call,
+	// resources/read, or prompts/get is rejected as HTTP 403 + JSON-RPC 403 before
+	// the SDK dispatches it, instead of the SDK's 200 result.
+	if s.authzGateEnabled {
+		streamableOpts = append(streamableOpts, server.WithCallGate(s.authzCallGate()))
+	}
+	streamableServer := server.NewStreamableHTTPServer(s.mcpServer, streamableOpts...)
 
 	// Create HTTP mux with separated authenticated and unauthenticated routes
 	mux := http.NewServeMux()
@@ -575,6 +596,13 @@ func (s *Server) Handler(_ context.Context) (http.Handler, error) {
 	// removed: every caller now routes through Serve, so authorization is enforced by the
 	// core admission seam (#5438) and capability/health filtering by the core, rather than
 	// by HTTP middleware.
+	//
+	// Authorization additionally runs a pre-dispatch CallGate INSIDE the streamable
+	// server (installed above only when Authz is configured): it re-runs the core
+	// admission decision for tools/call, resources/read, and prompts/get and rejects a
+	// denial as HTTP 403 + JSON-RPC 403 before dispatch. The gate sits before session
+	// validation (403-before-404) and inside the audit middleware, so a denied call is
+	// audited with outcome "denied". See call_gate.go.
 
 	var mcpHandler http.Handler = streamableServer
 

--- a/pkg/vmcp/server/testutil_test.go
+++ b/pkg/vmcp/server/testutil_test.go
@@ -126,6 +126,34 @@ func (c *MCPTestClient) CallTool(toolName string, args map[string]any) *http.Res
 	return resp
 }
 
+// ReadResource calls resources/read for the given URI and returns the raw response.
+func (c *MCPTestClient) ReadResource(uri string) *http.Response {
+	c.t.Helper()
+
+	resp := c.postMCP(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      c.nextID,
+		"method":  "resources/read",
+		"params":  map[string]any{"uri": uri},
+	}, c.sessionID)
+	c.nextID++
+	return resp
+}
+
+// GetPrompt calls prompts/get for the given prompt name and returns the raw response.
+func (c *MCPTestClient) GetPrompt(name string) *http.Response {
+	c.t.Helper()
+
+	resp := c.postMCP(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      c.nextID,
+		"method":  "prompts/get",
+		"params":  map[string]any{"name": name},
+	}, c.sessionID)
+	c.nextID++
+	return resp
+}
+
 // SessionID returns the current session ID (available after InitializeSession).
 func (c *MCPTestClient) SessionID() string {
 	return c.sessionID


### PR DESCRIPTION
## Summary

**Why:** On the vMCP Serve path, a Cedar-**denied** direct `tools/call` returned **HTTP 200 with JSON-RPC `-32602` "tool not found"** instead of an explicit authorization denial (Fixes #5827). Authorization on the Serve path is enforced by the core admission seam, which *filters* denied capabilities out of a session's advertised set — so a direct call to a denied tool reaches the SDK as an unknown tool and comes back as `-32602`. That is indistinguishable from a typo, **invisible to audit** (the auditor derives its outcome from the HTTP status, so a denial logged as an application error — or, for an argument-conditional policy, as a *success*), and inconsistent with the single-server proxy path (`thv run --authz-config`), which returns 403. The reporter needs an explicit authorization-denied response for audit and acceptance evidence.

**What:** Add pre-flight admission checks to the vMCP core and wire them to the `mcpcompat` `WithCallGate` seam so a denied call is rejected **before** SDK dispatch with **HTTP 403 + a JSON-RPC error (code 403)**.

- `core.VMCP` gains `CheckToolCall` / `CheckResourceRead` / `CheckPromptGet`, **extracted from the existing `CallTool` / `ReadResource` / `GetPrompt` admission blocks into shared helpers** — so the pre-flight check and the call path enforce one decision and cannot drift.
- A pre-dispatch gate (`pkg/vmcp/server/call_gate.go`) reads the parsed request + caller identity from context, runs the matching `Check*`, and maps an admission denial to `Denial{Code: 403, Message: "<kind> denied by authorization policy"}` (HTTP 403). Installed only when authorization is configured.
- The denial message depends only on the capability kind, never the name — so it is not a tool-existence oracle (under default-deny, denied / unadvertised / nonexistent all return an identical 403).
- Audit now records the denial **for free** via the existing `403 → denied` status mapping — no audit changes.

This fixes both denial modes consistently (a filtered tool *and* a registered-but-denied tool under an argument-conditional policy) and brings the vMCP path to parity with `thv run`.

**Code mode / rate limiting:** the code-mode decorator overrides `CheckToolCall` to admit `execute_tool_script` (the feature flag is the grant; each inner call is still individually authorized), and the rate-limit decorator deliberately does not intercept the pre-flight checks so a denied call consumes no tokens. `CallTool`'s own admission check is retained as defense-in-depth.

**Depends on:** toolhive-core **v0.0.29** (the `WithCallGate` seam) — bumped in this PR. Also depends on / builds atop #5729 (the mcp-go → mcpcompat migration).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Unit — `pkg/vmcp/core`: `Check*` allow / deny / fail-closed-on-authorizer-error, and an **anti-drift invariant** test asserting `Check*` denies **iff** `Call*` denies (including an argument-conditional Cedar policy, and asserting the absolute outcome so it proves args are actually consulted).
- [x] Unit — decorators: code-mode admits `execute_tool_script` under a deny-all inner and delegates otherwise; rate-limit `Check*` consumes no tokens.
- [x] Unit — the gate closure: method→check mapping, `ErrAuthorizationFailed`→403, non-authz error→admit, identity never logged.
- [x] Integration (`authz_integration_test.go`, real Cedar + real in-process streamable-HTTP echo backend through `server.New`→`Handler`): a denied direct `tools/call` and an argument-denied call now return **HTTP 403 + JSON-RPC code 403** (previously 200/`-32602` and 200/`isError`); allowed call → 200 + result (positive control); nonexistent tool → identical 403 (no oracle); `resources/read` + `prompts/get` denied → 403; no-Authz config → SDK `-32602`/200 (parity guard); code-mode + Authz → `execute_tool_script` runs (200) while a denied tool 403s; audit outcome is `denied`.
- [x] Manual (local build + `ghcr.io/stackloklabs/yardstick/yardstick-server:1.1.1`): a direct `tools/call` to a Cedar-denied tool returned `HTTP/1.1 403` + `{"error":{"code":403,"message":"call denied by authorization policy"}}`; adding the permit returned 200 + result.
- [x] `task test` (`-race`), `task lint`, `task docs`.

## Does this introduce a user-facing change?

Yes. A vMCP server with Cedar authorization now returns HTTP 403 (with a JSON-RPC error code 403 and a "denied by authorization policy" message) when a policy denies a `tools/call`, `resources/read`, or `prompts/get`, instead of a JSON-RPC `-32602` "not found" at HTTP 200. Denials are now recorded as `denied` in the audit log.

## Special notes for reviewers

- The single source of truth is the extracted `authorize*` helper shared by `Check*` and `Call*`; the anti-drift test guards it.
- The gate is a transport-level *representation* of the core's decision — `CallTool`'s internal admission check is intentionally retained (defense-in-depth for other embedders and for a misconfigured gate), so admitting on a transient non-authz error cannot bypass authorization.
- Denial code `403` (application space, matching `pkg/authz.handleUnauthorized`) is a deliberate single representation across `thv run` and vMCP; the tool-filter block path (#5764.2) can share the constant in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Large PR Justification

One logical change — return HTTP 403 for authorization-denied vMCP calls — that must land atomically. The three `core.Check*` methods are extracted from the existing admission blocks into shared helpers and added to the `VMCP` interface, so they compile lock-step with every implementation, decorator, and test fake (a split leaves the interface unsatisfied). The gate wiring, the anti-drift test that guards the single-source extraction, and the integration tests that prove the 403 behaviour belong to the same change and are meaningless apart. The majority of the diff is tests and docs — roughly 9 production files.
