### PR TITLE
Run MCP conformance suite against a vMCP endpoint

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -160,6 +160,10 @@ jobs:
     runs-on: ubuntu-8cores-32gb
     needs: build-binary
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [proxy, vmcp]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -185,12 +189,13 @@ jobs:
       - name: Run MCP conformance suite
         env:
           THV_BINARY: ${{ github.workspace }}/bin/thv
+          CONFORMANCE_TARGET: ${{ matrix.target }}
         run: ./test/conformance/run-conformance.sh
 
       - name: Upload conformance results
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: conformance-results
+          name: conformance-results-${{ matrix.target }}
           path: test/conformance/results
           retention-days: 7

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -220,6 +220,16 @@ tasks:
     deps: [build]
     env:
       THV_BINARY: "{{.PWD}}/bin/thv"
+      CONFORMANCE_TARGET: '{{.CONFORMANCE_TARGET | default "proxy"}}'
+    cmds:
+      - ./test/conformance/run-conformance.sh
+
+  conformance-vmcp:
+    desc: Run the MCP conformance suite against a `thv vmcp serve` deployment (requires Docker + Node)
+    deps: [build]
+    env:
+      THV_BINARY: "{{.PWD}}/bin/thv"
+      CONFORMANCE_TARGET: vmcp
     cmds:
       - ./test/conformance/run-conformance.sh
 

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -42,9 +42,30 @@ Lists scenarios that are known to fail and accepted. CI fails only on failures
 and also fails CI, so keep the list accurate. The CLI (`thv run`) proxy is
 transparent, so the list is currently empty.
 
+## Targets
+
+`run-conformance.sh` supports two targets via `CONFORMANCE_TARGET`:
+
+- **`proxy`** (default, `task conformance`) — runs the reference server through
+  `thv run` and tests the transparent CLI proxy endpoint. This path is
+  transport-transparent and does **not** exercise ToolHive's own MCP serving
+  code, so its baseline (`expected-failures.yaml`) is empty.
+- **`vmcp`** (`task conformance-vmcp`) — runs the reference server as a backend
+  in a group, aggregates it through `thv vmcp serve`, and tests the vMCP
+  endpoint. vMCP terminates and re-serves MCP using the migrated
+  `mcpcompat`/go-sdk serving surface, so this target is what actually exercises
+  that code. The generated config is patched from the `prefix` conflict strategy
+  to `priority` so backend tool names are preserved (unprefixed) for the suite's
+  fixtures, and the run asserts `serverInfo.name` identifies vMCP before testing.
+  Its baseline is `expected-failures-vmcp.yaml`.
+
 ## Scope
 
-Covers the CLI (`thv run`) proxy path with the `active` suite. Not covered:
+Covers the CLI (`thv run`) proxy path and the vMCP aggregator path
+(`thv vmcp serve`) with the `active` suite. The vmcp target is what exercises
+ToolHive's `mcpcompat`/go-sdk serving surface; its baseline lives in
+`expected-failures-vmcp.yaml` (sampling, completions, and resource subscribe are
+expected to fail until vMCP supports them). Not covered:
 
 - **Kubernetes operator proxy** — it rewrites the outbound `Host` header to the
   upstream Service identity, which breaks MCP servers that validate `Host` (per

--- a/test/conformance/expected-failures-vmcp.yaml
+++ b/test/conformance/expected-failures-vmcp.yaml
@@ -27,7 +27,11 @@ server:
   - tools-call-elicitation
   - elicitation-sep1034-defaults
   - elicitation-sep1330-enums
-  # Content-type / template handling gaps — likely real fixes (#5859).
+  # Embedded-resource decode bug (toolhive-core EmbeddedResource.UnmarshalJSON),
+  # fixed in core PR #173 — drops once that release is bumped in. Affects both the
+  # tool-call and prompt embedded-resource paths.
   - tools-call-mixed-content
   - tools-call-embedded-resource
+  - prompts-get-embedded-resource
+  # Resource templates not aggregated/served yet (#5859).
   - resources-templates-read

--- a/test/conformance/expected-failures-vmcp.yaml
+++ b/test/conformance/expected-failures-vmcp.yaml
@@ -1,0 +1,16 @@
+# Conformance baseline for the ToolHive vMCP aggregator (`thv vmcp serve`).
+#
+# Unlike the transparent CLI proxy, vMCP is an aggregator that terminates the MCP
+# protocol and re-serves an aggregated view of its backends using the migrated
+# mcpcompat/go-sdk serving surface. It does not (yet) proxy every capability of
+# an upstream server: sampling, completions, and resource subscribe are expected
+# to fail until vMCP implements them.
+#
+# List scenario names here that are KNOWN to fail and accepted. The suite fails
+# CI only on failures NOT listed here. An entry that starts passing again is
+# reported as a STALE entry and also fails CI, so keep this list accurate.
+#
+# This list is INTENTIONALLY EMPTY for now: the first CI run against vMCP reports
+# the true failure set, which is then transcribed here as the seeded baseline
+# (expected to include the sampling/completions/subscribe scenarios above).
+server: []

--- a/test/conformance/expected-failures-vmcp.yaml
+++ b/test/conformance/expected-failures-vmcp.yaml
@@ -1,16 +1,33 @@
 # Conformance baseline for the ToolHive vMCP aggregator (`thv vmcp serve`).
 #
-# Unlike the transparent CLI proxy, vMCP is an aggregator that terminates the MCP
-# protocol and re-serves an aggregated view of its backends using the migrated
-# mcpcompat/go-sdk serving surface. It does not (yet) proxy every capability of
-# an upstream server: sampling, completions, and resource subscribe are expected
-# to fail until vMCP implements them.
+# Unlike the transparent CLI proxy, vMCP terminates the MCP protocol and re-serves
+# an aggregated view of its backends using the migrated mcpcompat/go-sdk serving
+# surface. It does not (yet) proxy every capability of an upstream server.
 #
-# List scenario names here that are KNOWN to fail and accepted. The suite fails
-# CI only on failures NOT listed here. An entry that starts passing again is
-# reported as a STALE entry and also fails CI, so keep this list accurate.
+# List scenario names that are KNOWN to fail and accepted. The suite fails CI only
+# on failures NOT listed here. An entry that starts passing again is reported as a
+# STALE entry and also fails CI, so keep this list accurate — when a fix lands,
+# remove its entry here.
 #
-# This list is INTENTIONALLY EMPTY for now: the first CI run against vMCP reports
-# the true failure set, which is then transcribed here as the seeded baseline
-# (expected to include the sampling/completions/subscribe scenarios above).
-server: []
+# NOTE: `prompts-get-*` is deliberately ABSENT — it was a real bug (vMCP listed
+# prompts but never served prompts/get) fixed in #5857 (toolhive-core
+# SessionWithPrompts), so those scenarios now pass.
+#
+# The gaps below are triaged in #5859. Several ("worth a real fix") are likely
+# bugs to be fixed and removed from this list; the rest are aggregator limitations.
+server:
+  # Accepted aggregator limitations (no action expected).
+  - tools-call-sampling
+  - completion-complete
+  - resources-subscribe
+  - resources-unsubscribe
+  # Server-to-client forwarding not yet implemented in the vMCP serve path (#5859).
+  - tools-call-with-progress
+  - tools-call-with-logging
+  - tools-call-elicitation
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums
+  # Content-type / template handling gaps — likely real fixes (#5859).
+  - tools-call-mixed-content
+  - tools-call-embedded-resource
+  - resources-templates-read

--- a/test/conformance/run-conformance.sh
+++ b/test/conformance/run-conformance.sh
@@ -2,43 +2,85 @@
 # Run the MCP conformance suite against a ToolHive deployment.
 #
 # Packages the conformance repo's reference server (examples/servers/typescript)
-# dynamically at a pinned version, runs it through `thv run` (streamable-http),
-# and points `npx @modelcontextprotocol/conformance` at the proxied endpoint.
+# dynamically at a pinned version and points `npx @modelcontextprotocol/conformance`
+# at a ToolHive-exposed endpoint. Two targets are supported via CONFORMANCE_TARGET:
+#
+#   proxy  (default)  Runs the reference server through `thv run` (streamable-http)
+#                     and tests the transparent CLI proxy endpoint. This path does
+#                     not exercise the migrated mcpcompat/go-sdk serving code.
+#   vmcp              Runs the reference server as a backend in a group, aggregates
+#                     it through `thv vmcp serve`, and tests the vMCP endpoint. This
+#                     path DOES exercise the mcpcompat/go-sdk serving surface.
 #
 # A single CONFORMANCE_VERSION pins both the npm tool and the git server source
 # (repo tags vX.Y.Z map 1:1 to npm versions), keeping fixtures and tool in sync.
 #
 # Env:
-#   CONFORMANCE_VERSION  conformance tool + server version   (default: 0.1.16)
-#   CONFORMANCE_SUITE    suite to run: active|all|pending    (default: active)
-#   THV_BINARY           path to the thv binary              (default: thv)
+#   CONFORMANCE_TARGET   deployment under test: proxy|vmcp      (default: proxy)
+#   CONFORMANCE_VERSION  conformance tool + server version      (default: 0.1.16)
+#   CONFORMANCE_SUITE    suite to run: active|all|pending       (default: active)
+#   THV_BINARY           path to the thv binary                 (default: thv)
+#   VMCP_PORT            port for `thv vmcp serve` (vmcp target) (default: 8099)
 set -euo pipefail
 
+CONFORMANCE_TARGET="${CONFORMANCE_TARGET:-proxy}"
 CONFORMANCE_VERSION="${CONFORMANCE_VERSION:-0.1.16}"
 CONFORMANCE_SUITE="${CONFORMANCE_SUITE:-active}"
 THV_BINARY="${THV_BINARY:-thv}"
+VMCP_PORT="${VMCP_PORT:-8099}"
 SERVER_NAME="conf-sut-ci"
+GROUP_NAME="conf-vmcp-group"
 IMAGE="mcp-conformance-server:ci"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="${SCRIPT_DIR}/results"
-EXPECTED_FAILURES="${SCRIPT_DIR}/expected-failures.yaml"
 
 # thv proxying to a container is a local-only, trusted-dev workflow.
 export TOOLHIVE_DEV=true
 export TOOLHIVE_SKIP_DESKTOP_CHECK=1
 
+# Shared JSON-RPC initialize payload used by the readiness probe and the vMCP
+# serverInfo sanity check.
+INIT_PAYLOAD='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
+
 CLONE_DIR=""
+VMCP_PID=""
 cleanup() {
   # Diagnostics: capture the ToolHive proxy logs before teardown so a CI failure
   # (e.g. the sampling round-trip timing out) is debuggable from the uploaded
   # results artifact, not just the client-side checks.json.
   mkdir -p "${RESULTS_DIR}"
   "${THV_BINARY}" logs --proxy "${SERVER_NAME}" > "${RESULTS_DIR}/proxy-logs.txt" 2>&1 || true
-  "${THV_BINARY}" rm "${SERVER_NAME}" >/dev/null 2>&1 || true
+  if [ -n "${VMCP_PID}" ]; then
+    kill "${VMCP_PID}" >/dev/null 2>&1 || true
+  fi
+  "${THV_BINARY}" rm -f "${SERVER_NAME}" >/dev/null 2>&1 || true
+  if [ "${CONFORMANCE_TARGET}" = "vmcp" ]; then
+    # `group rm` prompts for confirmation only when the group still has
+    # workloads; feed "y" so the non-interactive EXIT trap can never block.
+    echo y | "${THV_BINARY}" group rm "${GROUP_NAME}" >/dev/null 2>&1 || true
+  fi
   [ -n "${CLONE_DIR}" ] && rm -rf "${CLONE_DIR}" || true
 }
 trap cleanup EXIT
+
+# resolve_workload_url prints the proxy URL of a running workload, polling until
+# it appears (or the retry budget is exhausted, in which case it prints nothing).
+resolve_workload_url() {
+  local name="$1" url=""
+  for _ in $(seq 1 30); do
+    url="$("${THV_BINARY}" list --format json 2>/dev/null \
+      | python3 -c "import sys,json
+d=json.load(sys.stdin)
+print(next((w['url'] for w in d if w.get('name')=='${name}' and w.get('status')=='running' and w.get('url')), ''))" \
+      2>/dev/null || true)"
+    [ -n "${url}" ] && break
+    sleep 2
+  done
+  printf '%s' "${url}"
+}
+
+echo "==> Target: ${CONFORMANCE_TARGET}"
 
 echo "==> Cloning conformance repo v${CONFORMANCE_VERSION}"
 CLONE_DIR="$(mktemp -d)"
@@ -63,36 +105,156 @@ echo "==> Building reference server image"
 cp "${SCRIPT_DIR}/Dockerfile" "${SERVER_DIR}/Dockerfile"
 docker build -t "${IMAGE}" "${SERVER_DIR}"
 
-echo "==> Starting server through ToolHive"
-"${THV_BINARY}" rm -f "${SERVER_NAME}" >/dev/null 2>&1 || true
-"${THV_BINARY}" run "${IMAGE}" \
-  --transport streamable-http --target-port 3000 --name "${SERVER_NAME}" --debug
+if [ "${CONFORMANCE_TARGET}" = "proxy" ]; then
+  # ---------------------------------------------------------------------------
+  # proxy target: test the transparent `thv run` CLI proxy endpoint directly.
+  # ---------------------------------------------------------------------------
+  EXPECTED_FAILURES="${SCRIPT_DIR}/expected-failures.yaml"
 
-echo "==> Resolving proxy URL"
-URL=""
-for _ in $(seq 1 30); do
-  URL="$("${THV_BINARY}" list --format json 2>/dev/null \
-    | python3 -c "import sys,json;   d=json.load(sys.stdin)
-print(next((w['url'] for w in d if w.get('name')=='${SERVER_NAME}' and w.get('status')=='running' and w.get('url')), ''))" \
-    2>/dev/null || true)"
-  [ -n "${URL}" ] && break
-  sleep 2
-done
-[ -z "${URL}" ] && { echo "ERROR: could not resolve ${SERVER_NAME} URL" >&2; "${THV_BINARY}" list || true; exit 1; }
-echo "    URL: ${URL}"
+  echo "==> Starting server through ToolHive"
+  "${THV_BINARY}" rm -f "${SERVER_NAME}" >/dev/null 2>&1 || true
+  "${THV_BINARY}" run "${IMAGE}" \
+    --transport streamable-http --target-port 3000 --name "${SERVER_NAME}" --debug
+
+  echo "==> Resolving proxy URL"
+  URL="$(resolve_workload_url "${SERVER_NAME}")"
+  [ -z "${URL}" ] && { echo "ERROR: could not resolve ${SERVER_NAME} URL" >&2; "${THV_BINARY}" list || true; exit 1; }
+  echo "    URL: ${URL}"
+
+elif [ "${CONFORMANCE_TARGET}" = "vmcp" ]; then
+  # ---------------------------------------------------------------------------
+  # vmcp target: run the reference server as a group backend, aggregate it
+  # through vMCP, and test the vMCP endpoint (exercises mcpcompat/go-sdk).
+  # ---------------------------------------------------------------------------
+  EXPECTED_FAILURES="${SCRIPT_DIR}/expected-failures-vmcp.yaml"
+  VMCP_CONFIG="${CLONE_DIR}/vmcp.yaml"
+
+  echo "==> Creating group ${GROUP_NAME}"
+  echo y | "${THV_BINARY}" group rm "${GROUP_NAME}" >/dev/null 2>&1 || true
+  "${THV_BINARY}" group create "${GROUP_NAME}"
+
+  echo "==> Starting backend workload through ToolHive"
+  "${THV_BINARY}" rm -f "${SERVER_NAME}" >/dev/null 2>&1 || true
+  "${THV_BINARY}" run "${IMAGE}" \
+    --transport streamable-http --target-port 3000 \
+    --name "${SERVER_NAME}" --group "${GROUP_NAME}"
+
+  echo "==> Waiting for backend to become running (so vmcp init can discover it)"
+  BACKEND_URL="$(resolve_workload_url "${SERVER_NAME}")"
+  [ -z "${BACKEND_URL}" ] && { echo "ERROR: backend ${SERVER_NAME} never became running" >&2; "${THV_BINARY}" list || true; exit 1; }
+  echo "    backend URL: ${BACKEND_URL}"
+
+  echo "==> Generating vMCP config with thv vmcp init"
+  "${THV_BINARY}" vmcp init --group "${GROUP_NAME}" --config "${VMCP_CONFIG}"
+
+  # Patch the generated config so tool names are PRESERVED (not prefixed with the
+  # backend name), otherwise the conformance suite's tool fixtures won't match.
+  # `thv vmcp init` emits:
+  #     aggregation:
+  #       conflictResolution: prefix
+  #       conflictResolutionConfig:
+  #         prefixFormat: "{workload}_"
+  # We rewrite it to the "priority" strategy with a single-backend priorityOrder:
+  #     aggregation:
+  #       conflictResolution: priority
+  #       conflictResolutionConfig:
+  #         priorityOrder:
+  #           - conf-sut-ci
+  # PyYAML may be absent, so this is a plain-text substitution (no yaml module).
+  echo "==> Patching aggregation strategy prefix -> priority"
+  python3 - "${VMCP_CONFIG}" "${SERVER_NAME}" <<'PY'
+import sys
+path, server = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as f:
+    text = f.read()
+text = text.replace(
+    "  conflictResolution: prefix",
+    "  conflictResolution: priority",
+)
+text = text.replace(
+    '    prefixFormat: "{workload}_"',
+    "    priorityOrder:\n      - " + server,
+)
+if "  conflictResolution: priority" not in text:
+    sys.exit("ERROR: could not patch conflictResolution to priority (template changed?)")
+if "prefixFormat" in text:
+    sys.exit("ERROR: prefixFormat still present after patch (template changed?)")
+with open(path, "w", encoding="utf-8") as f:
+    f.write(text)
+PY
+
+  echo "==> Patched vMCP config:"
+  echo "-----------------------------------------------------------------"
+  cat "${VMCP_CONFIG}"
+  echo "-----------------------------------------------------------------"
+
+  echo "==> Validating patched config"
+  "${THV_BINARY}" vmcp validate --config "${VMCP_CONFIG}"
+
+  echo "==> Starting thv vmcp serve on port ${VMCP_PORT}"
+  "${THV_BINARY}" vmcp serve --config "${VMCP_CONFIG}" --port "${VMCP_PORT}" &
+  VMCP_PID=$!
+  echo "    vmcp serve PID: ${VMCP_PID}"
+
+  URL="http://127.0.0.1:${VMCP_PORT}/mcp"
+  echo "    URL: ${URL}"
+
+else
+  echo "ERROR: unknown CONFORMANCE_TARGET '${CONFORMANCE_TARGET}' (expected proxy|vmcp)" >&2
+  exit 1
+fi
 
 echo "==> Waiting for endpoint to be ready"
+code=""
 for _ in $(seq 1 30); do
   code="$(curl -s -o /dev/null -w '%{http_code}' "${URL}" -X POST \
     -H 'content-type: application/json' \
     -H 'accept: application/json, text/event-stream' \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}' || true)"
+    -d "${INIT_PAYLOAD}" || true)"
   [ "${code}" = "200" ] && break
   sleep 2
 done
 [ "${code}" = "200" ] || { echo "ERROR: endpoint never became ready (last HTTP ${code})" >&2; exit 1; }
 
-echo "==> Running conformance suite (${CONFORMANCE_SUITE})"
+# For the vmcp target, prove we actually hit vMCP and not a mis-resolved URL by
+# asserting the initialize response identifies vMCP in result.serverInfo.name.
+if [ "${CONFORMANCE_TARGET}" = "vmcp" ]; then
+  echo "==> Sanity check: verifying serverInfo identifies vMCP"
+  INIT_RESP="$(curl -s "${URL}" -X POST \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' \
+    -d "${INIT_PAYLOAD}" || true)"
+  SERVER_INFO_NAME="$(printf '%s' "${INIT_RESP}" | python3 -c "
+import sys, json
+raw = sys.stdin.read()
+# streamable-http may frame the response as SSE ('data: {json}' lines).
+chunks = [l[5:].strip() for l in raw.splitlines() if l.strip().startswith('data:')]
+for c in (chunks or [raw]):
+    try:
+        d = json.loads(c)
+    except Exception:
+        continue
+    info = (d.get('result') or {}).get('serverInfo') or {}
+    if info.get('name'):
+        print(info['name'])
+        break
+" 2>/dev/null || true)"
+  echo "    serverInfo.name: ${SERVER_INFO_NAME:-<none>}"
+  case "$(printf '%s' "${SERVER_INFO_NAME}" | tr '[:upper:]' '[:lower:]')" in
+    *vmcp*|*virtual*)
+      echo "    OK: endpoint identifies as vMCP"
+      ;;
+    *)
+      echo "ERROR: serverInfo.name '${SERVER_INFO_NAME}' does not identify vMCP;" \
+           "the URL may not point at the vMCP server" >&2
+      echo "    raw initialize response: ${INIT_RESP}" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+echo "==> Running conformance suite (${CONFORMANCE_SUITE}) against ${CONFORMANCE_TARGET}"
+echo "    expected-failures: ${EXPECTED_FAILURES}"
 rm -rf "${RESULTS_DIR}"
 mkdir -p "${RESULTS_DIR}"
 npx -y "@modelcontextprotocol/conformance@${CONFORMANCE_VERSION}" server \


### PR DESCRIPTION
> **Draft:** the `expected-failures-vmcp.yaml` baseline is intentionally empty and will be seeded from this PR's own CI runs (vMCP is an aggregator, so a known subset of scenarios will fail until the baseline lists them). Marking ready once the vmcp conformance leg is green.

## Summary

- **Why:** the MCP Conformance job ran only against the `thv run` transparent proxy, which imports none of the migrated `mcpcompat`/go-sdk code. A green conformance run therefore said nothing about the mcp-go → go-sdk migration — the swapped SDK's serving surface (streamable-HTTP session lifecycle, initialize negotiation, list pagination, tool-call round-trips, error mapping) lives in vMCP, which the proxy path never exercises.
- **What:** a `CONFORMANCE_TARGET=proxy|vmcp` switch in `run-conformance.sh`. The `vmcp` target stands up a group, runs the reference server into it, and serves it through `thv vmcp` — patching the generated config from `prefix` to `priority` conflict resolution so tool names stay unprefixed and the suite's fixtures match. A `serverInfo` sanity check proves the suite hit vMCP, not a mis-resolved URL. The conformance CI job is now a matrix over both targets (`fail-fast: false`) with per-target result artifacts.

vMCP is an aggregator and does not implement sampling, completions, or resource-subscribe, so a subset of the `active` suite is expected to fail. `expected-failures-vmcp.yaml` starts empty on purpose so the first CI run reports the true failure set, which seeds the baseline.

Refs #5844 (item 2 of 2 — item 1, list-pagination cursor following, is #5851).

## Type of change

- [x] CI / test infrastructure (no production code)

## Test plan

- [x] `bash -n run-conformance.sh` and `actionlint` on the workflow pass; all YAML parses.
- [x] Config patch (`prefix` → `priority` + `priorityOrder`) validated against the exact block `thv vmcp init` emits, and `thv vmcp validate` runs in-harness before serve.
- [ ] **vmcp conformance leg green in CI** — iterating the baseline from CI output (this is the draft's purpose). The `proxy` leg must stay green throughout (no regression to the existing path).

## Special notes for reviewers

Held as a draft until the vMCP baseline is seeded and the leg is green. The harness emits diagnostics (patched config, resolved URL, `serverInfo.name`) to make baseline-building from CI logs straightforward.

Generated with [Claude Code](https://claude.com/claude-code)
