### PR TITLE
Capture proxy logs in conformance CI runs

### DIFF
--- a/test/conformance/run-conformance.sh
+++ b/test/conformance/run-conformance.sh
@@ -30,6 +30,11 @@ export TOOLHIVE_SKIP_DESKTOP_CHECK=1
 
 CLONE_DIR=""
 cleanup() {
+  # Diagnostics: capture the ToolHive proxy logs before teardown so a CI failure
+  # (e.g. the sampling round-trip timing out) is debuggable from the uploaded
+  # results artifact, not just the client-side checks.json.
+  mkdir -p "${RESULTS_DIR}"
+  "${THV_BINARY}" logs --proxy "${SERVER_NAME}" > "${RESULTS_DIR}/proxy-logs.txt" 2>&1 || true
   "${THV_BINARY}" rm "${SERVER_NAME}" >/dev/null 2>&1 || true
   [ -n "${CLONE_DIR}" ] && rm -rf "${CLONE_DIR}" || true
 }
@@ -61,7 +66,7 @@ docker build -t "${IMAGE}" "${SERVER_DIR}"
 echo "==> Starting server through ToolHive"
 "${THV_BINARY}" rm -f "${SERVER_NAME}" >/dev/null 2>&1 || true
 "${THV_BINARY}" run "${IMAGE}" \
-  --transport streamable-http --target-port 3000 --name "${SERVER_NAME}"
+  --transport streamable-http --target-port 3000 --name "${SERVER_NAME}" --debug
 
 echo "==> Resolving proxy URL"
 URL=""
@@ -89,8 +94,9 @@ done
 
 echo "==> Running conformance suite (${CONFORMANCE_SUITE})"
 rm -rf "${RESULTS_DIR}"
+mkdir -p "${RESULTS_DIR}"
 npx -y "@modelcontextprotocol/conformance@${CONFORMANCE_VERSION}" server \
   --url "${URL}" \
   --suite "${CONFORMANCE_SUITE}" \
   --expected-failures "${EXPECTED_FAILURES}" \
-  -o "${RESULTS_DIR}"
+  -o "${RESULTS_DIR}" 2>&1 | tee "${RESULTS_DIR}/suite-output.log"


### PR DESCRIPTION
## Summary

The `E2E Tests / MCP Conformance` job fails intermittently on `tools-call-sampling` — a 60s client-side `MCP error -32001: Request timed out` on the sampling server→client round-trip. It's a pre-existing, CI-only flake (it fails on ~2/3 of recent `main` commits and does **not** reproduce locally across 18 functional runs + CPU-starvation to `--cpus=0.25`).

The blocker to root-causing it: the uploaded `conformance-results` artifact only contains the conformance **client's** view (`checks.json` → "timed out"). That can't tell us *which side* stalled — the ToolHive proxy or the reference server. This PR closes that gap.

- Capture the ToolHive **proxy** logs (`thv logs --proxy`) into the results directory on teardown.
- `tee` the suite stdout into the results dir alongside them.
- Run the proxied server with `--debug` so the proxy logs show the per-request message flow.

The workflow already uploads `test/conformance/results` (`if: always()`), so these land in the existing `conformance-results` artifact — **no workflow change**.

## Type of change

- [x] Other (CI/test diagnostics)

## Test plan

- [x] Ran locally: `run-conformance.sh` produces `results/proxy-logs.txt` and `results/suite-output.log`, suite still passes 40/0.
- [x] `bash -n` syntax check.

## Does this introduce a user-facing change?

No — CI/test tooling only.

## Special notes for reviewers

- **This adds no fix** — it makes the next CI failure debuggable. The flake correlates with the #5729 go-sdk migration (now on `main`), not with any specific open PR.
- Caveat: `--debug` adds log I/O that slightly changes timing, so there's a small chance it perturbs the (timing-sensitive) flake. If it proves to mask it, we can gate `--debug` behind an env var.

Generated with [Claude Code](https://claude.com/claude-code)