### PR TITLE
Isolate HTTP transport in vmcp backend tests

### DIFF
--- a/pkg/vmcp/session/internal/backend/mcp_session_capabilities_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_capabilities_test.go
@@ -278,7 +278,15 @@ func (f *fakeBackend) writeError(w http.ResponseWriter, id json.RawMessage, e *j
 // is registered via t.Cleanup.
 func newTestClient(t *testing.T, url string) *mcpclient.Client {
 	t.Helper()
-	c, err := mcpclient.NewStreamableHttpClient(url, mcptransport.WithHTTPBasicClient(&http.Client{}))
+	// Each test client gets its own transport with keep-alive disabled. A bare
+	// &http.Client{} shares the process-global http.DefaultTransport, so across
+	// t.Parallel() subtests one client's teardown (t.Cleanup -> Close) can close
+	// idle connections a sibling is mid-request on. Go surfaces that as
+	// "connection broken: http: CloseIdleConnections called", which the
+	// streamable transport reports as a spurious 4xx/legacy-SSE init failure.
+	c, err := mcpclient.NewStreamableHttpClient(url, mcptransport.WithHTTPBasicClient(&http.Client{
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}))
 	require.NoError(t, err)
 	require.NoError(t, c.Start(context.Background()))
 	t.Cleanup(func() { _ = c.Close() })


### PR DESCRIPTION
## Summary

`TestInitAndQueryCapabilities_*` in `pkg/vmcp/session/internal/backend` is an
intermittent CI-only flake. It surfaced on an unrelated PR's CI run as:

```
initialize failed: transport error: server returned 4xx for initialize POST, likely a legacy SSE server
sending "notifications/initialized": rejected by transport:
  Post "http://127.0.0.1:.../mcp": net/http: HTTP/1.x transport connection broken:
  http: CloseIdleConnections called
```

**Why:** the test's subtests run with `t.Parallel()`, and `newTestClient` builds
each mcpcompat client from a bare `&http.Client{}`. A bare client has no
`Transport`, so it uses the process-global `http.DefaultTransport` — shared by
every parallel subtest. When one subtest's `t.Cleanup` closes its client,
`CloseIdleConnections` on that shared transport can tear down an idle keep-alive
connection that a *sibling* subtest is mid-request on. Go reports the broken
reused connection as `http: CloseIdleConnections called`, and the streamable
transport surfaces it as a spurious 4xx / legacy-SSE `initialize` failure. It is
a test-harness race only — no product code is involved.

**What:** give each test client its own `http.Transport` with `DisableKeepAlives:
true`, so no connection is pooled or shared across parallel subtests and the
reuse race cannot occur.

## Type of change

- [x] Test / CI infrastructure

## Test plan

- [x] `task lint-fix` — 0 issues
- [x] `go test ./pkg/vmcp/session/internal/backend/ -run TestInitAndQueryCapabilities -count=200 -race -cpu=4` — passes
- [ ] The original failure is rare and CI-load-dependent; it did **not** reproduce locally even at high `-count`, so this is a root-cause fix verified by reasoning + stress, not a before/after repro. Confidence is high because the fix removes the *necessary condition* (shared-transport connection reuse across parallel subtests).

## Special notes for reviewers

- Scoped intentionally to the one flake in this package. `newTestClient` is the
  only bare-`&http.Client{}` site here; sibling test files build sessions through
  a different path and were not affected by this failure.
- Part of deflaking `main` — the elicitation SSE conformance flake and the
  `thv llm teardown` E2E flake are separate issues tracked/handled elsewhere.

Generated with [Claude Code](https://claude.com/claude-code)