### PR TITLE
Align proxy batch E2E with intentional batch rejection

### DIFF
--- a/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
+++ b/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
@@ -39,7 +39,7 @@ var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http"
 			}
 		})
 
-		It("should respond to a single get_current_time request and a batch request", func() {
+		It("should respond to a single get_current_time request and reject a batch request", func() {
 			By("Starting the time MCP server with streamable-http proxy")
 			e2e.NewTHVCommand(config, "run",
 				"--name", serverName,
@@ -76,7 +76,7 @@ var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http"
 			result := mcpClient.ExpectToolCall(ctx, "get_current_time", arguments)
 			Expect(result.Content).ToNot(BeEmpty(), "Should return the current time")
 
-			By("Sending a batch JSON-RPC request")
+			By("Sending a batch JSON-RPC request, which the proxy must reject")
 			batch := []map[string]interface{}{
 				{
 					"method": "tools/call",
@@ -115,23 +115,23 @@ var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http"
 			resp, err := client.Do(req)
 			Expect(err).ToNot(HaveOccurred())
 			defer resp.Body.Close()
-			Expect(resp.StatusCode).To(Equal(200))
 
-			var responses []map[string]interface{}
+			// JSON-RPC batches were removed in MCP 2025-06-18 and are
+			// rejected by the proxy since they were invisible to authz,
+			// audit, and tool filtering (see #5931): a single -32600
+			// Invalid Request error with a null id and HTTP 400.
+			Expect(resp.StatusCode).To(Equal(400))
+
+			var errorResponse map[string]interface{}
 			decoder := json.NewDecoder(resp.Body)
-			err = decoder.Decode(&responses)
+			err = decoder.Decode(&errorResponse)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(responses).To(HaveLen(2))
 
-			ids := map[float64]bool{4: false, 5: false}
-			for _, r := range responses {
-				id, ok := r["id"].(float64)
-				Expect(ok).To(BeTrue(), "Each response should have an id")
-				ids[id] = true
-				Expect(r["result"]).ToNot(BeNil(), "Each response should have a result")
-			}
-			Expect(ids[4]).To(BeTrue())
-			Expect(ids[5]).To(BeTrue())
+			Expect(errorResponse["jsonrpc"]).To(Equal("2.0"))
+			Expect(errorResponse["id"]).To(BeNil(), "a batch rejection carries a null id")
+			rpcErr, ok := errorResponse["error"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "the body should be a JSON-RPC error response")
+			Expect(rpcErr["code"]).To(Equal(float64(-32600)), "batches are rejected as Invalid Request")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- #5931 deliberately rejects JSON-RPC batches at the proxy (`-32600`, `id: null`, HTTP 400) to close the authz/audit/tool-filter blind spot — but the streamable-http proxy E2E spec (`stdio_proxy_over_streamable_http_mcp_server_test.go`) still asserted the pre-change behavior (200 + two batch results). Result: the `E2E Tests Core (proxy)` required check is deterministically red on **every open PR**, regardless of content.
- This updates the spec's batch half to assert the new intentional contract instead: HTTP 400, `jsonrpc: "2.0"`, `id: null`, `error.code: -32600` — matching exactly what `mcp.WriteBatchUnsupportedError` / `classificationErrorBody` produce.

Fixes #5932

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `go build ./test/e2e/` and `go vet ./test/e2e/` pass
- [x] Assertions cross-checked against `pkg/mcp/batch.go` and `pkg/mcp/classification_response.go` (the code introduced by #5931), so the spec encodes the same contract the implementation ships
- [x] CI on this PR runs the updated spec in the proxy shard

## Does this introduce a user-facing change?

No — test-only change; the user-facing behavior change (batch rejection) landed in #5931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)