### PR TITLE
Deflake vMCP forwarding notification wait

### DIFF
--- a/pkg/vmcp/server/forwarding_realbackend_integration_test.go
+++ b/pkg/vmcp/server/forwarding_realbackend_integration_test.go
@@ -205,7 +205,13 @@ func newDownstreamClient(ctx context.Context, t *testing.T, vmcpURL string, with
 // waitNotification blocks for a forwarded notification with the given method.
 func (dc *downstreamClient) waitNotification(t *testing.T, method string) mcpmcp.JSONRPCNotification {
 	t.Helper()
-	deadline := time.After(5 * time.Second)
+	// Give the forwarded notification generous headroom: these are async,
+	// server-initiated messages relayed backend -> vMCP -> downstream, and under
+	// the full-suite parallel `-race` load on CI the round trip can take well over
+	// a second. The previous 5s deadline flaked (timed out) there while passing in
+	// milliseconds locally. Stay under the callers' 20s context so a genuine hang
+	// still fails cleanly rather than blocking to the context deadline.
+	deadline := time.After(15 * time.Second)
 	for {
 		select {
 		case n := <-dc.notifCh:


### PR DESCRIPTION
## Summary

**Why:** `TestForwarding_Progress_RealBackend` (and its sibling `TestForwarding_*_RealBackend` tests) flake on CI. `waitNotification` used a hardcoded **5s** deadline while waiting for an async, server-initiated notification relayed backend → vMCP → downstream client. Under the full-suite parallel `-race` + `-coverpkg=./...` load on the shared CI runner, that round trip can exceed 5s and the test times out (`forwarding_realbackend_integration_test.go:292: timed out waiting for notifications/progress notification`) — while it passes in ~30ms locally with no load. Observed failing twice consecutively on an unrelated PR's CI, passing 3/3 locally.

**What:**
- Raise `waitNotification`'s deadline from 5s to **15s**, with a comment explaining the async/CI-load rationale. It stays under the callers' 20s test context, so a genuine hang still fails cleanly rather than blocking to the context deadline.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests — `go test -race -run 'TestForwarding_' ./pkg/vmcp/server/` passes.
- [x] Linting — `task lint` reports 0 issues.

## Does this introduce a user-facing change?

No. Test-only change.

## Special notes for reviewers

- Surfaced while monitoring an unrelated PR (#5940, readiness-probe protocol version) whose only red check was this flake. Splitting the fix out here keeps that PR single-scoped; #5940 will be rebased on top once this lands.
- The wait channel (`notifCh`) uses a non-blocking send that drops on a full buffer — not the cause here (the buffer isn't the bottleneck under these tests), so this PR only addresses the timeout. If the tests flake again after this, a follow-up could make the notification capture more robust.

Generated with [Claude Code](https://claude.com/claude-code)