### PR TITLE
Ignore flaky tools-call-sampling in conformance CI

### DIFF
--- a/test/conformance/run-conformance.sh
+++ b/test/conformance/run-conformance.sh
@@ -95,8 +95,34 @@ done
 echo "==> Running conformance suite (${CONFORMANCE_SUITE})"
 rm -rf "${RESULTS_DIR}"
 mkdir -p "${RESULTS_DIR}"
+set +e
 npx -y "@modelcontextprotocol/conformance@${CONFORMANCE_VERSION}" server \
   --url "${URL}" \
   --suite "${CONFORMANCE_SUITE}" \
   --expected-failures "${EXPECTED_FAILURES}" \
   -o "${RESULTS_DIR}" 2>&1 | tee "${RESULTS_DIR}/suite-output.log"
+suite_rc=${PIPESTATUS[0]}
+set -e
+
+# Quarantine: tools-call-sampling flakes intermittently (~1/3) due to an upstream
+# reference-server bug, NOT a ToolHive defect. The everything-server sends its
+# server->client sampling/createMessage on the client's standalone GET SSE stream
+# without a relatedRequestId, so it races the tools/call handler; when the handler
+# wins, the request is dropped and the client times out at 60s. See:
+#   upstream: https://github.com/modelcontextprotocol/conformance/issues/407
+#   toolhive: #5886 (ingress Squid cold-start mitigation, reduces but can't
+#             eliminate the client-side ordering race)
+# We can't use expected-failures.yaml (a flaky entry stale-fails the ~2/3 of runs
+# where it passes), so ignore ONLY tools-call-sampling in the gating here; every
+# other scenario still fails the job. Remove this block once #407 is fixed
+# upstream and CONFORMANCE_VERSION is bumped to a release that contains the fix.
+if [ "${suite_rc}" -ne 0 ]; then
+  unexpected="$(sed -n '/Unexpected failures (not in baseline):/,$p' "${RESULTS_DIR}/suite-output.log" \
+    | grep -oE '✗ [a-z0-9-]+' | sed 's/✗ //' | sort -u)"
+  others="$(printf '%s\n' "${unexpected}" | grep -vE '^(tools-call-sampling)?$' || true)"
+  if [ -n "${unexpected}" ] && [ -z "${others}" ]; then
+    echo "==> Ignoring quarantined flaky scenario 'tools-call-sampling' (upstream conformance#407 / toolhive#5886); no other unexpected failures."
+    exit 0
+  fi
+  exit "${suite_rc}"
+fi


### PR DESCRIPTION
## Summary

**Why:** the `tools-call-sampling` MCP conformance scenario flakes ~1/3 of runs and intermittently reds every PR's `E2E Tests / MCP Conformance` check. Root cause is an **upstream reference-server bug, not a ToolHive defect** (filed as modelcontextprotocol/conformance#407): the `everything-server` sends its server→client `sampling/createMessage` on the client's standalone `GET /mcp` SSE stream with no `relatedRequestId`, so it races the `tools/call` handler; when the handler wins, the SDK drops the request on the not-yet-connected standalone stream (stores-and-silently-returns) and the client times out at 60s. Direct-to-server it's ~0% flaky; a proxy in front (ToolHive) widens the race.

**What:** post-filter the suite result in `run-conformance.sh` to ignore **only** `tools-call-sampling` (whether it passes or fails), while every other scenario still gates the job. `expected-failures.yaml` can't express a *flaky* scenario — listing it there stale-fails the ~2/3 of runs where it passes — so the exclusion is done in the harness with a clear revert marker.

## Type of change

- [x] CI / test infrastructure

## Test plan

- [x] Shell syntax check (`bash -n`) passes.
- [x] Self-tested the parse: a suite whose only unexpected failure is `tools-call-sampling` → job passes; `tools-call-sampling` + any other unexpected failure → job still fails.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

Temporary. Remove this block once modelcontextprotocol/conformance#407 is fixed upstream and `CONFORMANCE_VERSION` is bumped to a release containing the fix (there is currently no such tag — the bug is present at v0.1.16 and at upstream HEAD). Related ToolHive work: #5886 / #5887 (ingress Squid `standby=2`, which reduces but cannot eliminate the client-side ordering race — the residual is upstream-only).

Generated with [Claude Code](https://claude.com/claude-code)