### PR TITLE
Fix Envoy isolated-server readiness and enable e2e tests

### DIFF
--- a/pkg/container/docker/envoy.go
+++ b/pkg/container/docker/envoy.go
@@ -752,13 +752,28 @@ type envoyProxy struct {
 	client *Client
 }
 
-// SetupEgress implements networkProxy for the Envoy backend. Envoy consolidates
-// egress and ingress into a single container, so this creates that container
-// (both listeners) before the MCP container. Envoy's ingress upstream is a
-// STRICT_DNS cluster that resolves the MCP container lazily and keeps retrying,
-// so — unlike squid's cache_peer — pre-MCP creation is safe. The reserved
-// ingress port is carried back in egressResult for SetupIngress to return.
-func (e *envoyProxy) SetupEgress(ctx context.Context, spec proxySpec) (egressResult, error) {
+// SetupEgress implements networkProxy for the Envoy backend.
+//
+// Only the egress proxy env vars are returned here — no container is created
+// yet. Container creation is deferred to SetupIngress (which runs after
+// createMcpContainer) so that the MCP container's hostname is resolvable the
+// moment the Envoy STRICT_DNS ingress cluster first probes it. Creating Envoy
+// before the MCP container caused the ingress cluster to cache a negative DNS
+// response on Linux Docker Engine, preventing the server from ever becoming
+// ready within the readiness window (see #5922).
+func (*envoyProxy) SetupEgress(_ context.Context, spec proxySpec) (egressResult, error) {
+	egressContainerName := fmt.Sprintf("%s-egress", spec.WorkloadName)
+	return egressResult{EnvVars: addEgressEnvVars(nil, egressContainerName)}, nil
+}
+
+// SetupIngress implements networkProxy for the Envoy backend.
+//
+// Creates the Envoy container after the MCP container exists, with both the
+// egress forward-proxy listener and (for non-stdio transports) the ingress
+// reverse-proxy listener. Running after createMcpContainer ensures the
+// STRICT_DNS upstream cluster resolves the MCP hostname on the first probe,
+// avoiding the Linux Docker Engine readiness failure described in #5922.
+func (e *envoyProxy) SetupIngress(ctx context.Context, spec proxySpec, _ egressResult) (int, error) {
 	egressContainerName := fmt.Sprintf("%s-egress", spec.WorkloadName)
 
 	bootstrap := envoyBootstrap{
@@ -780,7 +795,7 @@ func (e *envoyProxy) SetupEgress(ctx context.Context, spec proxySpec) (egressRes
 	if spec.TransportType != "stdio" && spec.UpstreamPort > 0 {
 		port, err := networking.FindOrUsePort(spec.UpstreamPort + 1)
 		if err != nil {
-			return egressResult{}, fmt.Errorf("failed to find ingress port: %w", err)
+			return 0, fmt.Errorf("failed to find ingress port: %w", err)
 		}
 		ingressPort = port
 		bootstrap.StaticResources.Listeners = append(
@@ -795,11 +810,8 @@ func (e *envoyProxy) SetupEgress(ctx context.Context, spec proxySpec) (egressRes
 
 	configPath, err := writeEnvoyBootstrap(bootstrap)
 	if err != nil {
-		return egressResult{}, err // already wrapped with context
+		return 0, err
 	}
-	// On success the file must persist for the container's read-only bind mount,
-	// so it can't be unconditionally deferred away. Remove it only if setup fails
-	// past this point, so a failed deploy doesn't orphan a bootstrap in TempDir.
 	success := false
 	defer func() {
 		if !success {
@@ -812,12 +824,9 @@ func (e *envoyProxy) SetupEgress(ctx context.Context, spec proxySpec) (egressRes
 	slog.Debug("setting up envoy container", "name", egressContainerName, "image", envoyImage)
 
 	if err := e.client.imageManager.PullImage(ctx, envoyImage); err != nil {
-		// Fall back to a locally-present image; only proceed if it actually
-		// exists (ImageExists returns (false, nil) when absent, so the bool
-		// must be checked, not just the error).
 		exists, inspectErr := e.client.imageManager.ImageExists(ctx, envoyImage)
 		if inspectErr != nil || !exists {
-			return egressResult{}, fmt.Errorf("failed to pull envoy image: %w", err)
+			return 0, fmt.Errorf("failed to pull envoy image: %w", err)
 		}
 		//nolint:gosec // G706: envoy image name from config
 		slog.Debug("envoy image exists locally, continuing despite pull failure", "image", envoyImage)
@@ -827,18 +836,14 @@ func (e *envoyProxy) SetupEgress(ctx context.Context, spec proxySpec) (egressRes
 	lb.AddStandardLabels(envoyLabels, egressContainerName, egressContainerName, "stdio", 80)
 	envoyLabels[ToolhiveAuxiliaryWorkloadLabel] = LabelValueTrue
 
-	config := &container.Config{
+	containerConfig := &container.Config{
 		Image:  envoyImage,
 		Cmd:    []string{"-c", "/etc/envoy/envoy.json"},
 		Labels: envoyLabels,
 	}
 
 	mounts := []runtime.Mount{
-		{
-			Source:   configPath,
-			Target:   "/etc/envoy/envoy.json",
-			ReadOnly: true,
-		},
+		{Source: configPath, Target: "/etc/envoy/envoy.json", ReadOnly: true},
 	}
 
 	var exposedPorts map[string]struct{}
@@ -856,36 +861,24 @@ func (e *envoyProxy) SetupEgress(ctx context.Context, spec proxySpec) (egressRes
 		Mounts:      convertMounts(mounts),
 		NetworkMode: container.NetworkMode("bridge"),
 		SecurityOpt: []string{"label:disable"},
-		// Envoy distroless runs as nonroot and needs no capabilities; drop all.
-		CapDrop: []string{"ALL"},
+		CapDrop:     []string{"ALL"},
 		RestartPolicy: container.RestartPolicy{
 			Name: "unless-stopped",
 		},
 	}
 	if portBindings != nil {
 		if err := setupPortBindings(hostConfig, portBindings); err != nil {
-			return egressResult{}, fmt.Errorf("failed to setup port bindings: %w", err)
+			return 0, fmt.Errorf("failed to setup port bindings: %w", err)
 		}
 	}
-	if err := setupExposedPorts(config, exposedPorts); err != nil {
-		return egressResult{}, fmt.Errorf("failed to setup exposed ports: %w", err)
+	if err := setupExposedPorts(containerConfig, exposedPorts); err != nil {
+		return 0, fmt.Errorf("failed to setup exposed ports: %w", err)
 	}
 
-	if _, err := e.client.createContainer(ctx, egressContainerName, config, hostConfig, spec.Endpoints); err != nil {
-		return egressResult{}, fmt.Errorf("failed to create envoy container: %w", err)
+	if _, err := e.client.createContainer(ctx, egressContainerName, containerConfig, hostConfig, spec.Endpoints); err != nil {
+		return 0, fmt.Errorf("failed to create envoy container: %w", err)
 	}
 
-	success = true // keep the bootstrap file; the container bind-mounts it
-	return egressResult{
-		EnvVars:     addEgressEnvVars(nil, egressContainerName),
-		ingressPort: ingressPort,
-	}, nil
-}
-
-// SetupIngress implements networkProxy for the Envoy backend. Envoy already
-// created its ingress listener as part of the single container in SetupEgress,
-// so there is nothing more to create here — it simply returns the ingress port
-// reserved in SetupEgress (0 for stdio / UpstreamPort==0).
-func (*envoyProxy) SetupIngress(_ context.Context, _ proxySpec, egress egressResult) (int, error) {
-	return egress.ingressPort, nil
+	success = true
+	return ingressPort, nil
 }

--- a/pkg/container/docker/envoy_test.go
+++ b/pkg/container/docker/envoy_test.go
@@ -783,16 +783,20 @@ func TestEnvoyProxy_SetupOrchestration(t *testing.T) {
 				Endpoints:     map[string]*network.EndpointSettings{},
 			}
 
+			// SetupEgress must NOT create the container — it only returns env vars.
+			// Container creation is deferred to SetupIngress so the MCP hostname
+			// resolves on first probe (see #5922).
 			egress, err := e.SetupEgress(t.Context(), spec)
 			require.NoError(t, err)
-			assert.Equal(t, "app-egress", createdName, "envoy container must reuse the -egress name")
+			assert.Empty(t, createdName, "SetupEgress must not create the container")
 			assert.Equal(t, "http://app-egress:3128", egress.EnvVars["HTTP_PROXY"])
 
+			// SetupIngress creates the container and returns the ingress port.
 			ingressPort, err := e.SetupIngress(t.Context(), spec, egress)
 			require.NoError(t, err)
+			assert.Equal(t, "app-egress", createdName, "SetupIngress must create the -egress container")
 			if tt.wantIngress {
 				assert.Positive(t, ingressPort, "non-stdio must reserve an ingress port")
-				assert.Equal(t, egress.ingressPort, ingressPort, "SetupIngress must return the port reserved in SetupEgress")
 			} else {
 				assert.Zero(t, ingressPort, "stdio must not reserve an ingress port")
 			}

--- a/pkg/container/docker/networkproxy.go
+++ b/pkg/container/docker/networkproxy.go
@@ -74,16 +74,12 @@ type proxySpec struct {
 }
 
 // egressResult is the output of a successful SetupEgress call. It is passed to
-// SetupIngress so a consolidated backend can carry state (e.g. a reserved
-// ingress port) forward without holding per-workload state on the shared proxy.
+// SetupIngress so backends can carry any state set up during egress forward
+// without holding per-workload state on the shared proxy.
 type egressResult struct {
 	// EnvVars contains environment variables that must be merged into the MCP
 	// container's environment (e.g. HTTP_PROXY, HTTPS_PROXY).
 	EnvVars map[string]string
-	// ingressPort is the host-side ingress port reserved by a consolidated
-	// backend (envoy) when it created its container in SetupEgress. Per-container
-	// backends (squid) leave it 0 and bind the ingress port later in SetupIngress.
-	ingressPort int
 }
 
 // newNetworkProxy reads the TOOLHIVE_NETWORK_PROXY environment variable and

--- a/test/e2e/network_isolation_envoy_test.go
+++ b/test/e2e/network_isolation_envoy_test.go
@@ -8,10 +8,6 @@ package e2e_test
 // as the Squid suite in network_isolation_test.go — egress allowlist, inbound
 // Host gating, docker-gateway deny/allow — plus Envoy-specific guards such as
 // the route-timeout regression test.
-//
-// All tests are currently skipped pending resolution of #5922 (Envoy isolated
-// server does not reach ready state on Linux Docker Engine). Remove the
-// BeforeEach(Skip(...)) call to activate them once #5922 is fixed.
 
 import (
 	"context"
@@ -39,11 +35,6 @@ var _ = Describe("NetworkIsolationEnvoy", Label("proxy", "network", "isolation",
 	)
 
 	BeforeEach(func() {
-		// TODO(#5922): Remove this skip once Envoy isolated-server readiness on
-		// Linux Docker Engine is fixed. The tests are correct; the backend is not
-		// yet ready on that platform.
-		Skip("Envoy isolated-server readiness on Linux Docker Engine is broken — see #5922")
-
 		config = e2e.NewTestConfig()
 
 		var err error


### PR DESCRIPTION
## Summary

Fixes the Envoy network proxy's startup failure on Linux Docker Engine (#5922) and enables the Envoy e2e tests that were previously skipped.

Closes #5922. Part of #5900.

<details>
<summary><strong>Root cause and fix</strong></summary>

The Envoy container was created in `SetupEgress`, before `createMcpContainer`. The Envoy container's ingress listener uses a `STRICT_DNS` cluster pointing at the MCP container by hostname. On Linux Docker Engine, probing before the MCP container existed produced a cached negative DNS response — the ingress never recovered, leaving the server stuck in `starting` past the 120s readiness window.

**Fix:** move all Envoy container creation to `SetupIngress` (after `createMcpContainer`). `SetupEgress` now only computes and returns the proxy env vars. The container name is deterministic (`<name>-egress`), so no state needs threading through `egressResult`. The `egressResult.ingressPort` field is removed as no longer needed.

Also removes the `BeforeEach(Skip(...))` guard from `network_isolation_envoy_test.go`.

</details>

<details>
<summary><strong>Files changed</strong></summary>

- `envoy.go` — `SetupEgress` returns env vars only; `SetupIngress` creates the container
- `networkproxy.go` — remove unused `egressResult.ingressPort` field
- `envoy_test.go` — update orchestration test: container created in `SetupIngress`, not `SetupEgress`
- `network_isolation_envoy_test.go` — remove skip guard

</details>

## Type of change

- [x] Bug fix

## Test plan

- [x] `go build ./pkg/container/docker/...` passes
- [x] `golangci-lint` clean
- [x] `TestEnvoyProxy_SetupOrchestration` updated and passing
- [ ] CI e2e proxy shard — Envoy isolation tests now run (not skipped)

Generated with [Claude Code](https://claude.com/claude-code)