### PR TITLE
Return JSON-RPC error for filtered tool calls

### DIFF
--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -16,6 +16,13 @@ import (
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
+// filteredToolNotFoundMessage is the generic message returned to a client
+// that called a tool blocked by the tool filter. It deliberately matches what
+// a client would see for a tool that doesn't exist at all: see the NOTE above
+// the *toolCallFilter case in NewToolCallMappingMiddleware for why a filtered
+// tool must not be distinguishable from a nonexistent one.
+const filteredToolNotFoundMessage = "tool not found"
+
 var errToolNameNotFound = errors.New("tool name not found")
 var errBug = errors.New("there's a bug")
 var errKeepBuffering = errors.New("keep buffering")
@@ -275,9 +282,22 @@ func NewToolCallMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewar
 				// Unfortunately, implementing this behaviour is not trivial and requires
 				// session management, as the SSE stream is managed by the proxy in an entirely
 				// different thread of execution. As a consequence, the best thing we can
-				// do that is still compliant with the spec is to return a 400 Bad Request
-				// to the client.
+				// do that is still compliant with the spec is to return a JSON-RPC error
+				// for this call, over HTTP 200, that looks the same as calling a tool that
+				// doesn't exist (see filteredToolNotFoundMessage above).
+				//
+				// A client that only accepts an event stream (the legacy HTTP+SSE
+				// transport, whose real response is delivered on a separate stream we
+				// don't control from this middleware) can't be answered this way: the
+				// body written here IS the only response this call gets, and it must be
+				// something other than a stray JSON blob on a connection the client
+				// expects to be text/event-stream. So that path keeps the 400, same as
+				// the session-management limitation described above.
 				case *toolCallFilter:
+					if clientAcceptsJSON(r) {
+						writeFilteredToolCallError(w, toolCallRequest.ID)
+						return
+					}
 					w.WriteHeader(http.StatusBadRequest)
 					return
 
@@ -298,7 +318,7 @@ func NewToolCallMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewar
 					r.ContentLength = int64(len(bodyBytes))
 
 				// According to the current version of the MCP spec at
-				// https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolrequest
+				// https://modelcontextprotocol.io/specification/2025-11-25/schema#calltoolrequest
 				// this case can only happen if the request is malformed. The proxied MCP
 				// server should be able to process the request, but since we detect it here
 				// we short-circuit returning an error.
@@ -318,6 +338,73 @@ func NewToolCallMappingMiddleware(opts ...ToolMiddlewareOption) (types.Middlewar
 			next.ServeHTTP(w, r)
 		})
 	}, nil
+}
+
+// clientAcceptsJSON reports whether r's Accept header allows an
+// application/json response. An empty/absent header is treated as
+// accepting JSON, matching the common case of a client that doesn't bother
+// to negotiate. Each comma-separated entry's media-type token (i.e.
+// everything before any ";param=..." qualifier) is compared case-
+// insensitively against "application/json", the type wildcard
+// "application/*", and the full wildcard "*/*". Quality values (";q=") are
+// not honored: a token present with any q-value counts as accepted.
+func clientAcceptsJSON(r *http.Request) bool {
+	accept := r.Header.Get("Accept")
+	if accept == "" {
+		return true
+	}
+
+	for _, entry := range strings.Split(accept, ",") {
+		mediaType := strings.TrimSpace(strings.Split(entry, ";")[0])
+		if strings.EqualFold(mediaType, "application/json") ||
+			strings.EqualFold(mediaType, "application/*") ||
+			mediaType == "*/*" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// writeFilteredToolCallError writes a JSON-RPC error response, over HTTP 200,
+// for a tools/call request blocked by the tool filter. The error message is
+// the generic filteredToolNotFoundMessage: see the NOTE in NewToolCallMappingMiddleware
+// for why a filtered tool must look the same as one that doesn't exist.
+//
+// HTTP 200 (not 400) is deliberate: under MCP streamable HTTP, a validly
+// received JSON-RPC request that fails at the application level rides back
+// in a 200 response carrying a JSON-RPC error object, mirroring how
+// WriteClassificationError's peers (e.g. writeRateLimited) shape their body,
+// modulo status code.
+func writeFilteredToolCallError(w http.ResponseWriter, id any) {
+	body := filteredToolCallErrorBody(id)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	//nolint:gosec // G104: writing a JSON-RPC error response to an HTTP client
+	_, _ = w.Write(body)
+}
+
+// filteredToolCallErrorBody renders the JSON-RPC error body for a filtered
+// tool call, modeled on classificationErrorBody: the body is marshaled first
+// (with a hand-crafted fallback on marshal failure) so the caller only writes
+// headers/status once a valid body is ready.
+func filteredToolCallErrorBody(id any) []byte {
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"error": map[string]any{
+			"code":    CodeInvalidParams,
+			"message": filteredToolNotFoundMessage,
+		},
+		"id": id,
+	}
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		// This should never happen with simple map types, but return a
+		// hand-crafted fallback to guarantee a valid JSON-RPC error.
+		return []byte(`{"jsonrpc":"2.0","error":{"code":-32602,"message":"tool not found"},"id":null}`)
+	}
+	return body
 }
 
 // toolFilterWriter wraps http.ResponseWriter to capture and process SSE responses

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1872,6 +1874,234 @@ func TestNewListToolsMappingMiddleware_MissingContentTypeCannotSmuggleToolsList(
 			assert.Contains(t, recorder.Body.String(), "tool1")
 			assert.NotContains(t, recorder.Body.String(), "tool2",
 				"the excluded tool must not be exposed just because Content-Type was missing")
+		})
+	}
+}
+
+func TestClientAcceptsJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		accept string
+		want   bool
+	}{
+		{name: "application/json", accept: "application/json", want: true},
+		{name: "application/json with other alternatives", accept: "application/json, text/event-stream", want: true},
+		{name: "text/event-stream only", accept: "text/event-stream", want: false},
+		{name: "wildcard", accept: "*/*", want: true},
+		{name: "application subtype wildcard", accept: "application/*", want: true},
+		{name: "empty header", accept: "", want: true},
+		{name: "application/json with quality parameter", accept: "application/json;q=0.9", want: true},
+		{name: "uppercase media type is case-insensitive", accept: "APPLICATION/JSON", want: true},
+		{name: "application/json-patch+json is not application/json", accept: "application/json-patch+json", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			if tt.accept != "" {
+				req.Header.Set("Accept", tt.accept)
+			}
+
+			assert.Equal(t, tt.want, clientAcceptsJSON(req))
+		})
+	}
+}
+
+// TestNewToolCallMappingMiddleware_FilteredTool covers the HTTP-level
+// behavior of the *toolCallFilter case in NewToolCallMappingMiddleware: a
+// tools/call request for a tool blocked by the filter must be rejected with
+// a JSON-RPC error (never the raw, filter-specific "blocked" reason -- see
+// the NOTE above the *toolCallFilter case) rather than a bare HTTP 400,
+// unless the client can only receive an event stream, in which case the
+// legacy 400 fallback still applies.
+func TestNewToolCallMappingMiddleware_FilteredTool(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		accept        string
+		setAccept     bool
+		id            any
+		expectStatus  int
+		expectJSONRPC bool
+	}{
+		{
+			name:          "Accept: application/json - numeric id",
+			accept:        "application/json",
+			setAccept:     true,
+			id:            1,
+			expectStatus:  http.StatusOK,
+			expectJSONRPC: true,
+		},
+		{
+			name:          "Accept: application/json - string id",
+			accept:        "application/json",
+			setAccept:     true,
+			id:            "req-42",
+			expectStatus:  http.StatusOK,
+			expectJSONRPC: true,
+		},
+		{
+			name:          "Accept: application/json, text/event-stream",
+			accept:        "application/json, text/event-stream",
+			setAccept:     true,
+			id:            1,
+			expectStatus:  http.StatusOK,
+			expectJSONRPC: true,
+		},
+		{
+			name:         "Accept: text/event-stream only - falls back to 400",
+			accept:       "text/event-stream",
+			setAccept:    true,
+			id:           1,
+			expectStatus: http.StatusBadRequest,
+		},
+		{
+			name:          "No Accept header - JSON allowed by default",
+			setAccept:     false,
+			id:            1,
+			expectStatus:  http.StatusOK,
+			expectJSONRPC: true,
+		},
+		{
+			name:          "null id is echoed as null",
+			accept:        "application/json",
+			setAccept:     true,
+			id:            nil,
+			expectStatus:  http.StatusOK,
+			expectJSONRPC: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			middleware, err := NewToolCallMappingMiddleware(WithToolsFilter("allowed_tool"))
+			require.NoError(t, err)
+
+			nextCalled := false
+			next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+			})
+			handler := middleware(next)
+
+			idJSON, err := json.Marshal(tt.id)
+			require.NoError(t, err)
+			body := fmt.Sprintf(
+				`{"jsonrpc":"2.0","id":%s,"method":"tools/call","params":{"name":"blocked_tool"}}`,
+				idJSON,
+			)
+
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+			if tt.setAccept {
+				req.Header.Set("Accept", tt.accept)
+			}
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			assert.False(t, nextCalled, "next handler must not be called for a filtered tool")
+			assert.Equal(t, tt.expectStatus, recorder.Code)
+
+			if !tt.expectJSONRPC {
+				return
+			}
+
+			assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+
+			var response map[string]any
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+
+			assert.Equal(t, "2.0", response["jsonrpc"])
+			errObj, ok := response["error"].(map[string]any)
+			require.True(t, ok, "response must carry a JSON-RPC error object")
+			assert.Equal(t, float64(CodeInvalidParams), errObj["code"])
+			assert.Equal(t, "tool not found", errObj["message"])
+			assert.NotContains(t, errObj["message"], "filter",
+				"a filtered tool must look the same as a nonexistent one")
+
+			expectedID, err := json.Marshal(tt.id)
+			require.NoError(t, err)
+			actualID, err := json.Marshal(response["id"])
+			require.NoError(t, err)
+			assert.JSONEq(t, string(expectedID), string(actualID))
+		})
+	}
+}
+
+// TestNewToolCallMappingMiddleware_AllowedToolPassesThrough verifies that a
+// tools/call request for an allowed tool is forwarded unmodified.
+func TestNewToolCallMappingMiddleware_AllowedToolPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	middleware, err := NewToolCallMappingMiddleware(WithToolsFilter("allowed_tool"))
+	require.NoError(t, err)
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := middleware(next)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"allowed_tool"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Accept", "application/json")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	assert.True(t, nextCalled, "next handler must be called for an allowed tool")
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
+// TestNewToolCallMappingMiddleware_BogusRequest verifies that a malformed
+// tools/call request (missing/nil params, or params without a name) is still
+// rejected with a bare HTTP 400 -- unlike a filtered tool, this is a
+// malformed-request case, not a filtering decision, per the current MCP spec.
+func TestNewToolCallMappingMiddleware_BogusRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "params missing name",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"arguments":{}}}`,
+		},
+		{
+			name: "nil params",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			middleware, err := NewToolCallMappingMiddleware(WithToolsFilter("allowed_tool"))
+			require.NoError(t, err)
+
+			nextCalled := false
+			next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+			})
+			handler := middleware(next)
+
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.body))
+			req.Header.Set("Accept", "application/json")
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			assert.False(t, nextCalled, "next handler must not be called for a malformed request")
+			assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		})
 	}
 }

--- a/pkg/mcp/tool_middleware_test.go
+++ b/pkg/mcp/tool_middleware_test.go
@@ -186,12 +186,11 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		serverOpts     []testkit.TestMCPServerOption
-		opts           *[]ToolMiddlewareOption
-		expected       any
-		callToolName   string
-		expectedStatus int
+		name         string
+		serverOpts   []testkit.TestMCPServerOption
+		opts         *[]ToolMiddlewareOption
+		expected     any
+		callToolName string
 	}{
 		{
 			name: "No filter, No override - Call Foo",
@@ -201,10 +200,9 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 				//nolint:goconst
 				testkit.WithTool("Bar", "Bar tool", func() string { return "Bar" }),
 			},
-			opts:           nil,
-			expected:       "Foo",
-			callToolName:   "Foo",
-			expectedStatus: http.StatusOK,
+			opts:         nil,
+			expected:     "Foo",
+			callToolName: "Foo",
 		},
 		{
 			name: "Filter Foo, No override - Call Foo",
@@ -217,9 +215,8 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 			opts: &[]ToolMiddlewareOption{
 				WithToolsFilter("Foo"),
 			},
-			expected:       "Foo",
-			callToolName:   "Foo",
-			expectedStatus: http.StatusOK,
+			expected:     "Foo",
+			callToolName: "Foo",
 		},
 		{
 			name: "Filter Foo, No override - Call Bar",
@@ -232,9 +229,8 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 			opts: &[]ToolMiddlewareOption{
 				WithToolsFilter("Foo"),
 			},
-			expected:       nil,
-			callToolName:   "Bar",
-			expectedStatus: http.StatusBadRequest, // Bar is filtered out
+			expected:     nil,
+			callToolName: "Bar",
 		},
 		{
 			name: "No filter, Override MyFoo -> Foo - Call MyFoo",
@@ -247,9 +243,8 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 			opts: &[]ToolMiddlewareOption{
 				WithToolsOverride("Foo", "MyFoo", "Override description"),
 			},
-			expected:       "Foo",
-			callToolName:   "MyFoo",
-			expectedStatus: http.StatusOK,
+			expected:     "Foo",
+			callToolName: "MyFoo",
 		},
 		{
 			name: "No filter, Override MyFoo -> Foo - Call Bar",
@@ -262,9 +257,8 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 			opts: &[]ToolMiddlewareOption{
 				WithToolsOverride("Foo", "MyFoo", "Override description"),
 			},
-			expected:       "Bar",
-			callToolName:   "Bar",
-			expectedStatus: http.StatusOK,
+			expected:     "Bar",
+			callToolName: "Bar",
 		},
 		{
 			name: "Filter MyFoo, Override MyFoo -> Foo - Call MyFoo",
@@ -278,9 +272,8 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 				WithToolsFilter("MyFoo"),
 				WithToolsOverride("Foo", "MyFoo", "Override description"),
 			},
-			expected:       "Foo",
-			callToolName:   "MyFoo",
-			expectedStatus: http.StatusOK,
+			expected:     "Foo",
+			callToolName: "MyFoo",
 		},
 		{
 			name: "Filter MyFoo, Override MyFoo -> Foo - Call Bar",
@@ -294,9 +287,8 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 				WithToolsFilter("MyFoo"),
 				WithToolsOverride("Foo", "MyFoo", "Override description"),
 			},
-			expected:       nil,
-			callToolName:   "Bar",
-			expectedStatus: http.StatusBadRequest, // Bar is filtered out
+			expected:     nil,
+			callToolName: "Bar",
 		},
 		{
 			name: "No filter, Override Bar -> Foo - Call Foo",
@@ -309,9 +301,8 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 			opts: &[]ToolMiddlewareOption{
 				WithToolsOverride("Bar", "Foo", ""),
 			},
-			expected:       "Bar",
-			callToolName:   "Foo",
-			expectedStatus: http.StatusOK,
+			expected:     "Bar",
+			callToolName: "Foo",
 		},
 		{
 			name: "No filter, Override Bar -> Foo - Call Bar",
@@ -324,9 +315,8 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 			opts: &[]ToolMiddlewareOption{
 				WithToolsOverride("Foo", "Bar", ""),
 			},
-			expected:       "Foo",
-			callToolName:   "Bar",
-			expectedStatus: http.StatusOK,
+			expected:     "Foo",
+			callToolName: "Bar",
 		},
 		{
 			name: "Filter MyFoo, Override Foo -> MyFoo",
@@ -340,9 +330,8 @@ func TestNewToolCallMappingMiddleware_Scenarios(t *testing.T) {
 				WithToolsFilter("Foo"),
 				WithToolsOverride("Foo", "MyFoo", "Override description"),
 			},
-			expected:       nil,
-			callToolName:   "MyFoo",
-			expectedStatus: http.StatusBadRequest,
+			expected:     nil,
+			callToolName: "MyFoo",
 		},
 	}
 


### PR DESCRIPTION
## Summary

**Why:** When `thv run --tools-filter` blocked a `tools/call` for a filtered tool, the middleware returned a bare **HTTP 400** with no body. Clients expect a protocol-level JSON-RPC error, and a 400 on a *validly received* JSON-RPC request is off-spec — under MCP streamable HTTP an application-level failure rides back in an **HTTP 200** carrying a JSON-RPC error object (the spec's "Error Handling" section lists "Unknown tools" as a protocol error with a canonical `-32602` example).

**What:**
- A filtered `tools/call` now returns a JSON-RPC error `{"code":-32602,"message":"tool not found"}` over **HTTP 200** when the client's `Accept` header allows JSON (`application/json`, `application/*`, `*/*`, or absent), echoing the request `id`.
- The message is generic ("tool not found") **by design**: a filtered tool must be indistinguishable from a nonexistent one (the filter's long-standing documented intent — see the NOTE in `NewToolCallMappingMiddleware`). `-32602` matches what the MCP spec and the go-sdk return for an unknown tool, so the two responses look identical.
- A client that accepts **only** `text/event-stream` (the legacy HTTP+SSE transport, whose real response is delivered on a separate stream this middleware can't inject into) keeps the **HTTP 400** fallback — preserving the documented session-management limitation.
- The **malformed-request** case (`toolCallBogus`) intentionally stays HTTP 400, per this item's "keep 400 only for malformed" guidance.
- New helpers `clientAcceptsJSON` and `writeFilteredToolCallError`, modeled on the existing `writeRateLimited` / `classificationErrorBody` patterns.
- Dropped the dead, now-inaccurate `expectedStatus` column from the middleware scenario table (it was never asserted, and its filtered-case values were falsified by this change); the new httptest-based tests assert status directly.

Closes **item 2** of #5764. Item 3 (version-agnostic proxying docs + strict mode) remains, so this does not close the issue.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests — `go test -race ./pkg/mcp/...` passes. New/updated coverage:
  - `TestNewToolCallMappingMiddleware_FilteredTool` (httptest): filtered call with `Accept: application/json` (numeric, string, and `null` ids), a multi-value Accept, and no Accept header → HTTP 200 + `application/json` + JSON-RPC `-32602` "tool not found", `id` echoed, message does not leak "filter", and `next` never called; `Accept: text/event-stream` only → HTTP 400.
  - `TestClientAcceptsJSON`: `application/json`, multi-value, `*/*`, `application/*`, empty, `;q=` param, uppercase (case-insensitive), and the `application/json-patch+json` false-positive guard.
  - `_AllowedToolPassesThrough` (passthrough) and `_BogusRequest` (still 400 even with `Accept: application/json`).
- [x] Linting — `task lint` reports 0 issues; `task build` succeeds.

## Does this introduce a user-facing change?

Yes. A blocked `tools/call` through `thv run --tools-filter` now returns a JSON-RPC `-32602` "tool not found" error at HTTP 200 (for JSON-capable clients) instead of a bare HTTP 400, matching how a real MCP server reports an unknown tool.

## Special notes for reviewers

- **Reviewed by an MCP-spec + correctness/tests + security panel.** Spec: confirmed HTTP 200 + `-32602` is the prescribed shape and that `-32602` (not `-32601` or `isError:true`) is correct for an unknown tool. Security: fail-closed confirmed (the call is never forwarded in either branch), the echoed `id` is safely `json.Marshal`-ed (no reflection/injection), and the generic message meets the no-oracle goal.
- **Observability note:** telemetry/audit will now see HTTP **200** (with a JSON-RPC error) for a blocked filtered call instead of 400 — a dashboard that counted 4xx as "blocked" would need updating. This is a monitoring nuance, not a control change; the tool is still hard-blocked.
- **Deliberately out of scope:** the `toolCallBogus` (malformed request) path stays 400 per this item's wording; the spec technically buckets malformed requests as protocol errors too, so upgrading it to `-32602` is a reasonable future follow-up.

Generated with [Claude Code](https://claude.com/claude-code)