### PR TITLE
Send current MCP protocol version in readiness probe

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -42,6 +42,30 @@ import (
 // ErrContainerExitedRestartNeeded is returned when a container exits and needs to be restarted
 var ErrContainerExitedRestartNeeded = errors.New("container exited, restart needed")
 
+// probeProtocolVersion is the MCP protocol revision the readiness probe advertises
+// in the JSON-RPC params.protocolVersion of its initialize handshake.
+//
+// It is deliberately pinned to 2025-11-25 — the current stable revision and the
+// newest one that still defines the `initialize` method — rather than tracking
+// mcp.LATEST_PROTOCOL_VERSION. The upcoming 2026-07-28 revision (draft; subject to
+// change until it ships) removes `initialize` entirely (replaced by server/discover
+// + per-request _meta, SEP-2575), so a probe that sent method:"initialize" with a
+// 2026-07-28 version string would be internally inconsistent. When ToolHive adopts
+// 2026-07-28 (issue #5754) the probe must switch to server/discover — which, like
+// all 2026-07-28 Streamable HTTP POSTs, carries the required Mcp-Method/Mcp-Name
+// headers — and fall back to this initialize path for older backends. Pinning here
+// keeps the probe's method and version consistent regardless of what the SDK later
+// declares "latest".
+//
+// The value is sent only in the request body, NOT as an MCP-Protocol-Version
+// header: the spec scopes that header to requests made AFTER initialization
+// (carrying the negotiated version), and requires a server to reject an unsupported
+// header value with HTTP 400. Sending it on the initialize request itself would let
+// a backend that only supports an older revision 400 the probe — a false
+// "not-ready" — whereas body-based version negotiation degrades gracefully (the
+// server answers HTTP 200 with its own supported version).
+const probeProtocolVersion = "2025-11-25"
+
 // Runner is responsible for running an MCP server with the provided configuration
 type Runner struct {
 	// Config is the configuration for the runner
@@ -997,9 +1021,12 @@ func waitForInitializeSuccess(
 		// Format: http://localhost:port/mcp
 		endpoint = serverURL
 		method = "POST"
-		payload = `{"jsonrpc":"2.0","method":"initialize","id":"toolhive-init-check",` +
-			`"params":{"protocolVersion":"2024-11-05","capabilities":{},` +
-			`"clientInfo":{"name":"toolhive","version":"1.0"}}}`
+		payload = fmt.Sprintf(
+			`{"jsonrpc":"2.0","method":"initialize","id":"toolhive-init-check",`+
+				`"params":{"protocolVersion":%q,"capabilities":{},`+
+				`"clientInfo":{"name":"toolhive","version":"1.0"}}}`,
+			probeProtocolVersion,
+		)
 	case "sse":
 		// For SSE, just check if the SSE endpoint is available
 		// We can't easily call initialize without establishing a full SSE connection,
@@ -1049,7 +1076,10 @@ func waitForInitializeSuccess(
 			if method == "POST" {
 				req.Header.Set("Content-Type", "application/json")
 				req.Header.Set("Accept", "application/json, text/event-stream")
-				req.Header.Set("MCP-Protocol-Version", "2024-11-05")
+				// No MCP-Protocol-Version header: it is scoped to post-initialize
+				// requests (carrying the negotiated version) and a server MUST reject
+				// an unsupported value with HTTP 400. The initialize body's
+				// protocolVersion negotiates gracefully instead. See probeProtocolVersion.
 			}
 
 			resp, err := httpClient.Do(req) // #nosec G704 -- endpoint is the local MCP server readiness URL

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -5,8 +5,10 @@ package runner
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -265,6 +267,53 @@ func TestWaitForInitializeSuccess(t *testing.T) {
 		ctx := context.Background()
 		err := waitForInitializeSuccess(ctx, server.URL, "streamable", false, 5*time.Second)
 		assert.NoError(t, err)
+	})
+
+	t.Run("Streamable sends pinned probe protocol version in body only", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			mu             sync.Mutex
+			capturedBody   string
+			capturedHeader []string
+			headerPresent  bool
+		)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				mu.Lock()
+				capturedBody = string(body)
+				capturedHeader, headerPresent = r.Header["Mcp-Protocol-Version"]
+				mu.Unlock()
+
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}))
+		t.Cleanup(server.Close)
+
+		ctx := context.Background()
+		err := waitForInitializeSuccess(ctx, server.URL, "streamable-http", false, 5*time.Second)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		// Assert against an independent literal (not probeProtocolVersion) so that
+		// changing the pin forces a conscious test update — the const is deliberately
+		// pinned and must not silently track mcp.LATEST_PROTOCOL_VERSION.
+		assert.Contains(t, capturedBody, `"protocolVersion":"2025-11-25"`)
+		assert.NotContains(t, capturedBody, "2024-11-05")
+		// The probe intentionally does not advertise the 2026-07-28 revision, which
+		// removes the initialize method the probe relies on.
+		assert.NotContains(t, capturedBody, "2026-07-28")
+		// The MCP-Protocol-Version header is intentionally NOT sent on the initialize
+		// request: it is scoped to post-initialize requests and a server MUST 400 an
+		// unsupported value, which would falsely mark an older backend as not-ready.
+		assert.False(t, headerPresent, "initialize probe must not send an MCP-Protocol-Version header, got %q", capturedHeader)
 	})
 
 	t.Run("SSE success", func(t *testing.T) {


### PR DESCRIPTION
## Summary

**Why:** The runner's readiness probe hardcoded `"protocolVersion":"2024-11-05"` in its `initialize` request (and repeated it in the `MCP-Protocol-Version` header). MCP servers that reject that ancient revision report as never-ready even when healthy, so ToolHive waits out the full readiness timeout before failing to start them. This got more likely as backends move to newer, stricter SDKs.

**What:**
- Advertise a pinned, current revision — `probeProtocolVersion = "2025-11-25"` — in the `initialize` body instead of the hardcoded `2024-11-05`.
- The version is **deliberately pinned rather than tracking `mcp.LATEST_PROTOCOL_VERSION`**. The upcoming **2026-07-28** revision removes the `initialize` method entirely (SEP-2575, replaced by `server/discover` + per-request `_meta`), so coupling the probe to a moving "latest" constant would eventually emit a `method:"initialize"` request stamped with a version that no longer defines it. The 2026-07-28 migration is deferred to #5754.
- **Stop sending the `MCP-Protocol-Version` header on the initialize request.** The spec scopes that header to *post-initialization* requests carrying the *negotiated* version, and requires a server to reject an unsupported value with **HTTP 400**. Sending it on `initialize` would let a backend that only supports an older revision fail the probe, whereas body-based version negotiation degrades gracefully (the server answers HTTP 200 with its own supported version). This makes the probe robust across backend revisions in both directions.

Addresses **item 1** of #5764 (readiness probe protocol version). Items 2 (JSON-RPC error for filtered tool calls) and 3 (version-agnostic proxying docs + strict mode) remain, so this does not close the issue.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests — `go test -race ./pkg/runner/` (full package) passes, including a new `TestWaitForInitializeSuccess` subtest that captures the probe request and asserts: the body carries `"protocolVersion":"2025-11-25"` (independent literal, so the deliberate pin can't silently drift), the body contains neither `2024-11-05` nor `2026-07-28`, and **no** `MCP-Protocol-Version` header is sent.
- [x] Linting — `task lint` reports 0 issues; `task build` succeeds.

## Does this introduce a user-facing change?

No behavioral change users configure directly. Operationally, MCP servers that only accept recent protocol revisions now pass ToolHive's readiness probe instead of timing out at startup.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Planned with Claude Code via an architect → worker → cross-axis-review pipeline:

1. **Architect:** source the probe version from a current revision instead of the hardcoded `2024-11-05`. Initially proposed `mcp.LATEST_PROTOCOL_VERSION`.
2. **Spec check (mcp-protocol-expert):** verified against the 2025-11-25 spec and the 2026-07-28 draft changelog. Found that (a) tracking `LATEST` is unsafe because 2026-07-28 removes `initialize`, so the version was pinned to `2025-11-25` behind a documented `probeProtocolVersion` constant; and (b) the `MCP-Protocol-Version` header on `initialize` can trigger a spec-mandated HTTP 400 from older backends, so the header was dropped in favor of graceful body-based negotiation.
3. **Worker:** implemented the constant, the `fmt.Sprintf` body, header removal, and the regression test.
4. **Cross-axis review (security / correctness+conventions+tests / MCP-spec):** security clean; applied the header-drop finding, strengthened the test to assert an independent literal, and tightened the doc comment (2026-07-28 draft caveat).

</details>

## Special notes for reviewers

- **Deviation from the issue text:** #5764 item 1 literally says to update "the `MCP-Protocol-Version` header". This PR instead **removes** that header from the probe, because the review found keeping it (even at a current version) can falsely mark older-but-healthy backends as not-ready. The body-based version is the spec-correct negotiation channel.
- Pre-existing items in `waitForInitializeSuccess` intentionally left out of scope: the `defer resp.Body.Close()` inside the retry loop and closing the body without draining. Worth a separate cleanup PR.

Generated with [Claude Code](https://claude.com/claude-code)