### PR TITLE
Reject JSON-RPC batches to close authz blind spot

### DIFF
--- a/pkg/mcp/batch.go
+++ b/pkg/mcp/batch.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"bytes"
+	"net/http"
+)
+
+// batchUnsupported is the shared error rendered by both batch-rejection helpers.
+var batchUnsupported = &BatchUnsupportedError{}
+
+// BatchUnsupportedError indicates a client sent a JSON-RPC batch (a top-level
+// JSON array). Batching was removed from MCP in the 2025-06-18 revision, and
+// ToolHive serves only 2025-11-25 and 2026-07-28, so a batch can only originate
+// from an unsupported pre-2025-06-18 client.
+//
+// Batches are rejected outright rather than executed: the parser and the
+// downstream authz, audit, and tool-filter middleware each inspect a single
+// parsed request per call, so a batch that reached the backend would smuggle
+// every nested call past those controls (see #5745).
+type BatchUnsupportedError struct{}
+
+func (*BatchUnsupportedError) Error() string {
+	return "JSON-RPC batch requests are not supported (batching was removed in MCP revision 2025-06-18)"
+}
+
+// Code implements CodedError.
+func (*BatchUnsupportedError) Code() int64 { return CodeInvalidRequest }
+
+// Data implements CodedError.
+func (*BatchUnsupportedError) Data() map[string]any { return nil }
+
+// IsBatchRequest reports whether body is a JSON-RPC batch, i.e. a top-level JSON
+// array. Only the first non-whitespace byte is inspected, so a syntactically
+// malformed array (e.g. "[...") still classifies as a batch and is rejected
+// rather than silently mis-parsed as a single message.
+//
+// It trims the same Unicode whitespace as encoding/json (via bytes.TrimSpace) so
+// callers that gate execution on this function and callers that later
+// json-decode the body agree on what counts as a leading '[' — a narrower trim
+// would let a batch prefixed with, say, a vertical-tab slip past detection yet
+// still decode as an array. Every path that could forward a batch to a backend
+// must gate on this one function so the two never drift (see #5745).
+func IsBatchRequest(body []byte) bool {
+	trimmed := bytes.TrimSpace(body)
+	return len(trimmed) > 0 && trimmed[0] == '['
+}
+
+// WriteBatchUnsupportedError writes an HTTP 400 response carrying a JSON-RPC
+// "Invalid Request" error for a rejected batch. The JSON-RPC id is null: a
+// batch has no single request id to echo. Use this where an http.ResponseWriter
+// is available (the streamable proxy, ParsingMiddleware).
+func WriteBatchUnsupportedError(w http.ResponseWriter) {
+	body := classificationErrorBody(nil, batchUnsupported)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	//nolint:gosec // G104: writing a JSON-RPC error response to an HTTP client
+	_, _ = w.Write(body)
+}
+
+// BatchUnsupportedResponse builds an *http.Response carrying the batch-rejection
+// JSON-RPC error, for proxies that intercept at the RoundTripper layer (the
+// transparent proxy) where no http.ResponseWriter is available. Mirrors
+// ClassificationErrorResponse; the JSON-RPC id is null.
+func BatchUnsupportedResponse(req *http.Request) *http.Response {
+	return jsonRPCErrorResponse(req, nil, batchUnsupported)
+}

--- a/pkg/mcp/batch_test.go
+++ b/pkg/mcp/batch_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsBatchRequest(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "single request object", body: `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, want: false},
+		{name: "batch array", body: `[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`, want: true},
+		{name: "empty array", body: `[]`, want: true},
+		{name: "array with leading whitespace", body: "  \n\t [1]", want: true},
+		// Vertical tab / form feed are Unicode whitespace that json ignores;
+		// bytes.TrimSpace must strip them so detection matches decoding (#5745).
+		{name: "array with leading vertical tab", body: "\v\f[1]", want: true},
+		{name: "object with leading whitespace", body: "  \n\t {}", want: false},
+		{name: "empty body", body: ``, want: false},
+		{name: "whitespace only", body: "   \n\t", want: false},
+		{name: "malformed unterminated array", body: `[{"a":1}`, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsBatchRequest([]byte(tt.body)))
+		})
+	}
+}
+
+func TestBatchUnsupportedError(t *testing.T) {
+	t.Parallel()
+	err := &BatchUnsupportedError{}
+	// Must satisfy CodedError so the shared JSON-RPC error writer picks up its code.
+	var coded CodedError = err
+	assert.Equal(t, CodeInvalidRequest, coded.Code())
+	assert.Nil(t, coded.Data())
+	assert.NotEmpty(t, coded.Error())
+}
+
+func TestWriteBatchUnsupportedError(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+
+	WriteBatchUnsupportedError(w)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var resp struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      any    `json:"id"`
+		Error   struct {
+			Code    int64  `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "2.0", resp.JSONRPC)
+	assert.Nil(t, resp.ID)
+	assert.Equal(t, CodeInvalidRequest, resp.Error.Code)
+	assert.NotEmpty(t, resp.Error.Message)
+}

--- a/pkg/mcp/classification_response.go
+++ b/pkg/mcp/classification_response.go
@@ -32,6 +32,14 @@ func WriteClassificationError(w http.ResponseWriter, requestID any, err error) {
 // RoundTripper-produced *http.Response is generally expected to carry the
 // request it answers, and httputil.ReverseProxy relies on that field.
 func ClassificationErrorResponse(req *http.Request, requestID any, err error) *http.Response {
+	return jsonRPCErrorResponse(req, requestID, err)
+}
+
+// jsonRPCErrorResponse builds an HTTP 400 *http.Response carrying the JSON-RPC
+// error rendered from a CodedError. It backs both ClassificationErrorResponse
+// and BatchUnsupportedResponse so the RoundTripper-layer error shape lives in
+// one place.
+func jsonRPCErrorResponse(req *http.Request, requestID any, err error) *http.Response {
 	body := classificationErrorBody(requestID, err)
 	hdr := make(http.Header)
 	hdr.Set("Content-Type", "application/json")

--- a/pkg/mcp/parser.go
+++ b/pkg/mcp/parser.go
@@ -58,7 +58,10 @@ type ParsedMCPRequest struct {
 	ProtocolVersion string
 	// IsRequest indicates if this is a JSON-RPC request (vs response or notification)
 	IsRequest bool
-	// IsBatch indicates if this is a batch request
+	// IsBatch indicates if this is a batch request. It is always false: JSON-RPC
+	// batches are rejected by ParsingMiddleware before a ParsedMCPRequest is ever
+	// constructed (batching was removed in MCP 2025-06-18; see batch.go). The
+	// field is retained for wire/telemetry compatibility.
 	IsBatch bool
 }
 
@@ -106,6 +109,17 @@ func ParsingMiddleware(next http.Handler) http.Handler {
 
 		// Restore the request body for downstream handlers
 		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+		// Reject JSON-RPC batches before any downstream middleware or the
+		// transport proxy's batch executor can act on them. Batching was
+		// removed in MCP revision 2025-06-18; ToolHive serves only 2025-11-25
+		// and 2026-07-28. Authz, audit, and tool filtering each inspect a
+		// single parsed request per call, so a batch reaching the backend would
+		// smuggle every nested call past those controls (see #5745).
+		if IsBatchRequest(bodyBytes) {
+			WriteBatchUnsupportedError(w)
+			return
+		}
 
 		// Parse the MCP request and store in context
 		parsedRequest := parseMCPRequest(bodyBytes)
@@ -193,7 +207,9 @@ func parseMCPRequest(bodyBytes []byte) *ParsedMCPRequest {
 		ClientInfo:      clientInfo,
 		ProtocolVersion: protocolVersion,
 		IsRequest:       true,
-		IsBatch:         false, // TODO: Add batch request support if needed
+		// Batches are rejected in ParsingMiddleware before reaching here, so a
+		// parsed request is always a single, non-batch message.
+		IsBatch: false,
 	}
 }
 

--- a/pkg/mcp/parser_test.go
+++ b/pkg/mcp/parser_test.go
@@ -235,6 +235,70 @@ func TestParsingMiddleware(t *testing.T) {
 	}
 }
 
+func TestParsingMiddlewareRejectsBatch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "batch of requests",
+			body: `[{"jsonrpc":"2.0","id":1,"method":"tools/list"},` +
+				`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"danger"}}]`,
+		},
+		{
+			name: "batch with leading whitespace",
+			body: "  \n\t[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}]",
+		},
+		{
+			name: "empty batch",
+			body: `[]`,
+		},
+		{
+			name: "malformed batch (unterminated array)",
+			body: `[{"jsonrpc":"2.0","id":1,"method":"tools/call"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// The next handler must never run for a batch: reaching it means the
+			// batch bypassed rejection and would hit the backend uninspected.
+			nextCalled := false
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			middleware := ParsingMiddleware(testHandler)
+
+			req := httptest.NewRequest("POST", "/messages", bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			middleware.ServeHTTP(w, req)
+
+			assert.False(t, nextCalled, "batch must be rejected before the next handler")
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+
+			var resp struct {
+				JSONRPC string `json:"jsonrpc"`
+				ID      any    `json:"id"`
+				Error   struct {
+					Code    int64  `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			assert.Equal(t, "2.0", resp.JSONRPC)
+			assert.Nil(t, resp.ID, "batch rejection carries a null JSON-RPC id")
+			assert.Equal(t, CodeInvalidRequest, resp.Error.Code)
+			assert.NotEmpty(t, resp.Error.Message)
+		})
+	}
+}
+
 func TestParsingMiddlewareModernHeaders(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -1510,14 +1574,9 @@ func TestParsingMiddlewareErrorHandling(t *testing.T) {
 			body:         bytes.NewBufferString(`{"invalid json`),
 			expectParsed: false,
 		},
-		{
-			name:         "JSON array instead of object",
-			method:       "POST",
-			path:         "/messages",
-			contentType:  "application/json",
-			body:         bytes.NewBufferString(`[{"jsonrpc":"2.0"}]`),
-			expectParsed: false,
-		},
+		// A top-level JSON array is a JSON-RPC batch; ParsingMiddleware rejects
+		// it outright (see TestParsingMiddlewareRejectsBatch) rather than passing
+		// it through, so it is deliberately not exercised here.
 	}
 
 	for _, tt := range tests {
@@ -1597,32 +1656,6 @@ func TestExtractResourceAndArgumentsNilParams(t *testing.T) {
 			assert.Nil(t, meta)
 		})
 	}
-}
-
-func TestParsingMiddlewareWithBatchRequests(t *testing.T) {
-	t.Parallel()
-	// Test batch JSON-RPC requests (currently not supported but should not crash)
-	batchBody := `[
-		{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"tool1"}},
-		{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"tool2"}}
-	]`
-
-	var capturedCtx context.Context
-	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedCtx = r.Context()
-		w.WriteHeader(http.StatusOK)
-	})
-
-	middleware := ParsingMiddleware(testHandler)
-	req := httptest.NewRequest("POST", "/messages", bytes.NewBufferString(batchBody))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	middleware.ServeHTTP(w, req)
-
-	// Batch requests should not be parsed (not supported yet)
-	parsed := GetParsedMCPRequest(capturedCtx)
-	assert.Nil(t, parsed)
 }
 
 func TestConvenienceFunctionsWithNilContext(t *testing.T) {

--- a/pkg/mcp/revision.go
+++ b/pkg/mcp/revision.go
@@ -76,6 +76,11 @@ const (
 	// CodeInvalidParams is the standard JSON-RPC Invalid Params code, used
 	// as a fallback when the draft spec defines no dedicated code for the failure.
 	CodeInvalidParams int64 = -32602
+	// CodeInvalidRequest is the standard JSON-RPC Invalid Request code. ToolHive
+	// uses it to reject a message whose shape is not a valid single request for
+	// the negotiated protocol version — currently a JSON-RPC batch, which was
+	// removed from MCP in the 2025-06-18 revision (see batch.go).
+	CodeInvalidRequest int64 = -32600
 )
 
 // HeaderMismatchError indicates the MCP-Protocol-Version HTTP header did not match

--- a/pkg/transport/proxy/streamable/dispatcher.go
+++ b/pkg/transport/proxy/streamable/dispatcher.go
@@ -6,7 +6,6 @@ package streamable
 import (
 	"fmt"
 	"log/slog"
-	"time"
 
 	"golang.org/x/exp/jsonrpc2"
 )
@@ -50,19 +49,5 @@ func (p *HTTPProxy) dispatchResponses() {
 			slog.Warn("non-string response id (expected composite string); dropping",
 				"raw_id", fmt.Sprintf("%v", rawID))
 		}
-	}
-}
-
-// waitForResponse waits for a response on the given channel with timeout.
-func (p *HTTPProxy) waitForResponse(ch <-chan jsonrpc2.Message, timeout time.Duration) jsonrpc2.Message {
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case msg := <-ch:
-		return msg
-	case <-timer.C:
-		return nil
-	case <-p.shutdownCh:
-		return nil
 	}
 }

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -5,7 +5,6 @@
 package streamable
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -378,13 +377,13 @@ func (p *HTTPProxy) handlePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Batch vs single message
-	if isBatch(body) {
-		sessID, err := p.resolveSessionForBatch(w, r)
-		if err != nil {
-			return
-		}
-		p.handleBatchRequest(w, body, sessID)
+	// Reject JSON-RPC batches outright. Batching was removed in MCP revision
+	// 2025-06-18 and ToolHive serves only 2025-11-25 and 2026-07-28. Rejecting
+	// at the executor (not only in ParsingMiddleware) makes this independent of
+	// middleware presence, ordering, and Content-Type, so a batch can never
+	// reach the backend uninspected by authz/audit/tool-filtering (see #5745).
+	if mcp.IsBatchRequest(body) {
+		mcp.WriteBatchUnsupportedError(w)
 		return
 	}
 
@@ -418,42 +417,6 @@ func (p *HTTPProxy) handlePost(w http.ResponseWriter, r *http.Request) {
 
 	// Request/response path with correlation (JSON response)
 	p.handleSingleRequest(ctx, w, sessID, req, setSessionHeader)
-}
-
-// handleBatchRequest processes a batch JSON-RPC request and writes a batch response.
-func (p *HTTPProxy) handleBatchRequest(w http.ResponseWriter, body []byte, sessID string) {
-	rawMessages, ok := decodeBatch(w, body)
-	if !ok {
-		return
-	}
-
-	var responses []json.RawMessage
-	hadRequest := false
-
-	for _, raw := range rawMessages {
-		// Detect if this element is a request with an ID
-		if msg, err := jsonrpc2.DecodeMessage(raw); err == nil {
-			if req, ok := msg.(*jsonrpc2.Request); ok && req.ID.IsValid() {
-				hadRequest = true
-			}
-		}
-		resp := p.processSingleMessage(sessID, raw)
-		if resp != nil {
-			responses = append(responses, resp)
-		}
-	}
-
-	if !hadRequest {
-		// Per spec: batches containing only notifications/responses -> 202 Accepted, no body
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	// It's valid to return an empty array if requests produced no responses
-	if err := json.NewEncoder(w).Encode(responses); err != nil {
-		slog.Error("failed to encode batch response", "error", err)
-	}
 }
 
 // handleSingleRequest handles a single JSON-RPC request message end-to-end.
@@ -554,80 +517,6 @@ func (p *HTTPProxy) handleSingleRequestSSE(
 	flusher.Flush()
 }
 
-// processSingleMessage processes one raw JSON-RPC in a batch and returns encoded response bytes or nil.
-func (p *HTTPProxy) processSingleMessage(sessID string, raw json.RawMessage) json.RawMessage {
-	// Note: batch processing path
-	msg, err := jsonrpc2.DecodeMessage(raw)
-	if err != nil {
-		//nolint:gosec // G706: logging raw JSON-RPC data from HTTP request body
-		slog.Warn("skipping invalid message in batch", "raw", string(raw))
-		return nil
-	}
-
-	// Notifications: just forward and continue
-	if isNotification(msg) {
-		if err := p.SendMessageToDestination(msg); err != nil {
-			slog.Error("failed to send notification to destination", "error", err)
-		}
-		return nil
-	}
-
-	// Client responses: accept and forward, no HTTP body
-	if _, ok := msg.(*jsonrpc2.Response); ok {
-		if err := p.SendMessageToDestination(msg); err != nil {
-			slog.Error("failed to forward client response to destination", "error", err)
-		}
-		return nil
-	}
-
-	req, ok := msg.(*jsonrpc2.Request)
-	if !ok || !req.ID.IsValid() {
-		slog.Warn("skipping invalid batch item (not a request with ID/response/notification)",
-			"type", fmt.Sprintf("%T", msg))
-		return nil
-	}
-
-	waitCh, cleanup := p.createWaiter(sessID, req.ID)
-	defer cleanup()
-	bkey := idKeyFromID(req.ID)
-
-	// Transform outgoing request ID to composite and send
-	ck := compositeKey(sessID, bkey)
-	proxiedMsg, err := encodeRequestWithID(req, ck)
-	if err != nil {
-		slog.Error("failed to encode batch request", "error", err)
-		return nil
-	}
-	if err := p.SendMessageToDestination(proxiedMsg); err != nil {
-		slog.Error("failed to send message to destination", "error", err)
-		return nil
-	}
-
-	response := p.waitForResponse(waitCh, p.requestTimeout)
-	if response == nil {
-		slog.Warn("streamableHTTP: batch timeout waiting for key", "key", bkey)
-		return nil
-	}
-
-	if r, ok := response.(*jsonrpc2.Response); ok && r.ID.IsValid() {
-		restored, err := p.restoreResponseID(r, ck)
-		if err != nil {
-			slog.Error("failed to restore response ID", "error", err)
-			return nil
-		}
-		data, err := jsonrpc2.EncodeMessage(restored)
-		if err != nil {
-			slog.Error("failed to encode JSON-RPC response", "error", err)
-			return nil
-		}
-		return data
-	}
-
-	slog.Warn("received invalid message that is not a valid response",
-		"type", fmt.Sprintf("%T", response))
-	return nil
-}
-
 func encodeRequestWithID(req *jsonrpc2.Request, newID string) (jsonrpc2.Message, error) {
 	data, err := jsonrpc2.EncodeMessage(req)
 	if err != nil {
@@ -717,38 +606,6 @@ func (p *HTTPProxy) ensureSession(id string) error {
 	return p.sessionManager.AddWithID(id)
 }
 
-// resolveSessionForBatch resolves the session for batch POSTs.
-// Writes appropriate HTTP errors and returns an error when handling should stop.
-//
-// Batches don't exist under the Modern revision, so this path is Legacy-only
-// by construction; Modern message-shape enforcement (rejecting a batch outright)
-// is deferred.
-//
-// Sessionless POSTs receive a per-request UUID used solely as an in-process
-// routing token. Sessionless routing tokens MUST be unique per request:
-// sharing one (e.g. the empty string) across concurrent sessionless requests
-// causes waiters/idRestore overwrites in the in-process sync.Maps, which leaks
-// one client's response payload to another (with the JSON-RPC id rewritten to
-// the receiver's). This is a confidentiality bug, not a performance issue --
-// do not collapse the token. The UUID is not registered with sessionManager,
-// so no session object is created in any storage backend.
-func (p *HTTPProxy) resolveSessionForBatch(w http.ResponseWriter, r *http.Request) (string, error) {
-	sessID := r.Header.Get("Mcp-Session-Id")
-	if sessID == "" {
-		token, err := uuid.NewRandom()
-		if err != nil {
-			writeHTTPError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to generate routing token: %v", err))
-			return "", fmt.Errorf("generate routing token: %w", err)
-		}
-		return token.String(), nil
-	}
-	if _, ok := p.sessionManager.Get(sessID); !ok {
-		session.WriteNotFound(w, nil)
-		return "", fmt.Errorf("session not found")
-	}
-	return sessID, nil
-}
-
 // resolveSessionForRequest resolves session rules for a single JSON-RPC request.
 //
 // It first classifies the request as Modern or Legacy MCP (mcp.ClassifyRevision).
@@ -778,8 +635,8 @@ func (p *HTTPProxy) resolveSessionForRequest(
 	req *jsonrpc2.Request,
 ) (string, bool, error) {
 	// Classification/routing here applies only to the single id-bearing request
-	// path; the batch and notification/client-response paths are Legacy-only by
-	// construction, with Modern message-shape enforcement deferred.
+	// path; batches are rejected earlier in handlePost, and the
+	// notification/client-response path is Legacy-only by construction.
 	meta := mcp.ExtractMeta(req.Params)
 	protoHeader := r.Header.Get("MCP-Protocol-Version")
 	rev, err := mcp.ClassifyRevision(req.Method, meta, protoHeader)
@@ -839,22 +696,6 @@ func (p *HTTPProxy) resolveSessionForRequest(
 		return "", false, fmt.Errorf("session not found")
 	}
 	return sessID, false, nil
-}
-
-func isBatch(body []byte) bool {
-	t := bytes.TrimSpace(body)
-	return len(t) > 0 && t[0] == '['
-}
-
-func decodeBatch(w http.ResponseWriter, body []byte) ([]json.RawMessage, bool) {
-	var rawMessages []json.RawMessage
-	if err := json.Unmarshal(bytes.TrimSpace(body), &rawMessages); err != nil {
-		//nolint:gosec // G706: logging raw JSON-RPC batch data from HTTP request
-		slog.Warn("failed to decode batch JSON-RPC", "body", string(body))
-		writeHTTPError(w, http.StatusBadRequest, "Invalid batch JSON-RPC")
-		return nil, false
-	}
-	return rawMessages, true
 }
 
 // decodeJSONRPCMessage decodes a JSON-RPC message from the request body.

--- a/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -88,23 +89,17 @@ func TestHTTPRequestIgnoresNotifications(t *testing.T) {
 	assert.Equal(t, "req-123", responseData["id"])
 	assert.Equal(t, "operation complete", responseData["result"])
 
-	// Test batch request
+	// A batch request is rejected outright (see TestBatchRequestsRejected and
+	// #5745), not executed — batching was removed in MCP 2025-06-18.
 	batchJSON := `[{"jsonrpc": "2.0", "method": "test.batch", "id": "batch-1"}]`
 	resp2, err := http.Post(proxyURL, "application/json", bytes.NewReader([]byte(batchJSON)))
 	require.NoError(t, err)
 	defer resp2.Body.Close()
 
-	assert.Equal(t, http.StatusOK, resp2.StatusCode)
-
-	var batchResponse []map[string]interface{}
-	err = json.NewDecoder(resp2.Body).Decode(&batchResponse)
+	assert.Equal(t, http.StatusBadRequest, resp2.StatusCode)
+	batchBody, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err)
-
-	// Should have one response (notifications filtered out)
-	require.Len(t, batchResponse, 1)
-	assert.Equal(t, "2.0", batchResponse[0]["jsonrpc"])
-	assert.Equal(t, "batch-1", batchResponse[0]["id"])
-	assert.Equal(t, "operation complete", batchResponse[0]["result"])
+	assert.Contains(t, string(batchBody), `"code":-32600`)
 }
 
 // TestHTTPProxy_StartMountsAuthDiscoveryEndpoint is an integration test that

--- a/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
@@ -173,69 +173,87 @@ func TestPOSTNotificationOnlyAccepted(t *testing.T) {
 	assert.Equal(t, 0, len(body), "202 should have no body")
 }
 
-// TestBatchOnlyNotificationsAccepted returns 202 and no body per spec when no requests are present.
-func TestBatchOnlyNotificationsAccepted(t *testing.T) {
+// TestBatchRequestsRejected verifies that the streamable proxy rejects every
+// JSON-RPC batch (a top-level array) with an HTTP 400 JSON-RPC "Invalid Request"
+// (-32600) error instead of executing it. Batching was removed in MCP 2025-06-18
+// and ToolHive serves only 2025-11-25 and 2026-07-28, so a batch must never
+// reach the backend where its nested calls would bypass authz/audit/tool
+// filtering (see #5745). A backend is deliberately not started: reaching it
+// would itself be the bug under test.
+func TestBatchRequestsRejected(t *testing.T) {
 	t.Parallel()
 
 	const port = 8105
 	proxy := NewHTTPProxy("127.0.0.1", port, nil, nil)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 	require.NoError(t, proxy.Start(ctx), "proxy start")
-	defer func() { _ = proxy.Stop(ctx) }()
+	t.Cleanup(func() { _ = proxy.Stop(ctx) })
 
 	time.Sleep(50 * time.Millisecond)
-
 	url := "http://127.0.0.1:8105" + StreamableHTTPEndpoint
 
-	// Batch of only notifications (no ids)
-	batch := `[{"jsonrpc":"2.0","method":"progress","params":{"pct":10}},{"jsonrpc":"2.0","method":"progress","params":{"pct":20}}]`
-	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(batch)))
-	req.Header.Set("Content-Type", "application/json")
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+		sessionID   string
+	}{
+		{
+			name:        "only notifications",
+			body:        `[{"jsonrpc":"2.0","method":"progress","params":{"pct":10}},{"jsonrpc":"2.0","method":"progress","params":{"pct":20}}]`,
+			contentType: "application/json",
+		},
+		{
+			name:        "mixed notification and request",
+			body:        `[{"jsonrpc":"2.0","method":"progress"},{"jsonrpc":"2.0","id":"r1","method":"tools/list","params":{}}]`,
+			contentType: "application/json",
+		},
+		{
+			name:        "with stale session id",
+			body:        `[{"jsonrpc":"2.0","id":"b1","method":"tools/list"},{"jsonrpc":"2.0","id":"b2","method":"tools/list"}]`,
+			contentType: "application/json",
+			sessionID:   "expired-session-id",
+		},
+		{
+			// Regression for #5745: a batch smuggled under a non-JSON content
+			// type skips ParsingMiddleware/authz but must still be rejected at
+			// the executor.
+			name:        "non-json content type",
+			body:        `[{"jsonrpc":"2.0","id":"c1","method":"tools/call","params":{"name":"danger"}}]`,
+			contentType: "text/plain",
+		},
+		{
+			// Regression for #5745: leading Unicode whitespace must not let a
+			// batch evade detection (detector and json decoder must agree).
+			name:        "leading vertical tab",
+			body:        "\v[{\"jsonrpc\":\"2.0\",\"id\":\"d1\",\"method\":\"tools/call\"}]",
+			contentType: "application/json",
+		},
+	}
 
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(tt.body)))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", tt.contentType)
+			if tt.sessionID != "" {
+				req.Header.Set("Mcp-Session-Id", tt.sessionID)
+			}
 
-	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
-	body, _ := io.ReadAll(resp.Body)
-	assert.Equal(t, 0, len(body))
-}
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
 
-// TestBatchMixedNotificationsAndRequest returns an array with one response corresponding to the request id.
-func TestBatchMixedNotificationsAndRequest(t *testing.T) {
-	t.Parallel()
-
-	const port = 8106
-	proxy, ctx, cancel := startProxyWithBackend(t, port)
-	defer cancel()
-	defer func() { _ = proxy.Stop(ctx) }()
-
-	url := "http://127.0.0.1:8106" + StreamableHTTPEndpoint
-
-	// Batch includes a notification and a request "r1"
-	batch := `[{"jsonrpc":"2.0","method":"progress","params":{"pct":99}},{"jsonrpc":"2.0","id":"r1","method":"tools/list","params":{}}]`
-	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(batch)))
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-
-	var arr []map[string]any
-	err = json.NewDecoder(resp.Body).Decode(&arr)
-	require.NoError(t, err)
-	require.Len(t, arr, 1)
-
-	// Response should correspond to id "r1"
-	assert.Equal(t, "2.0", arr[0]["jsonrpc"])
-	assert.Equal(t, "r1", arr[0]["id"])
-	// And include a result map as sent by backend
-	_, hasResult := arr[0]["result"]
-	assert.True(t, hasResult, "batch response should include result")
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), `"code":-32600`)
+			assert.Contains(t, string(body), `"id":null`)
+		})
+	}
 }
 
 // TestDeleteUnknownSessionReturnsJSONRPCError verifies that DELETE with an
@@ -262,34 +280,6 @@ func TestDeleteUnknownSessionReturnsJSONRPCError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"code":-32001`)
 	assert.Contains(t, string(body), `"id":null`)
-}
-
-// TestBatchWithStaleSessionReturnsJSONRPCError verifies that a batch POST
-// with a stale session ID returns HTTP 404 with a JSON-RPC error body.
-func TestBatchWithStaleSessionReturnsJSONRPCError(t *testing.T) {
-	t.Parallel()
-
-	const port = 8108
-	proxy, ctx, cancel := startProxyWithBackend(t, port)
-	defer cancel()
-	defer func() { _ = proxy.Stop(ctx) }()
-
-	url := "http://127.0.0.1:8108" + StreamableHTTPEndpoint
-
-	batch := `[{"jsonrpc":"2.0","id":"b1","method":"tools/list","params":{}},{"jsonrpc":"2.0","id":"b2","method":"tools/list","params":{}}]`
-	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte(batch)))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Mcp-Session-Id", "expired-session-id")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Contains(t, string(body), `"code":-32001`)
 }
 
 // TestSingleRequestWithStaleSessionIncludesRequestID verifies that a single

--- a/pkg/transport/proxy/transparent/backend_routing_test.go
+++ b/pkg/transport/proxy/transparent/backend_routing_test.go
@@ -227,36 +227,70 @@ func TestRoundTripAllowsInitializeWithUnknownSession(t *testing.T) {
 	_ = resp.Body.Close()
 }
 
-// TestRoundTripAllowsBatchInitializeWithUnknownSession verifies that a JSON-RPC
-// batch payload containing an initialize call is forwarded even when its
-// Mcp-Session-Id is not yet in the session store.
-func TestRoundTripAllowsBatchInitializeWithUnknownSession(t *testing.T) {
+// TestRoundTripRejectsBatch verifies that the transparent proxy rejects JSON-RPC
+// batches with an HTTP 400 "Invalid Request" (-32600) instead of forwarding them
+// to the backend. Batching was removed in MCP 2025-06-18; forwarding a batch
+// would let its nested calls bypass authz/audit/tool-filtering (see #5745).
+// Rejection is Content-Type-independent: a batch under a non-JSON content type
+// must be rejected too (it skips the content-type-gated ParsingMiddleware). The
+// backend fails the test if it is ever reached.
+func TestRoundTripRejectsBatch(t *testing.T) {
 	t.Parallel()
 
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Mcp-Session-Id", uuid.New().String())
-		w.WriteHeader(http.StatusOK)
+	backend := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("backend must not be reached: batch should be rejected at the proxy")
 	}))
-	defer backend.Close()
+	t.Cleanup(backend.Close)
 
-	tt := newTracingTransport(http.DefaultTransport, NewTransparentProxyWithOptions(
-		"localhost", 0, backend.URL,
-		nil, nil, nil,
-		false, false, "sse",
-		nil, nil, "", false,
-		nil,
-	))
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+	}{
+		{
+			name:        "batch containing initialize",
+			body:        `[{"method":"initialize"},{"method":"tools/list"}]`,
+			contentType: "application/json",
+		},
+		{
+			name:        "batch of tool calls",
+			body:        `[{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"danger"}}]`,
+			contentType: "application/json",
+		},
+		{
+			name:        "batch under non-json content type",
+			body:        `[{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"danger"}}]`,
+			contentType: "text/plain",
+		},
+	}
 
-	req, err := http.NewRequest(http.MethodPost, backend.URL+"/mcp",
-		strings.NewReader(`[{"method":"initialize"},{"method":"tools/list"}]`))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Mcp-Session-Id", uuid.New().String()) // unknown but batch contains initialize
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			transport := newTracingTransport(http.DefaultTransport, NewTransparentProxyWithOptions(
+				"localhost", 0, backend.URL,
+				nil, nil, nil,
+				false, false, "sse",
+				nil, nil, "", false,
+				nil,
+			))
 
-	resp, err := tt.RoundTrip(req)
-	require.NoError(t, err)
-	require.NotEqual(t, http.StatusBadRequest, resp.StatusCode)
-	_ = resp.Body.Close()
+			req, err := http.NewRequest(http.MethodPost, backend.URL+"/mcp", strings.NewReader(tt.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", tt.contentType)
+			req.Header.Set("Mcp-Session-Id", uuid.New().String())
+
+			resp, err := transport.RoundTrip(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), `"code":-32600`)
+			assert.Contains(t, string(body), `"id":null`)
+		})
+	}
 }
 
 // TestRoundTripStoresBackendURLOnInitialize verifies that when an initialize

--- a/pkg/transport/proxy/transparent/revision_classification_test.go
+++ b/pkg/transport/proxy/transparent/revision_classification_test.go
@@ -171,7 +171,7 @@ func TestRoundTripClassifiesModernRequests(t *testing.T) {
 		assert.True(t, backendCalled.Load(), "backend must be contacted for a well-formed Modern request")
 	})
 
-	t.Run("batch with Modern header is forwarded, not rejected", func(t *testing.T) {
+	t.Run("batch is rejected before classification, backend not contacted", func(t *testing.T) {
 		t.Parallel()
 
 		var backendCalled atomic.Bool
@@ -181,6 +181,8 @@ func TestRoundTripClassifiesModernRequests(t *testing.T) {
 		})
 		tt, _ := newProxy(spy)
 
+		// Batches are rejected outright (batching was removed in MCP 2025-06-18)
+		// before revision classification or forwarding — see #5745.
 		req := httptest.NewRequest(http.MethodPost, "/mcp",
 			strings.NewReader(`[{"jsonrpc":"2.0","id":1,"method":"tools/call"}]`))
 		req.Header.Set("Content-Type", "application/json")
@@ -189,8 +191,8 @@ func TestRoundTripClassifiesModernRequests(t *testing.T) {
 		resp, err := tt.RoundTrip(req)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		assert.Equal(t, http.StatusOK, resp.StatusCode, "batches are never classified, so they must be forwarded")
-		assert.True(t, backendCalled.Load(), "backend must be contacted for a forwarded batch")
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "batches must be rejected, not forwarded")
+		assert.False(t, backendCalled.Load(), "backend must not be contacted for a rejected batch")
 	})
 
 	t.Run("large-integer id is preserved verbatim in the 400 body", func(t *testing.T) {

--- a/pkg/transport/proxy/transparent/revision_guard_regression_test.go
+++ b/pkg/transport/proxy/transparent/revision_guard_regression_test.go
@@ -30,12 +30,10 @@ import (
 // coverage this file complements.
 //
 // Scope: this suite covers single-request Modern-signal forgery only. Batch
-// payloads are never revision-classified (batching was removed from MCP in
-// 2025-06-18), so they cannot carry a Modern signal and are out of scope
-// here. The separate, pre-existing question of whether a batch containing
-// "initialize" should be exempt from the unknown-session guard (see
-// TestRoundTripAllowsBatchInitializeWithUnknownSession) is Legacy behavior
-// tracked for follow-up, not a Modern-spoofing vector.
+// payloads are rejected outright before revision classification (batching was
+// removed from MCP in 2025-06-18; see TestRoundTripRejectsBatch and #5745), so
+// they can neither carry a Modern signal nor reach the unknown-session guard
+// and are out of scope here.
 
 // modernToolsCallBody is a well-formed Modern (2026-07-28) JSON-RPC request:
 // not "initialize", a valid non-null id, and params._meta carrying both

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -582,6 +582,16 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return plainResponse(req, http.StatusRequestEntityTooLarge, "Request Entity Too Large"), nil
 	}
 
+	// Reject JSON-RPC batches before forwarding to the backend. This runs
+	// independently of Content-Type (unlike ParsingMiddleware), so a batch
+	// smuggled under a non-JSON content type cannot reach the backend where its
+	// nested calls would bypass authz/audit/tool-filtering. Batching was removed
+	// in MCP revision 2025-06-18; ToolHive serves only 2025-11-25 and 2026-07-28
+	// (see #5745).
+	if mcp.IsBatchRequest(reqBody) {
+		return mcp.BatchUnsupportedResponse(req), nil
+	}
+
 	// thv proxy does not provide the transport type, so we need to detect it from the request
 	path := req.URL.Path
 	isMCP := strings.HasPrefix(path, "/mcp")


### PR DESCRIPTION
## Summary

JSON-RPC **batch requests** (a top-level JSON array `[{...},{...}]`) were executed by the streamable HTTP proxy and forwarded raw by the transparent proxy, but the MCP parser middleware could not decode them — so **authz (Cedar), audit, and tool filtering, which each inspect a single parsed request, never saw the nested calls**. A batch could smuggle tool calls past Cedar policies, tool filtering, and audit logging: a request-smuggling / authz-audit blind spot.

Batching was **removed from MCP in the 2025-06-18 revision**. ToolHive serves only 2025-11-25 and 2026-07-28, so a batch can only originate from an unsupported pre-2025-06-18 client. Rather than teach every middleware to walk batch entries, this rejects batches outright (spec-conformant for the versions we serve; JSON-RPC `-32600` "Invalid Request", `id: null`, HTTP 400).

- Add `mcp.IsBatchRequest` (single shared detector, `bytes.TrimSpace` — matches `encoding/json`), `BatchUnsupportedError` (a `CodedError`), and the two JSON-RPC error writers `WriteBatchUnsupportedError` (ResponseWriter) / `BatchUnsupportedResponse` (RoundTripper), backed by one shared error-body/response builder.
- Reject batches in **three places** so no path can slip through: `ParsingMiddleware`, the streamable proxy `handlePost`, and the transparent proxy `RoundTrip`. Both **proxy** checks run **before session resolution/classification and independent of `Content-Type`**, so a batch cannot reach a backend uninspected even under a non-JSON content type or if the parser middleware were absent/reordered.
- **Delete** the now-unreachable streamable batch executor (`handleBatchRequest`, `processSingleMessage`, `decodeBatch`, `resolveSessionForBatch`, and the orphaned `waitForResponse`).

Fixes #5745

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — all affected packages pass (`pkg/mcp`, `pkg/transport/proxy/streamable`, `pkg/transport/proxy/transparent`, `pkg/authz`, `pkg/audit`, `pkg/telemetry`, `pkg/vmcp`, `pkg/runner`). The only failures in the full suite are pre-existing environmental ones in this sandbox (no container runtime, no kernel keyring) and are unrelated to this change.
- [x] Linting (`task lint-fix`) — 0 issues.
- New regression tests assert rejection (400 / `-32600` / `id:null`, backend never contacted) across both proxies, including the **non-JSON content-type** and **leading-whitespace** evasion cases; obsolete tests that asserted batch execution/forwarding were updated or removed.

## Does this introduce a user-facing change?

Yes. A client that POSTs a JSON-RPC batch now receives an HTTP 400 with a JSON-RPC `-32600` "Invalid Request" error instead of having the batch executed/forwarded. This only affects pre-2025-06-18 clients (the only revision where batching was valid); ToolHive serves 2025-11-25 and 2026-07-28, where batching does not exist.

## Special notes for reviewers

- Reviewed by a security + MCP-spec + Go-conventions panel. The security pass initially found that rejecting only in the parser was insufficient (the streamable executor and transparent forwarder run independent of `Content-Type`); the fix now rejects at both proxy executors. The MCP-spec pass confirmed unconditional rejection with `-32600` / `id:null` / HTTP 400 is correct for the revisions ToolHive serves.
- Batch rejection sits **after** the body-size limit read in both proxies, so it does not open an unbounded-read DoS.
- Minor, non-blocking follow-up: `parseRPCRequest`'s batch-scanning branch in the transparent proxy is now dead for the `RoundTrip` path and could be simplified in a later cleanup (harmless defense-in-depth left in place).

Generated with [Claude Code](https://claude.com/claude-code)