### PR TITLE
Update standalone-SSE test for filtered-tool error

### DIFF
--- a/pkg/transport/proxy/streamable/dispatcher_standalone_sse_integration_test.go
+++ b/pkg/transport/proxy/streamable/dispatcher_standalone_sse_integration_test.go
@@ -460,12 +460,19 @@ func TestStandaloneSSE_ListChangedRefiltersThroughExistingMiddleware(t *testing.
 	assert.Contains(t, string(listRespBody), "allowed_tool")
 	assert.NotContains(t, string(listRespBody), "filtered_tool")
 
-	// (3) tools/call POST for the filtered tool is still blocked.
+	// (3) tools/call POST for the filtered tool is still blocked. Since #5944 the
+	// tool-call filter returns a JSON-RPC error over HTTP 200 (the client accepts
+	// JSON) rather than a bare 400, so a filtered tool is indistinguishable from a
+	// tool that does not exist.
 	callBody := `{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"filtered_tool"}}`
 	callResp, err := http.Post(endpoint, "application/json", strings.NewReader(callBody)) //nolint:noctx // test-only
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = callResp.Body.Close() })
-	assert.Equal(t, http.StatusBadRequest, callResp.StatusCode)
+	assert.Equal(t, http.StatusOK, callResp.StatusCode)
+	callRespBody, err := io.ReadAll(callResp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(callRespBody), `"error"`)
+	assert.Contains(t, string(callRespBody), "tool not found")
 }
 
 // ------------------------- Routing security regressions -------------------------


### PR DESCRIPTION
## Summary

**Why:** `main`'s required **Tests / Test Go Code** check is currently **red on every PR**. `TestStandaloneSSE_ListChangedRefiltersThroughExistingMiddleware` (`pkg/transport/proxy/streamable/dispatcher_standalone_sse_integration_test.go:468`) asserts that a `tools/call` for a filtered tool returns **HTTP 400** — but #5944 changed the tool-call filter to return a **JSON-RPC error over HTTP 200** (a filtered tool is now indistinguishable from a nonexistent one). The test was added by #5934; #5934 and #5944 landed close together, so each was green in isolation but their combination is a **semantic merge collision** that leaves the unit-test suite deterministically failing on `main`.

**What:**
- Update step (3) of the test to assert the current behavior: **HTTP 200** with a JSON-RPC error body containing `"tool not found"`. The tool is still blocked (never forwarded to the backend); only the response envelope changed.

Verified locally: the test failed deterministically before this change and passes after; `task lint` clean.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests — `go test -race -run TestStandaloneSSE_ListChangedRefiltersThroughExistingMiddleware ./pkg/transport/proxy/streamable/` passes (failed before the change).
- [x] Linting — `task lint` 0 issues.

## Does this introduce a user-facing change?

No. Test-only change aligning an assertion with the behavior shipped in #5944.

## Special notes for reviewers

- This is a **test-only** fix for a main-branch regression; no production code changes. It unblocks the required Tests check for all open PRs.
- Root cause is the #5934 (test) × #5944 (behavior) merge interaction — neither PR's own CI saw the combination.

Generated with [Claude Code](https://claude.com/claude-code)