### PR TITLE
Translate AllowPort into Envoy egress RBAC policy

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -103,7 +103,7 @@ jobs:
           go mod download
       - name: Install Ginkgo CLI
         run: |
-          go install github.com/onsi/ginkgo/v2/ginkgo@latest
+          go install github.com/onsi/ginkgo/v2/ginkgo@v2.28.1
 
       - name: Download ToolHive binary
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7

--- a/docs/arch/15-envoy-network-proxy.md
+++ b/docs/arch/15-envoy-network-proxy.md
@@ -218,6 +218,7 @@ backend is stable.
 | L7 hostname deny | ✓ (`dstdomain`) | ✓ (`:authority` header match) |
 | Destination IP deny | ✓ (`dst` ACL, resolved IP) | ~ (IP literal in `:authority` only; resolved IP not enforced — see Known Limitations) |
 | Wildcard host allowlist | ✓ (`.example.com` dot-prefix) | ✓ (same syntax, regex match incl. apex + port) |
+| Port-based allowlist | ✓ (`AllowPort` ACL, AND-d with host) | ✓ (`:authority` suffix match, AND-d with host) |
 | Per-request DNS resolution | Via Squid resolver | Via DFP cluster |
 | Access logs | Per-container, text format | Unified stdout, structured |
 | Config format | Text template | Typed Go structs → protobuf-JSON |
@@ -241,10 +242,6 @@ backend is stable.
   `HTTP_PROXY`) is contained by the `Internal: true` network, not Envoy. True
   non-bypassable enforcement requires iptables TPROXY + an init container with
   `CAP_NET_ADMIN` — this is Phase 2 and requires its own architecture doc.
-- **No port-based allowlist.** `AllowPort` from the permission profile is not
-  yet translated into Envoy egress policy, so an allowlisted host is reachable on
-  any port. Squid honours `AllowPort`; the Envoy backend currently does not,
-  which is a parity gap. Tracked in #5915.
 - **Gateway deny matches the requested name, not the resolved IP.** The deny
   filter matches the `:authority` string (the gateway IP literal and the two
   Docker-internal hostnames). Because an HTTP RBAC filter cannot see the address

--- a/docs/arch/15-envoy-network-proxy.md
+++ b/docs/arch/15-envoy-network-proxy.md
@@ -218,7 +218,7 @@ backend is stable.
 | L7 hostname deny | ✓ (`dstdomain`) | ✓ (`:authority` header match) |
 | Destination IP deny | ✓ (`dst` ACL, resolved IP) | ~ (IP literal in `:authority` only; resolved IP not enforced — see Known Limitations) |
 | Wildcard host allowlist | ✓ (`.example.com` dot-prefix) | ✓ (same syntax, regex match incl. apex + port) |
-| Port-based allowlist | ✓ (`AllowPort` ACL, AND-d with host) | ~ (`:authority` suffix match, AND-d with host; plain-HTTP requests omit the port from `:authority` so `AllowPort:[80]` is more restrictive than Squid for unencrypted traffic — fail-closed, see Known Limitations) |
+| Port-based allowlist | ✓ (`AllowPort` ACL, AND-d with host) | ✓ (combined host+port regex; bare hostname allowed when port 80 is listed, matching Squid's plain-HTTP behaviour) |
 | Per-request DNS resolution | Via Squid resolver | Via DFP cluster |
 | Access logs | Per-container, text format | Unified stdout, structured |
 | Config format | Text template | Typed Go structs → protobuf-JSON |
@@ -238,13 +238,13 @@ backend is stable.
   tunnel closes, not when it opens. With keep-alive HTTP clients the log entry
   may be delayed by minutes. Egress access logs are visible in `docker logs` but
   appear after the connection closes.
-- **`AllowPort` is more restrictive than Squid for plain-HTTP traffic.** The
-  port constraint is matched against the HTTP `:authority` header. HTTPS CONNECT
-  tunnels always carry the port (`example.com:443`), so `AllowPort:[443]` works
-  correctly. Plain-HTTP requests omit the default port from `:authority`
-  (`example.com`, not `example.com:80`), so `AllowPort:[80]` will deny
-  plain-HTTP even to an allowlisted host. This is fail-closed (over-blocks, not
-  a bypass); Squid derives the port from the request URL and allows it.
+- **`AllowPort` with port 443 only will deny plain-HTTP traffic.** Port 80 is
+  treated as the HTTP default: when 80 is in `AllowPort`, a bare `:authority`
+  header (plain HTTP, which omits the default port) is permitted alongside the
+  explicit `host:80` form — matching Squid's `allowed_ports` behaviour. When
+  port 80 is NOT in `AllowPort` (e.g., `AllowPort:[443]` only), bare-hostname
+  authorities are denied since port 80 is not listed. This is fail-closed (over-
+  blocks rather than a bypass).
 - **No transparent L3/L4.** Non-cooperative traffic (workloads that ignore
   `HTTP_PROXY`) is contained by the `Internal: true` network, not Envoy. True
   non-bypassable enforcement requires iptables TPROXY + an init container with

--- a/docs/arch/15-envoy-network-proxy.md
+++ b/docs/arch/15-envoy-network-proxy.md
@@ -218,7 +218,7 @@ backend is stable.
 | L7 hostname deny | ✓ (`dstdomain`) | ✓ (`:authority` header match) |
 | Destination IP deny | ✓ (`dst` ACL, resolved IP) | ~ (IP literal in `:authority` only; resolved IP not enforced — see Known Limitations) |
 | Wildcard host allowlist | ✓ (`.example.com` dot-prefix) | ✓ (same syntax, regex match incl. apex + port) |
-| Port-based allowlist | ✓ (`AllowPort` ACL, AND-d with host) | ✓ (`:authority` suffix match, AND-d with host) |
+| Port-based allowlist | ✓ (`AllowPort` ACL, AND-d with host) | ~ (`:authority` suffix match, AND-d with host; plain-HTTP requests omit the port from `:authority` so `AllowPort:[80]` is more restrictive than Squid for unencrypted traffic — fail-closed, see Known Limitations) |
 | Per-request DNS resolution | Via Squid resolver | Via DFP cluster |
 | Access logs | Per-container, text format | Unified stdout, structured |
 | Config format | Text template | Typed Go structs → protobuf-JSON |
@@ -238,6 +238,13 @@ backend is stable.
   tunnel closes, not when it opens. With keep-alive HTTP clients the log entry
   may be delayed by minutes. Egress access logs are visible in `docker logs` but
   appear after the connection closes.
+- **`AllowPort` is more restrictive than Squid for plain-HTTP traffic.** The
+  port constraint is matched against the HTTP `:authority` header. HTTPS CONNECT
+  tunnels always carry the port (`example.com:443`), so `AllowPort:[443]` works
+  correctly. Plain-HTTP requests omit the default port from `:authority`
+  (`example.com`, not `example.com:80`), so `AllowPort:[80]` will deny
+  plain-HTTP even to an allowlisted host. This is fail-closed (over-blocks, not
+  a bypass); Squid derives the port from the request URL and allows it.
 - **No transparent L3/L4.** Non-cooperative traffic (workloads that ignore
   `HTTP_PROXY`) is contained by the `Internal: true` network, not Envoy. True
   non-bypassable enforcement requires iptables TPROXY + an init container with

--- a/pkg/container/docker/envoy.go
+++ b/pkg/container/docker/envoy.go
@@ -539,22 +539,70 @@ func buildAllowlistPolicies(spec proxySpec) map[string]envoyRBACPolicy {
 		}
 		return policies
 	}
+	// Build the port constraint once (shared across all host policies).
+	portPerm := portMatchPermission(out.AllowPort)
+
+	if len(out.AllowHost) == 0 && portPerm != nil {
+		// AllowPort only — any host on the listed ports.
+		policies["any-host-allowed-ports"] = envoyRBACPolicy{
+			Permissions: []envoyPermission{*portPerm},
+			Principals:  []envoyPrincipal{{Any: true}},
+		}
+		return policies
+	}
+
 	for _, host := range out.AllowHost {
-		policies[host] = envoyRBACPolicy{
-			Permissions: []envoyPermission{
-				{
-					Header: &envoyHeaderMatcher{
-						Name: ":authority",
-						StringMatch: &envoyStringMatch{
-							SafeRegex: &envoySafeRegex{Regex: hostMatchRegex(host)},
-						},
-					},
-				},
+		hostPerm := envoyPermission{
+			Header: &envoyHeaderMatcher{
+				Name:        ":authority",
+				StringMatch: &envoyStringMatch{SafeRegex: &envoySafeRegex{Regex: hostMatchRegex(host)}},
 			},
-			Principals: []envoyPrincipal{{Any: true}},
+		}
+		var perms []envoyPermission
+		if portPerm != nil {
+			// AllowHost + AllowPort: both must match (AND semantics within a policy).
+			// The host regex already tolerates an optional ":port" suffix; the port
+			// permission anchors it to exactly the listed port numbers, matching
+			// Squid's "allowed_ports AND allowed_dsts" ACL combination.
+			perms = []envoyPermission{hostPerm, *portPerm}
+		} else {
+			// AllowHost only — any port (matches original behaviour).
+			perms = []envoyPermission{hostPerm}
+		}
+		policies[host] = envoyRBACPolicy{
+			Permissions: perms,
+			Principals:  []envoyPrincipal{{Any: true}},
 		}
 	}
 	return policies
+}
+
+// portMatchPermission returns an envoyPermission that matches the :authority
+// port suffix against the given allowed ports, or nil when the list is empty
+// (meaning no port constraint). The permission uses an OR of exact port-suffix
+// matchers (":80", ":443", …) so it fires when the authority ends with any of
+// the allowed ports — covering both plain HTTP and HTTPS CONNECT, where the
+// authority always carries the port. Hosts accessed via plain HTTP without an
+// explicit port (authority = "example.com") are NOT matched by this permission,
+// which is conservative: if a caller specifies AllowPort they intend to
+// constrain traffic to those ports.
+func portMatchPermission(ports []int) *envoyPermission {
+	if len(ports) == 0 {
+		return nil
+	}
+	rules := make([]envoyPermission, 0, len(ports))
+	for _, p := range ports {
+		rules = append(rules, envoyPermission{
+			Header: &envoyHeaderMatcher{
+				Name:        ":authority",
+				StringMatch: &envoyStringMatch{Suffix: ":" + strconv.Itoa(p)},
+			},
+		})
+	}
+	if len(rules) == 1 {
+		return &rules[0]
+	}
+	return &envoyPermission{OrRules: &envoyOrRules{Rules: rules}}
 }
 
 // hostMatchRegex builds an anchored, case-insensitive RE2 pattern that matches

--- a/pkg/container/docker/envoy.go
+++ b/pkg/container/docker/envoy.go
@@ -547,70 +547,113 @@ func buildAllowlistPolicies(spec proxySpec) map[string]envoyRBACPolicy {
 		}
 		return policies
 	}
-	// Build the port constraint once (shared across all host policies).
-	portPerm := portMatchPermission(out.AllowPort)
-
-	if len(out.AllowHost) == 0 && portPerm != nil {
-		// AllowPort only — any host on the listed ports.
+	if len(out.AllowHost) == 0 && len(out.AllowPort) > 0 {
+		// AllowPort only — any host, but only on the listed ports.
+		// Use a single regex so both the explicit-port ("host:80") and the
+		// bare-hostname ("host", implying port 80) forms are handled correctly.
 		policies["any-host-allowed-ports"] = envoyRBACPolicy{
-			Permissions: []envoyPermission{*portPerm},
-			Principals:  []envoyPrincipal{{Any: true}},
+			Permissions: []envoyPermission{{
+				Header: &envoyHeaderMatcher{
+					Name:        ":authority",
+					StringMatch: &envoyStringMatch{SafeRegex: &envoySafeRegex{Regex: anyHostPortRegex(out.AllowPort)}},
+				},
+			}},
+			Principals: []envoyPrincipal{{Any: true}},
 		}
 		return policies
 	}
 
 	for _, host := range out.AllowHost {
-		hostPerm := envoyPermission{
-			Header: &envoyHeaderMatcher{
-				Name:        ":authority",
-				StringMatch: &envoyStringMatch{SafeRegex: &envoySafeRegex{Regex: hostMatchRegex(host)}},
-			},
-		}
-		var perms []envoyPermission
-		if portPerm != nil {
-			// AllowHost + AllowPort: both must match (AND semantics within a policy).
-			// The host regex already tolerates an optional ":port" suffix; the port
-			// permission anchors it to exactly the listed port numbers, matching
-			// Squid's "allowed_ports AND allowed_dsts" ACL combination.
-			perms = []envoyPermission{hostPerm, *portPerm}
+		var regex string
+		if len(out.AllowPort) > 0 {
+			// AllowHost + AllowPort: build a single regex that encodes both the
+			// host pattern and the allowed ports. Using a combined regex rather
+			// than separate AND-d permissions means plain-HTTP requests (where
+			// :authority omits the default port 80) are handled correctly — a
+			// bare "example.com" is permitted when port 80 is in the list.
+			regex = hostPortMatchRegex(host, out.AllowPort)
 		} else {
-			// AllowHost only — any port (matches original behaviour).
-			perms = []envoyPermission{hostPerm}
+			// AllowHost only — any port permitted.
+			regex = hostMatchRegex(host)
 		}
 		policies[host] = envoyRBACPolicy{
-			Permissions: perms,
-			Principals:  []envoyPrincipal{{Any: true}},
+			Permissions: []envoyPermission{{
+				Header: &envoyHeaderMatcher{
+					Name:        ":authority",
+					StringMatch: &envoyStringMatch{SafeRegex: &envoySafeRegex{Regex: regex}},
+				},
+			}},
+			Principals: []envoyPrincipal{{Any: true}},
 		}
 	}
 	return policies
 }
 
-// portMatchPermission returns an envoyPermission that matches the :authority
-// port suffix against the given allowed ports, or nil when the list is empty
-// (meaning no port constraint). The permission uses an OR of exact port-suffix
-// matchers (":80", ":443", …) so it fires when the authority ends with any of
-// the allowed ports — covering both plain HTTP and HTTPS CONNECT, where the
-// authority always carries the port. Hosts accessed via plain HTTP without an
-// explicit port (authority = "example.com") are NOT matched by this permission,
-// which is conservative: if a caller specifies AllowPort they intend to
-// constrain traffic to those ports.
-func portMatchPermission(ports []int) *envoyPermission {
-	if len(ports) == 0 {
-		return nil
+// hostPortMatchRegex builds a single anchored RE2 pattern that encodes both a
+// host allowlist entry and a port allowlist, so that AllowHost+AllowPort can be
+// expressed as one safe_regex permission rather than AND-ing two separate matchers.
+//
+// Port 80 is treated as the HTTP default: when 80 is in the ports list the port
+// suffix is optional, so a bare "example.com" authority (plain HTTP) is permitted
+// alongside "example.com:80". For all other ports the port suffix is required.
+//
+// The host portion mirrors hostMatchRegex semantics (leading dot / *. = subdomain
+// wildcard, case-insensitive, optional trailing dot, no port in the base pattern).
+func hostPortMatchRegex(host string, ports []int) string {
+	// Build the host portion (same logic as hostMatchRegex but without the
+	// trailing optional-port group — we handle ports explicitly below).
+	subdomains := false
+	switch {
+	case strings.HasPrefix(host, "*."):
+		host = host[2:]
+		subdomains = true
+	case strings.HasPrefix(host, "."):
+		host = host[1:]
+		subdomains = true
 	}
-	rules := make([]envoyPermission, 0, len(ports))
+	hostPattern := regexp.QuoteMeta(host)
+	if subdomains {
+		hostPattern = `(.*\.)?` + hostPattern
+	}
+
+	// Build the port alternatives.
+	includes80 := false
+	portAlts := make([]string, 0, len(ports))
 	for _, p := range ports {
-		rules = append(rules, envoyPermission{
-			Header: &envoyHeaderMatcher{
-				Name:        ":authority",
-				StringMatch: &envoyStringMatch{Suffix: ":" + strconv.Itoa(p)},
-			},
-		})
+		portAlts = append(portAlts, strconv.Itoa(p))
+		if p == 80 {
+			includes80 = true
+		}
 	}
-	if len(rules) == 1 {
-		return &rules[0]
+	portGroup := ":(?:" + strings.Join(portAlts, "|") + ")"
+
+	if includes80 {
+		// Port is optional: bare "example.com" counts as port 80.
+		return `(?i)` + hostPattern + `\.?(` + portGroup + `)?`
 	}
-	return &envoyPermission{OrRules: &envoyOrRules{Rules: rules}}
+	// Port is required: bare hostname is not accepted.
+	return `(?i)` + hostPattern + `\.?` + portGroup
+}
+
+// anyHostPortRegex builds a regex matching any hostname on the given ports.
+// When port 80 is in the list the port suffix is optional (bare hostname implies
+// port 80 for plain HTTP). For other ports the port suffix is required.
+func anyHostPortRegex(ports []int) string {
+	includes80 := false
+	portAlts := make([]string, 0, len(ports))
+	for _, p := range ports {
+		portAlts = append(portAlts, strconv.Itoa(p))
+		if p == 80 {
+			includes80 = true
+		}
+	}
+	// [^:]+ matches any hostname (hostnames contain no colons; IPv6 bracket
+	// addresses are outside the supported scope for this proxy backend).
+	portGroup := ":(?:" + strings.Join(portAlts, "|") + ")"
+	if includes80 {
+		return `(?i)[^:]+(` + portGroup + `)?`
+	}
+	return `(?i)[^:]+` + portGroup
 }
 
 // hostMatchRegex builds an anchored, case-insensitive RE2 pattern that matches

--- a/pkg/container/docker/envoy.go
+++ b/pkg/container/docker/envoy.go
@@ -664,8 +664,11 @@ func buildEgressCluster() envoyCluster {
 // localhost-only restriction; the container-side address must be 0.0.0.0 or
 // Docker's bridge forwarding cannot deliver traffic to the listener.
 //
-// When spec.Permissions.Inbound.AllowHost is set the virtual host domain list
-// is restricted to those entries; otherwise a wildcard domain ("*") is used.
+// The virtual host domain is always "*". Inbound host filtering is enforced
+// by the egress RBAC `:authority` matcher (hostMatchRegex), not the ingress
+// virtual host list — the transparent proxy sends "127.0.0.1:<port>" as the
+// Host header (port included), which would not match bare hostnames in a
+// domain list.
 func buildIngressListener(spec proxySpec, hostPort int) envoyListener {
 	domains := ingressDomains(spec)
 

--- a/pkg/container/docker/envoy.go
+++ b/pkg/container/docker/envoy.go
@@ -509,8 +509,16 @@ func buildAllowlistRBAC(spec proxySpec) *envoyHTTPRBAC {
 //   - spec.Permissions.Outbound is nil
 //
 // InsecureAllowAll produces a single wildcard policy. Each AllowHost entry
-// becomes a policy matching the :authority header via hostMatchRegex, which
-// mirrors Squid's dstdomain semantics (see hostMatchRegex for the syntax).
+// becomes a policy matching the :authority header via hostMatchRegex (Squid
+// dstdomain semantics). When AllowPort is also set, each host policy AND-s a
+// port-suffix permission so that host AND port must both match — mirroring
+// Squid's "allowed_ports AND allowed_dsts" combination.
+//
+// Known divergence from Squid: plain-HTTP requests omit the port from
+// :authority (e.g. "example.com" not "example.com:80"). A port-suffix matcher
+// for ":80" will not match the portless authority, so AllowPort:[80] with plain
+// HTTP is more restrictive than Squid's allowed_ports ACL. This is fail-closed
+// (over-blocks) rather than a bypass.
 //
 // When spec.AllowDockerGateway is set, an explicit ALLOW policy for the gateway
 // is added: omitting the deny filter alone is not enough, because the allowlist
@@ -834,6 +842,9 @@ func (*envoyProxy) SetupEgress(_ context.Context, spec proxySpec) (egressResult,
 // STRICT_DNS upstream cluster resolves the MCP hostname on the first probe,
 // avoiding the Linux Docker Engine readiness failure described in #5922.
 func (e *envoyProxy) SetupIngress(ctx context.Context, spec proxySpec, _ egressResult) (int, error) {
+	// The container is named <name>-egress (not <name>-proxy or similar) to
+	// preserve parity with the Squid backend: addEgressEnvVars and the suffix-
+	// based cleanup loop both key off this name.
 	egressContainerName := fmt.Sprintf("%s-egress", spec.WorkloadName)
 
 	bootstrap := envoyBootstrap{

--- a/pkg/container/docker/envoy.go
+++ b/pkg/container/docker/envoy.go
@@ -589,6 +589,42 @@ func buildAllowlistPolicies(spec proxySpec) map[string]envoyRBACPolicy {
 	return policies
 }
 
+// portGroupRegex builds the ":(?:port1|port2|…)" alternation for a list of
+// allowed ports. Returns (group, includes80) where includes80 indicates whether
+// port 80 is present (caller uses this to decide whether the port suffix is
+// optional). Shared by hostPortMatchRegex and anyHostPortRegex.
+func portGroupRegex(ports []int) (group string, includes80 bool) {
+	alts := make([]string, 0, len(ports))
+	for _, p := range ports {
+		alts = append(alts, strconv.Itoa(p))
+		if p == 80 {
+			includes80 = true
+		}
+	}
+	return ":(?:" + strings.Join(alts, "|") + ")", includes80
+}
+
+// hostBasePattern returns the escaped, case-insensitive host portion of an
+// :authority regex — without any trailing port group. It mirrors hostMatchRegex
+// semantics: leading dot / *. = subdomain wildcard, optional trailing dot.
+// Shared by hostPortMatchRegex and hostMatchRegex.
+func hostBasePattern(host string) string {
+	subdomains := false
+	switch {
+	case strings.HasPrefix(host, "*."):
+		host = host[2:]
+		subdomains = true
+	case strings.HasPrefix(host, "."):
+		host = host[1:]
+		subdomains = true
+	}
+	p := regexp.QuoteMeta(host)
+	if subdomains {
+		p = `(.*\.)?` + p
+	}
+	return p
+}
+
 // hostPortMatchRegex builds a single anchored RE2 pattern that encodes both a
 // host allowlist entry and a port allowlist, so that AllowHost+AllowPort can be
 // expressed as one safe_regex permission rather than AND-ing two separate matchers.
@@ -600,33 +636,8 @@ func buildAllowlistPolicies(spec proxySpec) map[string]envoyRBACPolicy {
 // The host portion mirrors hostMatchRegex semantics (leading dot / *. = subdomain
 // wildcard, case-insensitive, optional trailing dot, no port in the base pattern).
 func hostPortMatchRegex(host string, ports []int) string {
-	// Build the host portion (same logic as hostMatchRegex but without the
-	// trailing optional-port group — we handle ports explicitly below).
-	subdomains := false
-	switch {
-	case strings.HasPrefix(host, "*."):
-		host = host[2:]
-		subdomains = true
-	case strings.HasPrefix(host, "."):
-		host = host[1:]
-		subdomains = true
-	}
-	hostPattern := regexp.QuoteMeta(host)
-	if subdomains {
-		hostPattern = `(.*\.)?` + hostPattern
-	}
-
-	// Build the port alternatives.
-	includes80 := false
-	portAlts := make([]string, 0, len(ports))
-	for _, p := range ports {
-		portAlts = append(portAlts, strconv.Itoa(p))
-		if p == 80 {
-			includes80 = true
-		}
-	}
-	portGroup := ":(?:" + strings.Join(portAlts, "|") + ")"
-
+	portGroup, includes80 := portGroupRegex(ports)
+	hostPattern := hostBasePattern(host)
 	if includes80 {
 		// Port is optional: bare "example.com" counts as port 80.
 		return `(?i)` + hostPattern + `\.?(` + portGroup + `)?`
@@ -638,18 +649,11 @@ func hostPortMatchRegex(host string, ports []int) string {
 // anyHostPortRegex builds a regex matching any hostname on the given ports.
 // When port 80 is in the list the port suffix is optional (bare hostname implies
 // port 80 for plain HTTP). For other ports the port suffix is required.
+//
+// [^:]+ matches any hostname without an explicit port; IPv6 bracket addresses
+// (which contain colons) are outside the supported scope for this proxy backend.
 func anyHostPortRegex(ports []int) string {
-	includes80 := false
-	portAlts := make([]string, 0, len(ports))
-	for _, p := range ports {
-		portAlts = append(portAlts, strconv.Itoa(p))
-		if p == 80 {
-			includes80 = true
-		}
-	}
-	// [^:]+ matches any hostname (hostnames contain no colons; IPv6 bracket
-	// addresses are outside the supported scope for this proxy backend).
-	portGroup := ":(?:" + strings.Join(portAlts, "|") + ")"
+	portGroup, includes80 := portGroupRegex(ports)
 	if includes80 {
 		return `(?i)[^:]+(` + portGroup + `)?`
 	}
@@ -668,20 +672,7 @@ func anyHostPortRegex(ports []int) string {
 // The domain is regex-escaped so dots are literal, and the pattern is anchored
 // by Envoy so it cannot match "example.com.attacker.com".
 func hostMatchRegex(host string) string {
-	subdomains := false
-	switch {
-	case strings.HasPrefix(host, "*."):
-		host = host[2:]
-		subdomains = true
-	case strings.HasPrefix(host, "."):
-		host = host[1:]
-		subdomains = true
-	}
-	pattern := regexp.QuoteMeta(host)
-	if subdomains {
-		// Optional "sub." prefix at any depth, plus the apex itself.
-		pattern = `(.*\.)?` + pattern
-	}
+	pattern := hostBasePattern(host)
 	// (?i) case-insensitive (hostnames are); \.? tolerates a trailing-dot FQDN
 	// ("host.docker.internal." resolves identically and would otherwise bypass a
 	// deny); (:[0-9]+)? optional port.

--- a/pkg/container/docker/envoy_test.go
+++ b/pkg/container/docker/envoy_test.go
@@ -894,10 +894,11 @@ func TestListenerTimeoutsDisabledForStreaming(t *testing.T) {
 }
 
 // TestBuildAllowlistPolicies_AllowPort verifies that AllowPort entries are
-// translated into port-suffix matchers on the :authority header, matching
-// Squid's allowed_ports ACL behaviour. Tests cover:
-//   - AllowPort alone (any host on listed ports)
-//   - AllowHost + AllowPort (both must match — parity with Squid's AND logic)
+// translated into combined host+port regex matchers, matching Squid's
+// allowed_ports ACL behaviour including plain-HTTP bare-hostname support.
+// Tests cover:
+//   - AllowPort alone (any host on listed ports, bare hostname allowed when port 80 in list)
+//   - AllowHost + AllowPort (both must match; bare hostname allowed when port 80 in list)
 //   - AllowHost without AllowPort (any port, original behaviour)
 //   - InsecureAllowAll ignores port constraints
 func TestBuildAllowlistPolicies_AllowPort(t *testing.T) {
@@ -911,9 +912,10 @@ func TestBuildAllowlistPolicies_AllowPort(t *testing.T) {
 		denied  []string
 	}{
 		{
-			name:    "AllowPort only — any host allowed on listed ports",
-			out:     &permissions.OutboundNetworkPermissions{AllowPort: []int{80, 443}},
-			allowed: []string{"example.com:80", "anything.io:443"},
+			name: "AllowPort only — any host on listed ports; bare hostname allowed when port 80 listed",
+			out:  &permissions.OutboundNetworkPermissions{AllowPort: []int{80, 443}},
+			// Bare "example.com" = plain HTTP = port 80 → allowed
+			allowed: []string{"example.com:80", "anything.io:443", "example.com"},
 			denied:  []string{"example.com:8080", "example.com:22"},
 		},
 		{
@@ -998,8 +1000,8 @@ func permMatchesAuthority(perm envoyPermission, authority string) bool {
 
 // TestBuildAllowlistPolicies_AllowPort_Structure guards against a wrong
 // permMatchesAuthority re-implementation masking a config regression: it checks
-// the actual RBAC policy shape (SafeRegex host + Suffix port) rather than just
-// whether the helper says the authority is allowed or denied (F6).
+// the actual RBAC policy shape (single SafeRegex combining host + port) rather
+// than just whether the helper says the authority is allowed or denied (F6).
 func TestBuildAllowlistPolicies_AllowPort_Structure(t *testing.T) {
 	t.Parallel()
 	spec := proxySpec{
@@ -1017,18 +1019,18 @@ func TestBuildAllowlistPolicies_AllowPort_Structure(t *testing.T) {
 	require.NotNil(t, rbac)
 	policy, ok := rbac.Rules.Policies["example.com"]
 	require.True(t, ok, "expected policy keyed 'example.com'")
-	// Must have exactly 2 permissions: host regex AND port OR-rules.
-	require.Len(t, policy.Permissions, 2,
-		"AllowHost+AllowPort policy must have exactly 2 permissions (host AND port)")
-	hostPerm := policy.Permissions[0]
-	require.NotNil(t, hostPerm.Header, "first permission must be a header matcher")
-	require.NotNil(t, hostPerm.Header.StringMatch.SafeRegex, "host must use safe_regex")
-	portPerm := policy.Permissions[1]
-	require.NotNil(t, portPerm.OrRules, "second permission must be or_rules for port alternatives")
-	for _, r := range portPerm.OrRules.Rules {
-		require.NotNil(t, r.Header, "each port rule must be a header matcher")
-		require.NotEmpty(t, r.Header.StringMatch.Suffix, "port rule must use suffix match")
-	}
+	// Must have exactly 1 permission: a single SafeRegex encoding both host and port.
+	require.Len(t, policy.Permissions, 1,
+		"AllowHost+AllowPort policy must have exactly 1 combined safe_regex permission")
+	perm := policy.Permissions[0]
+	require.NotNil(t, perm.Header, "permission must be a header matcher")
+	require.NotNil(t, perm.Header.StringMatch, "permission must have a string match")
+	require.NotNil(t, perm.Header.StringMatch.SafeRegex, "permission must use safe_regex")
+	// The regex must encode port alternatives and allow bare hostname when port 80 is listed.
+	re := perm.Header.StringMatch.SafeRegex.Regex
+	assert.Contains(t, re, "80", "regex must reference port 80")
+	assert.Contains(t, re, "443", "regex must reference port 443")
+	assert.Contains(t, re, "?", "regex must make port optional when port 80 is listed (bare HTTP)")
 }
 
 // TestBuildAllowlistPolicies_AdditionalCases covers edge cases not in the main
@@ -1057,9 +1059,11 @@ func TestBuildAllowlistPolicies_AdditionalCases(t *testing.T) {
 		assert.False(t, listenerAllowsAuthority(l, "other.com:443"), "wrong host must be denied")
 	})
 
-	// F7b: Port-less authority (plain HTTP default port) — documents the known
-	// divergence from Squid where "example.com" (no port) does not match ":80".
-	t.Run("port-less authority is denied when AllowPort is set (known Squid divergence)", func(t *testing.T) {
+	// F7b: Port-less authority (plain HTTP default port) — Squid parity.
+	// Plain HTTP omits the port from :authority ("example.com" not "example.com:80").
+	// When port 80 is in AllowPort the port suffix is made optional so both the
+	// bare form and the explicit ":80" form are accepted, matching Squid behaviour.
+	t.Run("port-less authority is allowed when port 80 is in AllowPort (Squid parity)", func(t *testing.T) {
 		t.Parallel()
 		spec := proxySpec{
 			WorkloadName: "app",
@@ -1072,13 +1076,29 @@ func TestBuildAllowlistPolicies_AdditionalCases(t *testing.T) {
 			},
 		}
 		l := buildEgressListener(spec)
-		// Plain HTTP omits the port from :authority — "example.com" without ":80"
-		// does not satisfy the port suffix matcher. This is fail-closed (over-blocks)
-		// rather than a bypass; Squid allows this via the URL's implicit port.
-		assert.False(t, listenerAllowsAuthority(l, "example.com"),
-			"port-less authority must be denied when AllowPort is set (see F1 divergence note)")
+		// Bare hostname (plain HTTP) must be allowed when port 80 is listed.
+		assert.True(t, listenerAllowsAuthority(l, "example.com"),
+			"port-less authority must be allowed when port 80 is in AllowPort (plain HTTP parity with Squid)")
 		assert.True(t, listenerAllowsAuthority(l, "example.com:80"),
 			"explicit port 80 must be allowed")
+		assert.False(t, listenerAllowsAuthority(l, "example.com:443"),
+			"port 443 must not be allowed when only port 80 is listed")
+		// Bare hostname must be denied when port 80 is NOT in the list.
+		spec443 := proxySpec{
+			WorkloadName: "app",
+			GatewayIP:    dockerDefaultBridgeGatewayIP,
+			Permissions: &permissions.NetworkPermissions{
+				Outbound: &permissions.OutboundNetworkPermissions{
+					AllowHost: []string{"example.com"},
+					AllowPort: []int{443},
+				},
+			},
+		}
+		l443 := buildEgressListener(spec443)
+		assert.False(t, listenerAllowsAuthority(l443, "example.com"),
+			"port-less authority must be denied when port 80 is NOT in AllowPort")
+		assert.True(t, listenerAllowsAuthority(l443, "example.com:443"),
+			"explicit port 443 must be allowed")
 	})
 
 	// F8: Gateway-deny DENY filter is evaluated before the ALLOW filter even

--- a/pkg/container/docker/envoy_test.go
+++ b/pkg/container/docker/envoy_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -863,4 +864,132 @@ func TestListenerTimeoutsDisabledForStreaming(t *testing.T) {
 		}
 	}
 	assert.True(t, sawPlainHTTP, "egress must have a plain-HTTP route")
+}
+
+// TestBuildAllowlistPolicies_AllowPort verifies that AllowPort entries are
+// translated into port-suffix matchers on the :authority header, matching
+// Squid's allowed_ports ACL behaviour. Tests cover:
+//   - AllowPort alone (any host on listed ports)
+//   - AllowHost + AllowPort (both must match — parity with Squid's AND logic)
+//   - AllowHost without AllowPort (any port, original behaviour)
+//   - InsecureAllowAll ignores port constraints
+func TestBuildAllowlistPolicies_AllowPort(t *testing.T) {
+	t.Parallel()
+
+	// authorityAllowed checks whether the ALLOW RBAC filter in l permits the
+	// given :authority value by walking all policies and testing each permission
+	// against the authority string (replicating Envoy's full-string anchoring).
+	authorityAllowed := func(t *testing.T, l envoyListener, authority string) bool {
+		t.Helper()
+		rbac := findRBACFilter(l)
+		if rbac == nil {
+			return false
+		}
+		// A request is allowed when at least one policy's permissions all match.
+		for _, policy := range rbac.Rules.Policies {
+			allMatch := true
+			for _, perm := range policy.Permissions {
+				if !permMatchesAuthority(perm, authority) {
+					allMatch = false
+					break
+				}
+			}
+			if allMatch {
+				return true
+			}
+		}
+		return false
+	}
+
+	tests := []struct {
+		name string
+		out  *permissions.OutboundNetworkPermissions
+		// authority strings that must be allowed / denied
+		allowed []string
+		denied  []string
+	}{
+		{
+			name:    "AllowPort only — any host allowed on listed ports",
+			out:     &permissions.OutboundNetworkPermissions{AllowPort: []int{80, 443}},
+			allowed: []string{"example.com:80", "anything.io:443"},
+			denied:  []string{"example.com:8080", "example.com:22"},
+		},
+		{
+			name: "AllowHost + AllowPort — host AND port must match",
+			out: &permissions.OutboundNetworkPermissions{
+				AllowHost: []string{"example.com"},
+				AllowPort: []int{443},
+			},
+			allowed: []string{"example.com:443"},
+			denied: []string{
+				"example.com:80", // right host, wrong port
+				"other.com:443",  // right port, wrong host
+				"other.com:80",   // neither
+			},
+		},
+		{
+			name: "AllowHost without AllowPort — any port allowed",
+			out: &permissions.OutboundNetworkPermissions{
+				AllowHost: []string{"example.com"},
+			},
+			allowed: []string{"example.com:443", "example.com:8080", "example.com:22"},
+			denied:  []string{"other.com:443"},
+		},
+		{
+			name:    "InsecureAllowAll ignores AllowPort",
+			out:     &permissions.OutboundNetworkPermissions{InsecureAllowAll: true, AllowPort: []int{443}},
+			allowed: []string{"example.com:80", "anything.io:9999"},
+			denied:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			spec := proxySpec{
+				WorkloadName: "app",
+				GatewayIP:    dockerDefaultBridgeGatewayIP,
+				Permissions:  &permissions.NetworkPermissions{Outbound: tt.out},
+			}
+			listener := buildEgressListener(spec)
+			for _, a := range tt.allowed {
+				assert.True(t, authorityAllowed(t, listener, a),
+					"authority %q should be allowed", a)
+			}
+			for _, a := range tt.denied {
+				assert.False(t, authorityAllowed(t, listener, a),
+					"authority %q should be denied", a)
+			}
+		})
+	}
+}
+
+// permMatchesAuthority tests a single envoyPermission against an authority
+// string, replicating Envoy's full-string anchoring for safe_regex and
+// exact/suffix/prefix string matches.
+func permMatchesAuthority(perm envoyPermission, authority string) bool {
+	if perm.Any != nil && *perm.Any {
+		return true
+	}
+	if perm.Header != nil && perm.Header.Name == ":authority" && perm.Header.StringMatch != nil {
+		sm := perm.Header.StringMatch
+		switch {
+		case sm.SafeRegex != nil:
+			return regexp.MustCompile("^(?:" + sm.SafeRegex.Regex + ")$").MatchString(authority)
+		case sm.Exact != "":
+			return authority == sm.Exact
+		case sm.Suffix != "":
+			return strings.HasSuffix(authority, sm.Suffix)
+		case sm.Prefix != "":
+			return strings.HasPrefix(authority, sm.Prefix)
+		}
+	}
+	if perm.OrRules != nil {
+		for _, r := range perm.OrRules.Rules {
+			if permMatchesAuthority(r, authority) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/container/docker/envoy_test.go
+++ b/pkg/container/docker/envoy_test.go
@@ -490,6 +490,10 @@ func TestBuildIngressCluster_UpstreamAddress(t *testing.T) {
 
 	assert.Equal(t, ingressClusterName, cluster.Name)
 	assert.Equal(t, "STRICT_DNS", cluster.Type)
+	// V4_ONLY prevents slow AAAA lookup timeouts when IPv6 is unavailable.
+	// A regression dropping this would fail silently (extra latency only).
+	assert.Equal(t, "V4_ONLY", cluster.DnsLookupFamily,
+		"ingress STRICT_DNS cluster must use V4_ONLY to avoid IPv6 lookup timeouts")
 	require.NotNil(t, cluster.LoadAssignment)
 	require.NotEmpty(t, cluster.LoadAssignment.Endpoints)
 	require.NotEmpty(t, cluster.LoadAssignment.Endpoints[0].LBEndpoints)
@@ -748,9 +752,10 @@ func TestEnvoyBootstrap_ValidatesAgainstRealEnvoy(t *testing.T) {
 }
 
 // TestEnvoyProxy_SetupOrchestration covers the container-orchestration branch
-// logic of SetupEgress/SetupIngress without a live daemon: the egress container
-// is always created (named <name>-egress), a non-stdio workload reserves an
-// ingress port that SetupIngress returns, and a stdio workload reserves none.
+// logic of SetupEgress/SetupIngress without a live daemon. SetupEgress must NOT
+// create any container — it only returns env vars. SetupIngress creates the
+// Envoy container (named <name>-egress) and returns the ingress port (0 for
+// stdio).
 func TestEnvoyProxy_SetupOrchestration(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/container/docker/envoy_test.go
+++ b/pkg/container/docker/envoy_test.go
@@ -83,6 +83,28 @@ func authorityMatched(patterns []string, authority string) bool {
 	return false
 }
 
+// listenerAllowsAuthority returns true when the ALLOW RBAC filter in the given
+// listener would permit a request with the given :authority value.
+func listenerAllowsAuthority(listener envoyListener, authority string) bool {
+	rbac := findRBACFilter(listener)
+	if rbac == nil {
+		return false
+	}
+	for _, policy := range rbac.Rules.Policies {
+		allMatch := true
+		for _, perm := range policy.Permissions {
+			if !permMatchesAuthority(perm, authority) {
+				allMatch = false
+				break
+			}
+		}
+		if allMatch {
+			return true
+		}
+	}
+	return false
+}
+
 // findDenyRBACFilter returns the first RBAC filter with action == "DENY" from
 // the HCM inside the listener's first filter chain.
 func findDenyRBACFilter(listener envoyListener) *envoyHTTPRBAC {
@@ -881,31 +903,6 @@ func TestListenerTimeoutsDisabledForStreaming(t *testing.T) {
 func TestBuildAllowlistPolicies_AllowPort(t *testing.T) {
 	t.Parallel()
 
-	// authorityAllowed checks whether the ALLOW RBAC filter in l permits the
-	// given :authority value by walking all policies and testing each permission
-	// against the authority string (replicating Envoy's full-string anchoring).
-	authorityAllowed := func(t *testing.T, l envoyListener, authority string) bool {
-		t.Helper()
-		rbac := findRBACFilter(l)
-		if rbac == nil {
-			return false
-		}
-		// A request is allowed when at least one policy's permissions all match.
-		for _, policy := range rbac.Rules.Policies {
-			allMatch := true
-			for _, perm := range policy.Permissions {
-				if !permMatchesAuthority(perm, authority) {
-					allMatch = false
-					break
-				}
-			}
-			if allMatch {
-				return true
-			}
-		}
-		return false
-	}
-
 	tests := []struct {
 		name string
 		out  *permissions.OutboundNetworkPermissions
@@ -958,11 +955,11 @@ func TestBuildAllowlistPolicies_AllowPort(t *testing.T) {
 			}
 			listener := buildEgressListener(spec)
 			for _, a := range tt.allowed {
-				assert.True(t, authorityAllowed(t, listener, a),
+				assert.True(t, listenerAllowsAuthority(listener, a),
 					"authority %q should be allowed", a)
 			}
 			for _, a := range tt.denied {
-				assert.False(t, authorityAllowed(t, listener, a),
+				assert.False(t, listenerAllowsAuthority(listener, a),
 					"authority %q should be denied", a)
 			}
 		})
@@ -997,4 +994,125 @@ func permMatchesAuthority(perm envoyPermission, authority string) bool {
 		}
 	}
 	return false
+}
+
+// TestBuildAllowlistPolicies_AllowPort_Structure guards against a wrong
+// permMatchesAuthority re-implementation masking a config regression: it checks
+// the actual RBAC policy shape (SafeRegex host + Suffix port) rather than just
+// whether the helper says the authority is allowed or denied (F6).
+func TestBuildAllowlistPolicies_AllowPort_Structure(t *testing.T) {
+	t.Parallel()
+	spec := proxySpec{
+		WorkloadName: "app",
+		GatewayIP:    dockerDefaultBridgeGatewayIP,
+		Permissions: &permissions.NetworkPermissions{
+			Outbound: &permissions.OutboundNetworkPermissions{
+				AllowHost: []string{"example.com"},
+				AllowPort: []int{80, 443},
+			},
+		},
+	}
+	listener := buildEgressListener(spec)
+	rbac := findRBACFilter(listener)
+	require.NotNil(t, rbac)
+	policy, ok := rbac.Rules.Policies["example.com"]
+	require.True(t, ok, "expected policy keyed 'example.com'")
+	// Must have exactly 2 permissions: host regex AND port OR-rules.
+	require.Len(t, policy.Permissions, 2,
+		"AllowHost+AllowPort policy must have exactly 2 permissions (host AND port)")
+	hostPerm := policy.Permissions[0]
+	require.NotNil(t, hostPerm.Header, "first permission must be a header matcher")
+	require.NotNil(t, hostPerm.Header.StringMatch.SafeRegex, "host must use safe_regex")
+	portPerm := policy.Permissions[1]
+	require.NotNil(t, portPerm.OrRules, "second permission must be or_rules for port alternatives")
+	for _, r := range portPerm.OrRules.Rules {
+		require.NotNil(t, r.Header, "each port rule must be a header matcher")
+		require.NotEmpty(t, r.Header.StringMatch.Suffix, "port rule must use suffix match")
+	}
+}
+
+// TestBuildAllowlistPolicies_AdditionalCases covers edge cases not in the main
+// AllowPort table (F7): multi-port OR shape, port-less authority divergence from
+// Squid, and gateway-deny ordering under AllowPort-only (F8).
+func TestBuildAllowlistPolicies_AdditionalCases(t *testing.T) {
+	t.Parallel()
+
+	// F7a: AllowHost + multi-port — authority with a non-listed port is denied.
+	t.Run("AllowHost+multi-port denies non-listed port", func(t *testing.T) {
+		t.Parallel()
+		spec := proxySpec{
+			WorkloadName: "app",
+			GatewayIP:    dockerDefaultBridgeGatewayIP,
+			Permissions: &permissions.NetworkPermissions{
+				Outbound: &permissions.OutboundNetworkPermissions{
+					AllowHost: []string{"example.com"},
+					AllowPort: []int{80, 443},
+				},
+			},
+		}
+		l := buildEgressListener(spec)
+		assert.True(t, listenerAllowsAuthority(l, "example.com:443"), "port 443 must be allowed")
+		assert.True(t, listenerAllowsAuthority(l, "example.com:80"), "port 80 must be allowed")
+		assert.False(t, listenerAllowsAuthority(l, "example.com:8080"), "port 8080 must be denied")
+		assert.False(t, listenerAllowsAuthority(l, "other.com:443"), "wrong host must be denied")
+	})
+
+	// F7b: Port-less authority (plain HTTP default port) — documents the known
+	// divergence from Squid where "example.com" (no port) does not match ":80".
+	t.Run("port-less authority is denied when AllowPort is set (known Squid divergence)", func(t *testing.T) {
+		t.Parallel()
+		spec := proxySpec{
+			WorkloadName: "app",
+			GatewayIP:    dockerDefaultBridgeGatewayIP,
+			Permissions: &permissions.NetworkPermissions{
+				Outbound: &permissions.OutboundNetworkPermissions{
+					AllowHost: []string{"example.com"},
+					AllowPort: []int{80},
+				},
+			},
+		}
+		l := buildEgressListener(spec)
+		// Plain HTTP omits the port from :authority — "example.com" without ":80"
+		// does not satisfy the port suffix matcher. This is fail-closed (over-blocks)
+		// rather than a bypass; Squid allows this via the URL's implicit port.
+		assert.False(t, listenerAllowsAuthority(l, "example.com"),
+			"port-less authority must be denied when AllowPort is set (see F1 divergence note)")
+		assert.True(t, listenerAllowsAuthority(l, "example.com:80"),
+			"explicit port 80 must be allowed")
+	})
+
+	// F8: Gateway-deny DENY filter is evaluated before the ALLOW filter even
+	// when AllowPort-only is configured (deny-before-allow ordering).
+	t.Run("gateway-deny precedes AllowPort-only allow", func(t *testing.T) {
+		t.Parallel()
+		spec := proxySpec{
+			WorkloadName: "app",
+			GatewayIP:    dockerDefaultBridgeGatewayIP,
+			Permissions: &permissions.NetworkPermissions{
+				Outbound: &permissions.OutboundNetworkPermissions{
+					AllowPort: []int{443},
+				},
+			},
+		}
+		l := buildEgressListener(spec)
+		// The gateway deny filter must precede the allow filter.
+		deny := findDenyRBACFilter(l)
+		require.NotNil(t, deny, "DENY filter must be present")
+		hcm := l.FilterChains[0].Filters[0].TypedConfig.(*envoyHCM)
+		var denyIdx, allowIdx int
+		for i, f := range hcm.HTTPFilters {
+			if rbac, ok := f.TypedConfig.(*envoyHTTPRBAC); ok {
+				if rbac.Rules.Action == "DENY" {
+					denyIdx = i
+				} else {
+					allowIdx = i
+				}
+			}
+		}
+		assert.Less(t, denyIdx, allowIdx, "DENY filter must appear before ALLOW filter")
+		// Gateway IP must be denied even though port 443 is in AllowPort.
+		gatewayPats := collectAuthorityRegexes(deny)
+		assert.True(t, authorityMatched(gatewayPats, dockerDefaultBridgeGatewayIP+":443"),
+			"gateway IP on port 443 must be caught by the DENY filter")
+	})
 }

--- a/pkg/container/docker/envoy_test.go
+++ b/pkg/container/docker/envoy_test.go
@@ -1026,11 +1026,18 @@ func TestBuildAllowlistPolicies_AllowPort_Structure(t *testing.T) {
 	require.NotNil(t, perm.Header, "permission must be a header matcher")
 	require.NotNil(t, perm.Header.StringMatch, "permission must have a string match")
 	require.NotNil(t, perm.Header.StringMatch.SafeRegex, "permission must use safe_regex")
-	// The regex must encode port alternatives and allow bare hostname when port 80 is listed.
+	// The regex must actually match the expected authorities — including bare
+	// hostname (plain HTTP) because port 80 is listed. Evaluating the full regex
+	// here rather than inspecting its text guards against a reimplementation that
+	// produces a different but equivalent string (N2: the previous assertion of
+	// assert.Contains(re,"?") was vacuous because "?" appears in non-capturing groups).
 	re := perm.Header.StringMatch.SafeRegex.Regex
-	assert.Contains(t, re, "80", "regex must reference port 80")
-	assert.Contains(t, re, "443", "regex must reference port 443")
-	assert.Contains(t, re, "?", "regex must make port optional when port 80 is listed (bare HTTP)")
+	compile := func(r string) *regexp.Regexp { return regexp.MustCompile("^(?:" + r + ")$") }
+	assert.True(t, compile(re).MatchString("example.com"), "bare hostname must match (plain HTTP, port 80 implied)")
+	assert.True(t, compile(re).MatchString("example.com:80"), "explicit port 80 must match")
+	assert.True(t, compile(re).MatchString("example.com:443"), "explicit port 443 must match")
+	assert.False(t, compile(re).MatchString("example.com:8080"), "non-listed port must not match")
+	assert.False(t, compile(re).MatchString("other.com:443"), "wrong host must not match")
 }
 
 // TestBuildAllowlistPolicies_AdditionalCases covers edge cases not in the main
@@ -1134,5 +1141,45 @@ func TestBuildAllowlistPolicies_AdditionalCases(t *testing.T) {
 		gatewayPats := collectAuthorityRegexes(deny)
 		assert.True(t, authorityMatched(gatewayPats, dockerDefaultBridgeGatewayIP+":443"),
 			"gateway IP on port 443 must be caught by the DENY filter")
+	})
+
+	// N3: AllowPort-only with port 443 (no port 80) — bare hostname denied,
+	// explicit :443 allowed. Exercises the includes80=false branch of anyHostPortRegex.
+	t.Run("AllowPort-only port-443 — bare hostname denied, explicit port allowed", func(t *testing.T) {
+		t.Parallel()
+		spec := proxySpec{
+			WorkloadName: "app",
+			GatewayIP:    dockerDefaultBridgeGatewayIP,
+			Permissions: &permissions.NetworkPermissions{
+				Outbound: &permissions.OutboundNetworkPermissions{
+					AllowPort: []int{443},
+				},
+			},
+		}
+		l := buildEgressListener(spec)
+		assert.True(t, listenerAllowsAuthority(l, "anything.io:443"), "port 443 must be allowed")
+		assert.False(t, listenerAllowsAuthority(l, "anything.io"), "bare hostname must be denied (port 80 not listed)")
+		assert.False(t, listenerAllowsAuthority(l, "anything.io:80"), "port 80 must be denied")
+	})
+
+	// N4: Wildcard host + AllowPort — the subdomain (.*\.)? path in hostPortMatchRegex.
+	t.Run("wildcard AllowHost + AllowPort matches subdomains on listed ports only", func(t *testing.T) {
+		t.Parallel()
+		spec := proxySpec{
+			WorkloadName: "app",
+			GatewayIP:    dockerDefaultBridgeGatewayIP,
+			Permissions: &permissions.NetworkPermissions{
+				Outbound: &permissions.OutboundNetworkPermissions{
+					AllowHost: []string{"*.example.com"},
+					AllowPort: []int{443},
+				},
+			},
+		}
+		l := buildEgressListener(spec)
+		assert.True(t, listenerAllowsAuthority(l, "api.example.com:443"), "subdomain on allowed port must match")
+		assert.True(t, listenerAllowsAuthority(l, "example.com:443"), "apex on allowed port must match")
+		assert.False(t, listenerAllowsAuthority(l, "api.example.com:80"), "subdomain on disallowed port must not match")
+		assert.False(t, listenerAllowsAuthority(l, "api.example.com"), "bare subdomain must not match (port 80 not listed)")
+		assert.False(t, listenerAllowsAuthority(l, "other.com:443"), "non-matching host must not match")
 	})
 }

--- a/pkg/container/docker/networkproxy.go
+++ b/pkg/container/docker/networkproxy.go
@@ -27,21 +27,20 @@ import (
 type networkProxy interface {
 	// SetupEgress provisions egress enforcement BEFORE the MCP container is
 	// created and returns the environment variables to inject into the workload
-	// (HTTP_PROXY etc.). A per-container backend (squid) creates its egress
-	// container here; a consolidated backend (envoy) creates its single
-	// dual-listener container here and reserves the ingress port, carried back in
-	// the egressResult for SetupIngress to return.
+	// (HTTP_PROXY etc.). Both per-container (squid) and consolidated (envoy)
+	// backends create only their egress proxy here; ingress creation is always
+	// deferred to SetupIngress so the upstream hostname is resolvable on first
+	// probe.
 	//
 	// It must run before createMcpContainer so the returned env vars land in the
 	// workload's environment and the egress proxy has a head start.
 	SetupEgress(ctx context.Context, spec proxySpec) (egressResult, error)
 
-	// SetupIngress finalizes the ingress proxy AFTER the MCP container exists and
-	// returns the host-side ingress port (0 for stdio / UpstreamPort==0). A
-	// per-container backend (squid) creates its ingress container here — now that
-	// the MCP container's hostname resolves, avoiding a cached negative DNS lookup
+	// SetupIngress creates the ingress proxy AFTER the MCP container exists and
+	// returns the host-side ingress port (0 for stdio / UpstreamPort==0). Both
+	// backends create their ingress container here — once the MCP container exists
+	// its hostname resolves immediately, avoiding a cached negative DNS lookup
 	// that would leave the reverse proxy permanently unable to reach the upstream.
-	// A consolidated backend returns the port it reserved in SetupEgress.
 	//
 	// It must run after createMcpContainer.
 	SetupIngress(ctx context.Context, spec proxySpec, egress egressResult) (int, error)

--- a/pkg/container/docker/networkproxy.go
+++ b/pkg/container/docker/networkproxy.go
@@ -27,20 +27,26 @@ import (
 type networkProxy interface {
 	// SetupEgress provisions egress enforcement BEFORE the MCP container is
 	// created and returns the environment variables to inject into the workload
-	// (HTTP_PROXY etc.). Both per-container (squid) and consolidated (envoy)
-	// backends create only their egress proxy here; ingress creation is always
-	// deferred to SetupIngress so the upstream hostname is resolvable on first
-	// probe.
+	// (HTTP_PROXY etc.).
+	//
+	// Squid creates its egress container here. The Envoy backend creates no
+	// container in SetupEgress — it returns only env vars — and defers all
+	// container creation (both egress and ingress listeners, one container) to
+	// SetupIngress so the STRICT_DNS ingress cluster can resolve the MCP hostname
+	// on its first probe.
 	//
 	// It must run before createMcpContainer so the returned env vars land in the
-	// workload's environment and the egress proxy has a head start.
+	// workload's environment.
 	SetupEgress(ctx context.Context, spec proxySpec) (egressResult, error)
 
 	// SetupIngress creates the ingress proxy AFTER the MCP container exists and
-	// returns the host-side ingress port (0 for stdio / UpstreamPort==0). Both
-	// backends create their ingress container here — once the MCP container exists
-	// its hostname resolves immediately, avoiding a cached negative DNS lookup
-	// that would leave the reverse proxy permanently unable to reach the upstream.
+	// returns the host-side ingress port (0 for stdio / UpstreamPort==0).
+	//
+	// Squid creates its ingress container here. The Envoy backend creates its
+	// single dual-listener container here (both egress forward-proxy and ingress
+	// reverse-proxy listeners). Running after createMcpContainer ensures the MCP
+	// container's hostname resolves on first probe, avoiding a cached negative DNS
+	// lookup that would leave the ingress permanently unable to reach the upstream.
 	//
 	// It must run after createMcpContainer.
 	SetupIngress(ctx context.Context, spec proxySpec, egress egressResult) (int, error)

--- a/test/e2e/network_isolation_envoy_test.go
+++ b/test/e2e/network_isolation_envoy_test.go
@@ -219,6 +219,41 @@ var _ = Describe("NetworkIsolationEnvoy", Label("proxy", "network", "isolation",
 
 	// ── Envoy-specific regression guards ─────────────────────────────────────
 
+	// ── AllowPort enforcement ─────────────────────────────────────────────────
+
+	Describe("AllowPort enforcement", func() {
+		// This test proves that AllowPort is honoured end-to-end through a real
+		// Envoy container, not just in the generated config. It uses a restrictive
+		// profile that allows example.com on port 443 only and asserts:
+		//   - HTTPS (port 443) succeeds
+		//   - HTTP  (port 80)  is blocked
+		// This was a parity gap vs Squid (see #5915): before the fix, Envoy
+		// ignored AllowPort and the HTTP request would have succeeded.
+		It("blocks a request on a non-allowed port while permitting the allowed port", func() {
+			profile := `{
+				"name": "port-test",
+				"network": {
+					"outbound": {
+						"insecure_allow_all": false,
+						"allow_host": ["example.com"],
+						"allow_port": [443]
+					}
+				}
+			}`
+			server := startFetchServer("port", profile)
+
+			By("HTTPS request (port 443) must succeed")
+			httpsResult := fetchThrough(server, "https://example.com", 30*time.Second)
+			Expect(httpsResult.IsError).To(BeFalse(),
+				"https://example.com must be allowed (port 443 is in AllowPort)")
+
+			By("HTTP request (port 80) must be blocked")
+			httpResult := fetchThrough(server, "http://example.com", 30*time.Second)
+			Expect(httpResult.IsError).To(BeTrue(),
+				"http://example.com must be blocked (port 80 is not in AllowPort)")
+		})
+	})
+
 	Describe("Envoy route timeout disabled for long-lived streams", func() {
 		// Guards the timeout:"0s" fix. Envoy's default RouteAction.timeout is 15s;
 		// this test proves it was disabled by having the upstream sleep 16s (past

--- a/test/e2e/network_isolation_envoy_test.go
+++ b/test/e2e/network_isolation_envoy_test.go
@@ -77,7 +77,7 @@ var _ = Describe("NetworkIsolationEnvoy", Label("proxy", "network", "isolation",
 
 		envoyRun(config, runArgs...).ExpectSuccess()
 		Expect(e2e.WaitForMCPServer(config, serverName, 180*time.Second)).
-			To(Succeed(), "Envoy server should be running within 120 seconds")
+			To(Succeed(), "Envoy server should be running within 180 seconds")
 		return serverName
 	}
 


### PR DESCRIPTION
## Summary

Translates `AllowPort` into the Envoy egress RBAC policy, closing the parity gap with Squid's `allowed_ports` ACL. Also addresses all review findings from #5926 and pins the Ginkgo CLI version to eliminate a test environment mismatch.

Closes #5915. Part of #5900.

<details>
<summary><strong>AllowPort enforcement</strong></summary>

`AllowPort` entries are encoded into a single combined host+port safe_regex per policy. The key insight: plain-HTTP requests omit the default port 80 from `:authority` (`example.com`, not `example.com:80`). When port 80 is in `AllowPort` the port suffix is made optional, so bare hostnames (plain HTTP) are permitted alongside explicit `:80` — matching Squid's `allowed_ports` behaviour.

| Profile | Result |
|---------|--------|
| `AllowHost` + `AllowPort:[80,443]` | host AND (port 80 or 443 or bare hostname) |
| `AllowHost` + `AllowPort:[443]` | host AND explicit `:443` only (bare hostname denied) |
| `AllowPort:[80]` only | any host, port 80 or bare hostname |
| `AllowHost` only | any port (unchanged) |
| `InsecureAllowAll` | everything (ignores `AllowPort`) |

</details>

<details>
<summary><strong>Review findings from #5926 addressed</strong></summary>

- **F2** `networkproxy.go` docstrings: correctly describe that Envoy creates no container in `SetupEgress`; both listeners land in one container created in `SetupIngress`.
- **F3/F5** Documentation: `buildAllowlistPolicies` comment and arch doc comparison table updated; plain-HTTP divergence (port 443-only profiles) documented in Known Limitations.
- **F6** `listenerAllowsAuthority` extracted as a package-level helper replacing the ad-hoc closure, making structural test assertions independent of the reimplementation.
- **F7** New table cases: multi-port OR shape, port-less authority (now asserts Squid parity, not divergence), `AllowPort:[443]`-only correctly denies bare hostnames.
- **F8** Test asserting deny-before-allow ordering holds under `AllowPort`-only policy.
- **F9** Comment at container creation explaining why the Envoy container retains the `-egress` suffix.
- **CI** Ginkgo CLI pinned to `v2.28.1` (matching `go.mod`) to eliminate the version mismatch that caused `"flag parsing errors"` and intermittent test-isolation failures.

</details>

## Type of change

- [x] Bug fix / parity fix

## Test plan

- [x] `go build ./pkg/container/docker/...` passes
- [x] `golangci-lint` clean
- [x] `TestBuildAllowlistPolicies_AllowPort` — 4 table cases including bare-hostname parity
- [x] `TestBuildAllowlistPolicies_AllowPort_Structure` — asserts combined regex shape
- [x] `TestBuildAllowlistPolicies_AdditionalCases` — multi-port OR, port-less authority parity, gateway-deny ordering
- [x] `TestBuildIngressCluster_UpstreamAddress` — asserts `V4_ONLY`
- [x] `go test -c ./test/e2e/` compiles
- [x] CI `network-isolation` shard — Envoy e2e tests pass

Generated with [Claude Code](https://claude.com/claude-code)