### PR TITLE
Harden vMCP authz gate: single parse source and reserved-name check

### DIFF
--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -325,16 +325,26 @@ policies are configured:
 - An authorizer error fails **closed** (treated as a denial); a non-authorization
   (infrastructure) error admits, so the call path surfaces it through existing mapping —
   the gate never converts a plumbing fault into a 403.
+- **One decode per `tools/call`**: dispatch (`coreToolHandler`) prefers the transport
+  parse (`pkg/mcp`) the gate authorized on — via `gateParsedArgs`, keyed on matching
+  method + tool — so the gated decision, the enforced call-path decision, and the
+  forwarded backend arguments all derive from a single decoded map. Where no matching
+  parse exists (batch, embedders bypassing the transport, method/tool mismatch), dispatch
+  falls back to the SDK decode and makes a single decision on that single map, so no path
+  can produce an allow-then-deny split between gate and call.
 - **Code mode carve-out**: `execute_tool_script` is not in the admission seam (the feature
   flag is the grant, and each inner tool call the script makes is re-authorized by its real
   name), so the codemode decorator's `CheckToolCall` admits it while delegating every other
-  name to the inner core.
+  name to the inner core. A backend that advertised a tool named `execute_tool_script`
+  would be silently shadowed by the virtual tool and skip its own Cedar admission, so the
+  decorator fails **loud** (`ErrReservedToolName`) on that collision — `ListTools`,
+  `LookupTool`, and the `CallTool` script-binding path all refuse to serve rather than mask it.
 
 The `Call*` methods keep their internal admission checks as defense-in-depth for other
 embedders and misconfigured gates.
 
 **Implementation**: `pkg/vmcp/core/core_checks.go`, `pkg/vmcp/server/call_gate.go`,
-`pkg/vmcp/codemode/decorator.go`, `pkg/mcp/errors.go`
+`pkg/vmcp/server/serve_handlers.go`, `pkg/vmcp/codemode/decorator.go`, `pkg/mcp/errors.go`
 
 ## Health Monitoring
 

--- a/pkg/vmcp/codemode/decorator.go
+++ b/pkg/vmcp/codemode/decorator.go
@@ -18,6 +18,13 @@ import (
 	"github.com/stacklok/toolhive/pkg/vmcp/core"
 )
 
+// ErrReservedToolName is returned when a backend advertises a tool whose name collides
+// with the reserved execute_tool_script virtual tool. It is fail-loud on purpose: a
+// silent shadow would let the backend tool skip its own Cedar admission (LookupTool /
+// ListTools would resolve the virtual definition instead), so the decorator refuses to
+// serve rather than mask the backend tool (#5845).
+var ErrReservedToolName = errors.New("codemode: backend tool collides with reserved virtual tool name")
+
 // defaultScriptTimeout bounds the total wall-clock time of a single script execution.
 // The step limit caps CPU-equivalent work and Config.ToolCallTimeout caps each inner tool
 // call, but neither bounds a script that makes many sequential calls — without this an
@@ -94,10 +101,22 @@ func virtualToolInputSchema() map[string]any {
 // grant for every tool the feature can call. This is safe precisely because code mode adds
 // no reachability beyond the caller's already-authorized tool set.
 //
+// Because the decorator resolves execute_tool_script to its own virtual definition, a
+// backend that advertised a tool of the same name would be silently shadowed and skip
+// its Cedar admission. The decorator refuses that collision fail-loud via innerTools:
+// ListTools, LookupTool, and the CallTool script-binding path all error with
+// ErrReservedToolName rather than serve the shadowed set (#5845).
+//
 // The decorator is stateless and safe for concurrent use: a fresh [script.Executor] is
 // built per execution from the inner core's identity-filtered tool set, so two callers
 // never share an engine or a tool binding.
 type decorator struct {
+	// core.VMCP is embedded, so any method the decorator does not override is promoted
+	// straight to the inner core. The reserved-name collision guard (#5845) lives only in
+	// the overrides that read the inner tool set via innerTools (ListTools, LookupTool, and
+	// CallTool's script path). If core.VMCP ever grows another tool-set-reading method, it
+	// will auto-promote and bypass that guard — reintroducing the silent execute_tool_script
+	// shadow. Any such new method MUST be overridden here to funnel through innerTools.
 	core.VMCP
 	cfg Config
 }
@@ -120,11 +139,32 @@ func NewDecorator(inner core.VMCP, cfg *Config) core.VMCP {
 	}
 }
 
+// innerTools lists inner's admission-filtered tools and fails loud if any of them
+// collides with the reserved execute_tool_script name. Every decorator path that reads
+// inner's tool set goes through here so a shadowing backend tool is rejected once,
+// consistently: were it served, ListTools/LookupTool would advertise the virtual
+// definition in its place and the backend tool would never reach its own Cedar
+// admission (#5845). The defensive skips in virtualTool/bindTools remain as
+// belt-and-braces for the same name.
+func (d *decorator) innerTools(ctx context.Context, identity *auth.Identity) ([]vmcp.Tool, error) {
+	tools, err := d.VMCP.ListTools(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range tools {
+		if t.Name == script.ExecuteToolScriptName {
+			return nil, fmt.Errorf("%w: %q advertised by backend %q",
+				ErrReservedToolName, script.ExecuteToolScriptName, t.BackendID)
+		}
+	}
+	return tools, nil
+}
+
 // ListTools returns inner's tools plus the execute_tool_script virtual tool. The
 // virtual tool's description is generated from inner's (identity-filtered) tools, so
 // it lists exactly what the script may call for this identity.
 func (d *decorator) ListTools(ctx context.Context, identity *auth.Identity) ([]vmcp.Tool, error) {
-	tools, err := d.VMCP.ListTools(ctx, identity)
+	tools, err := d.innerTools(ctx, identity)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +182,7 @@ func (d *decorator) LookupTool(ctx context.Context, identity *auth.Identity, nam
 	if name != script.ExecuteToolScriptName {
 		return d.VMCP.LookupTool(ctx, identity, name)
 	}
-	tools, err := d.VMCP.ListTools(ctx, identity)
+	tools, err := d.innerTools(ctx, identity)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +222,10 @@ func (d *decorator) CallTool(
 
 	// Bind the script to the identity's admission-filtered tool set. Each inner call
 	// re-enters inner.CallTool, so admission is enforced per call by the real tool name.
-	tools, err := d.VMCP.ListTools(ctx, identity)
+	// innerTools fails loud on a reserved-name collision, so a shadowing backend tool
+	// surfaces as a transport error here rather than silently binding under the wrong
+	// admission (#5845).
+	tools, err := d.innerTools(ctx, identity)
 	if err != nil {
 		return nil, fmt.Errorf("codemode: list tools for script execution: %w", err)
 	}

--- a/pkg/vmcp/codemode/decorator_test.go
+++ b/pkg/vmcp/codemode/decorator_test.go
@@ -359,6 +359,75 @@ func TestCallTool_ToolCallTimeout(t *testing.T) {
 	assert.True(t, res.IsError, "a tool call exceeding ToolCallTimeout must fail the script")
 }
 
+// collidingBackendID is the BackendID recorded for the shadowing tool, asserted in the
+// fail-loud error so tests confirm the offending backend is named.
+const collidingBackendID = "evil-backend"
+
+// collidingBackend advertises a tool whose name equals the reserved virtual tool name,
+// simulating a backend that shadows execute_tool_script.
+func collidingBackend() *fakeCore {
+	return &fakeCore{
+		listTools: func(_ context.Context, _ *auth.Identity) ([]vmcp.Tool, error) {
+			return []vmcp.Tool{
+				{Name: "echo", Description: "Echoes its value back", BackendID: "b1"},
+				{Name: script.ExecuteToolScriptName, Description: "shadow", BackendID: collidingBackendID},
+			}, nil
+		},
+	}
+}
+
+// TestListTools_ReservedNameCollisionFails verifies ListTools fails loud when a backend
+// advertises a tool that collides with the reserved virtual tool name — serving it would
+// let the shadowed backend tool skip its Cedar admission (#5845).
+func TestListTools_ReservedNameCollisionFails(t *testing.T) {
+	t.Parallel()
+	d := NewDecorator(collidingBackend(), nil)
+
+	_, err := d.ListTools(t.Context(), nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrReservedToolName)
+	assert.Contains(t, err.Error(), collidingBackendID, "error must name the offending backend")
+}
+
+// TestLookupTool_ReservedNameCollisionFails verifies the collision is caught when
+// resolving execute_tool_script via LookupTool, mirroring ListTools.
+func TestLookupTool_ReservedNameCollisionFails(t *testing.T) {
+	t.Parallel()
+	d := NewDecorator(collidingBackend(), nil)
+
+	_, err := d.LookupTool(t.Context(), nil, script.ExecuteToolScriptName)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrReservedToolName)
+	assert.Contains(t, err.Error(), collidingBackendID)
+}
+
+// TestCallTool_ScriptExecutionFailsOnCollision verifies a script execution fails loud as
+// a transport error (not an IsError result) when a backend shadows the reserved name:
+// the script-binding path lists inner tools through innerTools, which refuses the set.
+func TestCallTool_ScriptExecutionFailsOnCollision(t *testing.T) {
+	t.Parallel()
+	d := NewDecorator(collidingBackend(), nil)
+
+	args := map[string]any{"script": `return echo(value="x")`}
+	_, err := d.CallTool(t.Context(), nil, script.ExecuteToolScriptName, args, nil)
+	require.Error(t, err, "a reserved-name collision must surface as a transport error, not an IsError result")
+	assert.ErrorIs(t, err, ErrReservedToolName)
+	assert.Contains(t, err.Error(), collidingBackendID)
+}
+
+// TestCheckToolCall_AdmitsScriptTool_OnCollision pins the deliberate asymmetry: even when
+// a backend shadows the reserved name, the pre-flight gate STILL admits execute_tool_script
+// (CheckToolCall does not run innerTools) — the fail-loud happens at dispatch/listing, not
+// at the gate. A refactor routing CheckToolCall through innerTools "for consistency" would
+// flip this to a 403 on collision and silently change the contract; this test catches that.
+func TestCheckToolCall_AdmitsScriptTool_OnCollision(t *testing.T) {
+	t.Parallel()
+	d := NewDecorator(collidingBackend(), nil)
+
+	require.NoError(t, d.CheckToolCall(t.Context(), nil, script.ExecuteToolScriptName, nil),
+		"the gate must admit the reserved name even under a backend collision; the shadow fails loud at dispatch/listing")
+}
+
 // TestCheckToolCall_AdmitsScriptTool_DelegatesRest verifies the pre-flight gate
 // override: execute_tool_script is admitted WITHOUT consulting inner admission
 // (even under a deny-all inner), so a pre-dispatch gate never 403s a code-mode call;

--- a/pkg/vmcp/server/call_gate.go
+++ b/pkg/vmcp/server/call_gate.go
@@ -34,15 +34,13 @@ import (
 // turns a denial into 403 before dispatch); the call-path check remains as
 // defense-in-depth for embedders that bypass this transport.
 //
-// One caveat for argument-conditional policies (tools/call): the gate authorizes on
-// parsed.Arguments (decoded by pkg/mcp's parser) while dispatch re-authorizes on the
-// SDK's decode of the same request bytes. Both are encoding/json over identical
-// bytes, so they agree for plain JSON today. If the two decoders ever diverge
-// (json.Number vs float64, a future typed-params path, duplicate-key handling), the
-// gate could ALLOW while the call path DENIES (re-introducing the 200/IsError this
-// closure exists to remove) or vice-versa. The invariant is that the gated decision
-// and the enforced decision must derive from the same parse; unifying the source is
-// tracked as a follow-up (see #5845).
+// For argument-conditional policies (tools/call), the gated decision and the enforced
+// decision derive from the SAME parse by construction: the gate authorizes on
+// parsed.Arguments (pkg/mcp's transport parse) and dispatch prefers that same map via
+// gateParsedArgs before re-authorizing and forwarding (see serve_handlers.go). Where
+// no matching parse exists (batch, embedders bypassing this transport, method/tool
+// mismatch), dispatch falls back to the SDK decode and makes a single decision on that
+// single map — so no path can produce an allow-then-deny split between gate and call.
 func (s *Server) authzCallGate() server.CallGate {
 	return func(ctx context.Context, _ *http.Request) *server.Denial {
 		// An unparsable body or a batch leaves no ParsedMCPRequest: admit and let the

--- a/pkg/vmcp/server/serve_handlers.go
+++ b/pkg/vmcp/server/serve_handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stacklok/toolhive-core/mcpcompat/server"
 	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/conversion"
 	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
@@ -179,11 +180,25 @@ func (s *Server) coreToolHandler(sessionID, toolName, backendName string) server
 			bi.BackendName = backendName
 		}
 
+		// Shape-check on the SDK decode first: a non-object payload is rejected before the
+		// core is reached. This validates request shape for the parse we forward too — both
+		// decode the same request bytes, so a valid transport parse implies a valid SDK
+		// shape (the substitution below only changes which equal-shaped map is used).
 		args, ok := req.Params.Arguments.(map[string]any)
 		if !ok {
 			wrappedErr := fmt.Errorf("%w: arguments must be object, got %T", vmcp.ErrInvalidInput, req.Params.Arguments)
 			slog.Warn("invalid arguments for tool", "tool", toolName, "error", wrappedErr)
 			return mcp.NewToolResultError(wrappedErr.Error()), nil
+		}
+
+		// Prefer the transport-parsed argument map so the pre-dispatch authz gate's
+		// decision, this handler's enforced decision, and the forwarded backend call
+		// all derive from one decode (#5845). A nil result means no matching parse is
+		// available (batch / embedders bypassing transport middleware / method or tool
+		// mismatch); those paths keep the SDK decode above and still make a single
+		// decision on a single map, so gate and dispatch cannot diverge.
+		if pa := gateParsedArgs(ctx, toolName); pa != nil {
+			args = pa
 		}
 
 		caller, _ := auth.IdentityFromContext(ctx)
@@ -204,6 +219,24 @@ func (s *Server) coreToolHandler(sessionID, toolName, backendName string) server
 			IsError:           result.IsError,
 		}, nil
 	}
+}
+
+// gateParsedArgs returns the argument map the pre-dispatch authz gate decided on
+// (pkg/mcp's transport parse), so the gated decision, this handler's enforced
+// decision, and the forwarded backend call all share one decode (#5845). It returns
+// parsed.Arguments only when the context carries a ParsedMCPRequest for the SAME
+// tools/call on the SAME tool with non-nil arguments.
+//
+// A nil result tells the caller to keep the SDK decode: batch requests, embedders
+// that bypass the transport middleware, or a method/tool mismatch leave no matching
+// parse. Those paths make a single decision on a single map (the SDK decode), so
+// there is still no allow-then-deny divergence between gate and dispatch.
+func gateParsedArgs(ctx context.Context, toolName string) map[string]any {
+	parsed := mcpparser.GetParsedMCPRequest(ctx)
+	if parsed == nil || parsed.Method != "tools/call" || parsed.ResourceID != toolName || parsed.Arguments == nil {
+		return nil
+	}
+	return parsed.Arguments
 }
 
 // coreResourceHandler builds the SDK handler for a Serve-path resource. It mirrors

--- a/pkg/vmcp/server/serve_handlers_test.go
+++ b/pkg/vmcp/server/serve_handlers_test.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// withParsedRequest installs a ParsedMCPRequest on ctx under the same context key
+// GetParsedMCPRequest reads, mirroring what the transport parsing middleware does.
+func withParsedRequest(ctx context.Context, parsed *mcpparser.ParsedMCPRequest) context.Context {
+	return context.WithValue(ctx, mcpparser.MCPRequestContextKey, parsed)
+}
+
+// TestCoreToolHandler_UsesGateParsedArguments verifies that when the context carries the
+// transport parse for this tools/call, the handler forwards the parser's argument map to
+// core.CallTool — the same map the pre-dispatch authz gate decided on (#5845) — rather
+// than the SDK's decode of the request.
+func TestCoreToolHandler_UsesGateParsedArguments(t *testing.T) {
+	t.Parallel()
+
+	const toolName = "t"
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: toolName}}}
+	srv, sessionID, _ := registerServeSession(t, fc)
+
+	// Disjoint keys so the assertion distinguishes a full replacement (correct) from a
+	// merge: a merge would leak "sdkonly" — a key the gate never authorized on — into the
+	// map forwarded to the backend, which is exactly the allow-then-execute-different-args
+	// hole #5845 closes.
+	ctx := withParsedRequest(t.Context(), &mcpparser.ParsedMCPRequest{
+		Method:     "tools/call",
+		ResourceID: toolName,
+		Arguments:  map[string]any{"src": "parser", "parseronly": "y"},
+	})
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: map[string]any{"src": "sdk", "sdkonly": "x"},
+	}}
+
+	res, err := srv.coreToolHandler(sessionID, toolName, "")(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.False(t, res.IsError)
+
+	gotArgs, _ := fc.lastCallToolArgs.Load().(map[string]any)
+	assert.Equal(t, map[string]any{"src": "parser", "parseronly": "y"}, gotArgs,
+		"the handler must forward exactly the gate's transport-parsed arguments, not the SDK decode")
+	assert.NotContains(t, gotArgs, "sdkonly",
+		"SDK-only keys the gate never authorized on must not reach the backend")
+}
+
+// TestCoreToolHandler_FallsBackToSDKArguments verifies the handler keeps the SDK decode
+// whenever no matching transport parse is available: a nil parse, a non-tools/call
+// method, a resource-ID mismatch, or nil parsed arguments. Each of these must derive the
+// call from the SDK's single decode so gate and dispatch cannot diverge.
+func TestCoreToolHandler_FallsBackToSDKArguments(t *testing.T) {
+	t.Parallel()
+
+	const toolName = "t"
+
+	tests := []struct {
+		name   string
+		parsed *mcpparser.ParsedMCPRequest
+	}{
+		{"nil parse", nil},
+		{
+			"method mismatch",
+			&mcpparser.ParsedMCPRequest{Method: "resources/read", ResourceID: toolName, Arguments: map[string]any{"src": "parser"}},
+		},
+		{
+			"resource-id mismatch",
+			&mcpparser.ParsedMCPRequest{Method: "tools/call", ResourceID: "other", Arguments: map[string]any{"src": "parser"}},
+		},
+		{
+			"nil arguments",
+			&mcpparser.ParsedMCPRequest{Method: "tools/call", ResourceID: toolName, Arguments: nil},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fc := &fakeCore{tools: []vmcp.Tool{{Name: toolName}}}
+			srv, sessionID, _ := registerServeSession(t, fc)
+
+			ctx := t.Context()
+			if tc.parsed != nil {
+				ctx = withParsedRequest(ctx, tc.parsed)
+			}
+			req := mcp.CallToolRequest{Params: mcp.CallToolParams{
+				Name:      toolName,
+				Arguments: map[string]any{"src": "sdk"},
+			}}
+
+			res, err := srv.coreToolHandler(sessionID, toolName, "")(ctx, req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			assert.False(t, res.IsError)
+
+			gotArgs, _ := fc.lastCallToolArgs.Load().(map[string]any)
+			assert.Equal(t, "sdk", gotArgs["src"],
+				"without a matching transport parse the handler must use the SDK decode")
+		})
+	}
+}
+
+// TestCoreToolHandler_NonObjectSDKArgsRejectedDespiteParse verifies the SDK type check
+// runs first: a non-object SDK arguments payload is rejected with ErrInvalidInput even
+// when a matching transport parse exists, so the gate's parse never masks a malformed
+// request shape.
+func TestCoreToolHandler_NonObjectSDKArgsRejectedDespiteParse(t *testing.T) {
+	t.Parallel()
+
+	const toolName = "t"
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: toolName}}}
+	srv, sessionID, _ := registerServeSession(t, fc)
+
+	ctx := withParsedRequest(t.Context(), &mcpparser.ParsedMCPRequest{
+		Method:     "tools/call",
+		ResourceID: toolName,
+		Arguments:  map[string]any{"src": "parser"},
+	})
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: "not-an-object",
+	}}
+
+	res, err := srv.coreToolHandler(sessionID, toolName, "")(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.IsError, "a non-object SDK arguments payload must be rejected")
+	assert.Equal(t, int32(0), fc.callToolCalls.Load(),
+		"the core must not be reached when the SDK arguments are not an object")
+}

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -116,6 +116,7 @@ type fakeCore struct {
 	callToolCalls      atomic.Int32
 	readResourceCalls  atomic.Int32
 	lastCallToolName   atomic.Value // string
+	lastCallToolArgs   atomic.Value // map[string]any
 	lastReadURI        atomic.Value // string
 
 	callErr error // when set, CallTool returns it (e.g. vmcp.ErrAuthorizationFailed)
@@ -130,10 +131,13 @@ func (f *fakeCore) ListTools(context.Context, *auth.Identity) ([]vmcp.Tool, erro
 }
 
 func (f *fakeCore) CallTool(
-	_ context.Context, _ *auth.Identity, name string, _ map[string]any, _ map[string]any,
+	_ context.Context, _ *auth.Identity, name string, args map[string]any, _ map[string]any,
 ) (*vmcp.ToolCallResult, error) {
 	f.callToolCalls.Add(1)
 	f.lastCallToolName.Store(name)
+	if args != nil {
+		f.lastCallToolArgs.Store(args)
+	}
 	if f.callErr != nil {
 		return nil, f.callErr
 	}


### PR DESCRIPTION
## Summary

Two hardening items split out of the #5841 review of the vMCP HTTP-403 authz gate. Both are correctness/security refinements to the gate that just merged; neither changes user-facing behavior on the happy path.

- **Why (item 1):** the pre-dispatch gate authorized `tools/call` on the transport parser's decoded arguments, while the Serve handler re-authorized *and forwarded the backend call* on the SDK's separate decode of the same bytes. For an argument-conditional Cedar policy those two decodes could diverge (`json.Number` vs `float64`, duplicate keys), letting the gate **ALLOW** while the call path **DENIED** — re-introducing the exact `200 + IsError` the gate was built to remove (or a spurious 403).
  **What:** `coreToolHandler` now prefers the transport-parsed argument map via a new `gateParsedArgs` helper, so the gate decision, the enforced decision, and the backend forward all derive from **one** decode. Fallback paths (batch, embedders bypassing the transport, method/tool mismatch) keep the SDK decode and make a single decision on a single map, so they cannot diverge. `core.CallTool` is untouched and remains standalone defense-in-depth.

- **Why (item 2):** a backend tool literally named `execute_tool_script` would be silently shadowed by the code-mode virtual tool and skip its Cedar policy.
  **What:** the codemode decorator now routes every inner tool-set read through a new `innerTools` funnel, which returns `ErrReservedToolName` (naming the offending backend) so a collision fails loud at listing/lookup/script execution instead of shadowing silently.

Item 3 of #5845 (verb parity for `elicitation/create`, `sampling/createMessage`, `tasks/*`) intentionally stays open: it is blocked on a core admission decision for those verbs, which does not exist yet. The gate's `default` case documents exactly how to add a verb once that seam exists. This PR therefore uses **Refs**, not **Closes**.

Refs #5845

## Type of change

- [x] Bug fix / hardening (non-breaking change which fixes an issue)

## Test plan

- [x] Unit tests: `TestCoreToolHandler_UsesGateParsedArguments` (proves the transport parse fully replaces the SDK decode using disjoint keys, so a merge that leaked un-authorized keys would fail), `TestCoreToolHandler_FallsBackToSDKArguments` (four fallback branches), `TestCoreToolHandler_NonObjectSDKArgsRejectedDespiteParse`; codemode `TestListTools_/TestLookupTool_/TestCallTool_ScriptExecutionFailsOnCollision` and `TestCheckToolCall_AdmitsScriptTool_OnCollision`.
- [x] `task build`, `task lint` (0 issues), and `go test -race ./pkg/vmcp/...` all pass locally.

## Special notes for reviewers

Reviewed by a security + architecture + conventions + test-adequacy panel before opening; findings folded in (disjoint-key precedence assertion, an embedded-`core.VMCP` warning comment documenting that new tool-listing methods must funnel through `innerTools`, and the gate-admits/dispatch-fails-loud asymmetry test).

Generated with [Claude Code](https://claude.com/claude-code)
