### PR TITLE
Update batch e2e test to expect rejection

### DIFF
--- a/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
+++ b/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"time"
 
@@ -39,7 +40,7 @@ var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http"
 			}
 		})
 
-		It("should respond to a single get_current_time request and a batch request", func() {
+		It("should respond to a single get_current_time request and reject a batch request", func() {
 			By("Starting the time MCP server with streamable-http proxy")
 			e2e.NewTHVCommand(config, "run",
 				"--name", serverName,
@@ -76,7 +77,12 @@ var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http"
 			result := mcpClient.ExpectToolCall(ctx, "get_current_time", arguments)
 			Expect(result.Content).ToNot(BeEmpty(), "Should return the current time")
 
-			By("Sending a batch JSON-RPC request")
+			By("Sending a batch JSON-RPC request, which must be rejected")
+			// JSON-RPC batching was removed in MCP revision 2025-06-18. ToolHive
+			// serves only 2025-11-25 and 2026-07-28, so the proxy rejects any
+			// batch (a top-level JSON array) with an HTTP 400 / JSON-RPC -32600
+			// "Invalid Request" and a null id, rather than forwarding its nested
+			// calls past authz/audit/tool-filtering (see #5745, #5931).
 			batch := []map[string]interface{}{
 				{
 					"method": "tools/call",
@@ -115,23 +121,12 @@ var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http"
 			resp, err := client.Do(req)
 			Expect(err).ToNot(HaveOccurred())
 			defer resp.Body.Close()
-			Expect(resp.StatusCode).To(Equal(200))
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest), "Batch requests must be rejected")
 
-			var responses []map[string]interface{}
-			decoder := json.NewDecoder(resp.Body)
-			err = decoder.Decode(&responses)
+			body, err := io.ReadAll(resp.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(responses).To(HaveLen(2))
-
-			ids := map[float64]bool{4: false, 5: false}
-			for _, r := range responses {
-				id, ok := r["id"].(float64)
-				Expect(ok).To(BeTrue(), "Each response should have an id")
-				ids[id] = true
-				Expect(r["result"]).ToNot(BeNil(), "Each response should have a result")
-			}
-			Expect(ids[4]).To(BeTrue())
-			Expect(ids[5]).To(BeTrue())
+			Expect(string(body)).To(ContainSubstring(`"code":-32600`), "Should carry a JSON-RPC Invalid Request error")
+			Expect(string(body)).To(ContainSubstring(`"id":null`), "Batch rejection carries a null JSON-RPC id")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

The `E2E Tests Core (proxy)` shard has been failing **deterministically on every open PR**, regardless of the PR's content. The cause is not a regression — it's a test that was missed when batch behavior changed on `main`.

PR #5931 ("Reject JSON-RPC batches to close authz blind spot", Fixes #5745) intentionally made the streamable-HTTP and transparent proxies **reject** any JSON-RPC batch (a top-level JSON array) with **HTTP 400 / JSON-RPC `-32600` "Invalid Request" / `id: null`**, instead of executing or forwarding it. Executing batches let nested tool calls bypass Cedar authz, audit, and tool filtering (each inspects a single parsed request), a request-smuggling blind spot. That PR updated every affected unit and integration test to assert rejection — but missed the e2e spec in `test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go`, which still POSTed a batch and asserted HTTP 200 with two responses.

This PR aligns that e2e test with the merged, spec-conformant behavior: the batch portion now asserts HTTP 400 with `"code":-32600` and `"id":null`. The single `get_current_time` request portion is unchanged.

Batching was removed from MCP in the **2025-06-18** revision. ToolHive serves only **2025-11-25** and **2026-07-28**, and the 2026-07-28 revision is stricter still (POST body "MUST be a single JSON-RPC request or notification"). So unconditional batch rejection is correct for every revision ToolHive serves.

Closes #5932

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] Linting (`task lint-fix`) — 0 issues.
- [x] Assertions now mirror the merged unit/integration tests from #5931 (400 / `-32600` / `id:null`).
- The e2e suite itself requires a container runtime to launch the `time` MCP server and was not run in this sandbox; the package compiles cleanly under `golangci-lint`.

## Does this introduce a user-facing change?

No. This only updates a test to match already-merged proxy behavior.

## Special notes for reviewers

Blanket array-rejection is correct **because ToolHive serves only revisions ≥ 2025-06-18**. If a pre-2025-06-18 revision were ever added to the served set, this assumption would need revisiting — it's now documented in a comment in the test.

Generated with [Claude Code](https://claude.com/claude-code)