### PR TITLE
Add opt-in strict MCP-Protocol-Version validation

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -102,6 +102,10 @@ type RunFlags struct {
 	// Proxy headers
 	TrustProxyHeaders bool
 
+	// StrictProtocolValidation enables strict MCP-Protocol-Version validation
+	// on the streamable HTTP proxy.
+	StrictProtocolValidation bool
+
 	// Endpoint prefix for SSE endpoint URLs
 	EndpointPrefix string
 
@@ -278,6 +282,9 @@ func AddRunFlags(cmd *cobra.Command, config *RunFlags) {
 	cmd.Flags().BoolVar(&config.TrustProxyHeaders, "trust-proxy-headers", false,
 		"Trust X-Forwarded-* headers from reverse proxies (X-Forwarded-Proto, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Prefix) "+
 			"(default false)")
+	cmd.Flags().BoolVar(&config.StrictProtocolValidation, "strict-protocol-validation", false,
+		"Reject client requests whose MCP-Protocol-Version header is an unknown/unsupported MCP revision with HTTP 400 "+
+			"(streamable-HTTP proxy only; an absent header is accepted). Off by default: any version is accepted.")
 	cmd.Flags().BoolVar(&config.Stateless, "stateless", false,
 		"Declare the server as stateless (POST-only, no SSE). "+
 			"Use for MCP servers implementing streamable-HTTP stateless mode.")
@@ -690,6 +697,7 @@ func buildRunnerConfig(
 		runner.WithNetworkIsolation(runFlags.IsolateNetwork),
 		runner.WithAllowDockerGateway(runFlags.AllowDockerGateway),
 		runner.WithTrustProxyHeaders(runFlags.TrustProxyHeaders),
+		runner.WithStrictProtocolValidation(runFlags.StrictProtocolValidation),
 		runner.WithStateless(runFlags.Stateless),
 		runner.WithSessionTTL(runFlags.SessionTTL),
 		runner.WithEndpointPrefix(runFlags.EndpointPrefix),

--- a/docs/arch/03-transport-architecture.md
+++ b/docs/arch/03-transport-architecture.md
@@ -771,6 +771,25 @@ For deployment behind reverse proxy, proxies respect X-Forwarded headers (Host, 
 
 **Security**: Only enable if ToolHive is behind trusted reverse proxy.
 
+### MCP-Protocol-Version Validation (Streamable HTTP)
+
+**Implementation**: `pkg/transport/proxy/streamable/streamable_proxy.go`, `pkg/transport/proxy/streamable/utils.go`
+
+By default, the streamable HTTP proxy is version-agnostic: it accepts any
+`MCP-Protocol-Version` header value (including an absent header, per the
+streamable HTTP spec's rule to assume `2025-03-26`). This is intentional --
+the proxy is transport-level and does not depend on a specific MCP revision,
+so it avoids being pedantic and breaking on new protocol dates.
+
+**Opt-in strict mode**: `thv run --strict-protocol-validation` rejects a
+request whose `MCP-Protocol-Version` header names an unknown/unsupported MCP
+revision with HTTP 400. An absent header is still accepted in strict mode.
+The set of recognized revisions is `supportedMCPVersions` in
+`pkg/transport/proxy/streamable/utils.go`. This is wired through
+`runner.WithStrictProtocolValidation` -> `RunConfig.StrictProtocolValidation`
+-> `types.Config.StrictProtocolValidation` -> `StdioTransport.SetStrictProtocolValidation`
+-> `streamable.WithStrictProtocolValidation`.
+
 ### SSE Endpoint URL Rewriting
 
 **Problem**: When using path-based ingress routing that strips path prefixes:

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -181,6 +181,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --secret stringArray                          Specify a secret to be fetched from the secrets manager and set as an environment variable (format: NAME,target=TARGET)
       --session-ttl duration                        Session inactivity timeout (e.g., 30m, 2h); zero uses the default (2h)
       --stateless                                   Declare the server as stateless (POST-only, no SSE). Use for MCP servers implementing streamable-HTTP stateless mode.
+      --strict-protocol-validation                  Reject client requests whose MCP-Protocol-Version header is an unknown/unsupported MCP revision with HTTP 400 (streamable-HTTP proxy only; an absent header is accepted). Off by default: any version is accepted.
       --target-host string                          Host to forward traffic to (only applicable to SSE or Streamable HTTP transport) (default "127.0.0.1")
       --target-port int                             Port for the container to expose (only applicable to SSE or Streamable HTTP transport)
       --thv-ca-bundle string                        Path to CA certificate bundle for ToolHive HTTP operations (JWKS, OIDC discovery, etc.)

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1502,6 +1502,10 @@ const docTemplate = `{
                         "description": "Stateless indicates the server only supports POST (no SSE/GET).\nWhen true, the proxy returns 405 for incoming GET requests and uses a\nPOST-based health check instead of the default GET probe.\nApplies to both remote URLs and local container workloads.",
                         "type": "boolean"
                     },
+                    "strict_protocol_validation": {
+                        "description": "StrictProtocolValidation enables strict MCP-Protocol-Version validation\non the streamable HTTP proxy: a request whose header names an unknown\nMCP revision is rejected with HTTP 400. Default false accepts any\nversion string (an absent header is always accepted in either mode).",
+                        "type": "boolean"
+                    },
                     "target_host": {
                         "description": "TargetHost is the host to forward traffic to (only applicable to SSE transport)",
                         "type": "string"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1495,6 +1495,10 @@
                         "description": "Stateless indicates the server only supports POST (no SSE/GET).\nWhen true, the proxy returns 405 for incoming GET requests and uses a\nPOST-based health check instead of the default GET probe.\nApplies to both remote URLs and local container workloads.",
                         "type": "boolean"
                     },
+                    "strict_protocol_validation": {
+                        "description": "StrictProtocolValidation enables strict MCP-Protocol-Version validation\non the streamable HTTP proxy: a request whose header names an unknown\nMCP revision is rejected with HTTP 400. Default false accepts any\nversion string (an absent header is always accepted in either mode).",
+                        "type": "boolean"
+                    },
                     "target_host": {
                         "description": "TargetHost is the host to forward traffic to (only applicable to SSE transport)",
                         "type": "string"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1567,6 +1567,13 @@ components:
             POST-based health check instead of the default GET probe.
             Applies to both remote URLs and local container workloads.
           type: boolean
+        strict_protocol_validation:
+          description: |-
+            StrictProtocolValidation enables strict MCP-Protocol-Version validation
+            on the streamable HTTP proxy: a request whose header names an unknown
+            MCP revision is rejected with HTTP 400. Default false accepts any
+            version string (an absent header is always accepted in either mode).
+          type: boolean
         target_host:
           description: TargetHost is the host to forward traffic to (only applicable
             to SSE transport)

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -207,6 +207,12 @@ type RunConfig struct {
 	// TrustProxyHeaders indicates whether to trust X-Forwarded-* headers from reverse proxies
 	TrustProxyHeaders bool `json:"trust_proxy_headers,omitempty" yaml:"trust_proxy_headers,omitempty"`
 
+	// StrictProtocolValidation enables strict MCP-Protocol-Version validation
+	// on the streamable HTTP proxy: a request whose header names an unknown
+	// MCP revision is rejected with HTTP 400. Default false accepts any
+	// version string (an absent header is always accepted in either mode).
+	StrictProtocolValidation bool `json:"strict_protocol_validation,omitempty" yaml:"strict_protocol_validation,omitempty"`
+
 	// Stateless indicates the server only supports POST (no SSE/GET).
 	// When true, the proxy returns 405 for incoming GET requests and uses a
 	// POST-based health check instead of the default GET probe.

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -376,6 +376,16 @@ func WithTrustProxyHeaders(trust bool) RunConfigBuilderOption {
 	}
 }
 
+// WithStrictProtocolValidation sets whether the streamable HTTP proxy rejects
+// requests carrying an unknown/unsupported MCP-Protocol-Version header with
+// HTTP 400. Default false accepts any version string.
+func WithStrictProtocolValidation(strict bool) RunConfigBuilderOption {
+	return func(b *runConfigBuilder) error {
+		b.config.StrictProtocolValidation = strict
+		return nil
+	}
+}
+
 // WithStateless declares the server is stateless (POST-only, no SSE).
 func WithStateless(stateless bool) RunConfigBuilderOption {
 	return func(b *runConfigBuilder) error {

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -1542,6 +1542,33 @@ func TestWithSessionTTL(t *testing.T) {
 	}
 }
 
+// TestWithStrictProtocolValidation verifies the builder option sets
+// RunConfig.StrictProtocolValidation, mirroring WithTrustProxyHeaders's
+// plumbing (see cmd/thv/app/run_flags.go's --strict-protocol-validation flag).
+func TestWithStrictProtocolValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		strict bool
+	}{
+		{name: "enabled", strict: true},
+		{name: "disabled (default)", strict: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			builder := &runConfigBuilder{config: NewRunConfig()}
+			err := WithStrictProtocolValidation(tt.strict)(builder)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.strict, builder.config.StrictProtocolValidation)
+		})
+	}
+}
+
 func TestResolveRegistryServerName(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -211,16 +211,17 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	// Create transport with runtime
 	transportConfig := types.Config{
-		Type:              r.Config.Transport,
-		ProxyPort:         r.Config.Port,
-		TargetPort:        r.Config.TargetPort,
-		Host:              r.Config.Host,
-		TargetHost:        r.Config.TargetHost,
-		Deployer:          r.Config.Deployer,
-		Debug:             r.Config.Debug,
-		TrustProxyHeaders: r.Config.TrustProxyHeaders,
-		EndpointPrefix:    r.Config.EndpointPrefix,
-		SessionTTL:        effectiveSessionTTL,
+		Type:                     r.Config.Transport,
+		ProxyPort:                r.Config.Port,
+		TargetPort:               r.Config.TargetPort,
+		Host:                     r.Config.Host,
+		TargetHost:               r.Config.TargetHost,
+		Deployer:                 r.Config.Deployer,
+		Debug:                    r.Config.Debug,
+		TrustProxyHeaders:        r.Config.TrustProxyHeaders,
+		StrictProtocolValidation: r.Config.StrictProtocolValidation,
+		EndpointPrefix:           r.Config.EndpointPrefix,
+		SessionTTL:               effectiveSessionTTL,
 	}
 
 	// Set proxy mode for stdio transport

--- a/pkg/transport/factory.go
+++ b/pkg/transport/factory.go
@@ -52,6 +52,7 @@ func (*Factory) Create(config types.Config, opts ...Option) (types.Transport, er
 			config.PrometheusHandler, config.Middlewares...,
 		)
 		stdio.SetProxyMode(config.ProxyMode)
+		stdio.SetStrictProtocolValidation(config.StrictProtocolValidation)
 		if config.SessionStorage != nil {
 			stdio.SetSessionStorage(config.SessionStorage)
 		}

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -120,6 +120,15 @@ type HTTPProxy struct {
 	// WithStandaloneSSE(false) to opt out.
 	standaloneSSE bool
 
+	// strictProtocolValidation controls whether handlePost rejects a request
+	// whose MCP-Protocol-Version header names an unknown/unsupported MCP
+	// revision (see isSupportedMCPVersion) with HTTP 400. Default false: any
+	// version string is accepted, since this proxy is transport-level and does
+	// not depend on a specific MCP revision. An absent header is always
+	// accepted, in either mode, per the streamable HTTP spec's rule to assume
+	// 2025-03-26 when the header is missing. Set via WithStrictProtocolValidation.
+	strictProtocolValidation bool
+
 	// Health checker
 	healthChecker *healthcheck.HealthChecker
 
@@ -188,6 +197,16 @@ func WithStandaloneSSE(enabled bool) Option {
 	return func(p *HTTPProxy) {
 		p.standaloneSSE = enabled
 	}
+}
+
+// WithStrictProtocolValidation enables strict MCP-Protocol-Version checking.
+// When enabled, a request whose MCP-Protocol-Version header names an
+// unsupported/unknown MCP revision is rejected with HTTP 400. An absent
+// header is still accepted (the streamable HTTP spec says to assume
+// 2025-03-26). Default (false) preserves the version-agnostic behavior:
+// any version string is accepted.
+func WithStrictProtocolValidation(enabled bool) Option {
+	return func(p *HTTPProxy) { p.strictProtocolValidation = enabled }
 }
 
 // NewHTTPProxy creates a new HTTPProxy for streamable HTTP transport.
@@ -495,9 +514,15 @@ func (p *HTTPProxy) handleDelete(w http.ResponseWriter, r *http.Request) {
 func (p *HTTPProxy) handlePost(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Optionally validate MCP-Protocol-Version; accept missing for compatibility
+	// MCP-Protocol-Version validation is opt-in via strictProtocolValidation
+	// (WithStrictProtocolValidation). Default (false) is version-agnostic:
+	// any header value is accepted, since this proxy is transport-level and
+	// does not depend on a specific MCP revision. When strict mode is
+	// enabled, a present-but-unrecognized version is rejected with 400; an
+	// absent header is always accepted in either mode, per the streamable
+	// HTTP spec's rule to assume 2025-03-26 when the header is missing.
 	protoVer := r.Header.Get("MCP-Protocol-Version")
-	if protoVer != "" && !isSupportedMCPVersion(protoVer) {
+	if p.strictProtocolValidation && protoVer != "" && !isSupportedMCPVersion(protoVer) {
 		writeHTTPError(w, http.StatusBadRequest, "Unsupported MCP-Protocol-Version")
 		return
 	}

--- a/pkg/transport/proxy/streamable/streamable_proxy_protocol_version_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_protocol_version_test.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package streamable
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandlePost_StrictProtocolValidation drives handlePost directly (no
+// server/backend needed: the notification body used below returns 202
+// without any upstream round-trip) to verify the MCP-Protocol-Version gate:
+//   - strict mode rejects a present-but-unrecognized version with 400
+//   - strict mode accepts a recognized version
+//   - strict mode accepts an absent header (assume 2025-03-26 per spec)
+//   - permissive mode (default, strict disabled) accepts any version,
+//     preserving the proxy's original version-agnostic behavior
+func TestHandlePost_StrictProtocolValidation(t *testing.T) {
+	t.Parallel()
+
+	// A notification (no id) is accepted and forwarded with 202 by
+	// handleNotificationOrClientResponse without waiting on any backend
+	// response, so these tests never need to start the proxy or a backend.
+	const notificationBody = `{"jsonrpc":"2.0","method":"progress","params":{"pct":50}}`
+
+	tests := []struct {
+		name           string
+		strict         bool
+		protocolHeader string
+		wantStatus     int
+	}{
+		{
+			name:           "strict on, unsupported version rejected",
+			strict:         true,
+			protocolHeader: "1999-01-01",
+			wantStatus:     http.StatusBadRequest,
+		},
+		{
+			name:           "strict on, supported version accepted",
+			strict:         true,
+			protocolHeader: "2025-11-25",
+			wantStatus:     http.StatusAccepted,
+		},
+		{
+			name:           "strict on, absent header accepted",
+			strict:         true,
+			protocolHeader: "",
+			wantStatus:     http.StatusAccepted,
+		},
+		{
+			name:           "strict off (default), unsupported version accepted",
+			strict:         false,
+			protocolHeader: "1999-01-01",
+			wantStatus:     http.StatusAccepted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			proxy := NewHTTPProxy("127.0.0.1", 0, nil, nil, WithStrictProtocolValidation(tt.strict))
+
+			req := httptest.NewRequest(http.MethodPost, StreamableHTTPEndpoint, bytes.NewReader([]byte(notificationBody)))
+			req.Header.Set("Content-Type", "application/json")
+			if tt.protocolHeader != "" {
+				req.Header.Set("MCP-Protocol-Version", tt.protocolHeader)
+			}
+			rec := httptest.NewRecorder()
+
+			proxy.handlePost(rec, req)
+
+			require.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}

--- a/pkg/transport/proxy/streamable/utils.go
+++ b/pkg/transport/proxy/streamable/utils.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive/pkg/mcp"
 )
 
 // sseKeepAliveInterval is the cadence at which an otherwise-idle SSE stream
@@ -189,9 +191,28 @@ func rewriteRequestParam(req *jsonrpc2.Request, key string, value any) (*jsonrpc
 	return &jsonrpc2.Request{ID: req.ID, Method: req.Method, Params: data}, nil
 }
 
-// isSupportedMCPVersion is intentionally permissive: we accept any present version string.
-// This avoids being pedantic and breaking on new protocol dates while remaining compliant,
-// since this proxy is transport-level and does not depend on specific MCP versions.
-func isSupportedMCPVersion(_ string) bool {
-	return true
+// supportedMCPVersions is the set of MCP protocol revision dates this proxy
+// recognizes when strict validation is enabled (WithStrictProtocolValidation).
+// The upcoming stateless revision is sourced from mcp.MCPVersionModern rather
+// than duplicated as a literal, so the strict gate and the ClassifyRevision
+// routing path (which keys off the same constant) cannot drift if that draft
+// date changes before it is finalized.
+var supportedMCPVersions = map[string]struct{}{
+	"2024-11-05":         {},
+	"2025-03-26":         {},
+	"2025-06-18":         {},
+	"2025-11-25":         {},
+	mcp.MCPVersionModern: {},
+}
+
+// isSupportedMCPVersion reports whether version is one of the known MCP
+// protocol revision dates in supportedMCPVersions. It is only consulted when
+// the proxy's strict protocol validation is enabled (see
+// WithStrictProtocolValidation); in the default permissive mode, handlePost
+// never calls it and any MCP-Protocol-Version header value is accepted, since
+// this proxy is transport-level and does not depend on a specific MCP
+// revision.
+func isSupportedMCPVersion(version string) bool {
+	_, ok := supportedMCPVersions[version]
+	return ok
 }

--- a/pkg/transport/proxy/streamable/utils_test.go
+++ b/pkg/transport/proxy/streamable/utils_test.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package streamable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsSupportedMCPVersion verifies membership in supportedMCPVersions: every
+// known MCP revision date returns true, and unknown/garbage/empty strings
+// return false. This function is only consulted by handlePost when strict
+// protocol validation is enabled (see WithStrictProtocolValidation).
+func TestIsSupportedMCPVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "2024-11-05 is supported", version: "2024-11-05", want: true},
+		{name: "2025-03-26 is supported", version: "2025-03-26", want: true},
+		{name: "2025-06-18 is supported", version: "2025-06-18", want: true},
+		{name: "2025-11-25 is supported", version: "2025-11-25", want: true},
+		{name: "2026-07-28 is supported", version: "2026-07-28", want: true},
+		{name: "unknown future date is not supported", version: "1999-01-01", want: false},
+		{name: "garbage string is not supported", version: "not-a-version", want: false},
+		{name: "empty string is not supported", version: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isSupportedMCPVersion(tt.version))
+		})
+	}
+}

--- a/pkg/transport/stdio.go
+++ b/pkg/transport/stdio.go
@@ -68,6 +68,11 @@ type StdioTransport struct {
 	authInfoHandler   http.Handler
 	prefixHandlers    map[string]http.Handler
 
+	// strictProtocolValidation controls whether the streamable HTTP proxy
+	// rejects an unknown/unsupported MCP-Protocol-Version header with 400.
+	// See streamable.WithStrictProtocolValidation.
+	strictProtocolValidation bool
+
 	// Mutex for protecting shared state
 	mutex sync.Mutex
 
@@ -137,6 +142,14 @@ func NewStdioTransport(
 // SetProxyMode allows configuring the proxy mode (SSE or Streamable HTTP)
 func (t *StdioTransport) SetProxyMode(mode types.ProxyMode) {
 	t.proxyMode = mode
+}
+
+// SetStrictProtocolValidation configures whether the streamable HTTP proxy
+// rejects requests carrying an unknown/unsupported MCP-Protocol-Version
+// header with HTTP 400. Default false preserves the version-agnostic
+// behavior of accepting any header value.
+func (t *StdioTransport) SetStrictProtocolValidation(strict bool) {
+	t.strictProtocolValidation = strict
 }
 
 // SetSessionStorage configures a custom session storage backend.
@@ -264,6 +277,7 @@ func (t *StdioTransport) streamableProxyOptions() []streamable.Option {
 	return append(opts,
 		streamable.WithAuthInfoHandler(t.authInfoHandler),
 		streamable.WithPrefixHandlers(t.prefixHandlers),
+		streamable.WithStrictProtocolValidation(t.strictProtocolValidation),
 	)
 }
 

--- a/pkg/transport/types/transport.go
+++ b/pkg/transport/types/transport.go
@@ -249,6 +249,12 @@ type Config struct {
 	// TrustProxyHeaders indicates whether to trust X-Forwarded-* headers from reverse proxies
 	TrustProxyHeaders bool
 
+	// StrictProtocolValidation enables strict MCP-Protocol-Version validation
+	// on the streamable HTTP proxy: a present-but-unsupported header value is
+	// rejected with HTTP 400. Default false accepts any version string. Only
+	// consulted for the stdio/streamable-HTTP proxy path (see factory.go).
+	StrictProtocolValidation bool
+
 	// ProxyMode is the proxy mode for stdio transport ("sse" or "streamable-http")
 	ProxyMode ProxyMode
 

--- a/pkg/workloads/upgrade/applier.go
+++ b/pkg/workloads/upgrade/applier.go
@@ -307,6 +307,7 @@ func (a *Applier) buildUpgradedConfig(
 		runner.WithNetworkIsolation(old.IsolateNetwork),
 		runner.WithAllowDockerGateway(old.AllowDockerGateway),
 		runner.WithTrustProxyHeaders(old.TrustProxyHeaders),
+		runner.WithStrictProtocolValidation(old.StrictProtocolValidation),
 		runner.WithProxyMode(old.ProxyMode),
 		runner.WithCmdArgs(slices.Clone(old.CmdArgs)),
 		runner.WithStateless(old.Stateless),

--- a/pkg/workloads/upgrade/applier_test.go
+++ b/pkg/workloads/upgrade/applier_test.go
@@ -507,6 +507,7 @@ func fullyConfiguredOld(t *testing.T) *runner.RunConfig {
 		PermissionProfileNameOrPath: "none",
 		IsolateNetwork:              true,
 		TrustProxyHeaders:           true,
+		StrictProtocolValidation:    true,
 		Stateless:                   true,
 		EndpointPrefix:              "/mcp",
 		SessionTTL:                  "30m",
@@ -569,6 +570,7 @@ func TestApplier_Apply_PreservesFullUserConfig(t *testing.T) {
 	assert.Equal(t, old.PermissionProfileNameOrPath, got.PermissionProfileNameOrPath, "named profile preserved")
 	assert.Equal(t, old.IsolateNetwork, got.IsolateNetwork)
 	assert.Equal(t, old.TrustProxyHeaders, got.TrustProxyHeaders)
+	assert.Equal(t, old.StrictProtocolValidation, got.StrictProtocolValidation)
 	assert.Equal(t, old.Stateless, got.Stateless)
 	assert.Equal(t, old.EndpointPrefix, got.EndpointPrefix)
 	assert.Equal(t, old.SessionTTL, got.SessionTTL)


### PR DESCRIPTION
## Summary

**Why:** The streamable HTTP proxy accepted **any** `MCP-Protocol-Version` header — `isSupportedMCPVersion` unconditionally returned `true` (`pkg/transport/proxy/streamable/utils.go`). This permissive stance is defensible for a transport-level proxy that doesn't depend on a specific MCP revision, but it was **undocumented**, and the spec says a server MUST reject an invalid/unsupported version with HTTP 400 — operators had no way to opt into that.

**What:**
- Add a **`--strict-protocol-validation`** flag (default **off**, preserving today's version-agnostic behavior byte-for-byte via a `p.strictProtocolValidation && …` short-circuit).
- When enabled, `handlePost` rejects a request whose `MCP-Protocol-Version` header names an unknown MCP revision with **HTTP 400**; an **absent** header is still accepted (the streamable HTTP spec says to assume `2025-03-26`).
- Known-version set `{2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25, mcp.MCPVersionModern}` — the upcoming stateless revision is sourced from `mcp.MCPVersionModern` (not a duplicated literal) so the strict gate and the `ClassifyRevision` routing path can't drift.
- Threaded end-to-end mirroring `TrustProxyHeaders`: CLI (`run_flags.go`) → `RunConfig` → `types.Config` → `StdioTransport` → streamable proxy `Option`; **preserved across `thv upgrade`** via the config applier.
- Documented the default version-agnostic stance and the opt-in flag in `docs/arch/03-transport-architecture.md`.

**Closes #5764** (items 1 & 2 landed in #5940 and #5944; this completes item 3).

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests — `go test -race` on the affected packages passes:
  - `TestHandlePost_StrictProtocolValidation` (real `handlePost` via httptest): strict+unsupported→**400**, strict+supported→not-400, strict+absent→not-400, **strict-off+unsupported→not-400** (default-behavior regression guard).
  - `TestIsSupportedMCPVersion`: all five known revisions → true; unknown/garbage/empty → false.
  - `TestWithStrictProtocolValidation` (runner builder) and the `thv upgrade` config-preservation guard extended to cover the new field (`applier_test.go`).
- [x] Linting — `task lint` 0 issues; `task build` succeeds; `task docs` regenerated (flag appears in `docs/cli/thv_run.md`).

## Does this introduce a user-facing change?

Yes. New `thv run --strict-protocol-validation` flag (default off). When enabled, the streamable-HTTP proxy returns HTTP 400 for a request carrying an unknown/unsupported `MCP-Protocol-Version` header; default behavior is unchanged (any version accepted).

## Special notes for reviewers

- **Reviewed by an MCP-spec + correctness/wiring + security panel.** Spec: confirmed the version set is correct and that including `2026-07-28` is required for consistency with `ClassifyRevision`; 400-on-present-unsupported and accept-on-absent match the spec. Security: fail-closed, default-off preserves posture exactly, no bypass/race/DoS. Correctness: caught a wiring gap where `thv upgrade` dropped the persisted flag — **fixed** in `applier.go` + regression test.
- **Scope:** the opt-in is CLI-only for now (mirrors where this proxy setting naturally lives). Operator-CRD and REST-API exposure — where `TrustProxyHeaders` also lives — are a deliberate follow-up, not included here.
- Strict rejection uses a plain-text 400 body (transport-level, emitted before body parse); the separate `ClassifyRevision` path uses a JSON-RPC error body. Both are spec-legal; unifying them is a possible follow-up.
- Unrelated: `TestStandaloneSSE_ListChangedRefiltersThroughExistingMiddleware` fails on `main` independently of this PR (reproduced with these changes stashed) — not introduced here.

Generated with [Claude Code](https://claude.com/claude-code)