### PR TITLE
Stop VirtualMCPServer hot-reconcile on cleared podTemplateSpec

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -1782,10 +1782,12 @@ func (r *VirtualMCPServerReconciler) podTemplateMetadataNeedsUpdate(
 	return false
 }
 
-// podTemplateSpecNeedsUpdate checks if the user-provided PodTemplateSpec has changed.
-// Instead of comparing full rendered templates (which always differ due to Kubernetes-defaulted
-// fields like terminationGracePeriodSeconds, dnsPolicy, etc.), this compares a SHA256 hash of
-// the raw PodTemplateSpec input stored as a deployment annotation.
+// podTemplateSpecNeedsUpdate checks if the user-provided PodTemplateSpec has changed, by
+// comparing a SHA256 hash of the raw input against the stored annotation rather than the
+// full rendered template (which always differs due to Kubernetes-defaulted fields).
+// Symmetric by design (#5818): an absent PodTemplateSpec expects an empty hash, so a stale
+// annotation left over after the field is cleared is treated as drift and gets pruned by
+// mergeDeploymentAnnotations on the next write, instead of being flagged forever.
 func (*VirtualMCPServerReconciler) podTemplateSpecNeedsUpdate(
 	ctx context.Context,
 	deployment *appsv1.Deployment,
@@ -1796,37 +1798,28 @@ func (*VirtualMCPServerReconciler) podTemplateSpecNeedsUpdate(
 		return true
 	}
 
-	// If no PodTemplateSpec is provided, update is only needed if one was previously applied
-	if vmcp.Spec.PodTemplateSpec == nil || vmcp.Spec.PodTemplateSpec.Raw == nil {
-		_, hadPrevious := deployment.Annotations[podTemplateSpecHashAnnotation]
-		return hadPrevious
-	}
-
-	// Compare hash of the raw PodTemplateSpec input against the stored annotation.
-	// Avoids comparing full rendered templates which always differ due to
-	// Kubernetes-defaulted fields (terminationGracePeriodSeconds, dnsPolicy, etc.).
-	// Uses HashRawJSON to ensure deterministic hashing regardless of JSON field ordering.
-	expectedHash, err := checksum.HashRawJSON(vmcp.Spec.PodTemplateSpec.Raw)
-	if err != nil {
-		// If we can't hash, assume update is needed
-		log.FromContext(ctx).Error(err, "Failed to hash PodTemplateSpec, assuming update needed")
-		return true
+	expectedHash := ""
+	if vmcp.Spec.PodTemplateSpec != nil && len(vmcp.Spec.PodTemplateSpec.Raw) > 0 {
+		hash, err := checksum.HashRawJSON(vmcp.Spec.PodTemplateSpec.Raw)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "Failed to hash PodTemplateSpec, assuming update needed")
+			return true
+		}
+		expectedHash = hash
 	}
 	return deployment.Annotations[podTemplateSpecHashAnnotation] != expectedHash
 }
 
-// mergeDeploymentAnnotations merges desired Deployment annotations onto the
-// live ones via ctrlutil.MergeAnnotations, then prunes imagePullRefsHashAnnotation
-// from the result if desired no longer wants it. MergeAnnotations preserves any
-// live key absent from desired so externally-managed annotations survive, but
-// imagePullRefsHashAnnotation is operator-owned: when the desired imagePullSecrets
-// list is empty, desired carries no annotation for it, and a stale value left by
-// a prior reconcile must be pruned explicitly or it survives forever and
-// imagePullSecretsNeedsUpdate flags drift on every reconcile (#5817).
+// mergeDeploymentAnnotations merges desired annotations onto the live ones via
+// ctrlutil.MergeAnnotations, then prunes the operator-owned hash annotations
+// (imagePullRefsHashAnnotation, podTemplateSpecHashAnnotation) that desired no longer wants —
+// MergeAnnotations otherwise preserves them forever once their source field goes empty (#5817, #5818).
 func mergeDeploymentAnnotations(desired, live map[string]string) map[string]string {
 	merged := ctrlutil.MergeAnnotations(desired, live)
-	if _, wantHash := desired[imagePullRefsHashAnnotation]; !wantHash {
-		delete(merged, imagePullRefsHashAnnotation)
+	for _, key := range []string{imagePullRefsHashAnnotation, podTemplateSpecHashAnnotation} {
+		if _, want := desired[key]; !want {
+			delete(merged, key)
+		}
 	}
 	return merged
 }

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -586,80 +587,6 @@ func TestVirtualMCPServerEnsureRBACResources_CustomServiceAccount(t *testing.T) 
 		Namespace: vmcp.Namespace,
 	}, rb)
 	assert.Error(t, err, "RoleBinding should not be created when custom ServiceAccount is provided")
-}
-
-// TestVirtualMCPServerEnsureDeployment tests Deployment creation
-func TestVirtualMCPServerEnsureDeployment(t *testing.T) {
-	t.Parallel()
-
-	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
-		v1beta1test.WithVMCPGroupRef(testGroupName),
-	)
-
-	// Create MCPGroup that the VirtualMCPServer references
-	mcpGroup := &mcpv1beta1.MCPGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testGroupName,
-			Namespace: "default",
-		},
-		Status: mcpv1beta1.MCPGroupStatus{
-			Phase: mcpv1beta1.MCPGroupPhaseReady,
-		},
-	}
-
-	// Create ConfigMap with checksum
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcpConfigMapName(vmcp.Name),
-			Namespace: "default",
-			Annotations: map[string]string{
-				"toolhive.stacklok.dev/content-checksum": "test-checksum-123",
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": "{}",
-		},
-	}
-
-	scheme := testutil.NewScheme(t)
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(vmcp, mcpGroup, configMap).
-		Build()
-
-	r := &VirtualMCPServerReconciler{
-		Client:           fakeClient,
-		Scheme:           scheme,
-		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}
-
-	result, err := r.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
-	require.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
-
-	// Verify Deployment was created
-	deployment := &appsv1.Deployment{}
-	err = fakeClient.Get(context.Background(), types.NamespacedName{
-		Name:      vmcp.Name,
-		Namespace: vmcp.Namespace,
-	}, deployment)
-	require.NoError(t, err)
-	assert.Equal(t, vmcp.Name, deployment.Name)
-	// spec.replicas is nil — nil-passthrough for HPA compatibility
-	assert.Nil(t, deployment.Spec.Replicas)
-
-	// Verify container configuration
-	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
-	container := deployment.Spec.Template.Spec.Containers[0]
-	assert.Equal(t, "vmcp", container.Name)
-	assert.NotEmpty(t, container.Image)
-	assert.Contains(t, container.Args, "serve")
-	assert.Contains(t, container.Args, "--config=/etc/vmcp-config/config.yaml")
-
-	// Verify checksum annotation is set using standard annotation key
-	assert.Equal(t, "test-checksum-123",
-		deployment.Spec.Template.Annotations[checksum.RunConfigChecksumAnnotation])
 }
 
 // TestVirtualMCPServerEnsureService tests Service creation
@@ -2037,6 +1964,70 @@ func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 			expectedUpdate: true,
 		},
 		{
+			name: "stale podTemplateSpec hash annotation",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      labelsForVirtualMCPServer(vmcp.Name),
+					Annotations: map[string]string{podTemplateSpecHashAnnotation: "stale-hash"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      expectedLabels,
+							Annotations: expectedAnnotations,
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "vmcp",
+									Image: getVmcpImage(),
+									Ports: []corev1.ContainerPort{
+										{ContainerPort: 4483},
+									},
+									Args: reconciler.buildContainerArgsForVmcp(vmcp),
+									Env:  mustBuildEnvVarsForVmcp(reconciler, vmcp),
+								},
+							},
+							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+		},
+		{
+			name: "stale imagePullSecrets hash annotation",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      labelsForVirtualMCPServer(vmcp.Name),
+					Annotations: map[string]string{imagePullRefsHashAnnotation: "stale-hash"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      expectedLabels,
+							Annotations: expectedAnnotations,
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "vmcp",
+									Image: getVmcpImage(),
+									Ports: []corev1.ContainerPort{
+										{ContainerPort: 4483},
+									},
+									Args: reconciler.buildContainerArgsForVmcp(vmcp),
+									Env:  mustBuildEnvVarsForVmcp(reconciler, vmcp),
+								},
+							},
+							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+		},
+		{
 			name: "no changes - no update needed",
 			deployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2076,6 +2067,56 @@ func TestVirtualMCPServerDeploymentNeedsUpdate(t *testing.T) {
 
 			needsUpdate := reconciler.deploymentNeedsUpdate(context.Background(), tt.deployment, vmcp, vmcpConfigChecksum, nil, []workloads.TypedWorkload{})
 			assert.Equal(t, tt.expectedUpdate, needsUpdate)
+		})
+	}
+}
+
+// Direct unit tests for podTemplateSpecNeedsUpdate live in
+// virtualmcpserver_podtemplatespec_reconcile_test.go, and for
+// imagePullSecretsNeedsUpdate in virtualmcpserver_deployment_test.go /
+// virtualmcpserver_default_imagepullsecrets_test.go — no need to duplicate here.
+
+func TestMergeDeploymentAnnotations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		desired  map[string]string
+		live     map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "prunes stale imagePullRefsHashAnnotation when desired no longer wants it",
+			desired:  map[string]string{},
+			live:     map[string]string{imagePullRefsHashAnnotation: "stale-hash"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "prunes stale podTemplateSpecHashAnnotation when desired no longer wants it",
+			desired:  map[string]string{},
+			live:     map[string]string{podTemplateSpecHashAnnotation: "stale-hash"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "keeps hash annotations desired still wants",
+			desired:  map[string]string{imagePullRefsHashAnnotation: "new-hash", podTemplateSpecHashAnnotation: "new-hash"},
+			live:     map[string]string{imagePullRefsHashAnnotation: "old-hash", podTemplateSpecHashAnnotation: "old-hash"},
+			expected: map[string]string{imagePullRefsHashAnnotation: "new-hash", podTemplateSpecHashAnnotation: "new-hash"},
+		},
+		{
+			name:     "preserves externally-managed annotations absent from desired",
+			desired:  map[string]string{},
+			live:     map[string]string{"external.io/managed-by": "someone-else"},
+			expected: map[string]string{"external.io/managed-by": "someone-else"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			merged := mergeDeploymentAnnotations(tt.desired, tt.live)
+			assert.Equal(t, tt.expected, merged)
 		})
 	}
 }
@@ -2380,6 +2421,19 @@ func TestVirtualMCPServerEnsureDeployment_CreateDeployment(t *testing.T) {
 	}, deployment)
 	assert.NoError(t, err)
 	assert.Equal(t, vmcp.Name, deployment.Name)
+	// spec.replicas is nil — nil-passthrough for HPA compatibility
+	assert.Nil(t, deployment.Spec.Replicas)
+
+	require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, "vmcp", container.Name)
+	assert.NotEmpty(t, container.Image)
+	assert.Contains(t, container.Args, "serve")
+	assert.Contains(t, container.Args, "--config=/etc/vmcp-config/config.yaml")
+
+	// Verify checksum annotation is set using standard annotation key
+	assert.Equal(t, "test-checksum",
+		deployment.Spec.Template.Annotations[checksum.RunConfigChecksumAnnotation])
 }
 
 func TestVirtualMCPServerEnsureDeployment_UpdateDeployment(t *testing.T) {
@@ -2534,115 +2588,129 @@ func TestVirtualMCPServerEnsureDeployment_NoUpdateNeeded(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, result)
 }
 
-// TestVirtualMCPServerEnsureDeployment_RemovesStaleImagePullSecretsHash is a
-// regression test for #5817: a stale imagePullRefsHashAnnotation left over
-// from a prior reconcile (when imagePullSecrets was non-empty) must be
-// removed once the desired list is empty, and reconciling again from that
-// cleaned-up state must be a no-op rather than looping forever.
-func TestVirtualMCPServerEnsureDeployment_RemovesStaleImagePullSecretsHash(t *testing.T) {
+// TestVirtualMCPServerEnsureDeployment_RemovesStaleHashAnnotation is a regression test
+// for #5817/#5818: a stale operator-owned hash annotation left over from a prior
+// reconcile (when the corresponding field was non-empty) must be removed once that
+// field is cleared, and reconciling again from the cleaned-up state must be a no-op
+// rather than looping forever.
+func TestVirtualMCPServerEnsureDeployment_RemovesStaleHashAnnotation(t *testing.T) {
 	t.Parallel()
 
-	scheme := testutil.NewScheme(t)
-
-	vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
-		v1beta1test.WithVMCPGroupRef(testGroupName),
-	)
-
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcpConfigMapName(vmcp.Name),
-			Namespace: "default",
-			Annotations: map[string]string{
-				checksum.ContentChecksumAnnotation: "test-checksum",
-			},
-		},
-		Data: map[string]string{
-			"config.yaml": "test-config",
-		},
+	tests := []struct {
+		name          string
+		staleHashAnno string
+	}{
+		{name: "imagePullSecrets", staleHashAnno: imagePullRefsHashAnnotation},
+		{name: "podTemplateSpec", staleHashAnno: podTemplateSpecHashAnnotation},
 	}
 
-	reconciler := &VirtualMCPServerReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
-		Scheme: scheme,
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	expectedLabels, expectedAnnotations := reconciler.buildPodTemplateMetadata(
-		labelsForVirtualMCPServer(vmcp.Name), vmcp, "test-checksum",
-	)
+			scheme := testutil.NewScheme(t)
 
-	// Deployment otherwise matches the desired state exactly, except it
-	// carries a stale imagePullRefsHashAnnotation from before imagePullSecrets
-	// was cleared on the VirtualMCPServer.
-	staleDeployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVmcpName,
-			Namespace: "default",
-			Labels:    labelsForVirtualMCPServer(vmcp.Name),
-			Annotations: map[string]string{
-				imagePullRefsHashAnnotation: "stale-hash",
-			},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: labelsForVirtualMCPServer(vmcp.Name),
-			},
-			Template: corev1.PodTemplateSpec{
+			vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default",
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+			)
+
+			configMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      expectedLabels,
-					Annotations: expectedAnnotations,
+					Name:      vmcpConfigMapName(vmcp.Name),
+					Namespace: "default",
+					Annotations: map[string]string{
+						checksum.ContentChecksumAnnotation: "test-checksum",
+					},
 				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "vmcp",
-							Image: getVmcpImage(),
-							Ports: []corev1.ContainerPort{
-								{ContainerPort: 4483},
+				Data: map[string]string{
+					"config.yaml": "test-config",
+				},
+			}
+
+			reconciler := &VirtualMCPServerReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+				Scheme: scheme,
+			}
+
+			expectedLabels, expectedAnnotations := reconciler.buildPodTemplateMetadata(
+				labelsForVirtualMCPServer(vmcp.Name), vmcp, "test-checksum",
+			)
+
+			// Deployment otherwise matches the desired state exactly, except it
+			// carries a stale hash annotation from before the corresponding
+			// VirtualMCPServer field was cleared.
+			staleDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testVmcpName,
+					Namespace: "default",
+					Labels:    labelsForVirtualMCPServer(vmcp.Name),
+					Annotations: map[string]string{
+						tt.staleHashAnno: "stale-hash",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: labelsForVirtualMCPServer(vmcp.Name),
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      expectedLabels,
+							Annotations: expectedAnnotations,
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "vmcp",
+									Image: getVmcpImage(),
+									Ports: []corev1.ContainerPort{
+										{ContainerPort: 4483},
+									},
+									Env: mustBuildEnvVarsForVmcp(reconciler, vmcp),
+								},
 							},
-							Env: mustBuildEnvVarsForVmcp(reconciler, vmcp),
+							ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
 						},
 					},
-					ServiceAccountName: vmcpServiceAccountName(vmcp.Name),
 				},
-			},
-		},
+			}
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(vmcp, configMap, staleDeployment).
+				Build()
+			reconciler.Client = k8sClient
+
+			// First reconcile cleans up the stale annotation.
+			result, err := reconciler.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
+			require.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+
+			deployment := &appsv1.Deployment{}
+			require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{
+				Name:      vmcp.Name,
+				Namespace: vmcp.Namespace,
+			}, deployment))
+			_, present := deployment.Annotations[tt.staleHashAnno]
+			assert.False(t, present, "stale hash annotation must be removed once the corresponding field is unset")
+
+			resourceVersionAfterCleanup := deployment.ResourceVersion
+
+			// Second reconcile from the now-clean steady state must be a no-op.
+			// Without both fixes, this would keep re-detecting drift and updating
+			// forever — the hot-reconcile loop from #5817/#5818.
+			result, err = reconciler.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
+			require.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+
+			deployment = &appsv1.Deployment{}
+			require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{
+				Name:      vmcp.Name,
+				Namespace: vmcp.Namespace,
+			}, deployment))
+			assert.Equal(t, resourceVersionAfterCleanup, deployment.ResourceVersion,
+				"reconciling from steady state must not write again")
+		})
 	}
-
-	k8sClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(vmcp, configMap, staleDeployment).
-		Build()
-	reconciler.Client = k8sClient
-
-	// First reconcile cleans up the stale annotation.
-	result, err := reconciler.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
-	require.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
-
-	deployment := &appsv1.Deployment{}
-	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{
-		Name:      vmcp.Name,
-		Namespace: vmcp.Namespace,
-	}, deployment))
-	_, present := deployment.Annotations[imagePullRefsHashAnnotation]
-	assert.False(t, present, "stale imagePullRefsHashAnnotation must be removed once desired list is empty")
-
-	resourceVersionAfterCleanup := deployment.ResourceVersion
-
-	// Second reconcile from the now-clean steady state must be a no-op.
-	// Without both fixes, this would keep re-detecting drift and updating
-	// forever — the hot-reconcile loop from #5817.
-	result, err = reconciler.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
-	require.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
-
-	deployment = &appsv1.Deployment{}
-	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{
-		Name:      vmcp.Name,
-		Namespace: vmcp.Namespace,
-	}, deployment))
-	assert.Equal(t, resourceVersionAfterCleanup, deployment.ResourceVersion,
-		"reconciling from steady state must not write again")
 }
 
 func TestVirtualMCPServerEnsureService_CreateService(t *testing.T) {
@@ -2962,144 +3030,101 @@ func TestVirtualMCPServerValidateEmbeddingServerRef(t *testing.T) {
 
 // TestVirtualMCPServerEnsureDeployment_ReplicaSync_SpecDriven verifies that when
 // spec.replicas is set, ensureDeployment updates the Deployment to match.
-func TestVirtualMCPServerEnsureDeployment_ReplicaSync_SpecDriven(t *testing.T) {
+// TestVirtualMCPServerEnsureDeployment_ReplicaSync covers spec.replicas
+// syncing to the live Deployment: a spec-driven value overrides whatever is
+// live, while nil leaves the live value untouched (HPA-managed passthrough).
+func TestVirtualMCPServerEnsureDeployment_ReplicaSync(t *testing.T) {
 	t.Parallel()
 
-	specReplicas := int32(3)
-	vmcp := v1beta1test.NewVirtualMCPServer("vmcp-replica-sync", "default",
-		v1beta1test.WithVMCPGroupRef(testGroupName),
-		v1beta1test.WithVMCPReplicas(specReplicas),
-	)
-
-	mcpGroup := &mcpv1beta1.MCPGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: testGroupName, Namespace: "default"},
-		Status:     mcpv1beta1.MCPGroupStatus{Phase: mcpv1beta1.MCPGroupPhaseReady},
-	}
-
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcpConfigMapName(vmcp.Name),
-			Namespace: "default",
-			Annotations: map[string]string{
-				checksum.ContentChecksumAnnotation: testChecksumValue,
-			},
+	tests := []struct {
+		name             string
+		specReplicas     *int32
+		existingReplicas int32
+		wantReplicas     int32
+	}{
+		{
+			name:             "spec-driven value overrides existing replica count",
+			specReplicas:     ptr.To(int32(3)),
+			existingReplicas: 1,
+			wantReplicas:     3,
 		},
-		Data: map[string]string{"config.yaml": "{}"},
-	}
-
-	// Existing deployment has 1 replica — simulates a pre-existing state
-	existingReplicas := int32(1)
-	existingDeployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcp.Name,
-			Namespace: "default",
-			Labels:    labelsForVirtualMCPServer(vmcp.Name),
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &existingReplicas,
-			Selector: &metav1.LabelSelector{MatchLabels: labelsForVirtualMCPServer(vmcp.Name)},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labelsForVirtualMCPServer(vmcp.Name)},
-				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "vmcp", Image: "test:latest"}}},
-			},
+		{
+			name:             "nil spec.replicas does not overwrite HPA-managed count",
+			specReplicas:     nil,
+			existingReplicas: 5,
+			wantReplicas:     5,
 		},
 	}
 
-	scheme := testutil.NewScheme(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(vmcp, mcpGroup, configMap, existingDeployment).
-		Build()
+			opts := []v1beta1test.VirtualMCPServerOption{v1beta1test.WithVMCPGroupRef(testGroupName)}
+			if tt.specReplicas != nil {
+				opts = append(opts, v1beta1test.WithVMCPReplicas(*tt.specReplicas))
+			}
+			vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default", opts...)
 
-	r := &VirtualMCPServerReconciler{
-		Client:           fakeClient,
-		Scheme:           scheme,
-		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+			mcpGroup := &mcpv1beta1.MCPGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: testGroupName, Namespace: "default"},
+				Status:     mcpv1beta1.MCPGroupStatus{Phase: mcpv1beta1.MCPGroupPhaseReady},
+			}
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmcpConfigMapName(vmcp.Name),
+					Namespace: "default",
+					Annotations: map[string]string{
+						checksum.ContentChecksumAnnotation: testChecksumValue,
+					},
+				},
+				Data: map[string]string{"config.yaml": "{}"},
+			}
+
+			existingReplicas := tt.existingReplicas
+			existingDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      vmcp.Name,
+					Namespace: "default",
+					Labels:    labelsForVirtualMCPServer(vmcp.Name),
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &existingReplicas,
+					Selector: &metav1.LabelSelector{MatchLabels: labelsForVirtualMCPServer(vmcp.Name)},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: labelsForVirtualMCPServer(vmcp.Name)},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "vmcp", Image: "test:latest"}}},
+					},
+				},
+			}
+
+			scheme := testutil.NewScheme(t)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(vmcp, mcpGroup, configMap, existingDeployment).
+				Build()
+
+			r := &VirtualMCPServerReconciler{
+				Client:           fakeClient,
+				Scheme:           scheme,
+				PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
+			}
+
+			result, err := r.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
+			require.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+
+			updated := &appsv1.Deployment{}
+			err = fakeClient.Get(context.Background(), types.NamespacedName{
+				Name: vmcp.Name, Namespace: vmcp.Namespace,
+			}, updated)
+			require.NoError(t, err)
+			require.NotNil(t, updated.Spec.Replicas)
+			assert.Equal(t, tt.wantReplicas, *updated.Spec.Replicas)
+		})
 	}
-
-	result, err := r.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
-	require.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
-
-	updated := &appsv1.Deployment{}
-	err = fakeClient.Get(context.Background(), types.NamespacedName{
-		Name: vmcp.Name, Namespace: vmcp.Namespace,
-	}, updated)
-	require.NoError(t, err)
-	require.NotNil(t, updated.Spec.Replicas)
-	assert.Equal(t, int32(3), *updated.Spec.Replicas)
-}
-
-// TestVirtualMCPServerEnsureDeployment_ReplicaSync_NilPassthrough verifies that when
-// spec.replicas is nil, ensureDeployment does not overwrite a live replica count (HPA-managed).
-func TestVirtualMCPServerEnsureDeployment_ReplicaSync_NilPassthrough(t *testing.T) {
-	t.Parallel()
-
-	// Replicas left nil — HPA manages replicas.
-	vmcp := v1beta1test.NewVirtualMCPServer("vmcp-nil-passthrough", "default",
-		v1beta1test.WithVMCPGroupRef(testGroupName),
-	)
-
-	mcpGroup := &mcpv1beta1.MCPGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: testGroupName, Namespace: "default"},
-		Status:     mcpv1beta1.MCPGroupStatus{Phase: mcpv1beta1.MCPGroupPhaseReady},
-	}
-
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcpConfigMapName(vmcp.Name),
-			Namespace: "default",
-			Annotations: map[string]string{
-				checksum.ContentChecksumAnnotation: testChecksumValue,
-			},
-		},
-		Data: map[string]string{"config.yaml": "{}"},
-	}
-
-	// Existing deployment has 5 replicas — set by HPA
-	hpaReplicas := int32(5)
-	existingDeployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      vmcp.Name,
-			Namespace: "default",
-			Labels:    labelsForVirtualMCPServer(vmcp.Name),
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &hpaReplicas,
-			Selector: &metav1.LabelSelector{MatchLabels: labelsForVirtualMCPServer(vmcp.Name)},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labelsForVirtualMCPServer(vmcp.Name)},
-				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "vmcp", Image: "test:latest"}}},
-			},
-		},
-	}
-
-	scheme := testutil.NewScheme(t)
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(vmcp, mcpGroup, configMap, existingDeployment).
-		Build()
-
-	r := &VirtualMCPServerReconciler{
-		Client:           fakeClient,
-		Scheme:           scheme,
-		PlatformDetector: ctrlutil.NewSharedPlatformDetector(),
-	}
-
-	result, err := r.ensureDeployment(context.Background(), vmcp, nil, []workloads.TypedWorkload{})
-	require.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, result)
-
-	updated := &appsv1.Deployment{}
-	err = fakeClient.Get(context.Background(), types.NamespacedName{
-		Name: vmcp.Name, Namespace: vmcp.Namespace,
-	}, updated)
-	require.NoError(t, err)
-	// HPA-managed replica count must not be overwritten
-	require.NotNil(t, updated.Spec.Replicas)
-	assert.Equal(t, int32(5), *updated.Spec.Replicas)
 }
 
 // mustBuildEnvVarsForVmcp is a test helper that calls buildEnvVarsForVmcp and panics on error.

--- a/cmd/thv-operator/pkg/registryapi/deployment.go
+++ b/cmd/thv-operator/pkg/registryapi/deployment.go
@@ -138,6 +138,12 @@ func (m *manager) upsertDeployment(
 	for k, v := range deployment.Annotations {
 		existing.Annotations[k] = v
 	}
+	// Prune the hash annotation if desired no longer wants it, otherwise it
+	// survives forever and deploymentNeedsUpdate reports drift on every
+	// reconcile (same bug class as #5817/#5818).
+	if _, wantHash := deployment.Annotations[podTemplateSpecHashAnnotation]; !wantHash {
+		delete(existing.Annotations, podTemplateSpecHashAnnotation)
+	}
 
 	// Ensure owner reference is set on the existing object
 	if err := controllerutil.SetControllerReference(mcpRegistry, existing, m.scheme); err != nil {

--- a/cmd/thv-operator/pkg/registryapi/deployment_test.go
+++ b/cmd/thv-operator/pkg/registryapi/deployment_test.go
@@ -13,8 +13,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 )
 
 func TestGetRegistryAPIImage(t *testing.T) {
@@ -524,6 +527,73 @@ func TestDeploymentNeedsUpdate(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestUpsertDeployment_RemovesStalePodTemplateSpecHash is a regression test
+// for the registry-api analog of #5817/#5818: a stale
+// podTemplateSpecHashAnnotation left over from a prior reconcile (when
+// spec.podTemplateSpec was set) must be removed once the field is cleared,
+// and upserting again from that cleaned-up state must be a no-op rather than
+// looping forever.
+func TestUpsertDeployment_RemovesStalePodTemplateSpecHash(t *testing.T) {
+	t.Parallel()
+
+	scheme := testutil.NewScheme(t)
+
+	mcpRegistry := &mcpv1beta1.MCPRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-registry",
+			Namespace: "test-namespace",
+		},
+		Spec: mcpv1beta1.MCPRegistrySpec{
+			ConfigYAML: "sources:\n  - name: k8s\n    kubernetes: {}\n",
+		},
+	}
+
+	mgr := &manager{scheme: scheme}
+
+	desired, err := mgr.buildRegistryAPIDeployment(context.Background(), mcpRegistry, "test-registry-registry-server-config")
+	require.NoError(t, err)
+
+	// Existing deployment matches desired exactly, except it carries a stale
+	// podTemplateSpecHashAnnotation from before spec.podTemplateSpec was
+	// cleared on the MCPRegistry.
+	staleDeployment := desired.DeepCopy()
+	staleDeployment.Annotations = map[string]string{
+		podTemplateSpecHashAnnotation: "stale-hash",
+	}
+
+	mgr.client = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(staleDeployment).
+		Build()
+
+	// First upsert cleans up the stale annotation.
+	_, err = mgr.upsertDeployment(context.Background(), mcpRegistry, desired.DeepCopy())
+	require.NoError(t, err)
+
+	deployment := &appsv1.Deployment{}
+	require.NoError(t, mgr.client.Get(context.Background(), client.ObjectKey{
+		Name:      mcpRegistry.GetAPIResourceName(),
+		Namespace: mcpRegistry.Namespace,
+	}, deployment))
+	_, present := deployment.Annotations[podTemplateSpecHashAnnotation]
+	assert.False(t, present, "stale podTemplateSpecHashAnnotation must be removed once PodTemplateSpec is unset")
+
+	resourceVersionAfterCleanup := deployment.ResourceVersion
+
+	// Second upsert from the now-clean steady state must be a no-op. Without
+	// the prune fix, this would keep re-detecting drift and updating forever.
+	_, err = mgr.upsertDeployment(context.Background(), mcpRegistry, desired.DeepCopy())
+	require.NoError(t, err)
+
+	deployment = &appsv1.Deployment{}
+	require.NoError(t, mgr.client.Get(context.Background(), client.ObjectKey{
+		Name:      mcpRegistry.GetAPIResourceName(),
+		Namespace: mcpRegistry.Namespace,
+	}, deployment))
+	assert.Equal(t, resourceVersionAfterCleanup, deployment.ResourceVersion,
+		"upserting from steady state must not write again")
 }
 
 func TestBuildRegistryAPIDeployment_PodTemplateSpecHash(t *testing.T) {


### PR DESCRIPTION
## Summary

Clearing `spec.podTemplateSpec` on a `VirtualMCPServer` (or on an `MCPRegistry` with a registry-api deployment) left the operator writing a no-op Deployment update on every reconcile, incrementing `metadata.generation` indefinitely. On a kind cluster this saturates etcd write bandwidth and can starve leader-election lease renewal, causing the operator to lose leadership and restart. Same bug class as #5817 (`imagePullSecrets`), now fixed for `podTemplateSpec`:

- Made `podTemplateSpecNeedsUpdate` a plain `stored != expected` hash comparison instead of the previous asymmetric presence check that always reported drift once a hash annotation existed.
- Extended `mergeDeploymentAnnotations` to prune `podTemplateSpecHashAnnotation` alongside `imagePullRefsHashAnnotation` when desired no longer wants it, collapsing the two prune checks into one loop.
- Fixed the identical bug in the MCPRegistry registry-api deployment path (`cmd/thv-operator/pkg/registryapi/deployment.go`), where the same stale annotation could survive an additive-only annotation merge.
- Added regression tests for both controllers, each reconciling twice from a stale-annotation fixture and asserting the second pass is a true no-op.
- Simplified the surrounding VirtualMCPServer Deployment test suite: merged a duplicate create-deployment test, consolidated two near-identical stale-annotation regression tests and two near-identical replica-sync tests into table-driven tests, filled a coverage gap in `TestVirtualMCPServerDeploymentNeedsUpdate` (previously only exercised 3 of the 5 branches it delegates to), and added a direct unit test for `mergeDeploymentAnnotations`.

Fixes #5818

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/controllers/virtualmcpserver_controller.go` | Symmetric `podTemplateSpecNeedsUpdate`; `mergeDeploymentAnnotations` prunes both hash annotations |
| `cmd/thv-operator/controllers/virtualmcpserver_controller_test.go` | Regression tests + test suite simplification (see summary) |
| `cmd/thv-operator/pkg/registryapi/deployment.go` | Same stale-annotation prune fix for the registry-api deployment path |
| `cmd/thv-operator/pkg/registryapi/deployment_test.go` | Regression test for the registry-api fix |

## Does this introduce a user-facing change?

Yes — clearing `spec.podTemplateSpec` (VirtualMCPServer or MCPRegistry) no longer causes a runaway reconcile loop that repeatedly updates the managed Deployment.

## Special notes for reviewers

Both fixes are required together: the symmetric comparison alone doesn't stop the loop, since the write path would still never remove the stale annotation via `MergeAnnotations`. Only pruning it explicitly at the write site converges to a steady state — same pattern as the `imagePullSecrets` fix in #5821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)