### PR TITLE
Drain backend notifications before per-call client close

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -1064,6 +1064,12 @@ func (h *httpBackendClient) CallTool(
 		return nil, fmt.Errorf("%w: tool call failed on backend %s: %w", vmcp.ErrBackendUnavailable, target.WorkloadID, err)
 	}
 
+	// Flush the backend's server->client stream before the deferred Close tears
+	// down this per-call client, so a fire-and-forget notification the backend
+	// emitted mid-call (progress/logging) is relayed downstream instead of being
+	// dropped. See drainServerToClientNotifications for the lost-notification race.
+	h.drainServerToClientNotifications(ctx, c)
+
 	// Extract _meta field from backend response
 	responseMeta := conversion.FromMCPMeta(result.Meta)
 

--- a/pkg/vmcp/client/forwarding.go
+++ b/pkg/vmcp/client/forwarding.go
@@ -62,6 +62,51 @@ func (h *httpBackendClient) enableBackendLogging(
 	}
 }
 
+// drainServerToClientNotifications flushes any in-flight backend->downstream
+// notification off the per-call backend client before it is closed, closing a
+// lost-notification race that otherwise drops fire-and-forget notifications
+// (notifications/progress, notifications/message) under load.
+//
+// The race: a backend emits such a notification mid tools/call and then returns
+// the result. The notification and the result travel on SEPARATE streams — the
+// notification on the standalone SSE stream, the result on the tools/call
+// response stream — and the client reads every stream through a single FIFO
+// channel feeding one receive loop. CallTool returns as soon as the RESULT is
+// read; its deferred Close then cancels the receive loop. If the standalone
+// stream's notification has not yet been read and enqueued for handling when
+// Close fires, it is discarded and never reaches newNotificationForwarder, so
+// the downstream client never sees it (a permanent loss, not a slow delivery).
+// Blocking server->client REQUESTS (elicitation/sampling) are immune: the
+// backend tool blocks on the response, so the client is guaranteed to still be
+// reading when they arrive.
+//
+// The fix is a synchronous ping used purely as a drain barrier. The backend
+// flushes the notification onto the wire before returning the result, so by the
+// time CallTool returns the notification bytes are already buffered on the
+// client's standalone connection. A ping is a full backend round-trip; while it
+// is in flight the receive loop drains the buffered notification off the shared
+// FIFO channel (a local buffered read completes far ahead of the ping's network
+// round-trip), enqueuing it for handling. Because the ping response arrives on
+// that same FIFO channel AFTER the notification, the ping returning proves the
+// notification was already read and enqueued. The subsequent Close then waits
+// for enqueued handlers to finish (jsonrpc2.Connection.Close drains the handler
+// queue), so the forward completes before teardown.
+//
+// Only runs when server->client forwarding is bound (fwd.notifier != nil, the
+// same condition under which the notification forwarder is registered); other
+// deployments keep the pre-forwarding fast path with no extra round-trip.
+// Best-effort: a ping failure only forgoes the barrier — the tool result is
+// already in hand, so it must not fail the call.
+func (h *httpBackendClient) drainServerToClientNotifications(ctx context.Context, c *client.Client) {
+	fwd := h.forwarders.Load()
+	if fwd == nil || fwd.notifier == nil {
+		return
+	}
+	if err := c.Ping(ctx); err != nil {
+		slog.Debug("notification drain ping failed; forwarded notifications may be lost", "error", err)
+	}
+}
+
 // forwardingClientOptions builds the client-level options that install the
 // elicitation and sampling handlers on a backend client, each closing over the
 // captured per-call downstream context so the handler can relay to the right


### PR DESCRIPTION
## Summary

`TestForwarding_Progress_RealBackend` (and `_Logging_`) flaked on CI because a fire-and-forget backend notification emitted mid `tools/call` (`notifications/progress`, `notifications/message`) was **dropped under load**, not merely delayed.

The notification and the tool result travel on separate streams — the notification on the standalone SSE stream, the result on the `tools/call` response stream — read through a single FIFO receive loop. `CallTool` returns as soon as the result is read, and its deferred `Close` cancels that loop; a notification not yet drained off the channel is then discarded and never reaches the downstream client. That is why the earlier fix (bumping the downstream wait 5s→15s) never helped — the message is *lost*, not slow. Blocking server→client requests (elicitation/sampling) are immune because the backend tool blocks on the response, so the client is still reading when they arrive.

**Fix:** before `Close`, when server→client forwarding is bound, issue a synchronous `Ping` as a drain barrier. The backend flushes the notification onto the wire before returning the result, so by the time `CallTool` returns its bytes are already buffered on the client; the ping's round-trip lets the receive loop drain that buffered notification off the shared channel and enqueue it for handling, and `Close` then waits for enqueued handlers before teardown. Best-effort (the result is already in hand) and skipped entirely when forwarding is not bound, so non-forwarding calls keep the fast path with no extra round-trip.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] Unit tests (`task test`) — `pkg/vmcp/server`, `pkg/vmcp/client` pass with `-race`
- [x] Linting (`task lint-fix`) — 0 issues
- [x] Manual testing (describe below)

Reproduced reliably under CPU contention before the fix (progress + logging forwarding tests time out); after the fix the full `TestForwarding` cluster passes 30/30 under 24× load and under `-race -count=20`.

## API Compatibility

- [x] This PR does not break the `v1beta1` API (no operator/CRD surface is touched).

## Special notes for reviewers

- **Rebased onto latest `main`.** This PR originally also carried a fix for the standalone-SSE filtered-tool-call test, but that was landed independently in **#5958**, so that commit was dropped on rebase — only the forwarding fix remains.
- This is the **minimal in-repo mitigation**. The robust fix belongs upstream in the SDK / `toolhive-core` mcpcompat: route mid-call notifications on the correlated *request* stream instead of the lossy standalone stream, or drain gracefully on close. Worth a linked upstream issue as follow-up.
- Tradeoff: one extra backend round-trip per forwarding `tools/call`, only when server→client forwarding is bound. The per-call client already does Start+Initialize+Close, so this is marginal.

Generated with [Claude Code](https://claude.com/claude-code)