### PR TITLE
Normalize opt-in multi-valued JWT claims for Cedar

### DIFF
--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -149,6 +150,16 @@ var (
 // ClientIDContextKey is the key used to store client ID in the context.
 type ClientIDContextKey struct{}
 
+// claimPrefix namespaces every JWT claim in the Cedar context/principal
+// attributes. claimSetPrefix namespaces the synthetic multi-valued-claim Sets.
+// They are deliberately disjoint: because every JWT claim is emitted under
+// claimPrefix, a token can never produce a claimSetPrefix key, so the synthetic
+// Sets cannot be shadowed or spoofed by claim content.
+const (
+	claimPrefix    = "claim_"
+	claimSetPrefix = "claimset_"
+)
+
 // Authorizer authorizes MCP operations using Cedar policies.
 type Authorizer struct {
 	// Cedar policy set
@@ -179,6 +190,10 @@ type Authorizer struct {
 	// claimKeyLog rate-limits the diagnostic log of resolved JWT claim keys
 	// so it emits at most once per 30 seconds instead of once per authorization check.
 	claimKeyLog *syncutil.AtMost
+	// multiValuedClaims lists JWT claim names normalized to a canonical unpadded
+	// space-delimited string, plus a companion Cedar Set, before Cedar evaluation.
+	// See ConfigOptions.MultiValuedClaims.
+	multiValuedClaims []string
 }
 
 // ConfigOptions represents the Cedar-specific authorization configuration options.
@@ -214,6 +229,43 @@ type ConfigOptions struct {
 	// names (e.g. "Platform::Group") are not yet supported and are rejected at
 	// construction. See issue #5072.
 	GroupEntityType string `json:"group_entity_type,omitempty" yaml:"group_entity_type,omitempty"`
+
+	// MultiValuedClaims lists JWT claim NAMES (bare, e.g. "scp" or "scope") whose
+	// value is exposed to Cedar in two normalized forms, regardless of whether the
+	// IdP emits the claim as a space-delimited string (Entra `scp`, Keycloak `scope`)
+	// or a JSON array (Okta `scp`):
+	//
+	//  1. "claim_<name>" (both principal attribute and context) is a space-delimited
+	//     string: an array is joined with single spaces; a string value is passed
+	//     through VERBATIM — its spacing and order are preserved, not
+	//     re-canonicalized. Use this with `like`/`==` string policies.
+	//  2. "claimset_<name>" (bare key, both principal attribute and context) is a Cedar
+	//     Set of the claim's elements. Use this with `.contains`/`.containsAll`/
+	//     `.containsAny` for exact-element matching that cannot be fooled by a
+	//     substring (e.g. "Mail.Read" will not match "Mail.ReadWrite"). The "claimset_"
+	//     prefix is reserved and never collides with a JWT claim, since all JWT
+	//     claims are surfaced under the "claim_" prefix.
+	//
+	// Only for claims whose ELEMENTS are space-free (OAuth scopes, per RFC 6749 §3.3).
+	// Do NOT list group/role claims or any claim whose elements can contain spaces
+	// (e.g. group display names) — element boundaries would become ambiguous.
+	//
+	// Backward compatibility: opt-in. When empty (default), "claim_<name>" is
+	// byte-identical to today and no "claimset_<name>" key is added. Listing a claim
+	// leaves OTHER claims untouched.
+	//
+	// Migration hazard: listing a claim that an IdP emits as an ARRAY changes its
+	// "claim_<name>" form from a Cedar Set to a String. A pre-existing policy that
+	// tested it with `like`/substring — which errored on the Set and so failed
+	// closed (deny) — will then match against the joined string and can
+	// substring-match (e.g. `context.claim_scp like "*Mail.Read*"` also matches
+	// "Mail.ReadWrite"), an unintended grant. Audit existing `like` policies on a
+	// claim before listing it, and prefer "claimset_<name>" with `.contains`/
+	// `.containsAll`/`.containsAny` for exact-element membership.
+	//
+	// Note: this unifies claim SHAPE, not NAME — `scp` and `scope` remain distinct
+	// claim names, so a policy still references one specific name.
+	MultiValuedClaims []string `json:"multi_valued_claims,omitempty" yaml:"multi_valued_claims,omitempty"`
 }
 
 // validateGroupEntityType validates a GroupEntityType value. Empty string is
@@ -269,6 +321,7 @@ func NewCedarAuthorizer(options ConfigOptions, serverName string) (authorizers.A
 		roleClaimName:           options.RoleClaimName,
 		serverName:              serverName,
 		claimKeyLog:             syncutil.NewAtMost(30 * time.Second),
+		multiValuedClaims:       options.MultiValuedClaims,
 	}
 
 	// Load policies
@@ -587,10 +640,132 @@ func extractClientIDFromClaims(claims jwt.MapClaims) (string, bool) {
 func preprocessClaims(claims jwt.MapClaims) map[string]interface{} {
 	preprocessed := make(map[string]interface{})
 	for k, v := range claims {
-		claimKey := fmt.Sprintf("claim_%s", k)
+		claimKey := claimPrefix + k
 		preprocessed[claimKey] = v
 	}
 	return preprocessed
+}
+
+// normalizeMultiValuedClaims returns claims with every claim named in names
+// and present in claims rewritten to a canonical unpadded space-delimited
+// string. This lets a single Cedar `like`/`==` policy match a claim regardless
+// of whether the IdP emitted it as a space-delimited string or a JSON array.
+// See ConfigOptions.MultiValuedClaims for the full rationale.
+//
+// When names is empty the input is returned directly (no copy); otherwise a
+// shallow copy is returned and the input is never mutated.
+//
+//   - array ([]interface{} or []string): elements joined with single spaces.
+//     Non-string elements are stringified with fmt.Sprint rather than
+//     dropped; nested array/object elements are skipped with a slog.Debug
+//     since they have no scalar string form.
+//   - string: passthrough, completely unchanged (not trimmed).
+//   - empty array, or an array with no usable elements: "" (empty string —
+//     present but empty).
+//   - claim absent from claims, or names empty: left untouched (no key
+//     fabricated).
+//
+// Only top-level claim keys are matched; there is no dot-notation support.
+// claims is not mutated.
+func normalizeMultiValuedClaims(claims jwt.MapClaims, names []string) jwt.MapClaims {
+	if len(names) == 0 {
+		// Nothing to normalize. Return the input directly — the sole caller
+		// (preprocessClaims) only reads it, so no defensive copy is needed and
+		// the opt-in-empty path pays no allocation.
+		return claims
+	}
+
+	out := make(jwt.MapClaims, len(claims))
+	for k, v := range claims {
+		out[k] = v
+	}
+
+	for _, name := range names {
+		v, ok := claims[name]
+		if !ok {
+			continue
+		}
+
+		switch val := v.(type) {
+		case string:
+			// Verbatim passthrough: out[name] already equals val (out is a copy
+			// of claims), so this is intentionally a no-op. The explicit branch
+			// documents the string contract and, importantly, keeps a string
+			// value out of the default "unrecognized type" log below. This is the
+			// one place the string handling diverges from addMultiValuedClaimSets,
+			// which collapses whitespace via strings.Fields for the Set form.
+			out[name] = val
+		case []interface{}:
+			out[name] = strings.Join(multiValuedTokens(name, val), " ")
+		case []string:
+			out[name] = strings.Join(val, " ")
+		default:
+			slog.Debug("multi-valued claim has unrecognized type, leaving unchanged",
+				"claim", name, "type", fmt.Sprintf("%T", v))
+		}
+	}
+
+	return out
+}
+
+// addMultiValuedClaimSets adds a bare "claimset_<name>" key to processed for every
+// claim named in names and present in raw, holding the claim's elements as a
+// []string (converted to a Cedar Set by convertToCedarValueAtDepth). This is
+// the companion to normalizeMultiValuedClaims's "claim_<name>" string form:
+// where "claim_<name>" supports substring-style `like` matching, "claimset_<name>"
+// supports exact-element `.contains`/`.containsAll`/`.containsAny` matching.
+// The "claimset_" prefix is reserved and cannot collide with a JWT claim, since all
+// JWT claims are "claim_"-prefixed by preprocessClaims.
+//
+// processed must already have the "claim_" prefix applied (i.e. this must run
+// after preprocessClaims) so the added key stays bare. raw is not mutated.
+func addMultiValuedClaimSets(processed map[string]interface{}, raw jwt.MapClaims, names []string) {
+	for _, name := range names {
+		v, ok := raw[name]
+		if !ok {
+			continue
+		}
+
+		// The array path shares multiValuedTokens with normalizeMultiValuedClaims
+		// (string-only elements) so the Set and the joined string stay in sync.
+		// The string path deliberately differs: normalize passes the string
+		// through verbatim, whereas here strings.Fields splits it into exact
+		// elements (collapsing irregular whitespace) — the two cannot share one
+		// coercion for that reason.
+		switch val := v.(type) {
+		case string:
+			processed[claimSetPrefix+name] = strings.Fields(val)
+		case []interface{}:
+			processed[claimSetPrefix+name] = multiValuedTokens(name, val)
+		case []string:
+			processed[claimSetPrefix+name] = slices.Clone(val)
+		default:
+			slog.Debug("multi-valued claim has unrecognized type, omitting claimset set",
+				"claim", name, "type", fmt.Sprintf("%T", v))
+		}
+	}
+}
+
+// multiValuedTokens extracts the string elements of a []interface{} claim value
+// for normalizeMultiValuedClaims and addMultiValuedClaimSets. Only string
+// elements are kept: OAuth scope tokens are strings (RFC 6749 §3.3), so a
+// non-string element (number, bool, null, or a nested array/object) is
+// malformed and is skipped with a slog.Debug rather than stringified. Skipping
+// (a) avoids spurious tokens like "<nil>" or "1e+06" polluting both claim
+// forms, and (b) keeps the array shape consistent with the string shape, whose
+// strings.Fields path likewise yields only real string tokens.
+func multiValuedTokens(claimName string, elems []interface{}) []string {
+	tokens := make([]string, 0, len(elems))
+	for _, elem := range elems {
+		s, ok := elem.(string)
+		if !ok {
+			slog.Debug("multi-valued claim element is not a string, skipping",
+				"claim", claimName, "type", fmt.Sprintf("%T", elem))
+			continue
+		}
+		tokens = append(tokens, s)
+	}
+	return tokens
 }
 
 // preprocessArguments adds an "arg_" prefix to all argument keys.
@@ -884,8 +1059,12 @@ func (a *Authorizer) AuthorizeWithJWTClaims(
 		extractGroups(resolvedClaims, a.roleClaimName)...,
 	))
 
-	// Preprocess claims and arguments
-	processedClaims := preprocessClaims(resolvedClaims)
+	// Preprocess claims and arguments. Multi-valued claim normalization runs
+	// after group/role extraction (which needs the raw claim shapes) and
+	// before the "claim_" prefix is applied.
+	normalizedClaims := normalizeMultiValuedClaims(resolvedClaims, a.multiValuedClaims)
+	processedClaims := preprocessClaims(normalizedClaims)
+	addMultiValuedClaimSets(processedClaims, resolvedClaims, a.multiValuedClaims)
 	processedArgs := preprocessArguments(arguments)
 
 	// Authorize based on the feature and operation

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -2571,6 +2571,205 @@ func TestAuthorizeWithJWTClaims_BackwardCompat(t *testing.T) {
 	}
 }
 
+// TestAuthorizeWithJWTClaims_MultiValuedClaimSets is the end-to-end proof that
+// both normalized surfaces work for both IdP shapes (array and space-delimited
+// string): the "claimset_<name>" Cedar Set for exact-element `.contains`/
+// `.containsAll` matching, and (in the containsAll subtest) that a missing
+// token correctly denies. It also proves `.contains` is exact-element — a
+// "Mail.ReadWrite" token does not satisfy a "Mail.Read" check.
+func TestAuthorizeWithJWTClaims_MultiValuedClaimSets(t *testing.T) {
+	t.Parallel()
+
+	newAuthorizerCtx := func(t *testing.T, scp interface{}) context.Context {
+		t.Helper()
+		identity := &auth.Identity{
+			PrincipalInfo: auth.PrincipalInfo{
+				Subject: "user1",
+				Claims: map[string]any{
+					"sub": "user1",
+					"scp": scp,
+				},
+			},
+		}
+		return auth.WithIdentity(context.Background(), identity)
+	}
+
+	t.Run("contains_exact_element_no_substring_bleed", func(t *testing.T) {
+		t.Parallel()
+
+		policy := `
+			permit(principal, action, resource)
+			when { context.claimset_scp.contains("Mail.Read") };
+		`
+		authorizer, err := NewCedarAuthorizer(ConfigOptions{
+			Policies:          []string{policy},
+			EntitiesJSON:      `[]`,
+			MultiValuedClaims: []string{"scp"},
+		}, "")
+		require.NoError(t, err)
+
+		tests := []struct {
+			name     string
+			scp      interface{}
+			wantAuth bool
+		}{
+			{
+				name:     "array_shaped_scp_permitted",
+				scp:      []interface{}{"User.Read.All", "Mail.Read"},
+				wantAuth: true,
+			},
+			{
+				name:     "string_shaped_scp_permitted",
+				scp:      "User.Read.All Mail.Read",
+				wantAuth: true,
+			},
+			{
+				name:     "substring_scope_not_matched",
+				scp:      []interface{}{"Mail.ReadWrite"},
+				wantAuth: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				authorized, err := authorizer.AuthorizeWithJWTClaims(
+					newAuthorizerCtx(t, tt.scp),
+					authorizers.MCPFeatureTool,
+					authorizers.MCPOperationCall,
+					"any-tool",
+					nil,
+				)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantAuth, authorized)
+			})
+		}
+	})
+
+	t.Run("contains_all_tokens", func(t *testing.T) {
+		t.Parallel()
+
+		policy := `
+			permit(principal, action, resource)
+			when { context.claimset_scp.containsAll(["User.Read.All", "Mail.Read"]) };
+		`
+		authorizer, err := NewCedarAuthorizer(ConfigOptions{
+			Policies:          []string{policy},
+			EntitiesJSON:      `[]`,
+			MultiValuedClaims: []string{"scp"},
+		}, "")
+		require.NoError(t, err)
+
+		tests := []struct {
+			name     string
+			scp      interface{}
+			wantAuth bool
+		}{
+			{
+				name:     "array_shaped_scp_has_both_tokens_permitted",
+				scp:      []interface{}{"User.Read.All", "Mail.Read", "Extra.Scope"},
+				wantAuth: true,
+			},
+			{
+				name:     "string_shaped_scp_has_both_tokens_permitted",
+				scp:      "User.Read.All Mail.Read",
+				wantAuth: true,
+			},
+			{
+				name:     "missing_one_token_denied",
+				scp:      []interface{}{"User.Read.All"},
+				wantAuth: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				authorized, err := authorizer.AuthorizeWithJWTClaims(
+					newAuthorizerCtx(t, tt.scp),
+					authorizers.MCPFeatureTool,
+					authorizers.MCPOperationCall,
+					"any-tool",
+					nil,
+				)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantAuth, authorized)
+			})
+		}
+	})
+
+	// principal_claimset_set proves the claimset_<name> Set also appears as a principal
+	// entity attribute, not just in the context — mirroring how claim_<name>
+	// is available on both surfaces.
+	t.Run("principal_claimset_set", func(t *testing.T) {
+		t.Parallel()
+
+		policy := `
+			permit(principal, action, resource)
+			when { principal.claimset_scp.contains("Mail.Read") };
+		`
+		authorizer, err := NewCedarAuthorizer(ConfigOptions{
+			Policies:          []string{policy},
+			EntitiesJSON:      `[]`,
+			MultiValuedClaims: []string{"scp"},
+		}, "")
+		require.NoError(t, err)
+
+		authorized, err := authorizer.AuthorizeWithJWTClaims(
+			newAuthorizerCtx(t, []interface{}{"User.Read.All", "Mail.Read"}),
+			authorizers.MCPFeatureTool,
+			authorizers.MCPOperationCall,
+			"any-tool",
+			nil,
+		)
+		require.NoError(t, err)
+		assert.True(t, authorized)
+	})
+}
+
+// TestAuthorizeWithJWTClaims_MultiValuedClaimsEmptyIsBackwardCompat verifies that
+// when MultiValuedClaims is unset, a whole-string equality policy on the claim
+// still matches — i.e. normalization is fully opt-in and byte-identical to the
+// pre-#5828 behavior when no claim names are listed.
+func TestAuthorizeWithJWTClaims_MultiValuedClaimsEmptyIsBackwardCompat(t *testing.T) {
+	t.Parallel()
+
+	policy := `
+		permit(principal, action, resource)
+		when { context.claim_scp == "User.Read.All Mail.Read" };
+	`
+
+	authorizer, err := NewCedarAuthorizer(ConfigOptions{
+		Policies:     []string{policy},
+		EntitiesJSON: `[]`,
+		// MultiValuedClaims intentionally left unset.
+	}, "")
+	require.NoError(t, err)
+
+	identity := &auth.Identity{
+		PrincipalInfo: auth.PrincipalInfo{
+			Subject: "user1",
+			Claims: map[string]any{
+				"sub": "user1",
+				"scp": "User.Read.All Mail.Read",
+			},
+		},
+	}
+	ctx := auth.WithIdentity(context.Background(), identity)
+
+	authorized, err := authorizer.AuthorizeWithJWTClaims(
+		ctx,
+		authorizers.MCPFeatureTool,
+		authorizers.MCPOperationCall,
+		"any-tool",
+		nil,
+	)
+	require.NoError(t, err)
+	assert.True(t, authorized, "unpadded whole-string equality must still match when MultiValuedClaims is unset")
+}
+
 // TestParseCedarEntityID tests the parseCedarEntityID helper function.
 func TestParseCedarEntityID(t *testing.T) {
 	t.Parallel()
@@ -2764,6 +2963,201 @@ func TestPreprocessClaims(t *testing.T) {
 			t.Parallel()
 			got := preprocessClaims(tt.claims)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestNormalizeMultiValuedClaims tests the normalizeMultiValuedClaims helper,
+// which rewrites listed claims to a canonical unpadded space-delimited string
+// so a single Cedar `like`/`==` policy matches regardless of whether the IdP
+// emitted the claim as a space-delimited string or a JSON array.
+func TestNormalizeMultiValuedClaims(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		names  []string
+		want   jwt.MapClaims
+	}{
+		{
+			name:   "array_of_strings_joined_unpadded",
+			claims: jwt.MapClaims{"scp": []interface{}{"a", "b"}},
+			names:  []string{"scp"},
+			want:   jwt.MapClaims{"scp": "a b"},
+		},
+		{
+			name:   "string_array_joined_unpadded",
+			claims: jwt.MapClaims{"scp": []string{"a", "b"}},
+			names:  []string{"scp"},
+			want:   jwt.MapClaims{"scp": "a b"},
+		},
+		{
+			name:   "single_element_array_unpadded",
+			claims: jwt.MapClaims{"scp": []interface{}{"a"}},
+			names:  []string{"scp"},
+			want:   jwt.MapClaims{"scp": "a"},
+		},
+		{
+			name:   "string_passthrough_unchanged",
+			claims: jwt.MapClaims{"scp": "a b"},
+			names:  []string{"scp"},
+			want:   jwt.MapClaims{"scp": "a b"},
+		},
+		{
+			name:   "string_with_edge_and_internal_spaces_unchanged",
+			claims: jwt.MapClaims{"scp": "  a  b  "},
+			names:  []string{"scp"},
+			want:   jwt.MapClaims{"scp": "  a  b  "},
+		},
+		{
+			name:   "empty_array_becomes_empty_string",
+			claims: jwt.MapClaims{"scp": []interface{}{}},
+			names:  []string{"scp"},
+			want:   jwt.MapClaims{"scp": ""},
+		},
+		{
+			name:   "absent_claim_stays_absent",
+			claims: jwt.MapClaims{"sub": "user1"},
+			names:  []string{"scp"},
+			want:   jwt.MapClaims{"sub": "user1"},
+		},
+		{
+			name:   "claim_not_in_names_untouched",
+			claims: jwt.MapClaims{"scp": []interface{}{"a", "b"}, "sub": "user1"},
+			names:  []string{"scope"},
+			want:   jwt.MapClaims{"scp": []interface{}{"a", "b"}, "sub": "user1"},
+		},
+		{
+			name:   "non_string_elements_skipped",
+			claims: jwt.MapClaims{"scp": []interface{}{"a", 1, true}},
+			names:  []string{"scp"},
+			want:   jwt.MapClaims{"scp": "a"},
+		},
+		{
+			name:   "nested_element_skipped",
+			claims: jwt.MapClaims{"scp": []interface{}{"a", []interface{}{"nested"}}},
+			names:  []string{"scp"},
+			want:   jwt.MapClaims{"scp": "a"},
+		},
+		{
+			name:   "empty_names_list_leaves_contents_identical",
+			claims: jwt.MapClaims{"scp": []interface{}{"a", "b"}, "sub": "user1"},
+			names:  nil,
+			want:   jwt.MapClaims{"scp": []interface{}{"a", "b"}, "sub": "user1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeMultiValuedClaims(tt.claims, tt.names)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestAddMultiValuedClaimSets tests the addMultiValuedClaimSets helper, which
+// injects a bare "claimset_<name>" key holding the claim's elements as a []string
+// (converted to a Cedar Set downstream) — the companion to
+// normalizeMultiValuedClaims's "claim_<name>" string form.
+func TestAddMultiValuedClaimSets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		processed map[string]interface{}
+		raw       jwt.MapClaims
+		names     []string
+		want      map[string]interface{}
+	}{
+		{
+			name:      "array_claim_becomes_set",
+			processed: map[string]interface{}{"claim_scp": "a b"},
+			raw:       jwt.MapClaims{"scp": []interface{}{"a", "b"}},
+			names:     []string{"scp"},
+			want:      map[string]interface{}{"claim_scp": "a b", "claimset_scp": []string{"a", "b"}},
+		},
+		{
+			name:      "string_claim_split_into_set",
+			processed: map[string]interface{}{"claim_scp": "a b"},
+			raw:       jwt.MapClaims{"scp": "a b"},
+			names:     []string{"scp"},
+			want:      map[string]interface{}{"claim_scp": "a b", "claimset_scp": []string{"a", "b"}},
+		},
+		{
+			// Companion to normalizeMultiValuedClaims's verbatim passthrough:
+			// claim_scp keeps irregular spacing untouched, while claimset_scp
+			// collapses it via strings.Fields into exact elements.
+			name:      "multi_space_string_collapsed_into_set",
+			processed: map[string]interface{}{"claim_scp": "  a  b  "},
+			raw:       jwt.MapClaims{"scp": "  a  b  "},
+			names:     []string{"scp"},
+			want:      map[string]interface{}{"claim_scp": "  a  b  ", "claimset_scp": []string{"a", "b"}},
+		},
+		{
+			name:      "empty_array_becomes_empty_set",
+			processed: map[string]interface{}{"claim_scp": ""},
+			raw:       jwt.MapClaims{"scp": []interface{}{}},
+			names:     []string{"scp"},
+			want:      map[string]interface{}{"claim_scp": "", "claimset_scp": []string{}},
+		},
+		{
+			name:      "empty_string_becomes_empty_set",
+			processed: map[string]interface{}{"claim_scp": ""},
+			raw:       jwt.MapClaims{"scp": ""},
+			names:     []string{"scp"},
+			want:      map[string]interface{}{"claim_scp": "", "claimset_scp": []string{}},
+		},
+		{
+			name:      "absent_claim_no_key_added",
+			processed: map[string]interface{}{"claim_sub": "user1"},
+			raw:       jwt.MapClaims{"sub": "user1"},
+			names:     []string{"scp"},
+			want:      map[string]interface{}{"claim_sub": "user1"},
+		},
+		{
+			name:      "claim_not_in_names_no_key_added",
+			processed: map[string]interface{}{"claim_scp": "a b"},
+			raw:       jwt.MapClaims{"scp": []interface{}{"a", "b"}},
+			names:     []string{"scope"},
+			want:      map[string]interface{}{"claim_scp": "a b"},
+		},
+		{
+			name:      "non_string_elements_skipped",
+			processed: map[string]interface{}{"claim_scp": "a"},
+			raw:       jwt.MapClaims{"scp": []interface{}{"a", 1, true}},
+			names:     []string{"scp"},
+			want:      map[string]interface{}{"claim_scp": "a", "claimset_scp": []string{"a"}},
+		},
+		{
+			name:      "nested_element_skipped",
+			processed: map[string]interface{}{"claim_scp": "a"},
+			raw:       jwt.MapClaims{"scp": []interface{}{"a", []interface{}{"nested"}}},
+			names:     []string{"scp"},
+			want:      map[string]interface{}{"claim_scp": "a", "claimset_scp": []string{"a"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			addMultiValuedClaimSets(tt.processed, tt.raw, tt.names)
+			assert.Equal(t, tt.want, tt.processed)
+
+			// The injected key must be bare "claimset_<name>", never
+			// "claim_claimset_<name>" — it must not be reachable via the
+			// claim_-prefix path.
+			for _, name := range tt.names {
+				_, hadRaw := tt.raw[name]
+				if !hadRaw {
+					continue
+				}
+				_, hasBareKey := tt.processed["claimset_"+name]
+				_, hasWrongKey := tt.processed["claim_claimset_"+name]
+				assert.True(t, hasBareKey, "expected bare claimset_%s key", name)
+				assert.False(t, hasWrongKey, "must not add claim_claimset_%s", name)
+			}
 		})
 	}
 }
@@ -2980,6 +3374,51 @@ func TestConfigOptionsRoleClaimNameJSON(t *testing.T) {
 					"empty RoleClaimName must be omitted from JSON output")
 			} else {
 				assert.Contains(t, string(marshalled), "role_claim_name")
+			}
+		})
+	}
+}
+
+// TestConfigOptionsMultiValuedClaimsJSON verifies JSON marshal/unmarshal of the
+// MultiValuedClaims field, including backward compatibility when the field is absent.
+func TestConfigOptionsMultiValuedClaimsJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		jsonInput     string
+		want          []string
+		wantOmitOnMar bool // when true, marshal output must NOT contain "multi_valued_claims"
+	}{
+		{
+			name:      "present",
+			jsonInput: `{"policies":["permit(principal,action,resource);"],"multi_valued_claims":["scp","scope"]}`,
+			want:      []string{"scp", "scope"},
+		},
+		{
+			name:          "absent_gives_nil",
+			jsonInput:     `{"policies":["permit(principal,action,resource);"]}`,
+			want:          nil,
+			wantOmitOnMar: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var opts ConfigOptions
+			err := json.Unmarshal([]byte(tt.jsonInput), &opts)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, opts.MultiValuedClaims)
+
+			marshalled, err := json.Marshal(opts)
+			require.NoError(t, err)
+			if tt.wantOmitOnMar {
+				assert.NotContains(t, string(marshalled), "multi_valued_claims",
+					"empty MultiValuedClaims must be omitted from JSON output")
+			} else {
+				assert.Contains(t, string(marshalled), "multi_valued_claims")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

OAuth scope claims arrive in different shapes across identity providers: **Entra** (`scp`) and **Keycloak** (`scope`) emit a single space-delimited string, while **Okta** (`scp`) emits a JSON array. The Cedar authorizer maps a string to a Cedar `String` and an array to a `Set`, and there is no single Cedar expression that tests element membership across both shapes — a type mismatch *errors*, and an erroring policy is silently ignored (a `permit` fails closed). So a policy authored for one IdP's claim shape silently mis-authorizes another's.

This adds an **opt-in** `multi_valued_claims` field to the `cedarv1` authz config. For each listed claim name, the authorizer exposes two forms, on both the principal entity and the request context:

- **`claim_<name>`** — a canonical **unpadded space-delimited string** (arrays joined with single spaces; strings passed through unchanged), so existing `like`/`==` string-membership policies match uniformly across IdPs.
- **`claimset_<name>`** — a companion Cedar **`Set`** of the claim's elements, for exact-element membership via `.contains()` / `.containsAll()` / `.containsAny()` (no substring bleed — `Mail.Read` never matches `Mail.ReadWrite`, and no `like`-metacharacter escaping concern).

The `claimset_` prefix is reserved and cannot be shadowed or spoofed by a JWT claim, because every JWT claim is emitted under the `claim_` prefix. The field is opt-in: with it empty, output is **byte-identical** to today, so existing deployments are unaffected.

Closes #5828

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Unit tests were run scoped to the changed package (`go test ./pkg/authz/authorizers/cedar/...`) and are green, covering: array→join, verbatim string passthrough, single-element, empty array, absent claim, non-listed claim, non-string elements, multi-space input; `claimset_` Set construction from both the array and string shapes; exact-element `.contains` with no substring bleed and `.containsAll`; the bare-key / never-`claim_claimset_` assertion; and an empty-config backward-compat regression. Full `task test` and `task lint-fix` run in CI.

## Does this introduce a user-facing change?

Yes. A new optional `multi_valued_claims` list on the `cedarv1` authorization config. When set, each named claim is additionally exposed as a `claimset_<name>` Cedar `Set` and its `claim_<name>` string form is normalized (arrays joined). Unset (default) changes nothing.

## Special notes for reviewers

- **Scope is deliberately the Cedar authorizer only** — no operator CRD field and no vMCP config plumbing. The `claimset_`/join behavior is consumed via the raw `cedarv1` config (the `thv` CLI, a raw `MCPAuthzConfig` configMap, or the enterprise policy compiler, which writes the cedar config directly). A typed operator CRD field was intentionally omitted (YAGNI) — and because `VirtualMCPServerSpec` embeds the vmcp config struct, a vMCP config field would surface in the CRD schema, which we're deliberately avoiding here.
- **Why keep the joined string *and* add a Set:** the joined string preserves the already-shipped `like`-based enterprise `Contains` predicate byte-for-byte, so array-claim (Okta) support lights up as a runtime-only, zero-coordination change with no regression to existing string-IdP (Entra) deployments. The `Set` is the strictly-better representation for *new* multi-value policies and is purely additive.
- Related enterprise work depends on this: stacklok/toolhive#5828 is consumed by the enterprise `Contains` claim operator.

<sub>Generated with [Claude Code](https://claude.com/claude-code)</sub>
