### PR TITLE
Emit conformant JSON-RPC on authz denial responses

### DIFF
--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -13,8 +13,6 @@ import (
 	"net/http"
 	"strings"
 
-	"golang.org/x/exp/jsonrpc2"
-
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
 	"github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/transport/ssecommon"
@@ -124,34 +122,43 @@ func shouldSkipSubsequentAuthorization(method string) bool {
 	return false
 }
 
-// handleUnauthorized handles unauthorized requests.
-func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
-	// Create an error response
+// unauthorizedErrorBody renders a JSON-RPC 2.0 error body for an authorization
+// denial. Modeled on mcp.classificationErrorBody / filteredToolCallErrorBody:
+// marshal first (with a hand-crafted fallback) so callers only write headers
+// once a valid body is ready. Directly encoding *jsonrpc2.Response is wrong
+// here: that struct has no json tags / MarshalJSON, so encoding/json emits
+// capitalized keys and omits the mandatory "jsonrpc" field (#5950).
+func unauthorizedErrorBody(msgID any, err error) []byte {
 	errorMsg := "Unauthorized"
 	if err != nil {
 		errorMsg = err.Error()
 	}
 
-	// Create a JSON-RPC error response
-	id, err := mcp.ConvertToJSONRPC2ID(msgID)
-	if err != nil {
-		id = jsonrpc2.ID{} // Use empty ID if conversion fails
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"error": map[string]any{
+			"code":    mcp.JSONRPCCodeDenied,
+			"message": errorMsg,
+		},
+		"id": msgID,
 	}
-
-	errorResponse := &jsonrpc2.Response{
-		ID:    id,
-		Error: jsonrpc2.NewError(mcp.JSONRPCCodeDenied, errorMsg),
+	body, marshalErr := json.Marshal(resp)
+	if marshalErr != nil {
+		// This should never happen with simple map types, but return a
+		// hand-crafted fallback to guarantee a valid JSON-RPC error.
+		return []byte(`{"jsonrpc":"2.0","error":{"code":403,"message":"Unauthorized"},"id":null}`)
 	}
+	return body
+}
 
-	// Set the response headers
+// handleUnauthorized handles unauthorized requests.
+func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
+	body := unauthorizedErrorBody(msgID, err)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusForbidden)
-
-	// Write the error response
-	if err := json.NewEncoder(w).Encode(errorResponse); err != nil {
-		// If we can't encode the error response, log it and return a simple error
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-	}
+	//nolint:gosec // G104: writing a JSON-RPC error response to an HTTP client
+	_, _ = w.Write(body)
 }
 
 // Middleware creates an HTTP middleware that authorizes MCP requests.

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -1561,3 +1561,76 @@ func TestHandleToolsCall(t *testing.T) {
 		})
 	}
 }
+
+// TestUnauthorizedErrorBodyJSONRPCConformant guards #5950: authz denial bodies
+// must be valid JSON-RPC 2.0 (lowercase keys + mandatory "jsonrpc":"2.0").
+// encoding/json on *jsonrpc2.Response previously emitted Result/Error/ID.
+func TestUnauthorizedErrorBodyJSONRPCConformant(t *testing.T) {
+	t.Parallel()
+
+	body := unauthorizedErrorBody(float64(1), errors.New("unknown MCP method: server/discover (not configured for authorization)"))
+
+	// Wire-byte assertions: reject the pre-fix capitalized envelope.
+	raw := string(body)
+	assert.NotContains(t, raw, `"Result"`)
+	assert.NotContains(t, raw, `"Error"`)
+	assert.NotContains(t, raw, `"ID"`)
+	assert.Contains(t, raw, `"jsonrpc"`)
+	assert.Contains(t, raw, `"error"`)
+	assert.Contains(t, raw, `"id"`)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	assert.Equal(t, "2.0", parsed["jsonrpc"])
+	assert.EqualValues(t, 1, parsed["id"])
+
+	errObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, mcpparser.JSONRPCCodeDenied, errObj["code"])
+	assert.Contains(t, errObj["message"], "server/discover")
+	_, hasResult := parsed["result"]
+	assert.False(t, hasResult, "error responses must not include a result field")
+}
+
+// TestHandleUnauthorizedHTTPWireBytes exercises the product path for #5950:
+// unknown MCP method (server/discover) returns HTTP 403 with a conformant
+// JSON-RPC error body on the wire.
+func TestHandleUnauthorizedHTTPWireBytes(t *testing.T) {
+	t.Parallel()
+
+	authorizer, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{
+		Policies:     []string{`permit(principal, action == Action::"call_tool", resource == Tool::"weather");`},
+		EntitiesJSON: `[]`,
+	}, "")
+	require.NoError(t, err)
+
+	reqBody := []byte(`{"jsonrpc":"2.0","id":42,"method":"server/discover","params":{}}`)
+	req, err := http.NewRequest(http.MethodPost, "/mcp", bytes.NewBuffer(reqBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "user123", Claims: jwt.MapClaims{"sub": "user123"}}}
+	req = req.WithContext(auth.WithIdentity(req.Context(), identity))
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mcpparser.ParsingMiddleware(Middleware(authorizer, handler, nil)).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	wire := rr.Body.Bytes()
+	t.Logf("wire bytes: %s", wire)
+
+	assert.NotContains(t, string(wire), `"Result"`)
+	assert.NotContains(t, string(wire), `"Error"`)
+	assert.NotContains(t, string(wire), `"ID"`)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(wire, &parsed))
+	assert.Equal(t, "2.0", parsed["jsonrpc"])
+	assert.EqualValues(t, 42, parsed["id"])
+	errObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, mcpparser.JSONRPCCodeDenied, errObj["code"])
+	assert.Contains(t, errObj["message"], "server/discover")
+}

--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -525,21 +525,29 @@ func (rfw *ResponseFilteringWriter) filterResourcesResponse(response *jsonrpc2.R
 	return filteredResponse, nil
 }
 
+// filteringErrorBody renders a JSON-RPC 2.0 error body when response filtering
+// fails. Same envelope shape as unauthorizedErrorBody: hand-built lowercase
+// keys with an explicit "jsonrpc":"2.0". Do not json.Marshal a
+// *jsonrpc2.Response here (#5950).
+func filteringErrorBody(id jsonrpc2.ID, err error) []byte {
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"error": map[string]any{
+			"code":    int64(500),
+			"message": fmt.Sprintf("Error filtering response: %v", err),
+		},
+		"id": id.Raw(),
+	}
+	body, marshalErr := json.Marshal(resp)
+	if marshalErr != nil {
+		return []byte(`{"jsonrpc":"2.0","error":{"code":500,"message":"Internal server error"},"id":null}`)
+	}
+	return body
+}
+
 // writeErrorResponse writes an error response
 func (rfw *ResponseFilteringWriter) writeErrorResponse(id jsonrpc2.ID, err error) error {
-	errorResponse := &jsonrpc2.Response{
-		ID:    id,
-		Error: jsonrpc2.NewError(500, fmt.Sprintf("Error filtering response: %v", err)),
-	}
-
-	errorData, marshalErr := json.Marshal(errorResponse)
-	if marshalErr != nil {
-		// If we can't even marshal the error, write a simple error
-		rfw.ResponseWriter.WriteHeader(http.StatusInternalServerError)
-		_, writeErr := rfw.ResponseWriter.Write([]byte(`{"error": "Internal server error"}`))
-		return writeErr
-	}
-
+	errorData := filteringErrorBody(id, err)
 	rfw.ResponseWriter.WriteHeader(http.StatusInternalServerError)
 	_, writeErr := rfw.ResponseWriter.Write(errorData)
 	return writeErr

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -1173,3 +1173,24 @@ func TestResponseFilteringWriter_JSON_DisguisedResponseFrame(t *testing.T) {
 	assert.NotContains(t, rr.Body.String(), "admin_tool",
 		"smuggled result on the application/json transport leaked past the filter")
 }
+
+// TestFilteringErrorBodyJSONRPCConformant guards the sibling encoder of #5950:
+// response-filter failure bodies must also use lowercase JSON-RPC 2.0 keys.
+func TestFilteringErrorBodyJSONRPCConformant(t *testing.T) {
+	t.Parallel()
+
+	body := filteringErrorBody(jsonrpc2.Int64ID(7), assert.AnError)
+	raw := string(body)
+	assert.NotContains(t, raw, `"Result"`)
+	assert.NotContains(t, raw, `"Error"`)
+	assert.NotContains(t, raw, `"ID"`)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	assert.Equal(t, "2.0", parsed["jsonrpc"])
+	assert.EqualValues(t, 7, parsed["id"])
+	errObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.EqualValues(t, 500, errObj["code"])
+	assert.Contains(t, errObj["message"], "Error filtering response")
+}


### PR DESCRIPTION
## Summary

Authz denial responses were not valid JSON-RPC 2.0. `handleUnauthorized` encoded a `*jsonrpc2.Response` with `encoding/json` directly. That struct has no json tags / MarshalJSON, so the wire body used capitalized keys (`Result` / `Error` / `ID`) and omitted the mandatory `"jsonrpc":"2.0"` field. Spec-strict MCP clients cannot read `error` / `id` on a 403.

**What changed**

- Build the denial body as a lowercase `map[string]any` with `"jsonrpc":"2.0"`, `"id"`, and `"error"` (same pattern as `classificationErrorBody` / `filteredToolCallErrorBody`)
- Apply the same envelope to the sibling response-filter failure path (`writeErrorResponse` / `filteringErrorBody`), which had the same direct-marshal bug
- Add wire-byte regression tests for both helpers plus an HTTP product-path test for `server/discover` 403

Fixes #5950

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit / package tests (`go test ./pkg/authz/ ...`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

### Evidence

Before (issue report, `POST /mcp` `server/discover` with authz enabled):

```json
{"Result":null,"Error":{"code":403,"message":"unknown MCP method: server/discover (not configured for authorization)"},"ID":{}}
```

After fix, HTTP product-path wire bytes from `TestHandleUnauthorizedHTTPWireBytes`:

```
{"error":{"code":403,"message":"unknown MCP method: server/discover (not configured for authorization)"},"id":42,"jsonrpc":"2.0"}
```

Targeted tests (Windows):

```
go test ./pkg/authz/ -count=1 -run "UnauthorizedErrorBody|HandleUnauthorizedHTTP|FilteringErrorBody" -v
--- PASS: TestUnauthorizedErrorBodyJSONRPCConformant (0.00s)
--- PASS: TestFilteringErrorBodyJSONRPCConformant (0.00s)
--- PASS: TestHandleUnauthorizedHTTPWireBytes (0.00s)
PASS
ok  	github.com/stacklok/toolhive/pkg/authz	3.155s
```

Full package:

```
go test ./pkg/authz/ -count=1
ok  	github.com/stacklok/toolhive/pkg/authz	2.624s
```

### What was not tested

- Live authz-enabled proxy against a real MCP go-sdk client on this box (no local authz proxy harness here). Product path covered via ParsingMiddleware + Middleware HTTP recorder with the issue's `server/discover` method.
- Full `task lint-fix` / e2e suite (targeted package tests only).

## Does this introduce a user-facing change?

Yes. Authorization-denied MCP responses now use a JSON-RPC 2.0 envelope (`jsonrpc`, `id`, `error` lowercase). Clients that already accepted the capitalized keys via case-insensitive unmarshal remain compatible; spec-strict clients can now parse the denial.

## Special notes for reviewers

- AI assistance: Cursor/Grok; human reviewed; Evidence is from commands run on this machine.
- Sibling coverage: response-filter internal error encoding used the same broken marshal path and is fixed in this PR.

## AI disclosure

This change was developed with AI assistance (Cursor/Grok). The author reviewed the diff, ran the Evidence commands above, and takes responsibility for the patch.
