### PR TITLE
Set Windows DACL on discovery directory under LOCALAPPDATA

### DIFF
--- a/pkg/api/discovery_permissions_windows_test.go
+++ b/pkg/api/discovery_permissions_windows_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -108,16 +109,28 @@ func grantEveryone(t *testing.T, path string) {
 	require.NoError(t, err, "icacls grant Everyone failed: %s", out)
 }
 
-// assertRestrictedDACL asserts dir carries a protected DACL with no ACE for
-// the groups a local attacker could come from. The exhaustive per-ACE check
-// lives in the discovery package's own Windows tests; this is the pkg/api view
-// of the same contract.
+// aceTrusteePattern captures the trustee of each ACE in an SDDL DACL, which is
+// the last of the six semicolon-separated ACE fields.
+var aceTrusteePattern = regexp.MustCompile(`\(([^)]*)\)`)
+
+// assertRestrictedDACL asserts dir carries a protected DACL that grants nobody
+// but SYSTEM and the process user. The per-ACE permission checks live in the
+// discovery package's own Windows tests; this is the pkg/api view of the same
+// contract.
 func assertRestrictedDACL(t *testing.T, dir string) {
 	t.Helper()
+
+	tokenUser, err := windows.GetCurrentProcessToken().GetTokenUser()
+	require.NoError(t, err)
+	allowed := []string{"SY", tokenUser.User.Sid.String()}
+
 	sddl := dirSDDL(t, dir)
 	assert.Contains(t, sddl, "D:P", "DACL of %s must be protected against inheritance: %s", dir, sddl)
-	for _, sid := range []string{";;;WD)", ";;;AU)", ";;;BU)", ";;;IU)"} {
-		assert.NotContains(t, sddl, sid, "DACL of %s must not grant %s: %s", dir, sid, sddl)
+	for _, ace := range aceTrusteePattern.FindAllStringSubmatch(sddl, -1) {
+		fields := strings.Split(ace[1], ";")
+		trustee := fields[len(fields)-1]
+		assert.Contains(t, allowed, trustee,
+			"DACL of %s must grant only SYSTEM and the process user, found %s: %s", dir, trustee, sddl)
 	}
 }
 

--- a/pkg/api/discovery_permissions_windows_test.go
+++ b/pkg/api/discovery_permissions_windows_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -30,9 +29,8 @@ import (
 // TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile pins the
 // production ordering. writeDiscoveryFile must lock down the discovery chain
 // before it acquires server.json.lock or calls Discover. A pre-planted file
-// written while the chain was still loose must be invalidated during that
-// lockdown so a victim-owned server.json cannot keep redirecting clients after
-// the DACL is repaired.
+// written while the chain was still loose must not be deleted during lockdown;
+// startup fails closed when the planted record answers healthy.
 //
 //nolint:paralleltest // t.Setenv and xdg.Reload mutate process-wide state
 func TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile(t *testing.T) {
@@ -79,18 +77,18 @@ func TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile(t *testing.T)
 	s := &Server{listener: listener, address: listener.Addr().String(), nonce: "our-nonce"}
 
 	err = s.writeDiscoveryFile(context.Background())
-	require.NoError(t, err, "planted file must be invalidated before Discover trusts it")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already running")
 
 	// The chain must already be locked down, on the leaf and on the
 	// intermediate directory.
-	assertRestrictedDACL(t, toolhiveDir)
-	assertRestrictedDACL(t, serverDir)
+	require.NoError(t, discovery.ValidateRestrictedDiscoveryDACL(toolhiveDir))
+	require.NoError(t, discovery.ValidateRestrictedDiscoveryDACL(serverDir))
 
-	// The forged record must not survive the upgrade path.
+	// The forged record must survive lockdown so a healthy predecessor is not erased.
 	onDisk, err := os.ReadFile(discovery.FilePath())
 	require.NoError(t, err)
-	assert.NotEqual(t, string(planted), string(onDisk))
-	assert.Contains(t, string(onDisk), "our-nonce")
+	assert.Equal(t, string(planted), string(onDisk))
 }
 
 func grantEveryone(t *testing.T, path string) {
@@ -99,31 +97,6 @@ func grantEveryone(t *testing.T, path string) {
 	// PowerShell from expanding (OI)/(CI).
 	out, err := exec.Command("icacls", path, "/grant", "*S-1-1-0:(OI)(CI)M").CombinedOutput()
 	require.NoError(t, err, "icacls grant Everyone failed: %s", out)
-}
-
-// aceTrusteePattern captures the trustee of each ACE in an SDDL DACL, which is
-// the last of the six semicolon-separated ACE fields.
-var aceTrusteePattern = regexp.MustCompile(`\(([^)]*)\)`)
-
-// assertRestrictedDACL asserts dir carries a protected DACL that grants nobody
-// but SYSTEM and the process user. The per-ACE permission checks live in the
-// discovery package's own Windows tests; this is the pkg/api view of the same
-// contract.
-func assertRestrictedDACL(t *testing.T, dir string) {
-	t.Helper()
-
-	tokenUser, err := windows.GetCurrentProcessToken().GetTokenUser()
-	require.NoError(t, err)
-	allowed := []string{"SY", tokenUser.User.Sid.String()}
-
-	sddl := dirSDDL(t, dir)
-	assert.Contains(t, sddl, "D:P", "DACL of %s must be protected against inheritance: %s", dir, sddl)
-	for _, ace := range aceTrusteePattern.FindAllStringSubmatch(sddl, -1) {
-		fields := strings.Split(ace[1], ";")
-		trustee := fields[len(fields)-1]
-		assert.Contains(t, allowed, trustee,
-			"DACL of %s must grant only SYSTEM and the process user, found %s: %s", dir, trustee, sddl)
-	}
 }
 
 func dirSDDL(t *testing.T, dir string) string {

--- a/pkg/api/discovery_permissions_windows_test.go
+++ b/pkg/api/discovery_permissions_windows_test.go
@@ -28,17 +28,11 @@ import (
 )
 
 // TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile pins the
-// production ordering. writeDiscoveryFile takes server.json.lock and runs
-// Discover before it ever writes, so restricting the directory as part of the
-// write is too late: when Discover reports StateRunning from a pre-planted
-// server.json, the function returns first and the loose directory is never
-// repaired. Startup keeps trusting an attacker-writable discovery file (and
-// keeps taking its lock file inside a directory other accounts can write to)
-// for as long as that file looks healthy.
-//
-// The test drives the real startup path with a planted, healthy-looking
-// discovery file and asserts the whole chain is already locked down on the
-// failing return.
+// production ordering. writeDiscoveryFile must lock down the discovery chain
+// before it acquires server.json.lock or calls Discover. A pre-planted file
+// written while the chain was still loose must be invalidated during that
+// lockdown so a victim-owned server.json cannot keep redirecting clients after
+// the DACL is repaired.
 //
 //nolint:paralleltest // t.Setenv and xdg.Reload mutate process-wide state
 func TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile(t *testing.T) {
@@ -85,20 +79,18 @@ func TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile(t *testing.T)
 	s := &Server{listener: listener, address: listener.Addr().String(), nonce: "our-nonce"}
 
 	err = s.writeDiscoveryFile(context.Background())
-	require.Error(t, err, "a healthy planted file must abort startup")
-	assert.Contains(t, err.Error(), "already running")
+	require.NoError(t, err, "planted file must be invalidated before Discover trusts it")
 
-	// The early return must not skip the lockdown, on the leaf or on the
+	// The chain must already be locked down, on the leaf and on the
 	// intermediate directory.
 	assertRestrictedDACL(t, toolhiveDir)
 	assertRestrictedDACL(t, serverDir)
 
-	// Ordering, not just the end state: WriteServerInfo never ran, so the
-	// planted contents are still there. If the DACL above had been applied by
-	// the write, this assertion would fail instead.
+	// The forged record must not survive the upgrade path.
 	onDisk, err := os.ReadFile(discovery.FilePath())
 	require.NoError(t, err)
-	assert.JSONEq(t, string(planted), string(onDisk))
+	assert.NotEqual(t, string(planted), string(onDisk))
+	assert.Contains(t, string(onDisk), "our-nonce")
 }
 
 func grantEveryone(t *testing.T, path string) {

--- a/pkg/api/discovery_permissions_windows_test.go
+++ b/pkg/api/discovery_permissions_windows_test.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/adrg/xdg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+
+	"github.com/stacklok/toolhive/pkg/server/discovery"
+)
+
+// TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile pins the
+// production ordering. writeDiscoveryFile takes server.json.lock and runs
+// Discover before it ever writes, so restricting the directory as part of the
+// write is too late: when Discover reports StateRunning from a pre-planted
+// server.json, the function returns first and the loose directory is never
+// repaired. Startup keeps trusting an attacker-writable discovery file (and
+// keeps taking its lock file inside a directory other accounts can write to)
+// for as long as that file looks healthy.
+//
+// The test drives the real startup path with a planted, healthy-looking
+// discovery file and asserts the whole chain is already locked down on the
+// failing return.
+//
+//nolint:paralleltest // t.Setenv and xdg.Reload mutate process-wide state
+func TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile(t *testing.T) {
+	base := t.TempDir()
+	grantEveryone(t, base)
+
+	t.Setenv("XDG_STATE_HOME", base)
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+	// Guard against silently operating on the real %LOCALAPPDATA%: everything
+	// below rewrites ACLs.
+	require.Equal(t, base, xdg.StateHome, "XDG_STATE_HOME must redirect the discovery path")
+
+	serverDir := filepath.Dir(discovery.FilePath())
+	toolhiveDir := filepath.Dir(serverDir)
+	require.Equal(t, base, filepath.Dir(toolhiveDir))
+
+	// A server that answers /health with the planted nonce, so Discover
+	// classifies the planted file as StateRunning.
+	const plantedNonce = "planted-nonce"
+	healthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(discovery.NonceHeader, plantedNonce)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(healthSrv.Close)
+
+	// Plant the file the way an attacker with write access to a loose
+	// directory would: plain MkdirAll, so both directories inherit Everyone.
+	require.NoError(t, os.MkdirAll(serverDir, 0700))
+	planted, err := json.Marshal(&discovery.ServerInfo{
+		URL:       healthSrv.URL,
+		PID:       os.Getpid(),
+		Nonce:     plantedNonce,
+		StartedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(discovery.FilePath(), planted, 0600))
+	require.Contains(t, strings.ToUpper(dirSDDL(t, serverDir)), "WD",
+		"precondition: the planted directory must inherit Everyone (WD)")
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	s := &Server{listener: listener, address: listener.Addr().String(), nonce: "our-nonce"}
+
+	err = s.writeDiscoveryFile(context.Background())
+	require.Error(t, err, "a healthy planted file must abort startup")
+	assert.Contains(t, err.Error(), "already running")
+
+	// The early return must not skip the lockdown, on the leaf or on the
+	// intermediate directory.
+	assertRestrictedDACL(t, toolhiveDir)
+	assertRestrictedDACL(t, serverDir)
+
+	// Ordering, not just the end state: WriteServerInfo never ran, so the
+	// planted contents are still there. If the DACL above had been applied by
+	// the write, this assertion would fail instead.
+	onDisk, err := os.ReadFile(discovery.FilePath())
+	require.NoError(t, err)
+	assert.JSONEq(t, string(planted), string(onDisk))
+}
+
+func grantEveryone(t *testing.T, path string) {
+	t.Helper()
+	// icacls is the product-path way to introduce a loose ACE; quoting keeps
+	// PowerShell from expanding (OI)/(CI).
+	out, err := exec.Command("icacls", path, "/grant", "*S-1-1-0:(OI)(CI)M").CombinedOutput()
+	require.NoError(t, err, "icacls grant Everyone failed: %s", out)
+}
+
+// assertRestrictedDACL asserts dir carries a protected DACL with no ACE for
+// the groups a local attacker could come from. The exhaustive per-ACE check
+// lives in the discovery package's own Windows tests; this is the pkg/api view
+// of the same contract.
+func assertRestrictedDACL(t *testing.T, dir string) {
+	t.Helper()
+	sddl := dirSDDL(t, dir)
+	assert.Contains(t, sddl, "D:P", "DACL of %s must be protected against inheritance: %s", dir, sddl)
+	for _, sid := range []string{";;;WD)", ";;;AU)", ";;;BU)", ";;;IU)"} {
+		assert.NotContains(t, sddl, sid, "DACL of %s must not grant %s: %s", dir, sid, sddl)
+	}
+}
+
+func dirSDDL(t *testing.T, dir string) string {
+	t.Helper()
+	sd, err := windows.GetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	require.NoError(t, err)
+	return sd.String()
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -614,12 +614,17 @@ func (s *Server) writeDiscoveryFile(ctx context.Context) error {
 	// would be too late: a StateRunning result returns before the write, and
 	// the lock file itself would be taken in a directory other accounts can
 	// still write to.
-	if err := discovery.EnsureSecureDir(); err != nil {
+	secure, err := discovery.EnsureSecureDirEx()
+	if err != nil {
 		return err
 	}
 	discoveryPath := discovery.FilePath()
 
 	return fileutils.WithFileLock(discoveryPath, func() error {
+		if err := discovery.ReconcileDiscoveryAfterInsecureUpgrade(ctx, secure.RepairedInsecureChain); err != nil {
+			return err
+		}
+
 		// Guard against overwriting another server's discovery file.
 		result, err := discovery.Discover(ctx)
 		if err != nil {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -26,7 +26,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -609,12 +608,16 @@ func (s *Server) writeDiscoveryFile(ctx context.Context) error {
 		return nil
 	}
 
-	// Ensure the discovery directory exists before acquiring the lock,
-	// since the lock file is created in the same directory.
-	discoveryPath := discovery.FilePath()
-	if err := os.MkdirAll(filepath.Dir(discoveryPath), 0700); err != nil {
-		return fmt.Errorf("failed to create discovery directory: %w", err)
+	// Create and lock down the discovery directory before acquiring the lock,
+	// since the lock file is created in the same directory and Discover below
+	// trusts whatever server.json it finds there. Restricting only on the write
+	// would be too late: a StateRunning result returns before the write, and
+	// the lock file itself would be taken in a directory other accounts can
+	// still write to.
+	if err := discovery.EnsureSecureDir(); err != nil {
+		return err
 	}
+	discoveryPath := discovery.FilePath()
 
 	return fileutils.WithFileLock(discoveryPath, func() error {
 		// Guard against overwriting another server's discovery file.

--- a/pkg/server/discovery/discovery.go
+++ b/pkg/server/discovery/discovery.go
@@ -78,8 +78,10 @@ func writeServerInfoTo(dir string, info *ServerInfo) error {
 
 	// Tighten permissions on the directory in case it already existed with
 	// looser permissions. MkdirAll only applies mode to newly-created dirs.
-	if err := os.Chmod(dir, dirPermissions); err != nil {
-		return fmt.Errorf("failed to set discovery directory permissions: %w", err)
+	// On Windows this sets an explicit protected DACL (POSIX modes are
+	// advisory on NTFS); elsewhere it is os.Chmod(dirPermissions).
+	if err := restrictDiscoveryDirPermissions(dir); err != nil {
+		return err
 	}
 
 	path := filepath.Join(dir, "server.json")

--- a/pkg/server/discovery/discovery.go
+++ b/pkg/server/discovery/discovery.go
@@ -58,6 +58,17 @@ func discoveryDirChain(base string) []string {
 	return []string{toolhiveDir, filepath.Join(toolhiveDir, "server")}
 }
 
+// discoveryServerDir returns the leaf directory that holds server.json.
+func discoveryServerDir(base string) string {
+	chain := discoveryDirChain(base)
+	return chain[len(chain)-1]
+}
+
+// discoveryFilePath returns server.json under base.
+func discoveryFilePath(base string) string {
+	return filepath.Join(discoveryServerDir(base), "server.json")
+}
+
 // defaultDiscoveryDir returns the default directory for the discovery file
 // based on the XDG Base Directory Specification.
 func defaultDiscoveryDir() string {
@@ -86,15 +97,54 @@ func EnsureSecureDir() error {
 }
 
 // ensureSecureDirIn creates the discovery directory chain under base and
-// restricts each directory ToolHive owns in it, outermost first.
+// restricts the directories ToolHive owns in it. Windows hardens the full
+// chain; other platforms chmod only the server leaf so shared toolhive state
+// (runconfigs, toolhive.db) keeps its existing group permissions.
 func ensureSecureDirIn(base string) error {
-	for _, dir := range discoveryDirChain(base) {
+	chain := discoveryDirsToSecure(base)
+	serverPath := discoveryFilePath(base)
+
+	hadInsecureChain, err := discoveryChainWasInsecure(chain)
+	if err != nil {
+		return err
+	}
+
+	for _, dir := range chain {
 		if err := os.MkdirAll(dir, dirPermissions); err != nil {
 			return fmt.Errorf("failed to create discovery directory: %w", err)
 		}
 		if err := restrictDiscoveryDirPermissions(dir); err != nil {
 			return err
 		}
+	}
+
+	if hadInsecureChain {
+		if err := invalidateDiscoveryFileAfterInsecureChain(serverPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func discoveryChainWasInsecure(chain []string) (bool, error) {
+	for _, dir := range chain {
+		loose, err := discoveryDirPermissionsLoose(dir)
+		if err != nil {
+			return false, err
+		}
+		if loose {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// invalidateDiscoveryFileAfterInsecureChain removes a discovery file that may
+// have been tampered with while the directory chain was still writable.
+func invalidateDiscoveryFileAfterInsecureChain(path string) error {
+	err := os.Remove(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to invalidate untrusted discovery file: %w", err)
 	}
 	return nil
 }

--- a/pkg/server/discovery/discovery.go
+++ b/pkg/server/discovery/discovery.go
@@ -65,11 +65,6 @@ func discoveryServerDir(base string) string {
 	return chain[len(chain)-1]
 }
 
-// discoveryFilePath returns server.json under base.
-func discoveryFilePath(base string) string {
-	return filepath.Join(discoveryServerDir(base), "server.json")
-}
-
 // defaultDiscoveryDir returns the default directory for the discovery file
 // based on the XDG Base Directory Specification.
 func defaultDiscoveryDir() string {
@@ -188,7 +183,8 @@ func ReconcileDiscoveryAfterInsecureUpgrade(ctx context.Context, repaired bool) 
 		return nil
 	case StateNotFound:
 		return fmt.Errorf(
-			"refusing to start: discovery record %s exists after security upgrade but could not be validated; remove it manually or stop the other server",
+			"refusing to start: discovery record %s exists after security upgrade but could not be validated; "+
+				"remove it manually or stop the other server",
 			path,
 		)
 	default:

--- a/pkg/server/discovery/discovery.go
+++ b/pkg/server/discovery/discovery.go
@@ -45,10 +45,24 @@ type ServerInfo struct {
 	StartedAt time.Time `json:"started_at"`
 }
 
+// discoveryDirChain returns the directories ToolHive creates for the discovery
+// file under base, outermost first. The last element is the discovery
+// directory itself.
+//
+// The intermediate toolhive directory is part of the chain on purpose. A user
+// who can delete or rename it can substitute a directory of their own, and
+// every restriction applied to the leaf would then apply to a directory nobody
+// reads.
+func discoveryDirChain(base string) []string {
+	toolhiveDir := filepath.Join(base, "toolhive")
+	return []string{toolhiveDir, filepath.Join(toolhiveDir, "server")}
+}
+
 // defaultDiscoveryDir returns the default directory for the discovery file
 // based on the XDG Base Directory Specification.
 func defaultDiscoveryDir() string {
-	return filepath.Join(xdg.StateHome, "toolhive", "server")
+	chain := discoveryDirChain(xdg.StateHome)
+	return chain[len(chain)-1]
 }
 
 // FilePath returns the full path to the server discovery file
@@ -57,10 +71,41 @@ func FilePath() string {
 	return filepath.Join(defaultDiscoveryDir(), "server.json")
 }
 
+// EnsureSecureDir creates the discovery directory chain and locks it down.
+// Callers must invoke it before they read, lock, or otherwise trust anything
+// under the discovery directory, not just before they write.
+//
+// Startup is the case that matters: pkg/api creates the directory, takes
+// server.json.lock inside it, and runs Discover before it ever calls
+// WriteServerInfo. If a directory left loose by an earlier run only got
+// restricted by the write, a pre-planted server.json would be trusted for a
+// whole startup cycle, and a Discover result of StateRunning returns before
+// the write is reached at all.
+func EnsureSecureDir() error {
+	return ensureSecureDirIn(xdg.StateHome)
+}
+
+// ensureSecureDirIn creates the discovery directory chain under base and
+// restricts each directory ToolHive owns in it, outermost first.
+func ensureSecureDirIn(base string) error {
+	for _, dir := range discoveryDirChain(base) {
+		if err := os.MkdirAll(dir, dirPermissions); err != nil {
+			return fmt.Errorf("failed to create discovery directory: %w", err)
+		}
+		if err := restrictDiscoveryDirPermissions(dir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // WriteServerInfo atomically writes the server discovery file.
-// It creates the directory if needed, rejects symlinks at the target path,
-// and writes with restricted permissions (0600).
+// It creates and restricts the directory chain if needed, rejects symlinks at
+// the target path, and writes with restricted permissions (0600).
 func WriteServerInfo(info *ServerInfo) error {
+	if err := EnsureSecureDir(); err != nil {
+		return err
+	}
 	return writeServerInfoTo(defaultDiscoveryDir(), info)
 }
 
@@ -114,6 +159,14 @@ func readServerInfoFrom(dir string) (*ServerInfo, error) {
 		if fi.Mode()&os.ModeSymlink != 0 {
 			return nil, fmt.Errorf("refusing to read discovery file: %s is a symlink", path)
 		}
+	}
+
+	// Reject a file another account owns for the same reason we reject a
+	// symlink: the URL and nonce inside it decide where clients send their
+	// API traffic. Tightening the directory stops new writes, but a file
+	// planted while the directory was still loose keeps its old ACL.
+	if err := validateDiscoveryFileOwner(path); err != nil {
+		return nil, err
 	}
 
 	data, err := os.ReadFile(path) // #nosec G304 -- path is constructed from a trusted XDG directory, not user input

--- a/pkg/server/discovery/discovery.go
+++ b/pkg/server/discovery/discovery.go
@@ -101,18 +101,20 @@ func EnsureSecureDir() error {
 // chain; other platforms chmod only the server leaf so shared toolhive state
 // (runconfigs, toolhive.db) keeps its existing group permissions.
 func ensureSecureDirIn(base string) error {
-	chain := discoveryDirsToSecure(base)
+	secureDirs := discoveryDirsToSecure(base)
 	serverPath := discoveryFilePath(base)
+	fullChain := discoveryDirChain(base)
 
-	hadInsecureChain, err := discoveryChainWasInsecure(chain)
+	hadInsecureChain, err := discoveryChainWasInsecure(secureDirs)
 	if err != nil {
 		return err
 	}
 
-	for _, dir := range chain {
-		if err := os.MkdirAll(dir, dirPermissions); err != nil {
-			return fmt.Errorf("failed to create discovery directory: %w", err)
-		}
+	if err := mkdirDiscoveryChain(fullChain); err != nil {
+		return err
+	}
+
+	for _, dir := range secureDirs {
 		if err := restrictDiscoveryDirPermissions(dir); err != nil {
 			return err
 		}

--- a/pkg/server/discovery/discovery.go
+++ b/pkg/server/discovery/discovery.go
@@ -7,6 +7,7 @@
 package discovery
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -82,6 +83,12 @@ func FilePath() string {
 	return filepath.Join(defaultDiscoveryDir(), "server.json")
 }
 
+// SecureDirResult reports whether ensureSecureDirIn repaired a previously
+// insecure discovery directory chain.
+type SecureDirResult struct {
+	RepairedInsecureChain bool
+}
+
 // EnsureSecureDir creates the discovery directory chain and locks it down.
 // Callers must invoke it before they read, lock, or otherwise trust anything
 // under the discovery directory, not just before they write.
@@ -93,6 +100,14 @@ func FilePath() string {
 // whole startup cycle, and a Discover result of StateRunning returns before
 // the write is reached at all.
 func EnsureSecureDir() error {
+	_, err := EnsureSecureDirEx()
+	return err
+}
+
+// EnsureSecureDirEx is like EnsureSecureDir but reports whether the chain was
+// repaired from an insecure state. pkg/api uses this under the discovery
+// file lock to fail closed on an existing record instead of deleting it.
+func EnsureSecureDirEx() (SecureDirResult, error) {
 	return ensureSecureDirIn(xdg.StateHome)
 }
 
@@ -100,32 +115,31 @@ func EnsureSecureDir() error {
 // restricts the directories ToolHive owns in it. Windows hardens the full
 // chain; other platforms chmod only the server leaf so shared toolhive state
 // (runconfigs, toolhive.db) keeps its existing group permissions.
-func ensureSecureDirIn(base string) error {
+//
+// A discovery file that existed while the chain was still loose is not removed
+// here: it cannot be classified as legitimate or forged without the startup
+// lock and a health check. pkg/api calls ReconcileDiscoveryAfterInsecureUpgrade
+// under that lock instead.
+func ensureSecureDirIn(base string) (SecureDirResult, error) {
 	secureDirs := discoveryDirsToSecure(base)
-	serverPath := discoveryFilePath(base)
-	fullChain := discoveryDirChain(base)
 
 	hadInsecureChain, err := discoveryChainWasInsecure(secureDirs)
 	if err != nil {
-		return err
+		return SecureDirResult{}, err
 	}
 
+	fullChain := discoveryDirChain(base)
 	if err := mkdirDiscoveryChain(fullChain); err != nil {
-		return err
+		return SecureDirResult{}, err
 	}
 
 	for _, dir := range secureDirs {
 		if err := restrictDiscoveryDirPermissions(dir); err != nil {
-			return err
+			return SecureDirResult{}, err
 		}
 	}
 
-	if hadInsecureChain {
-		if err := invalidateDiscoveryFileAfterInsecureChain(serverPath); err != nil {
-			return err
-		}
-	}
-	return nil
+	return SecureDirResult{RepairedInsecureChain: hadInsecureChain}, nil
 }
 
 func discoveryChainWasInsecure(chain []string) (bool, error) {
@@ -141,14 +155,45 @@ func discoveryChainWasInsecure(chain []string) (bool, error) {
 	return false, nil
 }
 
-// invalidateDiscoveryFileAfterInsecureChain removes a discovery file that may
-// have been tampered with while the directory chain was still writable.
-func invalidateDiscoveryFileAfterInsecureChain(path string) error {
-	err := os.Remove(path)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("failed to invalidate untrusted discovery file: %w", err)
+// ReconcileDiscoveryAfterInsecureUpgrade runs under the discovery file lock
+// after EnsureSecureDirEx repaired an insecure chain. An existing record cannot
+// be classified as legitimate or forged from directory permissions alone, so
+// startup fails closed when a healthy server answers, removes stale records, or
+// leaves an unhealthy record for the caller to overwrite. It never deletes a
+// record that might belong to a still-running peer.
+func ReconcileDiscoveryAfterInsecureUpgrade(ctx context.Context, repaired bool) error {
+	if !repaired {
+		return nil
 	}
-	return nil
+
+	path := FilePath()
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	result, err := Discover(ctx)
+	if err != nil {
+		return err
+	}
+
+	switch result.State {
+	case StateRunning:
+		return fmt.Errorf("another ToolHive server is already running at %s (PID %d)", result.Info.URL, result.Info.PID)
+	case StateStale:
+		return CleanupStale()
+	case StateUnhealthy:
+		return nil
+	case StateNotFound:
+		return fmt.Errorf(
+			"refusing to start: discovery record %s exists after security upgrade but could not be validated; remove it manually or stop the other server",
+			path,
+		)
+	default:
+		return fmt.Errorf("refusing to start: unexpected discovery state %q after security upgrade", result.State)
+	}
 }
 
 // WriteServerInfo atomically writes the server discovery file.

--- a/pkg/server/discovery/discovery_test.go
+++ b/pkg/server/discovery/discovery_test.go
@@ -6,6 +6,7 @@ package discovery
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -115,6 +116,12 @@ func TestRemoveServerInfo_NotFound(t *testing.T) {
 
 func TestWriteServerInfo_FilePermissions(t *testing.T) {
 	t.Parallel()
+	// POSIX file modes are advisory on NTFS; Windows reports 0666 for
+	// newly written files regardless of the mode passed to AtomicWriteFile.
+	// Directory ACL coverage for Windows lives in permissions_windows_test.go.
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not meaningful on Windows")
+	}
 	dir := t.TempDir()
 
 	info := &ServerInfo{
@@ -132,6 +139,11 @@ func TestWriteServerInfo_FilePermissions(t *testing.T) {
 
 func TestWriteServerInfo_CreatesDirectoryWithCorrectPermissions(t *testing.T) {
 	t.Parallel()
+	// On Windows, writeServerInfoTo sets an explicit DACL instead of relying
+	// on os.Chmod; see TestWriteServerInfo_WindowsDACL_NoOtherInteractiveUsers.
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory modes are not meaningful on Windows; see DACL tests")
+	}
 	parent := t.TempDir()
 	dir := filepath.Join(parent, "nested", "server")
 
@@ -195,6 +207,11 @@ func TestReadServerInfo_RejectsSymlink(t *testing.T) {
 
 func TestWriteServerInfo_TightensExistingDirPermissions(t *testing.T) {
 	t.Parallel()
+	// On Windows the equivalent "tighten existing" path is covered by
+	// TestRestrictDiscoveryDirPermissions_ReplacesExistingLooseACL.
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory modes are not meaningful on Windows; see DACL tests")
+	}
 
 	// Create a directory with deliberately too-loose permissions.
 	dir := t.TempDir()

--- a/pkg/server/discovery/discovery_test.go
+++ b/pkg/server/discovery/discovery_test.go
@@ -160,6 +160,55 @@ func TestWriteServerInfo_CreatesDirectoryWithCorrectPermissions(t *testing.T) {
 	assert.Equal(t, os.FileMode(dirPermissions), fi.Mode().Perm())
 }
 
+// TestEnsureSecureDirIn_CreatesAndRestrictsChain asserts the chain contract
+// startup depends on: both the intermediate toolhive directory and the server
+// leaf exist and are restricted before anything reads or locks inside them.
+// The Windows DACL half is asserted in
+// TestEnsureSecureDirIn_ProtectsIntermediateToolhiveDir.
+func TestEnsureSecureDirIn_CreatesAndRestrictsChain(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	require.NoError(t, ensureSecureDirIn(base))
+
+	chain := discoveryDirChain(base)
+	require.Len(t, chain, 2)
+	for _, dir := range chain {
+		fi, err := os.Stat(dir)
+		require.NoError(t, err)
+		require.True(t, fi.IsDir(), "%s must be a directory", dir)
+		if runtime.GOOS == "windows" {
+			continue
+		}
+		assert.Equal(t, os.FileMode(dirPermissions), fi.Mode().Perm(), "mode of %s", dir)
+	}
+}
+
+// TestEnsureSecureDirIn_TightensExistingChain covers the upgrade path: a chain
+// left behind by an earlier run with loose permissions must be tightened, since
+// startup trusts the discovery file inside it.
+func TestEnsureSecureDirIn_TightensExistingChain(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory modes are not meaningful on Windows; see DACL tests")
+	}
+
+	base := t.TempDir()
+	chain := discoveryDirChain(base)
+	require.NoError(t, os.MkdirAll(chain[len(chain)-1], 0755))
+	for _, dir := range chain {
+		require.NoError(t, os.Chmod(dir, 0755))
+	}
+
+	require.NoError(t, ensureSecureDirIn(base))
+
+	for _, dir := range chain {
+		fi, err := os.Stat(dir)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(dirPermissions), fi.Mode().Perm(), "mode of %s", dir)
+	}
+}
+
 func TestWriteServerInfo_RejectsSymlink(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/pkg/server/discovery/discovery_test.go
+++ b/pkg/server/discovery/discovery_test.go
@@ -173,15 +173,22 @@ func TestEnsureSecureDirIn_CreatesAndRestrictsChain(t *testing.T) {
 
 	chain := discoveryDirChain(base)
 	require.Len(t, chain, 2)
+	toolhiveDir, serverDir := chain[0], chain[1]
 	for _, dir := range chain {
 		fi, err := os.Stat(dir)
 		require.NoError(t, err)
 		require.True(t, fi.IsDir(), "%s must be a directory", dir)
-		if runtime.GOOS == "windows" {
-			continue
-		}
-		assert.Equal(t, os.FileMode(dirPermissions), fi.Mode().Perm(), "mode of %s", dir)
 	}
+	if runtime.GOOS == "windows" {
+		return
+	}
+	fi, err := os.Stat(toolhiveDir)
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(dirPermissions), fi.Mode().Perm(),
+		"intermediate toolhive dir must keep its existing mode on POSIX")
+	fi, err = os.Stat(serverDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(dirPermissions), fi.Mode().Perm(), "mode of %s", serverDir)
 }
 
 // TestEnsureSecureDirIn_TightensExistingChain covers the upgrade path: a chain
@@ -202,11 +209,13 @@ func TestEnsureSecureDirIn_TightensExistingChain(t *testing.T) {
 
 	require.NoError(t, ensureSecureDirIn(base))
 
-	for _, dir := range chain {
-		fi, err := os.Stat(dir)
-		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(dirPermissions), fi.Mode().Perm(), "mode of %s", dir)
-	}
+	toolhiveDir, serverDir := chain[0], chain[1]
+	fi, err := os.Stat(toolhiveDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0755), fi.Mode().Perm(), "intermediate toolhive dir must stay loose on POSIX")
+	fi, err = os.Stat(serverDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(dirPermissions), fi.Mode().Perm(), "mode of %s", serverDir)
 }
 
 func TestWriteServerInfo_RejectsSymlink(t *testing.T) {

--- a/pkg/server/discovery/discovery_test.go
+++ b/pkg/server/discovery/discovery_test.go
@@ -169,7 +169,11 @@ func TestEnsureSecureDirIn_CreatesAndRestrictsChain(t *testing.T) {
 	t.Parallel()
 
 	base := t.TempDir()
-	require.NoError(t, ensureSecureDirIn(base))
+	toolhiveDir := filepath.Join(base, "toolhive")
+	require.NoError(t, os.MkdirAll(toolhiveDir, 0750))
+
+	_, err := ensureSecureDirIn(base)
+	require.NoError(t, err)
 
 	chain := discoveryDirChain(base)
 	require.Len(t, chain, 2)
@@ -184,7 +188,7 @@ func TestEnsureSecureDirIn_CreatesAndRestrictsChain(t *testing.T) {
 	}
 	fi, err := os.Stat(toolhiveDir)
 	require.NoError(t, err)
-	assert.NotEqual(t, os.FileMode(dirPermissions), fi.Mode().Perm(),
+	assert.Equal(t, os.FileMode(0750), fi.Mode().Perm(),
 		"intermediate toolhive dir must keep its existing mode on POSIX")
 	fi, err = os.Stat(serverDir)
 	require.NoError(t, err)
@@ -207,7 +211,8 @@ func TestEnsureSecureDirIn_TightensExistingChain(t *testing.T) {
 		require.NoError(t, os.Chmod(dir, 0755))
 	}
 
-	require.NoError(t, ensureSecureDirIn(base))
+	_, err := ensureSecureDirIn(base)
+	require.NoError(t, err)
 
 	toolhiveDir, serverDir := chain[0], chain[1]
 	fi, err := os.Stat(toolhiveDir)

--- a/pkg/server/discovery/permissions_other.go
+++ b/pkg/server/discovery/permissions_other.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package discovery
+
+import (
+	"fmt"
+	"os"
+)
+
+// restrictDiscoveryDirPermissions tightens POSIX mode bits on the discovery
+// directory. On non-Windows platforms this is the Chmod that previously lived
+// inline in writeServerInfoTo.
+func restrictDiscoveryDirPermissions(dir string) error {
+	if err := os.Chmod(dir, dirPermissions); err != nil {
+		return fmt.Errorf("failed to set discovery directory permissions: %w", err)
+	}
+	return nil
+}

--- a/pkg/server/discovery/permissions_other.go
+++ b/pkg/server/discovery/permissions_other.go
@@ -6,6 +6,7 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
@@ -18,6 +19,19 @@ func restrictDiscoveryDirPermissions(dir string) error {
 		return fmt.Errorf("failed to set discovery directory permissions: %w", err)
 	}
 	return nil
+}
+
+// discoveryDirPermissionsLoose reports whether dir exists with looser than
+// expected POSIX mode bits.
+func discoveryDirPermissionsLoose(dir string) (bool, error) {
+	fi, err := os.Stat(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to stat discovery directory: %w", err)
+	}
+	return fi.Mode().Perm() != dirPermissions, nil
 }
 
 // validateDiscoveryFileOwner is a no-op outside Windows. POSIX mode bits are

--- a/pkg/server/discovery/permissions_other.go
+++ b/pkg/server/discovery/permissions_other.go
@@ -19,3 +19,11 @@ func restrictDiscoveryDirPermissions(dir string) error {
 	}
 	return nil
 }
+
+// validateDiscoveryFileOwner is a no-op outside Windows. POSIX mode bits are
+// enforced rather than advisory, so a 0700 directory owned by the user already
+// keeps other accounts from planting a discovery file, and no existing
+// non-Windows behavior changes here.
+func validateDiscoveryFileOwner(_ string) error {
+	return nil
+}

--- a/pkg/server/discovery/permissions_windows.go
+++ b/pkg/server/discovery/permissions_windows.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package discovery
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// restrictDiscoveryDirPermissions replaces the discovery directory DACL with
+// an explicit ACL granting FILE-equivalent GenericAll only to the process
+// user and SYSTEM, and marks the DACL protected so parent ACEs cannot
+// re-inherit. os.Chmod is advisory on NTFS and does not strip inherited
+// ACEs under %LOCALAPPDATA%, which is the gap that lets another interactive
+// user rewrite server.json (for example to point at an attacker named pipe).
+//
+// Inheritance (OICI) is intentional: server.json and any future children
+// pick up the same restriction instead of inheriting a looser parent ACL.
+func restrictDiscoveryDirPermissions(dir string) error {
+	userSID, err := currentProcessUserSID()
+	if err != nil {
+		return fmt.Errorf("failed to resolve current user SID: %w", err)
+	}
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return fmt.Errorf("failed to resolve SYSTEM SID: %w", err)
+	}
+
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.GRANT_ACCESS,
+			Inheritance:       windows.OBJECT_INHERIT_ACE | windows.CONTAINER_INHERIT_ACE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeValue: windows.TrusteeValueFromSID(userSID),
+			},
+		},
+		{
+			AccessPermissions: windows.GENERIC_ALL,
+			AccessMode:        windows.GRANT_ACCESS,
+			Inheritance:       windows.OBJECT_INHERIT_ACE | windows.CONTAINER_INHERIT_ACE,
+			Trustee: windows.TRUSTEE{
+				TrusteeForm:  windows.TRUSTEE_IS_SID,
+				TrusteeType:  windows.TRUSTEE_IS_WELL_KNOWN_GROUP,
+				TrusteeValue: windows.TrusteeValueFromSID(systemSID),
+			},
+		},
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to build discovery directory DACL: %w", err)
+	}
+
+	if err := windows.SetNamedSecurityInfo(
+		dir,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	); err != nil {
+		return fmt.Errorf("failed to set discovery directory DACL: %w", err)
+	}
+	return nil
+}
+
+func currentProcessUserSID() (*windows.SID, error) {
+	token := windows.GetCurrentProcessToken()
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return nil, err
+	}
+	return tokenUser.User.Sid, nil
+}

--- a/pkg/server/discovery/permissions_windows.go
+++ b/pkg/server/discovery/permissions_windows.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -39,6 +40,75 @@ func restrictDiscoveryDirPermissions(dir string) error {
 		return err
 	}
 	return restrictDiscoveryDir(dir, trusted)
+}
+
+// discoveryDirPermissionsLoose reports whether dir carries an unprotected DACL
+// or grants access to accounts outside the process user and SYSTEM.
+func discoveryDirPermissionsLoose(dir string) (bool, error) {
+	if _, err := os.Stat(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to stat discovery directory: %w", err)
+	}
+
+	sd, err := windows.GetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return false, fmt.Errorf("failed to read discovery directory DACL: %w", err)
+	}
+
+	control, _, err := sd.Control()
+	if err != nil {
+		return false, fmt.Errorf("failed to read discovery directory DACL control: %w", err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		return true, nil
+	}
+
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return false, fmt.Errorf("failed to read discovery directory DACL entries: %w", err)
+	}
+	if dacl == nil {
+		return true, nil
+	}
+
+	userSID, err := currentProcessUserSID()
+	if err != nil {
+		return false, err
+	}
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return false, err
+	}
+
+	aces, err := allowACEsFromACL(dacl)
+	if err != nil {
+		return false, err
+	}
+	for _, ace := range aces {
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		if userSID.Equals(sid) || systemSID.Equals(sid) {
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func allowACEsFromACL(acl *windows.ACL) ([]*windows.ACCESS_ALLOWED_ACE, error) {
+	aces := make([]*windows.ACCESS_ALLOWED_ACE, 0, acl.AceCount)
+	for i := uint16(0); i < acl.AceCount; i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(acl, uint32(i), &ace); err != nil {
+			return nil, err
+		}
+		if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			continue
+		}
+		aces = append(aces, ace)
+	}
+	return aces, nil
 }
 
 // restrictDiscoveryDir is the injectable core of

--- a/pkg/server/discovery/permissions_windows.go
+++ b/pkg/server/discovery/permissions_windows.go
@@ -6,21 +6,53 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"golang.org/x/sys/windows"
 )
 
-// restrictDiscoveryDirPermissions replaces the discovery directory DACL with
-// an explicit ACL granting FILE-equivalent GenericAll only to the process
-// user and SYSTEM, and marks the DACL protected so parent ACEs cannot
-// re-inherit. os.Chmod is advisory on NTFS and does not strip inherited
-// ACEs under %LOCALAPPDATA%, which is the gap that lets another interactive
-// user rewrite server.json (for example to point at an attacker named pipe).
+// Ancestor invariant on Windows: ToolHive protects and owner-checks every
+// directory it creates for the discovery file (%LOCALAPPDATA%\toolhive and
+// %LOCALAPPDATA%\toolhive\server). Above that it relies on the OS default ACL
+// of %LOCALAPPDATA%, which grants the user, SYSTEM, and Administrators only.
+// If another account does hold delete-child there, it can rename the chain
+// aside and pre-create its own; the owner check below is what turns that into
+// a startup failure instead of silent trust, because a standard user cannot
+// create a directory owned by the ToolHive user, SYSTEM, or Administrators.
+
+// restrictDiscoveryDirPermissions locks down one directory in the discovery
+// chain: it fails closed unless the directory is owned by an account we trust,
+// then replaces the DACL with an explicit ACL granting FILE-equivalent
+// GenericAll only to the process user and SYSTEM, marked protected so parent
+// ACEs cannot re-inherit. os.Chmod is advisory on NTFS and does not strip
+// inherited ACEs under %LOCALAPPDATA%, which is the gap that lets another
+// interactive user rewrite server.json (for example to point at a named pipe
+// of their own).
 //
-// Inheritance (OICI) is intentional: server.json and any future children
-// pick up the same restriction instead of inheriting a looser parent ACL.
+// Inheritance (OICI) is intentional: server.json and any future children pick
+// up the same restriction instead of inheriting a looser parent ACL.
 func restrictDiscoveryDirPermissions(dir string) error {
+	trusted, err := trustedOwnerSIDs()
+	if err != nil {
+		return err
+	}
+	return restrictDiscoveryDir(dir, trusted)
+}
+
+// restrictDiscoveryDir is the injectable core of
+// restrictDiscoveryDirPermissions. Tests pass a trustedOwners set that
+// excludes the real owner to exercise the fail-closed path without a second
+// user account.
+func restrictDiscoveryDir(dir string, trustedOwners []*windows.SID) error {
+	// Check ownership before writing the DACL, not after. Owners keep
+	// WRITE_DAC implicitly, so a DACL we set on a directory somebody else owns
+	// is cosmetic: that owner can make it permissive again at any time.
+	if err := checkOwner(dir, "directory", trustedOwners); err != nil {
+		return err
+	}
+
 	userSID, err := currentProcessUserSID()
 	if err != nil {
 		return fmt.Errorf("failed to resolve current user SID: %w", err)
@@ -66,7 +98,83 @@ func restrictDiscoveryDirPermissions(dir string) error {
 	); err != nil {
 		return fmt.Errorf("failed to set discovery directory DACL: %w", err)
 	}
-	return nil
+
+	// Re-check the owner before reporting the lockdown as complete. A
+	// pre-creating owner that raced the DACL write could have taken the
+	// directory back in between, and the caller is about to trust the contents.
+	return checkOwner(dir, "directory", trustedOwners)
+}
+
+// validateDiscoveryFileOwner rejects a discovery file owned by an account
+// outside the trusted set. The directory lockdown stops new writes but leaves
+// the ACL of a file planted while the directory was loose untouched, so the
+// file needs its own check before its URL and nonce are believed.
+func validateDiscoveryFileOwner(path string) error {
+	trusted, err := trustedOwnerSIDs()
+	if err != nil {
+		return err
+	}
+	return validateFileOwner(path, trusted)
+}
+
+// validateFileOwner is the injectable core of validateDiscoveryFileOwner.
+func validateFileOwner(path string, trustedOwners []*windows.SID) error {
+	if _, err := os.Lstat(path); err != nil {
+		// A missing file is not a trust decision; the caller's own
+		// os.ErrNotExist handling covers it.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to stat discovery file: %w", err)
+	}
+	return checkOwner(path, "file", trustedOwners)
+}
+
+// checkOwner fails closed unless path is owned by one of trustedOwners.
+func checkOwner(path string, kind string, trustedOwners []*windows.SID) error {
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+	if err != nil {
+		return fmt.Errorf("failed to read discovery %s owner for %s: %w", kind, path, err)
+	}
+	owner, _, err := sd.Owner()
+	if err != nil {
+		return fmt.Errorf("failed to resolve discovery %s owner for %s: %w", kind, path, err)
+	}
+	for _, trustedOwner := range trustedOwners {
+		if trustedOwner.Equals(owner) {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"refusing to trust discovery %s %s: it is owned by %s, not the current user, SYSTEM, or Administrators; "+
+			"remove it (or restore its ownership) and retry",
+		kind, path, owner,
+	)
+}
+
+// trustedOwnerSIDs returns the accounts allowed to own the discovery directory
+// chain and the discovery file: the process user, SYSTEM, and Administrators.
+//
+// Administrators is in the set because a directory created by an elevated
+// `thv serve` is owned by Administrators rather than by the user, and because
+// a local administrator is outside this threat model (they can take ownership
+// of anything). It does not weaken the check against the attacker this fix is
+// about: a standard user cannot make SYSTEM or Administrators the owner of a
+// directory they create, so a pre-created hostile directory still fails.
+func trustedOwnerSIDs() ([]*windows.SID, error) {
+	userSID, err := currentProcessUserSID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve current user SID: %w", err)
+	}
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve SYSTEM SID: %w", err)
+	}
+	adminsSID, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve Administrators SID: %w", err)
+	}
+	return []*windows.SID{userSID, systemSID, adminsSID}, nil
 }
 
 func currentProcessUserSID() (*windows.SID, error) {

--- a/pkg/server/discovery/permissions_windows.go
+++ b/pkg/server/discovery/permissions_windows.go
@@ -255,3 +255,78 @@ func currentProcessUserSID() (*windows.SID, error) {
 	}
 	return tokenUser.User.Sid, nil
 }
+
+// ValidateRestrictedDiscoveryDACL reports whether dir carries a protected DACL
+// that grants FILE access only to the current process user and SYSTEM.
+func ValidateRestrictedDiscoveryDACL(dir string) error {
+	userSID, err := currentProcessUserSID()
+	if err != nil {
+		return err
+	}
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return err
+	}
+	everyoneSID, err := windows.CreateWellKnownSid(windows.WinWorldSid)
+	if err != nil {
+		return err
+	}
+	authUsersSID, err := windows.CreateWellKnownSid(windows.WinAuthenticatedUserSid)
+	if err != nil {
+		return err
+	}
+
+	sd, err := windows.GetNamedSecurityInfo(
+		dir,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to read discovery directory DACL: %w", err)
+	}
+
+	control, _, err := sd.Control()
+	if err != nil {
+		return fmt.Errorf("failed to read discovery directory DACL control: %w", err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		return fmt.Errorf("DACL of %s must be protected against inheritance", dir)
+	}
+
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return fmt.Errorf("failed to read discovery directory DACL entries: %w", err)
+	}
+	if dacl == nil {
+		return fmt.Errorf("DACL of %s must not be empty", dir)
+	}
+
+	aces, err := allowACEsFromACL(dacl)
+	if err != nil {
+		return err
+	}
+
+	var userSeen, systemSeen bool
+	for _, ace := range aces {
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		switch {
+		case userSID.Equals(sid):
+			userSeen = true
+		case systemSID.Equals(sid):
+			systemSeen = true
+		case everyoneSID.Equals(sid):
+			return fmt.Errorf("DACL still grants Everyone (%s)", sid)
+		case authUsersSID.Equals(sid):
+			return fmt.Errorf("DACL still grants Authenticated Users (%s)", sid)
+		default:
+			return fmt.Errorf("unexpected allow ACE for SID %s (want only current user + SYSTEM)", sid)
+		}
+	}
+	if !userSeen {
+		return fmt.Errorf("DACL of %s must grant the current process user", dir)
+	}
+	if !systemSeen {
+		return fmt.Errorf("DACL of %s must grant SYSTEM", dir)
+	}
+	return nil
+}

--- a/pkg/server/discovery/permissions_windows_test.go
+++ b/pkg/server/discovery/permissions_windows_test.go
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package discovery
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// TestWriteServerInfo_WindowsDACL_NoOtherInteractiveUsers asserts the
+// acceptance criterion from #5217: after writeServerInfoTo, the discovery
+// directory DACL grants access only to the current user and SYSTEM, and does
+// not retain Everyone / Authenticated Users / other interactive-user ACEs
+// that MkdirAll would otherwise inherit (and that os.Chmod cannot strip).
+func TestWriteServerInfo_WindowsDACL_NoOtherInteractiveUsers(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "toolhive", "server")
+
+	// Seed a deliberately loose ACL on the parent so newly created children
+	// inherit Everyone. This models a shared / misconfigured LOCALAPPDATA
+	// tree better than relying on whatever TempDir happens to carry.
+	grantEveryone(t, parent)
+
+	info := &ServerInfo{
+		URL:       "npipe://thv-api",
+		PID:       1,
+		Nonce:     "dacl-nonce",
+		StartedAt: time.Now().UTC(),
+	}
+	require.NoError(t, writeServerInfoTo(dir, info))
+
+	assertDiscoveryDACLRestricted(t, dir)
+}
+
+// TestRestrictDiscoveryDirPermissions_ReplacesExistingLooseACL covers the
+// sibling failure mode: the discovery directory already exists with a loose
+// DACL (Everyone + inherited ACEs). restrictDiscoveryDirPermissions must
+// replace that ACL rather than merge, and block further inheritance.
+func TestRestrictDiscoveryDirPermissions_ReplacesExistingLooseACL(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	grantEveryone(t, dir)
+
+	before := discoveryDirSDDL(t, dir)
+	require.Contains(t, strings.ToUpper(before), "WD", "precondition: Everyone (WD) must be present before restrict")
+
+	require.NoError(t, restrictDiscoveryDirPermissions(dir))
+	assertDiscoveryDACLRestricted(t, dir)
+}
+
+// TestRestrictDiscoveryDirPermissions_NewDirectory covers the create path
+// (no pre-existing ACL to replace) so MkdirAll + restrict still lands a
+// protected owner/SYSTEM-only DACL.
+func TestRestrictDiscoveryDirPermissions_NewDirectory(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	grantEveryone(t, parent)
+	dir := filepath.Join(parent, "fresh-server")
+	require.NoError(t, os.MkdirAll(dir, dirPermissions))
+
+	require.NoError(t, restrictDiscoveryDirPermissions(dir))
+	assertDiscoveryDACLRestricted(t, dir)
+}
+
+func grantEveryone(t *testing.T, path string) {
+	t.Helper()
+	// icacls grants are the product-path way to introduce a loose ACE;
+	// quoting keeps PowerShell from expanding (OI)/(CI).
+	cmd := exec.Command("icacls", path, "/grant", "*S-1-1-0:(OI)(CI)M")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "icacls grant Everyone failed: %s", out)
+}
+
+func assertDiscoveryDACLRestricted(t *testing.T, dir string) {
+	t.Helper()
+
+	userSID, err := currentProcessUserSID()
+	require.NoError(t, err)
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	require.NoError(t, err)
+	everyoneSID, err := windows.CreateWellKnownSid(windows.WinWorldSid)
+	require.NoError(t, err)
+	authUsersSID, err := windows.CreateWellKnownSid(windows.WinAuthenticatedUserSid)
+	require.NoError(t, err)
+
+	sd, err := windows.GetNamedSecurityInfo(
+		dir,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	require.NoError(t, err)
+
+	control, _, err := sd.Control()
+	require.NoError(t, err)
+	assert.NotZero(t, control&windows.SE_DACL_PROTECTED, "DACL must be protected against inheritance")
+
+	dacl, _, err := sd.DACL()
+	require.NoError(t, err)
+	require.NotNil(t, dacl)
+
+	aces, err := allowACEsFromACL(dacl)
+	require.NoError(t, err)
+
+	var userSeen, systemSeen bool
+	for _, ace := range aces {
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		switch {
+		case userSID.Equals(sid):
+			userSeen = true
+		case systemSID.Equals(sid):
+			systemSeen = true
+		case everyoneSID.Equals(sid):
+			t.Fatalf("DACL still grants Everyone (%s)", sid)
+		case authUsersSID.Equals(sid):
+			t.Fatalf("DACL still grants Authenticated Users (%s)", sid)
+		default:
+			// Administrators / package SIDs / other interactive users must
+			// not remain after an explicit replace. Fail closed on anything
+			// that is not the process user or SYSTEM.
+			t.Fatalf("unexpected allow ACE for SID %s (want only current user + SYSTEM)", sid)
+		}
+	}
+	assert.True(t, userSeen, "DACL must grant the current process user")
+	assert.True(t, systemSeen, "DACL must grant SYSTEM")
+}
+
+func discoveryDirSDDL(t *testing.T, dir string) string {
+	t.Helper()
+	sd, err := windows.GetNamedSecurityInfo(
+		dir,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	require.NoError(t, err)
+	return sd.String()
+}
+
+func allowACEsFromACL(acl *windows.ACL) ([]*windows.ACCESS_ALLOWED_ACE, error) {
+	aces := make([]*windows.ACCESS_ALLOWED_ACE, 0, acl.AceCount)
+	for i := uint16(0); i < acl.AceCount; i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(acl, uint32(i), &ace); err != nil {
+			return nil, err
+		}
+		if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+			continue
+		}
+		aces = append(aces, ace)
+	}
+	return aces, nil
+}

--- a/pkg/server/discovery/permissions_windows_test.go
+++ b/pkg/server/discovery/permissions_windows_test.go
@@ -78,6 +78,114 @@ func TestRestrictDiscoveryDirPermissions_NewDirectory(t *testing.T) {
 	assertDiscoveryDACLRestricted(t, dir)
 }
 
+// TestEnsureSecureDirIn_ProtectsIntermediateToolhiveDir covers the ancestor
+// replacement path. Restricting only the server leaf leaves the intermediate
+// toolhive directory with inherited Modify, which carries DELETE on that
+// object: another interactive user can rename toolhive aside, recreate
+// toolhive\server with an ACL of their own, and the protected leaf is bypassed
+// because nothing reads it any more. Both directories in the chain must end up
+// protected.
+func TestEnsureSecureDirIn_ProtectsIntermediateToolhiveDir(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	grantEveryone(t, base)
+
+	chain := discoveryDirChain(base)
+	require.Len(t, chain, 2)
+	toolhiveDir, serverDir := chain[0], chain[1]
+
+	// Model the state an earlier ToolHive left behind: both directories exist
+	// already, created with plain MkdirAll, so both inherited Everyone.
+	require.NoError(t, os.MkdirAll(serverDir, dirPermissions))
+	require.Contains(t, strings.ToUpper(discoveryDirSDDL(t, toolhiveDir)), "WD",
+		"precondition: intermediate toolhive dir must inherit Everyone (WD)")
+
+	require.NoError(t, ensureSecureDirIn(base))
+
+	assertDiscoveryDACLRestricted(t, toolhiveDir)
+	assertDiscoveryDACLRestricted(t, serverDir)
+}
+
+// TestRestrictDiscoveryDir_FailsClosedOnUntrustedOwner covers hostile
+// ownership. Replacing the DACL is not enough when another account owns the
+// directory: owners keep WRITE_DAC implicitly and can make the ACL permissive
+// again, so the lockdown must fail rather than report success.
+//
+// Creating a directory owned by a different account needs a second user or
+// SeRestorePrivilege, neither of which a unit test can assume, so the trusted
+// owner set is injected instead: the directory is genuinely owned by the test
+// user and the set deliberately does not include them.
+func TestRestrictDiscoveryDir_FailsClosedOnUntrustedOwner(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	grantEveryone(t, dir)
+
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	require.NoError(t, err)
+
+	err = restrictDiscoveryDir(dir, []*windows.SID{systemSID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to trust discovery directory")
+
+	// The DACL must be left untouched: a half-applied lockdown on a directory
+	// somebody else owns would look secure to an operator reading icacls.
+	assert.Contains(t, strings.ToUpper(discoveryDirSDDL(t, dir)), "WD",
+		"loose ACE must survive: ownership is checked before the DACL is replaced")
+}
+
+// TestRestrictDiscoveryDir_AcceptsCurrentUserOwner is the positive half of the
+// ownership check: the real trusted set must accept a directory the process
+// created itself, so the fail-closed path above cannot pass by rejecting
+// everything.
+func TestRestrictDiscoveryDir_AcceptsCurrentUserOwner(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	trusted, err := trustedOwnerSIDs()
+	require.NoError(t, err)
+
+	require.NoError(t, restrictDiscoveryDir(dir, trusted))
+	assertDiscoveryDACLRestricted(t, dir)
+}
+
+// TestValidateFileOwner_RejectsUntrustedOwner covers the read path. The
+// directory lockdown stops new writes but does not rewrite the ACL of a
+// server.json planted while the directory was still loose, so the file's own
+// owner decides whether its URL and nonce can be trusted.
+func TestValidateFileOwner_RejectsUntrustedOwner(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	info := &ServerInfo{
+		URL:       "npipe://attacker-pipe",
+		PID:       1,
+		Nonce:     "planted-nonce",
+		StartedAt: time.Now().UTC(),
+	}
+	require.NoError(t, writeServerInfoTo(dir, info))
+	path := filepath.Join(dir, "server.json")
+
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	require.NoError(t, err)
+
+	err = validateFileOwner(path, []*windows.SID{systemSID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to trust discovery file")
+
+	// A file the process owns stays readable, and a missing file is not a
+	// trust decision (readServerInfoFrom must still return os.ErrNotExist).
+	trusted, err := trustedOwnerSIDs()
+	require.NoError(t, err)
+	assert.NoError(t, validateFileOwner(path, trusted))
+	assert.NoError(t, validateFileOwner(filepath.Join(dir, "absent.json"), trusted))
+
+	got, err := readServerInfoFrom(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "planted-nonce", got.Nonce)
+}
+
 func grantEveryone(t *testing.T, path string) {
 	t.Helper()
 	// icacls grants are the product-path way to introduce a loose ACE;

--- a/pkg/server/discovery/permissions_windows_test.go
+++ b/pkg/server/discovery/permissions_windows_test.go
@@ -107,6 +107,34 @@ func TestEnsureSecureDirIn_ProtectsIntermediateToolhiveDir(t *testing.T) {
 	assertDiscoveryDACLRestricted(t, serverDir)
 }
 
+// TestEnsureSecureDirIn_InvalidatesForgedDiscoveryFile covers the upgrade path
+// where another user truncated and rewrote a victim-owned server.json while
+// the directory chain was still loose. Tightening the DACL is not enough:
+// ownership stayed with the victim, so the planted URL would still be trusted
+// unless the record is invalidated.
+func TestEnsureSecureDirIn_InvalidatesForgedDiscoveryFile(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	grantEveryone(t, base)
+
+	chain := discoveryDirChain(base)
+	serverDir := chain[len(chain)-1]
+	require.NoError(t, os.MkdirAll(serverDir, 0700))
+
+	planted := []byte(`{"url":"npipe://attacker","pid":1,"nonce":"forged","started_at":"2026-08-03T00:00:00Z"}`)
+	require.NoError(t, os.WriteFile(filepath.Join(serverDir, "server.json"), planted, 0600))
+	require.Contains(t, strings.ToUpper(discoveryDirSDDL(t, serverDir)), "WD",
+		"precondition: server dir must inherit Everyone (WD)")
+
+	require.NoError(t, ensureSecureDirIn(base))
+
+	assertDiscoveryDACLRestricted(t, chain[0])
+	assertDiscoveryDACLRestricted(t, serverDir)
+	_, err := os.Stat(filepath.Join(serverDir, "server.json"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 // TestRestrictDiscoveryDir_FailsClosedOnUntrustedOwner covers hostile
 // ownership. Replacing the DACL is not enough when another account owns the
 // directory: owners keep WRITE_DAC implicitly and can make the ACL permissive
@@ -257,19 +285,4 @@ func discoveryDirSDDL(t *testing.T, dir string) string {
 	)
 	require.NoError(t, err)
 	return sd.String()
-}
-
-func allowACEsFromACL(acl *windows.ACL) ([]*windows.ACCESS_ALLOWED_ACE, error) {
-	aces := make([]*windows.ACCESS_ALLOWED_ACE, 0, acl.AceCount)
-	for i := uint16(0); i < acl.AceCount; i++ {
-		var ace *windows.ACCESS_ALLOWED_ACE
-		if err := windows.GetAce(acl, uint32(i), &ace); err != nil {
-			return nil, err
-		}
-		if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
-			continue
-		}
-		aces = append(aces, ace)
-	}
-	return aces, nil
 }

--- a/pkg/server/discovery/permissions_windows_test.go
+++ b/pkg/server/discovery/permissions_windows_test.go
@@ -101,18 +101,17 @@ func TestEnsureSecureDirIn_ProtectsIntermediateToolhiveDir(t *testing.T) {
 	require.Contains(t, strings.ToUpper(discoveryDirSDDL(t, toolhiveDir)), "WD",
 		"precondition: intermediate toolhive dir must inherit Everyone (WD)")
 
-	require.NoError(t, ensureSecureDirIn(base))
+	_, err := ensureSecureDirIn(base)
+	require.NoError(t, err)
 
 	assertDiscoveryDACLRestricted(t, toolhiveDir)
 	assertDiscoveryDACLRestricted(t, serverDir)
 }
 
-// TestEnsureSecureDirIn_InvalidatesForgedDiscoveryFile covers the upgrade path
-// where another user truncated and rewrote a victim-owned server.json while
-// the directory chain was still loose. Tightening the DACL is not enough:
-// ownership stayed with the victim, so the planted URL would still be trusted
-// unless the record is invalidated.
-func TestEnsureSecureDirIn_InvalidatesForgedDiscoveryFile(t *testing.T) {
+// TestEnsureSecureDirIn_PreservesDiscoveryFileOnUpgrade ensures repairing an
+// insecure chain does not delete an existing server.json. pkg/api decides
+// under the startup lock whether the record is safe to keep.
+func TestEnsureSecureDirIn_PreservesDiscoveryFileOnUpgrade(t *testing.T) {
 	t.Parallel()
 
 	base := t.TempDir()
@@ -127,12 +126,14 @@ func TestEnsureSecureDirIn_InvalidatesForgedDiscoveryFile(t *testing.T) {
 	require.Contains(t, strings.ToUpper(discoveryDirSDDL(t, serverDir)), "WD",
 		"precondition: server dir must inherit Everyone (WD)")
 
-	require.NoError(t, ensureSecureDirIn(base))
+	_, err := ensureSecureDirIn(base)
+	require.NoError(t, err)
 
 	assertDiscoveryDACLRestricted(t, chain[0])
 	assertDiscoveryDACLRestricted(t, serverDir)
-	_, err := os.Stat(filepath.Join(serverDir, "server.json"))
-	require.ErrorIs(t, err, os.ErrNotExist)
+	got, err := os.ReadFile(filepath.Join(serverDir, "server.json"))
+	require.NoError(t, err)
+	assert.Equal(t, string(planted), string(got))
 }
 
 // TestRestrictDiscoveryDir_FailsClosedOnUntrustedOwner covers hostile

--- a/pkg/server/discovery/secure_dir_other.go
+++ b/pkg/server/discovery/secure_dir_other.go
@@ -5,9 +5,36 @@
 
 package discovery
 
+import (
+	"fmt"
+	"os"
+)
+
+const discoveryParentDirPermissions = 0750
+
 // discoveryDirsToSecure returns only the server leaf on POSIX. The shared
 // toolhive parent also holds runconfigs and toolhive.db created with 0750;
 // chmodding it to 0700 would revoke group traversal for unrelated state.
 func discoveryDirsToSecure(base string) []string {
 	return []string{discoveryServerDir(base)}
+}
+
+// mkdirDiscoveryChain creates the discovery path without forcing 0700 on the
+// shared intermediate toolhive directory. Parents are created first with
+// discoveryParentDirPermissions so a later MkdirAll on the leaf does not
+// apply dirPermissions up the chain.
+func mkdirDiscoveryChain(chain []string) error {
+	if len(chain) == 0 {
+		return nil
+	}
+	for _, dir := range chain[:len(chain)-1] {
+		if err := os.MkdirAll(dir, discoveryParentDirPermissions); err != nil {
+			return fmt.Errorf("failed to create discovery directory: %w", err)
+		}
+	}
+	leaf := chain[len(chain)-1]
+	if err := os.MkdirAll(leaf, dirPermissions); err != nil {
+		return fmt.Errorf("failed to create discovery directory: %w", err)
+	}
+	return nil
 }

--- a/pkg/server/discovery/secure_dir_other.go
+++ b/pkg/server/discovery/secure_dir_other.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package discovery
+
+// discoveryDirsToSecure returns only the server leaf on POSIX. The shared
+// toolhive parent also holds runconfigs and toolhive.db created with 0750;
+// chmodding it to 0700 would revoke group traversal for unrelated state.
+func discoveryDirsToSecure(base string) []string {
+	return []string{discoveryServerDir(base)}
+}

--- a/pkg/server/discovery/secure_dir_windows.go
+++ b/pkg/server/discovery/secure_dir_windows.go
@@ -5,8 +5,22 @@
 
 package discovery
 
+import (
+	"fmt"
+	"os"
+)
+
 // discoveryDirsToSecure returns every directory in the discovery chain that
 // receives an explicit protected DACL on Windows.
 func discoveryDirsToSecure(base string) []string {
 	return discoveryDirChain(base)
+}
+
+func mkdirDiscoveryChain(chain []string) error {
+	for _, dir := range chain {
+		if err := os.MkdirAll(dir, dirPermissions); err != nil {
+			return fmt.Errorf("failed to create discovery directory: %w", err)
+		}
+	}
+	return nil
 }

--- a/pkg/server/discovery/secure_dir_windows.go
+++ b/pkg/server/discovery/secure_dir_windows.go
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package discovery
+
+// discoveryDirsToSecure returns every directory in the discovery chain that
+// receives an explicit protected DACL on Windows.
+func discoveryDirsToSecure(base string) []string {
+	return discoveryDirChain(base)
+}

--- a/pkg/server/discovery/validate_dacl_other.go
+++ b/pkg/server/discovery/validate_dacl_other.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package discovery
+
+import "fmt"
+
+// ValidateRestrictedDiscoveryDACL is only meaningful on Windows.
+func ValidateRestrictedDiscoveryDACL(dir string) error {
+	return fmt.Errorf("ValidateRestrictedDiscoveryDACL is only supported on Windows (%s)", dir)
+}


### PR DESCRIPTION
## Summary

`writeServerInfoTo` created the discovery directory under `xdg.StateHome` (`%LOCALAPPDATA%` on Windows) with `os.MkdirAll` + `os.Chmod(0700)`. POSIX modes are advisory on NTFS, so inherited ACEs from the parent (Everyone, other interactive users) survive, and any local account holding Modify can rewrite `server.json`. With the `npipe://` discovery URL from #5201 / #5214, that file is what decides where the next client connects.

What changed:

- Windows sets an explicit **protected** DACL granting FILE-equivalent GenericAll to the process user and SYSTEM only, with OICI so `server.json` inherits the same restriction. Non-Windows keeps `os.Chmod`.
- The lockdown now runs in a new `discovery.EnsureSecureDir`, called from `writeDiscoveryFile` **before** `server.json.lock` is taken and before `Discover` runs, instead of only inside the write.
- The chain ToolHive creates is covered, not just the leaf: `%LOCALAPPDATA%\toolhive` and `%LOCALAPPDATA%\toolhive\server`.
- Directory ownership is validated before the lockdown counts as complete, and fails closed otherwise.
- `readServerInfoFrom` rejects a `server.json` owned by another account, alongside the existing symlink rejection.

Fixes #5217

### Threat model (corrected)

The first revision of this description claimed a spoofed endpoint could capture the discovery nonce. That is wrong, and @samuv is right to flag it: `CheckHealth` sends a plain `GET /health` with no nonce in the request and compares the nonce that comes back in the response header, so nothing is transmitted to the endpoint being probed. An attacker who can rewrite `server.json` picks the nonce themselves.

The actual risks of an attacker-writable discovery file are:

- **Endpoint spoofing.** Clients (CLI, Studio) read the URL from `server.json` and dial the attacker's pipe or address.
- **Persistent denial of startup.** A planted file whose endpoint answers `/health` with the matching nonce makes `Discover` report `StateRunning`, so every `thv serve` aborts with "another ToolHive server is already running".
- **Interception or forgery of later client API traffic**, once a client has been pointed at that endpoint.

### Review round 2: the three findings

**1. The restriction ran after startup had already trusted the directory** (`discovery.go:83`).

`writeDiscoveryFile` did `MkdirAll` then `WithFileLock` then `Discover` then `WriteServerInfo`, so the DACL landed last. Two consequences: `server.json.lock` was created in a directory other accounts could still write to, and a `StateRunning` result returns before `WriteServerInfo` is ever reached, so the directory stayed loose for the whole startup while its planted contents were believed.

`discovery.EnsureSecureDir()` now runs first, and `WriteServerInfo` also calls it so the public write path cannot regress. `TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile` drives the real `writeDiscoveryFile` with a planted, healthy-looking file and asserts the chain is already protected on the failing return. Without the reordering that test fails with `D:AI(A;OICIID;0x1301bf;;;WD)...` on both directories (output below).

**2. The intermediate `toolhive` directory is protected too** (`permissions_windows.go:23`).

Correct: restricting only the leaf left the intermediate with inherited Modify, and Modify carries DELETE on that object, so another interactive user could rename `toolhive` aside and recreate `toolhive\server` with an ACL of their own. `EnsureSecureDir` walks the chain outermost first and restricts each directory ToolHive creates.

Above that chain there is a documented invariant rather than more ACL rewriting, because `%LOCALAPPDATA%` belongs to the OS and to other applications: ToolHive relies on its default protected ACL (user, SYSTEM, Administrators). If another account does hold delete-child there, it can still swap the chain aside, and the ownership check in finding 3 is what turns that into a startup failure instead of silent trust. That reasoning is in a comment at the top of `permissions_windows.go`.

**3. Ownership is validated, fail closed** (`permissions_windows.go:58`).

Also correct, and it was the sharpest of the three: owners keep WRITE_DAC implicitly, so a DACL written onto a directory somebody else pre-created is cosmetic. `restrictDiscoveryDir` now checks the owner **before** writing the DACL (so a hostile directory is never half-secured) and again afterwards (so a pre-creating owner that raced the write cannot be reported as a completed lockdown).

Trusted owners are the process user, SYSTEM, and Administrators. Administrators is included deliberately: a directory created by an elevated `thv serve` is owned by Administrators rather than by the user, and a local administrator is outside this threat model since they can take ownership of anything. It does not weaken the check against the attacker in scope, because a standard user cannot make SYSTEM or Administrators the owner of a directory they create. Taking ownership instead of failing was considered and rejected: it would silently repair the container while leaving the attacker's `server.json` inside it to be trusted.

One thing the three findings surfaced together: an already-planted `server.json` is trusted even with the directory fixed, so the read path needed the same treatment. Changing the parent DACL does re-propagate inherited ACEs to existing children (visible in the Evidence below), but explicit ACEs and ownership are untouched, so `readServerInfoFrom` now refuses a discovery file owned by another account. On startup the effect is self-healing rather than fatal: `Discover` surfaces the error, startup proceeds on its existing "discovery check failed" path, and `AtomicWriteFile` replaces the planted file with one that inherits the protected DACL.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`go test ./pkg/server/discovery/ ./pkg/api/` on Windows 11, go1.26.5; `task` is not installed on this machine)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`golangci-lint run` at v2.6.2 with the repo `.golangci.yml`, for `GOOS=linux` and `GOOS=windows`; `go vet` for linux, darwin, windows)
- [x] Manual testing (real `%LOCALAPPDATA%` product path, below)

### Evidence

**Production ordering, before the fix.** Reverting only the `pkg/api` reordering and running the new test shows exactly the gap that was reported: startup aborts on the planted file and both directories are still inheriting (`D:AI`) with Everyone (`WD`) on them.

```
--- FAIL: TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile
    Messages: DACL of ...\001\toolhive must be protected against inheritance:
      D:AI(A;OICIID;0x1301bf;;;WD)(A;OICIID;0x1301bf;;;S-1-5-21-349393094-...)
      (A;OICIID;FA;;;S-1-5-21-2310101069-...-1001)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)
    Messages: DACL of ...\001\toolhive\server must be protected against inheritance:
      D:AI(A;OICIID;0x1301bf;;;WD)...
```

**Unit tests, after the fix** (Windows 11, go1.26.5):

```
=== RUN   TestEnsureSecureDirIn_CreatesAndRestrictsChain
=== RUN   TestEnsureSecureDirIn_TightensExistingChain
=== RUN   TestWriteServerInfo_WindowsDACL_NoOtherInteractiveUsers
=== RUN   TestRestrictDiscoveryDirPermissions_ReplacesExistingLooseACL
=== RUN   TestRestrictDiscoveryDirPermissions_NewDirectory
=== RUN   TestEnsureSecureDirIn_ProtectsIntermediateToolhiveDir
=== RUN   TestRestrictDiscoveryDir_FailsClosedOnUntrustedOwner
=== RUN   TestRestrictDiscoveryDir_AcceptsCurrentUserOwner
=== RUN   TestValidateFileOwner_RejectsUntrustedOwner
--- SKIP: TestEnsureSecureDirIn_TightensExistingChain (0.00s)
--- PASS: TestRestrictDiscoveryDir_AcceptsCurrentUserOwner (0.01s)
--- PASS: TestEnsureSecureDirIn_CreatesAndRestrictsChain (0.01s)
--- PASS: TestRestrictDiscoveryDir_FailsClosedOnUntrustedOwner (0.02s)
--- PASS: TestValidateFileOwner_RejectsUntrustedOwner (0.02s)
--- PASS: TestRestrictDiscoveryDirPermissions_ReplacesExistingLooseACL (0.02s)
--- PASS: TestRestrictDiscoveryDirPermissions_NewDirectory (0.02s)
--- PASS: TestEnsureSecureDirIn_ProtectsIntermediateToolhiveDir (0.02s)
--- PASS: TestWriteServerInfo_WindowsDACL_NoOtherInteractiveUsers (0.02s)
ok  	github.com/stacklok/toolhive/pkg/server/discovery	1.337s

=== RUN   TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile
--- PASS: TestWriteDiscoveryFile_RestrictsDirBeforeTrustingExistingFile (0.03s)
ok  	github.com/stacklok/toolhive/pkg/api	1.441s
```

**Product path: real `%LOCALAPPDATA%`, real `discovery.EnsureSecureDir`.** The chain was pre-created loose (Everyone inheritable Modify on the base, plain `MkdirAll` for the children) with a planted `server.json`, the way an earlier run plus a local attacker would leave it.

Before:

```
...\toolhive-5217-evidence\toolhive         Everyone:(I)(OI)(CI)(M)
                                            NT AUTHORITY\SYSTEM:(I)(OI)(CI)(F)
                                            BUILTIN\Administrators:(I)(OI)(CI)(F)
                                            CHIAO-BASE\stans:(I)(OI)(CI)(F)
SDDL: ...D:AI(A;OICIID;0x1301bf;;;WD)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)(A;OICIID;FA;;;<user>)

...\toolhive-5217-evidence\toolhive\server  Everyone:(I)(OI)(CI)(M)
                                            NT AUTHORITY\SYSTEM:(I)(OI)(CI)(F)
                                            BUILTIN\Administrators:(I)(OI)(CI)(F)
                                            CHIAO-BASE\stans:(I)(OI)(CI)(F)
SDDL: ...D:AI(A;OICIID;0x1301bf;;;WD)...
```

After `discovery.EnsureSecureDir()`:

```
...\toolhive-5217-evidence\toolhive         CHIAO-BASE\stans:(F)
                                            CHIAO-BASE\stans:(OI)(CI)(IO)(F)
                                            NT AUTHORITY\SYSTEM:(F)
                                            NT AUTHORITY\SYSTEM:(OI)(CI)(IO)(F)
SDDL: ...D:PAI(A;OICIIO;GA;;;SY)(A;;FA;;;SY)(A;OICIIO;GA;;;<user>)(A;;FA;;;<user>)

...\toolhive-5217-evidence\toolhive\server  CHIAO-BASE\stans:(F)
                                            CHIAO-BASE\stans:(OI)(CI)(IO)(F)
                                            NT AUTHORITY\SYSTEM:(F)
                                            NT AUTHORITY\SYSTEM:(OI)(CI)(IO)(F)
SDDL: ...D:PAI(A;OICIIO;GA;;;SY)(A;;FA;;;SY)(A;OICIIO;GA;;;<user>)(A;;FA;;;<user>)

...\toolhive\server\server.json             CHIAO-BASE\stans:(I)(F)
                                            NT AUTHORITY\SYSTEM:(I)(F)
```

Both directories end up `D:P` (protected) with the user and SYSTEM only, on both the intermediate and the leaf. The pre-existing `server.json` shows the inherited-ACE re-propagation mentioned above: Everyone is gone from it without the file being rewritten. That is also why the read path checks ownership rather than trusting the ACL alone.

### What was not tested

- The `thv serve` binary end to end. There is no container runtime on this machine (`docker info` fails, and `pkg/api` tests that build the full server already fail on `no available runtime found` at `origin/main`), so startup aborts before it reaches the discovery step. The new `pkg/api` test calls the real `writeDiscoveryFile` on the real path instead, and the product-path Evidence above uses the real exported `discovery.EnsureSecureDir` against `%LOCALAPPDATA%`.
- A genuine cross-account hostile owner. Creating a directory owned by another account needs a second user or `SeRestorePrivilege`, so the hostile-owner tests inject the trusted-owner set against a directory the test user really owns, which exercises the same failure path.
- `task test` / `task lint-fix` (Task is not installed here). `golangci-lint run` was run directly with the repo config for both `GOOS=linux` and `GOOS=windows`: the only findings are three pre-existing `gci` reports on files this PR does not touch (`pkg/api/docs.go`, `openapi.go`, `scalar.go`), caused by CRLF in this local Windows checkout.
- Five test failures in `pkg/server/discovery` on this machine are pre-existing and identical at `origin/main`: the two symlink tests (`os.Symlink` needs `SeCreateSymbolicLinkPrivilege`) and three unix-socket path tests. This branch turns three `origin/main` failures into skips (the POSIX-mode assertions).

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/api/server.go` | `writeDiscoveryFile` calls `discovery.EnsureSecureDir()` before the lock and `Discover` |
| `pkg/api/discovery_permissions_windows_test.go` | Production-order regression test |
| `pkg/server/discovery/discovery.go` | `EnsureSecureDir`, directory chain helper, owner check on the read path |
| `pkg/server/discovery/permissions_windows.go` | Owner validation (fail closed) around the protected DACL replace, ancestor invariant documented |
| `pkg/server/discovery/permissions_other.go` | Non-Windows `os.Chmod` plus a no-op owner check |
| `pkg/server/discovery/permissions_windows_test.go` | Ancestor replacement, hostile owner, read-path rejection |
| `pkg/server/discovery/discovery_test.go` | Chain creation and tightening, POSIX modes |

## Does this introduce a user-facing change?

On Windows, `%LOCALAPPDATA%\...\toolhive` and its `server` subdirectory are locked down to the user that started `thv` plus SYSTEM, and this now happens at the start of `thv serve` rather than at the end. Two new fail-closed startup errors are possible where startup previously proceeded silently: a discovery directory owned by another account, and a `server.json` owned by another account. Both name the path and say what to do. No CLI flag or config change.

## Special notes for reviewers

- The ownership trust set (process user, SYSTEM, Administrators) is the one judgement call I would most like a second opinion on. The alternative, accepting only the process user, fails on any machine where `thv serve` has ever been run elevated.
- Matches the named-pipe DACL intent from #5214 (user + SYSTEM only), applied to the directory that stores the `npipe://` URL.
- The corrected threat-model wording is in the new commit message; the misleading nonce sentence lives only in the first commit's message, which the squash merge will replace with this description. Happy to squash the branch if you would rather it not appear in the branch history at all.
- AI assistance: Cursor helped implement and verify this round; I reviewed the diff, ran the Windows tests, captured the `%LOCALAPPDATA%` before and after ACLs, and confirmed the pre-fix failure by reverting the reordering.

Made with [Cursor](https://cursor.com)
