### PR TITLE
Bound delegated token audience by subject token

### DIFF
--- a/pkg/authserver/server/tokenexchange/handler.go
+++ b/pkg/authserver/server/tokenexchange/handler.go
@@ -127,26 +127,7 @@ func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, requester fosi
 		return err
 	}
 
-	if err := h.grantAudiences(ctx, requester, client); err != nil {
-		return err
-	}
-
-	if err := h.grantResourceAudience(ctx, requester, client); err != nil {
-		return err
-	}
-
-	if err := h.grantDefaultAudience(ctx, requester, client); err != nil {
-		return err
-	}
-
-	// The delegated token must not target a resource the subject token was not
-	// itself valid for. Every granted audience must be covered by the subject
-	// token's audience — delegation narrows, never broadens, the resource
-	// boundary. This mirrors grantScopes, which bounds scopes by the subject
-	// token; without it a client registered for audiences A and B could
-	// exchange a user token minted for A into a token for B, an escalation the
-	// user never consented to.
-	if err := ensureAudienceSubsetOfSubject(requester.GetGrantedAudience(), validatedClaims.Audience); err != nil {
+	if err := h.grantAndBoundAudiences(ctx, requester, client, validatedClaims); err != nil {
 		return err
 	}
 
@@ -356,6 +337,32 @@ func (h *Handler) grantScopes(
 		requester.GrantScope(scope)
 	}
 	return nil
+}
+
+// grantAndBoundAudiences resolves the delegated token's audience from the
+// request (explicit "audience", RFC 8707 "resource", or the configured
+// default) and then bounds the result by the subject token.
+//
+// The delegated token must not target a resource the subject token was not
+// itself valid for: every granted audience must be covered by the subject
+// token's audience — delegation narrows, never broadens, the resource
+// boundary. This mirrors grantScopes, which bounds scopes by the subject
+// token; without it a client registered for audiences A and B could exchange a
+// user token minted for A into a token for B, an escalation the user never
+// consented to.
+func (h *Handler) grantAndBoundAudiences(
+	ctx context.Context, requester fosite.AccessRequester, client fosite.Client, validatedClaims *ValidatedClaims,
+) error {
+	if err := h.grantAudiences(ctx, requester, client); err != nil {
+		return err
+	}
+	if err := h.grantResourceAudience(ctx, requester, client); err != nil {
+		return err
+	}
+	if err := h.grantDefaultAudience(ctx, requester, client); err != nil {
+		return err
+	}
+	return ensureAudienceSubsetOfSubject(requester.GetGrantedAudience(), validatedClaims.Audience)
 }
 
 // grantAudiences validates that the requested audience is allowed for this

--- a/pkg/authserver/server/tokenexchange/handler.go
+++ b/pkg/authserver/server/tokenexchange/handler.go
@@ -139,6 +139,17 @@ func (h *Handler) HandleTokenEndpointRequest(ctx context.Context, requester fosi
 		return err
 	}
 
+	// The delegated token must not target a resource the subject token was not
+	// itself valid for. Every granted audience must be covered by the subject
+	// token's audience — delegation narrows, never broadens, the resource
+	// boundary. This mirrors grantScopes, which bounds scopes by the subject
+	// token; without it a client registered for audiences A and B could
+	// exchange a user token minted for A into a token for B, an escalation the
+	// user never consented to.
+	if err := ensureAudienceSubsetOfSubject(requester.GetGrantedAudience(), validatedClaims.Audience); err != nil {
+		return err
+	}
+
 	// Build the delegated session with the user's identity and the agent's act claim.
 	delegatedSession := session.New(
 		validatedClaims.Subject,
@@ -423,6 +434,25 @@ func (h *Handler) grantDefaultAudience(ctx context.Context, requester fosite.Acc
 		"audience", defaultAudience,
 	)
 	requester.GrantAudience(defaultAudience)
+	return nil
+}
+
+// ensureAudienceSubsetOfSubject verifies that every audience granted to the
+// delegated token is covered by the subject token's own audience. A subject
+// token always carries at least one audience (the validator rejects tokens
+// whose aud does not intersect the server's allowed audiences), so an empty
+// subject audience here can only reject.
+func ensureAudienceSubsetOfSubject(granted, subjectAud []string) error {
+	subj := make(map[string]bool, len(subjectAud))
+	for _, a := range subjectAud {
+		subj[a] = true
+	}
+	for _, a := range granted {
+		if !subj[a] {
+			return errorsx.WithStack(server.ErrInvalidTarget.WithHintf(
+				"The delegated token audience %q is not covered by the subject token's audience.", a))
+		}
+	}
 	return nil
 }
 

--- a/pkg/authserver/server/tokenexchange/handler_test.go
+++ b/pkg/authserver/server/tokenexchange/handler_test.go
@@ -512,6 +512,58 @@ func TestTokenExchangeHandler_HandleTokenEndpointRequest(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			// The subject token is valid only for testIssuer, but the client is
+			// registered for a second audience. Requesting that second audience
+			// must be rejected: delegation cannot broaden the resource boundary.
+			name: "audience escalation blocked by subject token",
+			ctx:  func(_ *testing.T) context.Context { return context.Background() },
+			client: func() *fosite.DefaultClient {
+				c := defaultClient()
+				c.Audience = []string{testIssuer, "https://other.example.com"}
+				return c
+			},
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				f := defaultFormValues(t, tj)
+				f.Set("audience", "https://other.example.com")
+				return f
+			},
+			lifespan:     15 * time.Minute,
+			wantErr:      true,
+			wantFositeIs: server.ErrInvalidTarget,
+			hintContains: "not covered by the subject token",
+		},
+		{
+			// The subject token carries both audiences, so requesting one of them
+			// is within the delegated boundary and must succeed.
+			name: "audience within subject token granted",
+			ctx:  func(_ *testing.T) context.Context { return context.Background() },
+			client: func() *fosite.DefaultClient {
+				c := defaultClient()
+				c.Audience = []string{testIssuer, "https://other.example.com"}
+				return c
+			},
+			form: func(t *testing.T) url.Values {
+				t.Helper()
+				claims := validClaims()
+				claims.Audience = jwt.Audience{testIssuer, "https://other.example.com"}
+				token := tj.signToken(t, claims, validExtraClaims())
+				f := url.Values{
+					"grant_type":         {oauthproto.GrantTypeTokenExchange},
+					"subject_token":      {token},
+					"subject_token_type": {oauthproto.TokenTypeAccessToken},
+				}
+				f.Set("audience", "https://other.example.com")
+				return f
+			},
+			lifespan: 15 * time.Minute,
+			check: func(t *testing.T, req *fosite.AccessRequest) {
+				t.Helper()
+				assert.Contains(t, req.GetGrantedAudience(), "https://other.example.com",
+					"audience covered by the subject token should be granted")
+			},
+		},
+		{
 			name:   "valid resource parameter granted as audience",
 			ctx:    func(_ *testing.T) context.Context { return context.Background() },
 			client: defaultClient,


### PR DESCRIPTION
## Summary

Token exchange (RFC 8693) bounded the delegated token's **scopes** by the subject token but not its **audience**. A confidential client registered for audiences A and B could exchange a user token minted only for A into a delegated token for B — an escalation to a resource the user never consented to. `grantScopes` already narrows scopes to the subject token; audience had no equivalent bound.

This adds `ensureAudienceSubsetOfSubject`, enforced after all audiences are granted (from the `audience` param, the `resource` param, or the default-audience fallback), so every granted audience must be covered by the subject token's own `aud`. Delegation narrows, never broadens, the resource boundary.

Note: this handler is not yet wired up to live confidential clients, so no active deployment is affected — this lands the fix ahead of that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Unit tests added: audience escalation blocked by subject token; audience within subject token granted.
- [x] Existing token-exchange handler tests pass unchanged (subject tokens carry `aud=[testIssuer]`, which the default/resource grants stay within).

Generated with [Claude Code](https://claude.com/claude-code)