### PR TITLE
Fix isolation error wording and log-level rationale from #5794 review

### DIFF
--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -404,6 +404,14 @@ func ReadJSON(r io.Reader) (*RunConfig, error) {
 
 // degradeNetworkIsolation drops network isolation from a loaded config when its
 // resolved network mode cannot enforce it, so status/list reflect reality.
+//
+// ReadJSON is reached from read-only paths (thv list, status, export, API GETs)
+// as well as deploy. The "none" case logs at DEBUG since it's merely redundant
+// (already maximally confined) and would otherwise fire on every read of a
+// static, already-known condition. The host/custom case stays at WARN even on
+// read paths: it means the user's --isolate-network request is being silently
+// ignored, which they should keep seeing until they either drop the flag or
+// switch network modes. See #5775.
 func degradeNetworkIsolation(config *RunConfig) {
 	if !config.IsolateNetwork {
 		return

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -1255,11 +1255,15 @@ func (b *runConfigBuilder) reconcileNetworkIsolation() error {
 
 	// host (or other non-bridge) is less restrictive than isolation, so dropping
 	// it reduces confinement. Fail fast when it was explicitly requested.
+	//
+	// The mode may come from --permission-profile rather than --network, so the
+	// message names the resolved mode instead of assuming a flag the user may
+	// never have passed. See #5794 review discussion.
 	if b.isolateNetworkExplicit {
 		return fmt.Errorf(
-			"network isolation cannot be enforced with --network %s: "+
-				"drop --network %s to keep enforced isolation, or pass --isolate-network=false to keep %s networking",
-			mode, mode, mode)
+			"network isolation cannot be enforced with the resolved network mode %q: "+
+				"use a bridge network mode to keep enforced isolation, or pass --isolate-network=false to keep %q networking",
+			mode, mode)
 	}
 
 	c.IsolateNetwork = false

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -1707,9 +1707,11 @@ func TestRunConfigBuilder_NetworkIsolationReconciliation(t *testing.T) {
 
 			if tt.expectError {
 				require.Error(t, err, "expected build to fail fast")
-				// The error must name both ways out.
-				assert.Contains(t, err.Error(), "drop --network "+tt.networkMode,
-					"error should offer dropping the network mode")
+				// The error must name the resolved mode (not assume it came from
+				// --network, since it may have come from --permission-profile)
+				// and both ways out.
+				assert.Contains(t, err.Error(), `"`+tt.networkMode+`"`,
+					"error should name the resolved network mode")
 				assert.Contains(t, err.Error(), "pass --isolate-network=false",
 					"error should offer disabling isolation")
 				return


### PR DESCRIPTION
## Summary

#5794 (merged) reconciled network isolation with network mode. rdimitrov's
post-merge review left two follow-up comments this PR addresses:

- The fail-fast error for `--isolate-network=true` conflicting with a
  non-bridge network mode assumed the mode always came from `--network`,
  telling users to `drop --network host` even when the mode actually came
  from a `--permission-profile` file (where there's no `--network` flag to
  drop). The error now names the resolved mode directly instead of assuming
  a specific flag.
- Clarified in `degradeNetworkIsolation` why the `none` and host/custom
  degrade paths intentionally log at different levels: `none` is DEBUG
  (redundant, not a security reduction), while host/custom stays at WARN
  even on read paths (`thv list`, status, export) since it means the
  user's `--isolate-network` request is being silently ignored.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Updated `TestRunConfigBuilder_NetworkIsolationReconciliation` in
`pkg/runner/config_builder_test.go` to assert the error names the resolved
mode instead of an assumed `--network` flag.

## Does this introduce a user-facing change?

Yes. The fail-fast error message when `--isolate-network=true` conflicts
with a non-bridge network mode now names the resolved network mode
directly (e.g. `"host"`) instead of assuming it came from `--network`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)