### PR TITLE
Consume backend list_changed in vMCP and propagate to clients

### DIFF
--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -177,7 +177,7 @@ Beyond tools, vMCP aggregates and serves the full complement of MCP capabilities
 
 | Capability | Served? | Notes |
 |------------|---------|-------|
-| Tools (`tools/list`, `tools/call`) | Yes | Aggregated, conflict-resolved, admission-filtered |
+| Tools (`tools/list`, `tools/call`) | Yes | Aggregated, conflict-resolved, admission-filtered; a backend's asynchronous `notifications/tools/list_changed` is propagated to already-registered sessions — see below |
 | Resources (`resources/list`, `resources/read`) | Yes | Admission-filtered per identity |
 | Resource templates (`resources/templates/list`) | Yes | Templated reads route through the same `ReadResource` path; the router matches an expanded URI against the aggregated templates, and an exact template-string key routes to its backend |
 | Prompts (`prompts/list`, `prompts/get`) | Yes | Served per-session |
@@ -189,6 +189,85 @@ The completion handler is a single global handler installed via `WithCompletionH
 ### Subscription limitation (ack-level)
 
 vMCP advertises `resources.subscribe: true` and answers `resources/subscribe` / `resources/unsubscribe` at **ack level**: the request is accepted (enforcing session binding and validating the URI is an advertised, admitted resource), and go-sdk records the subscription. vMCP does **not** currently propagate backend `notifications/resources/updated` to the subscribed client — doing so requires persistent per-session backend connections, which is out of scope. Clients that subscribe will receive a success ack but no update stream yet.
+
+### Tools list_changed propagation (#5748)
+
+Unlike the per-call backend client (`pkg/vmcp/client`), the **persistent**
+per-session backend connection (`pkg/vmcp/session/internal/backend`) stays
+open for the session's lifetime, so it can observe a backend's asynchronous
+(out-of-band) notifications rather than only mid-call traffic. When a
+non-nil `ListChangedSink` is supplied at connection time, the connector:
+
+- Enables `WithContinuousListening()` on streamable-HTTP backends (opens a
+  standalone GET stream) — gated **strictly** on a non-nil sink, because some
+  backends hang when this stream is opened against them. SSE backends need no
+  extra option: their whole session is already one continuous stream.
+- Registers an `OnNotification` handler that dispatches
+  `notifications/tools/list_changed` to the sink (`kind="tools"`) and
+  logs `notifications/message` received out-of-call (log-only; no relay).
+
+The sink is built once per session, at registration (`pkg/vmcp/server`'s
+`buildListChangedSink`), closing over the SDK `ClientSession`, the session ID,
+and the caller's identity **captured at registration time** (a deliberate
+snapshot, not re-resolved per firing — see the token-staleness note below).
+It is threaded through `MultiSessionFactory.MakeSessionWithID` (a trailing
+variadic parameter so the many pre-existing call sites are unaffected) down
+to every backend connector opened for that session.
+
+When the sink fires for `kind="tools"`, it:
+
+1. Calls `core.InvalidateCapabilityCache()`, which purges the **entire**
+   per-identity capability cache (`aggregator.CacheInvalidator`) — coarse
+   (not scoped to the one backend that changed) but simple, and briefly
+   de-optimizes other identities' caches rather than risking a stale read for
+   the one that matters. An aggregator that does not implement
+   `CacheInvalidator` WARN-logs instead of silently no-opping.
+2. Re-derives the session's advertised tool set from the (now cold) cache via
+   the same `serveSessionTools` helper session registration uses, and
+   **replaces** — not merges — the SDK session's tool store
+   (`SessionWithTools.SetSessionTools`), so a tool the backend removed
+   disappears rather than lingering from the registration-time merge.
+
+The go-sdk server auto-emits `notifications/tools/list_changed` to the
+downstream client whenever `SetSessionTools` changes something, now that
+`WithToolCapabilities(true)` is set (`pkg/vmcp/server/serve.go`).
+
+**Identity staleness (B1)**: the sink reuses the identity captured at
+registration for its re-aggregation and admission view. If that identity's
+upstream tokens are refreshed later (see #5323), the resync's `core.ListTools`
+call authorizes/aggregates against the (potentially stale) captured tokens,
+not the live per-request ones. This only affects the *accuracy of the
+asynchronous resync's own view* — every live call still authenticates via the
+fresh per-request identity through `enforceSessionBinding`, so staleness here
+cannot grant a call that would otherwise be denied.
+
+**Registration-time emission (R1)**: go-sdk's own `AddTool`/`RemoveTools`
+debounce (10ms) and then broadcast `notifications/tools/list_changed` to
+**every** session currently connected to the shared `*gosdk.Server` — not
+only the session whose tool overlay changed — and a session is eligible for
+that broadcast from the moment its transport connects (`Server.bind`), before
+its own `initialize`/`notifications/initialized` round-trip completes.
+go-sdk's own source documents this as a known upstream gap ("potential spec
+violation... when the feature list changes before the session ... is
+initialized"). This means every session's registration-time per-session
+`AddTool` calls (`setSessionToolsDirect`) now cause a broadcast to every other
+already-connected session too. There is no supported hook to scope or
+suppress this without patching the vendored SDK, so it is accepted as a
+benign nuisance: MCP notifications are inherently a "you may want to refetch"
+hint, so an extra one only costs an idempotent `tools/list` round-trip — it
+never changes what any given session's own `tools/list` actually returns.
+
+**Scope**: tools only. Resources/prompts `list_changed` propagation is a
+tracked follow-up — the backend connector does not dispatch those
+notification methods to the sink yet, and cross-pod session restore
+(`RestoreSession`) does not thread a sink at all (no live `ClientSession` to
+resync there).
+
+**Implementation**: `pkg/vmcp/session/internal/backend/mcp_session.go`
+(`ListChangedSink`, connector wiring), `pkg/vmcp/aggregator/aggregator.go`
+and `caching_aggregator.go` (`CacheInvalidator`), `pkg/vmcp/core/core_vmcp.go`
+(`InvalidateCapabilityCache`), `pkg/vmcp/server/serve_list_changed.go`
+(`buildListChangedSink`, `resyncSessionTools`).
 
 ### Mid-call forwarding (elicitation / sampling / progress / logging)
 

--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -203,26 +203,59 @@ non-nil `ListChangedSink` is supplied at connection time, the connector:
   backends hang when this stream is opened against them. SSE backends need no
   extra option: their whole session is already one continuous stream.
 - Registers an `OnNotification` handler that dispatches
-  `notifications/tools/list_changed` to the sink (`kind="tools"`) and
-  logs `notifications/message` received out-of-call (log-only; no relay).
+  `notifications/tools/list_changed` to the sink (`kind=KindTools`, a typed
+  `ChangeKind` constant rather than a bare string so a typo is a compile
+  error) and logs `notifications/message` received out-of-call (log-only; no
+  relay).
 
 The sink is built once per session, at registration (`pkg/vmcp/server`'s
 `buildListChangedSink`), closing over the SDK `ClientSession`, the session ID,
-and the caller's identity **captured at registration time** (a deliberate
-snapshot, not re-resolved per firing — see the token-staleness note below).
-It is threaded through `MultiSessionFactory.MakeSessionWithID` (a trailing
-variadic parameter so the many pre-existing call sites are unaffected) down
-to every backend connector opened for that session.
+and the caller's identity **and per-request forwarded headers** captured **at
+registration time** (a deliberate snapshot, not re-resolved per firing — see
+the token-staleness note below). It is threaded through
+`MultiSessionFactory.MakeSessionWithID` / `SessionManager.CreateSession` (a
+single nilable `ListChangedSink` parameter) down to every backend connector
+opened for that session.
 
-When the sink fires for `kind="tools"`, it:
+**The sink is non-blocking (runs on the backend receive-loop goroutine).** It
+must not do real work inline: the mcpcompat client dispatches notifications
+synchronously on its receive loop, so a blocking sink would stall that
+backend's notification delivery and let a misbehaving backend amplify one
+notification into unbounded work. The sink therefore only hands off to a
+**per-session coalescing worker** (`listChangedResyncWorker`): `trigger()`
+sets a dirty flag and, at most, starts **one** worker goroutine — never one
+goroutine per notification. At most one resync runs at a time per session;
+notifications that arrive while a resync is in flight collapse into a single
+follow-up run, so a notification storm is bounded to O(1) concurrent work per
+session. The worker goroutine exits when idle, so an idle session holds no
+goroutine.
 
-1. Calls `core.InvalidateCapabilityCache()`, which purges the **entire**
-   per-identity capability cache (`aggregator.CacheInvalidator`) — coarse
-   (not scoped to the one backend that changed) but simple, and briefly
-   de-optimizes other identities' caches rather than risking a stale read for
-   the one that matters. An aggregator that does not implement
-   `CacheInvalidator` WARN-logs instead of silently no-opping.
-2. Re-derives the session's advertised tool set from the (now cold) cache via
+The worker's resync body (`runListChangedResync`), off the receive loop:
+
+1. **Liveness guard** — looks the session up via `GetMultiSession` and returns
+   immediately if it was terminated/expired, so a storm of notifications for a
+   dead session drives no work.
+2. **Reconstructs the request context** — starts from a server-lifetime base
+   context (`Server.resyncBaseCtx`, cancelled on `Stop` so in-flight backend
+   sweeps never outlive the server) and layers on the captured identity
+   (`auth.WithIdentity`) and forwarded headers
+   (`headerforward.WithForwardedHeaders`). This is **security-critical**: the
+   capability cache key and the outbound backend authentication are derived
+   from the **context** (not from an explicit identity argument), so without
+   this the resync would enumerate backends *unauthenticated* — advertising
+   tool metadata the principal's own credentials would not surface, or wrongly
+   dropping credential-gated tools, while replacing the correctly-scoped
+   registration-time set.
+3. Calls `core.InvalidateCapabilityCache()`, which purges the **entire**
+   per-identity capability cache (`aggregator.CacheInvalidator`). This is
+   coarse (not scoped to the one backend that changed): the LRU key is a hash
+   of identity + forwarded headers + backend-set, so per-backend invalidation
+   would need a reverse index that is disproportionate here. The coalescing
+   above already bounds the purge to at most once per resync burst, and a
+   purge only forces the next call per identity to re-sweep — an accepted
+   de-opt / follow-up. An aggregator that does not implement `CacheInvalidator`
+   WARN-logs instead of silently no-opping.
+4. Re-derives the session's advertised tool set from the (now cold) cache via
    the same `serveSessionTools` helper session registration uses, and
    **replaces** — not merges — the SDK session's tool store
    (`SessionWithTools.SetSessionTools`), so a tool the backend removed
@@ -264,10 +297,13 @@ notification methods to the sink yet, and cross-pod session restore
 resync there).
 
 **Implementation**: `pkg/vmcp/session/internal/backend/mcp_session.go`
-(`ListChangedSink`, connector wiring), `pkg/vmcp/aggregator/aggregator.go`
-and `caching_aggregator.go` (`CacheInvalidator`), `pkg/vmcp/core/core_vmcp.go`
+(`ChangeKind`/`KindTools`, `ListChangedSink`, connector wiring),
+`pkg/vmcp/aggregator/aggregator.go` and `caching_aggregator.go`
+(`CacheInvalidator`), `pkg/vmcp/core/core_vmcp.go`
 (`InvalidateCapabilityCache`), `pkg/vmcp/server/serve_list_changed.go`
-(`buildListChangedSink`, `resyncSessionTools`).
+(`listChangedResyncWorker` coalescing, `buildListChangedSink`,
+`runListChangedResync`, `resyncSessionTools`) with `Server.resyncBaseCtx`
+cancelled on `Stop`.
 
 ### Mid-call forwarding (elicitation / sampling / progress / logging)
 

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -8,37 +8,145 @@ const docTemplate = `{
     "schemes": {{ marshal .Schemes }},
     "components": {
         "schemas": {
-            "github_com_stacklok_toolhive-core_registry_types.Registry": {
-                "description": "Full registry data",
+            "auth.TokenValidatorConfig": {
+                "description": "DEPRECATED: Middleware configuration.\nOIDCConfig contains OIDC configuration",
                 "properties": {
-                    "groups": {
-                        "description": "Groups is a slice of group definitions containing related MCP servers",
+                    "allowPrivateIP": {
+                        "description": "AllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses",
+                        "type": "boolean"
+                    },
+                    "audience": {
+                        "description": "Audience is the expected audience for the token",
+                        "type": "string"
+                    },
+                    "authTokenFile": {
+                        "description": "AuthTokenFile is the path to file containing bearer token for authentication",
+                        "type": "string"
+                    },
+                    "cacertPath": {
+                        "description": "CACertPath is the path to the CA certificate bundle for HTTPS requests",
+                        "type": "string"
+                    },
+                    "clientID": {
+                        "description": "ClientID is the OIDC client ID",
+                        "type": "string"
+                    },
+                    "clientSecret": {
+                        "description": "ClientSecret is the optional OIDC client secret for introspection",
+                        "type": "string"
+                    },
+                    "insecureAllowHTTP": {
+                        "description": "InsecureAllowHTTP allows HTTP (non-HTTPS) OIDC issuers for development/testing\nWARNING: This is insecure and should NEVER be used in production",
+                        "type": "boolean"
+                    },
+                    "introspectionURL": {
+                        "description": "IntrospectionURL is the optional introspection endpoint for validating tokens",
+                        "type": "string"
+                    },
+                    "issuer": {
+                        "description": "Issuer is the OIDC issuer URL (e.g., https://accounts.google.com)",
+                        "type": "string"
+                    },
+                    "jwksurl": {
+                        "description": "JWKSURL is the URL to fetch the JWKS from",
+                        "type": "string"
+                    },
+                    "resourceURL": {
+                        "description": "ResourceURL is the explicit resource URL for OAuth discovery (RFC 9728)",
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "description": "Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728)\nIf empty, defaults to [\"openid\"]",
                         "items": {
-                            "$ref": "#/components/schemas/registry.Group"
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "core.Workload": {
+                "properties": {
+                    "created_at": {
+                        "description": "CreatedAt is the timestamp when the workload was created.",
+                        "type": "string"
+                    },
+                    "group": {
+                        "description": "Group is the name of the group this workload belongs to, if any.",
+                        "type": "string"
+                    },
+                    "labels": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Labels are the container labels (excluding standard ToolHive labels)",
+                        "type": "object"
+                    },
+                    "name": {
+                        "description": "Name is the name of the workload.\nIt is used as a unique identifier.",
+                        "type": "string"
+                    },
+                    "package": {
+                        "description": "Package specifies the Workload Package used to create this Workload.",
+                        "type": "string"
+                    },
+                    "port": {
+                        "description": "Port is the port on which the workload is exposed.\nThis is embedded in the URL.",
+                        "type": "integer"
+                    },
+                    "proxy_mode": {
+                        "description": "ProxyMode is the proxy mode that clients should use to connect.\nFor stdio transports, this will be the proxy mode (sse or streamable-http).\nFor direct transports (sse/streamable-http), this will be the same as TransportType.",
+                        "type": "string"
+                    },
+                    "remote": {
+                        "description": "Remote indicates whether this is a remote workload (true) or a container workload (false).",
+                        "type": "boolean"
+                    },
+                    "started_at": {
+                        "description": "StartedAt is when the container was last started (changes on restart)",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "Status is the current status of the workload.",
+                        "enum": [
+                            "running",
+                            "stopped",
+                            "error",
+                            "starting",
+                            "stopping",
+                            "unhealthy",
+                            "removing",
+                            "unknown",
+                            "unauthenticated",
+                            "auth_retrying",
+                            "policy_stopped"
+                        ],
+                        "type": "string"
+                    },
+                    "status_context": {
+                        "description": "StatusContext provides additional context about the workload's status.\nThe exact meaning is determined by the status and the underlying runtime.",
+                        "type": "string"
+                    },
+                    "tools": {
+                        "description": "ToolsFilter is the filter on tools applied to the workload.",
+                        "items": {
+                            "type": "string"
                         },
                         "type": "array",
                         "uniqueItems": false
                     },
-                    "last_updated": {
-                        "description": "LastUpdated is the timestamp when the registry was last updated, in RFC3339 format",
+                    "transport_type": {
+                        "description": "TransportType is the type of transport used for this workload.",
+                        "enum": [
+                            "stdio",
+                            "sse",
+                            "streamable-http",
+                            "inspector"
+                        ],
                         "type": "string"
                     },
-                    "remote_servers": {
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/registry.RemoteServerMetadata"
-                        },
-                        "description": "RemoteServers is a map of server names to their corresponding remote server definitions\nThese are MCP servers accessed via HTTP/HTTPS using the thv proxy command",
-                        "type": "object"
-                    },
-                    "servers": {
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/registry.ImageMetadata"
-                        },
-                        "description": "Servers is a map of server names to their corresponding server definitions",
-                        "type": "object"
-                    },
-                    "version": {
-                        "description": "Version is the schema version of the registry",
+                    "url": {
+                        "description": "URL is the URL of the workload exposed by the ToolHive proxy.",
                         "type": "string"
                     }
                 },
@@ -114,63 +222,6 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
-            "github_com_stacklok_toolhive_pkg_auth.TokenValidatorConfig": {
-                "description": "DEPRECATED: Middleware configuration.\nOIDCConfig contains OIDC configuration",
-                "properties": {
-                    "allowPrivateIP": {
-                        "description": "AllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses",
-                        "type": "boolean"
-                    },
-                    "audience": {
-                        "description": "Audience is the expected audience for the token",
-                        "type": "string"
-                    },
-                    "authTokenFile": {
-                        "description": "AuthTokenFile is the path to file containing bearer token for authentication",
-                        "type": "string"
-                    },
-                    "cacertPath": {
-                        "description": "CACertPath is the path to the CA certificate bundle for HTTPS requests",
-                        "type": "string"
-                    },
-                    "clientID": {
-                        "description": "ClientID is the OIDC client ID",
-                        "type": "string"
-                    },
-                    "clientSecret": {
-                        "description": "ClientSecret is the optional OIDC client secret for introspection",
-                        "type": "string"
-                    },
-                    "insecureAllowHTTP": {
-                        "description": "InsecureAllowHTTP allows HTTP (non-HTTPS) OIDC issuers for development/testing\nWARNING: This is insecure and should NEVER be used in production",
-                        "type": "boolean"
-                    },
-                    "introspectionURL": {
-                        "description": "IntrospectionURL is the optional introspection endpoint for validating tokens",
-                        "type": "string"
-                    },
-                    "issuer": {
-                        "description": "Issuer is the OIDC issuer URL (e.g., https://accounts.google.com)",
-                        "type": "string"
-                    },
-                    "jwksurl": {
-                        "description": "JWKSURL is the URL to fetch the JWKS from",
-                        "type": "string"
-                    },
-                    "resourceURL": {
-                        "description": "ResourceURL is the explicit resource URL for OAuth discovery (RFC 9728)",
-                        "type": "string"
-                    },
-                    "scopes": {
-                        "description": "Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728)\nIf empty, defaults to [\"openid\"]",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object"
-            },
             "github_com_stacklok_toolhive_pkg_auth_awssts.Config": {
                 "description": "AWSStsConfig contains AWS STS token exchange configuration for accessing AWS services",
                 "properties": {
@@ -230,111 +281,6 @@ const docTemplate = `{
                     "role_arn": {
                         "description": "RoleArn is the IAM role ARN to assume when this mapping matches.",
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_auth_remote.Config": {
-                "description": "RemoteAuthConfig contains OAuth configuration for remote MCP servers",
-                "properties": {
-                    "authorize_url": {
-                        "type": "string"
-                    },
-                    "bearer_token": {
-                        "description": "Bearer token configuration (alternative to OAuth)",
-                        "type": "string"
-                    },
-                    "bearer_token_file": {
-                        "type": "string"
-                    },
-                    "cached_cimd_client_id": {
-                        "description": "CachedCIMDClientID stores the CIMD metadata URL used as client_id when CIMD\nauthentication was used. Kept separate from CachedClientID (which holds\nDCR-issued IDs) so the two can have independent lifecycles — DCR credential\nrotation clears CachedClientID without touching the stable CIMD URL.\nRead by resolveClientCredentials to send the correct client_id on token refresh.",
-                        "type": "string"
-                    },
-                    "cached_client_id": {
-                        "description": "Cached DCR client credentials for persistence across restarts.\nThese are obtained during Dynamic Client Registration and needed to refresh tokens.\nClientID is stored as plain text since it's public information.",
-                        "type": "string"
-                    },
-                    "cached_client_secret_ref": {
-                        "type": "string"
-                    },
-                    "cached_dcr_callback_port": {
-                        "description": "CachedDCRCallbackPort is the callback port that was actually registered\nduring DCR. It may differ from CallbackPort when the requested port was\nunavailable and a fallback port was selected.",
-                        "type": "integer"
-                    },
-                    "cached_refresh_token_ref": {
-                        "description": "Cached OAuth token reference for persistence across restarts.\nThe refresh token is stored securely in the secret manager, and this field\ncontains the reference to retrieve it (e.g., \"OAUTH_REFRESH_TOKEN_workload\").\nThis enables session restoration without requiring a new browser-based login.",
-                        "type": "string"
-                    },
-                    "cached_reg_client_uri": {
-                        "description": "CachedRegClientURI is the registration_client_uri from the DCR response.\nThis is the endpoint used for RFC 7592 client read/update/delete operations.\nStored as plain text since it is not sensitive.",
-                        "type": "string"
-                    },
-                    "cached_reg_token_ref": {
-                        "description": "CachedRegTokenRef is a secret manager reference to the registration_access_token\nreturned in the DCR response. Used for RFC 7592 client update operations.\nStored as a secret reference since it's sensitive.",
-                        "type": "string"
-                    },
-                    "cached_secret_expiry": {
-                        "description": "ClientSecretExpiresAt indicates when the client secret expires (if provided by the DCR server).\nA zero value means the secret does not expire.",
-                        "type": "string"
-                    },
-                    "cached_token_auth_method": {
-                        "description": "CachedTokenEndpointAuthMethod is the auth method used for the token endpoint\n(e.g., \"client_secret_basic\", \"none\"). Persisted for RFC 7592 updates.",
-                        "type": "string"
-                    },
-                    "cached_token_expiry": {
-                        "type": "string"
-                    },
-                    "callback_port": {
-                        "type": "integer"
-                    },
-                    "client_id": {
-                        "type": "string"
-                    },
-                    "client_secret": {
-                        "type": "string"
-                    },
-                    "client_secret_file": {
-                        "type": "string"
-                    },
-                    "issuer": {
-                        "description": "OAuth endpoint configuration (from registry)",
-                        "type": "string"
-                    },
-                    "oauth_params": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "OAuth parameters for server-specific customization",
-                        "type": "object"
-                    },
-                    "resource": {
-                        "description": "Resource is the OAuth 2.0 resource indicator (RFC 8707).",
-                        "type": "string"
-                    },
-                    "scope_param_name": {
-                        "description": "ScopeParamName overrides the query parameter name used to send scopes in the\nauthorization URL. When empty, the standard \"scope\" parameter is used.\nSome providers require a non-standard name (e.g., Slack uses \"user_scope\").",
-                        "type": "string"
-                    },
-                    "scopes": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "skip_browser": {
-                        "type": "boolean"
-                    },
-                    "timeout": {
-                        "example": "5m",
-                        "type": "string"
-                    },
-                    "token_url": {
-                        "type": "string"
-                    },
-                    "use_pkce": {
-                        "type": "boolean"
                     }
                 },
                 "type": "object"
@@ -611,7 +557,7 @@ const docTemplate = `{
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.SigningKeyRunConfig"
                     },
                     "storage": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RunConfig"
+                        "$ref": "#/components/schemas/storage.RunConfig"
                     },
                     "token_lifespans": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.TokenLifespanRunConfig"
@@ -773,115 +719,6 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.ACLUserRunConfig": {
-                "description": "ACLUserConfig contains ACL user authentication configuration.",
-                "properties": {
-                    "password_env_var": {
-                        "description": "PasswordEnvVar is the environment variable containing the Redis password.",
-                        "type": "string"
-                    },
-                    "username_env_var": {
-                        "description": "UsernameEnvVar is the environment variable containing the Redis username.",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.RedisRunConfig": {
-                "description": "RedisConfig is the Redis-specific configuration when Type is \"redis\".",
-                "properties": {
-                    "acl_user_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.ACLUserRunConfig"
-                    },
-                    "addr": {
-                        "description": "Addr is the Redis server address (host:port). Required for standalone and cluster modes.\nMutually exclusive with SentinelConfig.",
-                        "type": "string"
-                    },
-                    "auth_type": {
-                        "description": "AuthType must be \"aclUser\" - only ACL user authentication is supported.",
-                        "type": "string"
-                    },
-                    "cluster_mode": {
-                        "description": "ClusterMode enables the Redis Cluster protocol. Requires Addr to be set.",
-                        "type": "boolean"
-                    },
-                    "dial_timeout": {
-                        "description": "DialTimeout is the timeout for establishing connections (e.g., \"5s\").",
-                        "type": "string"
-                    },
-                    "key_prefix": {
-                        "description": "KeyPrefix for multi-tenancy, typically \"thv:auth:{ns}:{name}:\".",
-                        "type": "string"
-                    },
-                    "read_timeout": {
-                        "description": "ReadTimeout is the timeout for read operations (e.g., \"3s\").",
-                        "type": "string"
-                    },
-                    "sentinel_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.SentinelRunConfig"
-                    },
-                    "sentinel_tls": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RedisTLSRunConfig"
-                    },
-                    "tls": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RedisTLSRunConfig"
-                    },
-                    "write_timeout": {
-                        "description": "WriteTimeout is the timeout for write operations (e.g., \"3s\").",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.RedisTLSRunConfig": {
-                "description": "SentinelTLS configures TLS for Sentinel connections. Only applies when SentinelConfig is set.",
-                "properties": {
-                    "ca_cert_file": {
-                        "description": "CACertFile is the path to a PEM-encoded CA certificate file.",
-                        "type": "string"
-                    },
-                    "insecure_skip_verify": {
-                        "description": "InsecureSkipVerify skips certificate verification.",
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.RunConfig": {
-                "description": "Storage configures the storage backend for the auth server.\nIf nil, defaults to in-memory storage.",
-                "properties": {
-                    "redis_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RedisRunConfig"
-                    },
-                    "type": {
-                        "description": "Type specifies the storage backend type. Defaults to \"memory\".",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.SentinelRunConfig": {
-                "description": "SentinelConfig contains Sentinel-specific configuration.\nMutually exclusive with Addr.",
-                "properties": {
-                    "db": {
-                        "description": "DB is the Redis database number (default: 0).",
-                        "type": "integer"
-                    },
-                    "master_name": {
-                        "description": "MasterName is the name of the Redis Sentinel master.",
-                        "type": "string"
-                    },
-                    "sentinel_addrs": {
-                        "description": "SentinelAddrs is the list of Sentinel addresses (host:port).",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    }
-                },
-                "type": "object"
-            },
             "github_com_stacklok_toolhive_pkg_authz.Config": {
                 "description": "DEPRECATED: Middleware configuration.\nAuthzConfig contains the authorization configuration",
                 "properties": {
@@ -991,149 +828,6 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
-            "github_com_stacklok_toolhive_pkg_container_runtime.WorkloadStatus": {
-                "description": "Current status of the workload",
-                "enum": [
-                    "running",
-                    "stopped",
-                    "error",
-                    "starting",
-                    "stopping",
-                    "unhealthy",
-                    "removing",
-                    "unknown",
-                    "unauthenticated",
-                    "auth_retrying",
-                    "policy_stopped",
-                    "running",
-                    "stopped",
-                    "error",
-                    "starting",
-                    "stopping",
-                    "unhealthy",
-                    "removing",
-                    "unknown",
-                    "unauthenticated",
-                    "auth_retrying",
-                    "policy_stopped",
-                    "running",
-                    "stopped",
-                    "error",
-                    "starting",
-                    "stopping",
-                    "unhealthy",
-                    "removing",
-                    "unknown",
-                    "unauthenticated",
-                    "auth_retrying",
-                    "policy_stopped"
-                ],
-                "type": "string",
-                "x-enum-varnames": [
-                    "WorkloadStatusRunning",
-                    "WorkloadStatusStopped",
-                    "WorkloadStatusError",
-                    "WorkloadStatusStarting",
-                    "WorkloadStatusStopping",
-                    "WorkloadStatusUnhealthy",
-                    "WorkloadStatusRemoving",
-                    "WorkloadStatusUnknown",
-                    "WorkloadStatusUnauthenticated",
-                    "WorkloadStatusAuthRetrying",
-                    "WorkloadStatusPolicyStopped"
-                ]
-            },
-            "github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig": {
-                "description": "RuntimeConfig allows overriding the default runtime configuration\nfor this specific workload (base images and packages)",
-                "properties": {
-                    "additional_packages": {
-                        "description": "AdditionalPackages lists extra packages to install in the builder and\nruntime stages.\nExamples for Alpine: [\"git\", \"make\", \"gcc\"]\nExamples for Debian: [\"git\", \"build-essential\"]",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "builder_image": {
-                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
-                        "type": "string"
-                    },
-                    "runtime_env": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "RuntimeEnv contains environment variables to inject into the Dockerfile's\nfinal runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),\nwhich only affects the builder stage, these variables are baked into the\nshipped image and are present in the running container's process\nenvironment at startup. Use this for values a packaged MCP server reads at\nprocess start (e.g. feature flags, cache backend selection), not for\nbuild-time package manager configuration.\nKeys must be uppercase with underscores, values are validated for safety.",
-                        "type": "object"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_core.Workload": {
-                "properties": {
-                    "created_at": {
-                        "description": "CreatedAt is the timestamp when the workload was created.",
-                        "type": "string"
-                    },
-                    "group": {
-                        "description": "Group is the name of the group this workload belongs to, if any.",
-                        "type": "string"
-                    },
-                    "labels": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "Labels are the container labels (excluding standard ToolHive labels)",
-                        "type": "object"
-                    },
-                    "name": {
-                        "description": "Name is the name of the workload.\nIt is used as a unique identifier.",
-                        "type": "string"
-                    },
-                    "package": {
-                        "description": "Package specifies the Workload Package used to create this Workload.",
-                        "type": "string"
-                    },
-                    "port": {
-                        "description": "Port is the port on which the workload is exposed.\nThis is embedded in the URL.",
-                        "type": "integer"
-                    },
-                    "proxy_mode": {
-                        "description": "ProxyMode is the proxy mode that clients should use to connect.\nFor stdio transports, this will be the proxy mode (sse or streamable-http).\nFor direct transports (sse/streamable-http), this will be the same as TransportType.",
-                        "type": "string"
-                    },
-                    "remote": {
-                        "description": "Remote indicates whether this is a remote workload (true) or a container workload (false).",
-                        "type": "boolean"
-                    },
-                    "started_at": {
-                        "description": "StartedAt is when the container was last started (changes on restart)",
-                        "type": "string"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_runtime.WorkloadStatus"
-                    },
-                    "status_context": {
-                        "description": "StatusContext provides additional context about the workload's status.\nThe exact meaning is determined by the status and the underlying runtime.",
-                        "type": "string"
-                    },
-                    "tools": {
-                        "description": "ToolsFilter is the filter on tools applied to the workload.",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "transport_type": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.TransportType"
-                    },
-                    "url": {
-                        "description": "URL is the URL of the workload exposed by the ToolHive proxy.",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
             "github_com_stacklok_toolhive_pkg_groups.Group": {
                 "properties": {
                     "name": {
@@ -1159,62 +853,6 @@ const docTemplate = `{
                         },
                         "type": "array",
                         "uniqueItems": false
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_ignore.Config": {
-                "description": "IgnoreConfig contains configuration for ignore processing",
-                "properties": {
-                    "loadGlobal": {
-                        "description": "Whether to load global ignore patterns",
-                        "type": "boolean"
-                    },
-                    "printOverlays": {
-                        "description": "Whether to print resolved overlay paths for debugging",
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_oauthproto_tokenexchange.Config": {
-                "description": "TokenExchangeConfig contains token exchange configuration for external authentication",
-                "properties": {
-                    "audience": {
-                        "description": "Audience is the target audience for the exchanged token",
-                        "type": "string"
-                    },
-                    "client_id": {
-                        "description": "ClientID is the OAuth 2.0 client identifier",
-                        "type": "string"
-                    },
-                    "client_secret": {
-                        "description": "ClientSecret is the OAuth 2.0 client secret",
-                        "type": "string"
-                    },
-                    "external_token_header_name": {
-                        "description": "ExternalTokenHeaderName is the name of the custom header to use when HeaderStrategy is \"custom\"",
-                        "type": "string"
-                    },
-                    "header_strategy": {
-                        "description": "HeaderStrategy determines how to inject the token\nValid values: HeaderStrategyReplace (default), HeaderStrategyCustom",
-                        "type": "string"
-                    },
-                    "scopes": {
-                        "description": "Scopes is the list of scopes to request for the exchanged token",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "subject_token_type": {
-                        "description": "SubjectTokenType specifies the type of the subject token being exchanged.\nCommon values: oauthproto.TokenTypeAccessToken (default), oauthproto.TokenTypeIDToken, oauthproto.TokenTypeJWT.\nIf empty, defaults to oauthproto.TokenTypeAccessToken.",
-                        "type": "string"
-                    },
-                    "token_url": {
-                        "description": "TokenURL is the OAuth 2.0 token endpoint URL",
-                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -1294,7 +932,7 @@ const docTemplate = `{
                     "additional_middleware_configs": {
                         "description": "AdditionalMiddlewareConfigs carries pre-built middleware configs injected by\nexternal-auth handlers (reached via *[]RunConfigBuilderOption) rather than\nderived from typed RunConfig fields. PopulateMiddlewareConfigs splices these\ninto the chain in the backend-egress group — after auth and before recovery —\ninstead of discarding them. Upstream carries these configs verbatim and never\ninspects their parameters; the middleware type identity (e.g. an enterprise\nauth type) is supplied by the caller via types.MiddlewareConfig.Type.\n\nEach entry's Type is expected to be a NEW egress middleware type (e.g. OBO),\nnot one already produced from a typed RunConfig field (auth, authz, audit,\ntokenExchange, awssts, …). Dispatch in the proxyrunner is purely by Type\nstring, so an injected Type that shadows a typed-field type would add a\nsecond instance of that middleware to the chain; the seam does not validate\nagainst this.",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig"
+                            "$ref": "#/components/schemas/types.MiddlewareConfig"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -1385,7 +1023,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "ignore_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_ignore.Config"
+                        "$ref": "#/components/schemas/ignore.Config"
                     },
                     "image": {
                         "description": "Image is the Docker image to run",
@@ -1410,7 +1048,7 @@ const docTemplate = `{
                     "middleware_configs": {
                         "description": "MiddlewareConfigs contains the list of middleware to apply to the transport\nand the configuration for each middleware.",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig"
+                            "$ref": "#/components/schemas/types.MiddlewareConfig"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -1428,7 +1066,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "oidc_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_auth.TokenValidatorConfig"
+                        "$ref": "#/components/schemas/auth.TokenValidatorConfig"
                     },
                     "permission_profile_name_or_path": {
                         "description": "PermissionProfileNameOrPath is the name or path of the permission profile",
@@ -1439,7 +1077,12 @@ const docTemplate = `{
                         "type": "integer"
                     },
                     "proxy_mode": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.ProxyMode"
+                        "description": "ProxyMode is the effective HTTP protocol the proxy uses.\nFor stdio transports, this is the configured mode (sse or streamable-http).\nFor direct transports (sse/streamable-http), this matches the transport type.\nNote: \"sse\" is deprecated; use \"streamable-http\" instead.",
+                        "enum": [
+                            "sse",
+                            "streamable-http"
+                        ],
+                        "type": "string"
                     },
                     "publish": {
                         "description": "Publish lists ports to publish to the host in format \"hostPort:containerPort\"",
@@ -1469,14 +1112,14 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "remote_auth_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_auth_remote.Config"
+                        "$ref": "#/components/schemas/remote.Config"
                     },
                     "remote_url": {
                         "description": "RemoteURL is the URL of the remote MCP server (if running remotely)",
                         "type": "string"
                     },
                     "runtime_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
+                        "$ref": "#/components/schemas/templates.RuntimeConfig"
                     },
                     "scaling_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_runner.ScalingConfig"
@@ -1515,14 +1158,14 @@ const docTemplate = `{
                         "type": "integer"
                     },
                     "telemetry_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_telemetry.Config"
+                        "$ref": "#/components/schemas/telemetry.Config"
                     },
                     "thv_ca_bundle": {
                         "description": "DEPRECATED: No longer appears to be used.\nThvCABundle is the path to the CA certificate bundle for ToolHive HTTP operations",
                         "type": "string"
                     },
                     "token_exchange_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_oauthproto_tokenexchange.Config"
+                        "$ref": "#/components/schemas/tokenexchange.Config"
                     },
                     "tools_filter": {
                         "description": "DEPRECATED: Middleware configuration.\nToolsFilter is the list of tools to filter",
@@ -1540,7 +1183,14 @@ const docTemplate = `{
                         "type": "object"
                     },
                     "transport": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.TransportType"
+                        "description": "Transport is the transport mode (stdio, sse, or streamable-http)",
+                        "enum": [
+                            "stdio",
+                            "sse",
+                            "streamable-http",
+                            "inspector"
+                        ],
+                        "type": "string"
                     },
                     "trust_proxy_headers": {
                         "description": "TrustProxyHeaders indicates whether to trust X-Forwarded-* headers from reverse proxies",
@@ -1607,18 +1257,6 @@ const docTemplate = `{
                     },
                     "name": {
                         "description": "Name is the redefined name of the tool",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_secrets.SecretParameter": {
-                "description": "Bearer token for authentication (alternative to OAuth)",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "target": {
                         "type": "string"
                     }
                 },
@@ -2033,125 +1671,6 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
-            "github_com_stacklok_toolhive_pkg_telemetry.Config": {
-                "description": "DEPRECATED: Middleware configuration.\nTelemetryConfig contains the OpenTelemetry configuration",
-                "properties": {
-                    "caCertPath": {
-                        "description": "CACertPath is the file path to a CA certificate bundle for the OTLP endpoint.\nWhen set, the OTLP exporters use this CA to verify the collector's TLS certificate\ninstead of relying solely on the system CA pool.\n+optional",
-                        "type": "string"
-                    },
-                    "customAttributes": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "CustomAttributes contains custom resource attributes to be added to all telemetry signals.\nThese are parsed from CLI flags (--otel-custom-attributes) or environment variables\n(OTEL_RESOURCE_ATTRIBUTES) as key=value pairs.\n+optional",
-                        "type": "object"
-                    },
-                    "enablePrometheusMetricsPath": {
-                        "description": "EnablePrometheusMetricsPath controls whether to expose Prometheus-style /metrics endpoint.\nThe metrics are served on the main transport port at /metrics.\nThis is separate from OTLP metrics which are sent to the Endpoint.\n+kubebuilder:default=false\n+optional",
-                        "type": "boolean"
-                    },
-                    "endpoint": {
-                        "description": "Endpoint is the OTLP endpoint URL\n+optional",
-                        "type": "string"
-                    },
-                    "environmentVariables": {
-                        "description": "EnvironmentVariables is a list of environment variable names that should be\nincluded in telemetry spans as attributes. Only variables in this list will\nbe read from the host machine and included in spans for observability.\nExample: [\"NODE_ENV\", \"DEPLOYMENT_ENV\", \"SERVICE_VERSION\"]\n+optional",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "headers": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "Headers contains authentication headers for the OTLP endpoint.\n+optional",
-                        "type": "object"
-                    },
-                    "insecure": {
-                        "description": "Insecure indicates whether to use HTTP instead of HTTPS for the OTLP endpoint.\n+kubebuilder:default=false\n+optional",
-                        "type": "boolean"
-                    },
-                    "metricsEnabled": {
-                        "description": "MetricsEnabled controls whether OTLP metrics are enabled.\nWhen false, OTLP metrics are not sent even if an endpoint is configured.\nThis is independent of EnablePrometheusMetricsPath.\n+kubebuilder:default=false\n+optional",
-                        "type": "boolean"
-                    },
-                    "samplingRate": {
-                        "description": "SamplingRate is the trace sampling rate (0.0-1.0) as a string.\nOnly used when TracingEnabled is true.\nExample: \"0.05\" for 5% sampling.\n+kubebuilder:default=\"0.05\"\n+optional",
-                        "type": "string"
-                    },
-                    "serviceName": {
-                        "description": "ServiceName is the service name for telemetry.\nWhen omitted, defaults to the server name (e.g., VirtualMCPServer name).\n+optional",
-                        "type": "string"
-                    },
-                    "serviceVersion": {
-                        "description": "ServiceVersion is the service version for telemetry.\nWhen omitted, defaults to the ToolHive version.\n+optional",
-                        "type": "string"
-                    },
-                    "tracingEnabled": {
-                        "description": "TracingEnabled controls whether distributed tracing is enabled.\nWhen false, no tracer provider is created even if an endpoint is configured.\n+kubebuilder:default=false\n+optional",
-                        "type": "boolean"
-                    },
-                    "useLegacyAttributes": {
-                        "description": "UseLegacyAttributes controls whether legacy (pre-MCP OTEL semconv) attribute names\nare emitted alongside the new standard attribute names. When true, spans include both\nold and new attribute names for backward compatibility with existing dashboards.\nCurrently defaults to true; this will change to false in a future release.\n+kubebuilder:default=true\n+optional",
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig": {
-                "properties": {
-                    "parameters": {
-                        "description": "Parameters is a JSON object containing the middleware parameters.\nIt is stored as a raw message to allow flexible parameter types.",
-                        "type": "object"
-                    },
-                    "type": {
-                        "description": "Type is a string representing the middleware type.",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_transport_types.ProxyMode": {
-                "description": "ProxyMode is the effective HTTP protocol the proxy uses.\nFor stdio transports, this is the configured mode (sse or streamable-http).\nFor direct transports (sse/streamable-http), this matches the transport type.\nNote: \"sse\" is deprecated; use \"streamable-http\" instead.",
-                "enum": [
-                    "sse",
-                    "streamable-http",
-                    "sse",
-                    "streamable-http"
-                ],
-                "type": "string",
-                "x-enum-varnames": [
-                    "ProxyModeSSE",
-                    "ProxyModeStreamableHTTP"
-                ]
-            },
-            "github_com_stacklok_toolhive_pkg_transport_types.TransportType": {
-                "description": "Transport is the transport mode (stdio, sse, or streamable-http)",
-                "enum": [
-                    "stdio",
-                    "sse",
-                    "streamable-http",
-                    "inspector",
-                    "stdio",
-                    "sse",
-                    "streamable-http",
-                    "inspector",
-                    "stdio",
-                    "sse",
-                    "streamable-http",
-                    "inspector"
-                ],
-                "type": "string",
-                "x-enum-varnames": [
-                    "TransportTypeStdio",
-                    "TransportTypeSSE",
-                    "TransportTypeStreamableHTTP",
-                    "TransportTypeInspector"
-                ]
-            },
             "github_com_stacklok_toolhive_pkg_webhook.Config": {
                 "properties": {
                     "failure_policy": {
@@ -2337,6 +1856,20 @@ const docTemplate = `{
                     "StatusUnknown"
                 ]
             },
+            "ignore.Config": {
+                "description": "IgnoreConfig contains configuration for ignore processing",
+                "properties": {
+                    "loadGlobal": {
+                        "description": "Whether to load global ignore patterns",
+                        "type": "boolean"
+                    },
+                    "printOverlays": {
+                        "description": "Whether to print resolved overlay paths for debugging",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
             "model.Argument": {
                 "properties": {
                     "choices": {
@@ -2393,11 +1926,15 @@ const docTemplate = `{
             "model.ArgumentType": {
                 "enum": [
                     "positional",
+                    "named",
+                    "positional",
                     "named"
                 ],
                 "example": "positional",
                 "type": "string",
                 "x-enum-varnames": [
+                    "ArgumentTypePositional",
+                    "ArgumentTypeNamed",
                     "ArgumentTypePositional",
                     "ArgumentTypeNamed"
                 ]
@@ -2407,10 +1944,18 @@ const docTemplate = `{
                     "string",
                     "number",
                     "boolean",
+                    "filepath",
+                    "string",
+                    "number",
+                    "boolean",
                     "filepath"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
+                    "FormatString",
+                    "FormatNumber",
+                    "FormatBoolean",
+                    "FormatFilePath",
                     "FormatString",
                     "FormatNumber",
                     "FormatBoolean",
@@ -3007,12 +2552,12 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "runtime_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
+                        "$ref": "#/components/schemas/templates.RuntimeConfig"
                     },
                     "secrets": {
                         "description": "Secret parameters to inject",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter"
+                            "$ref": "#/components/schemas/secrets.SecretParameter"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -3128,7 +2673,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "registry": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-core_registry_types.Registry"
+                        "$ref": "#/components/schemas/registry.Registry"
                     },
                     "server_count": {
                         "description": "Number of servers in the registry",
@@ -3464,7 +3009,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "bearer_token": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter"
+                        "$ref": "#/components/schemas/secrets.SecretParameter"
                     },
                     "callback_port": {
                         "description": "Specific port for OAuth callback server",
@@ -3475,7 +3020,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "client_secret": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter"
+                        "$ref": "#/components/schemas/secrets.SecretParameter"
                     },
                     "issuer": {
                         "description": "OAuth/OIDC issuer URL (e.g., https://accounts.google.com)",
@@ -3719,12 +3264,12 @@ const docTemplate = `{
                         "type": "integer"
                     },
                     "runtime_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
+                        "$ref": "#/components/schemas/templates.RuntimeConfig"
                     },
                     "secrets": {
                         "description": "Secret parameters to inject",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter"
+                            "$ref": "#/components/schemas/secrets.SecretParameter"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -3901,7 +3446,7 @@ const docTemplate = `{
                     "workloads": {
                         "description": "List of container information for each workload",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_core.Workload"
+                            "$ref": "#/components/schemas/core.Workload"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -3913,7 +3458,21 @@ const docTemplate = `{
                 "description": "Response containing workload status information",
                 "properties": {
                     "status": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_runtime.WorkloadStatus"
+                        "description": "Current status of the workload",
+                        "enum": [
+                            "running",
+                            "stopped",
+                            "error",
+                            "starting",
+                            "stopping",
+                            "unhealthy",
+                            "removing",
+                            "unknown",
+                            "unauthenticated",
+                            "auth_retrying",
+                            "policy_stopped"
+                        ],
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -4234,6 +3793,42 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
+            "registry.Registry": {
+                "description": "Full registry data",
+                "properties": {
+                    "groups": {
+                        "description": "Groups is a slice of group definitions containing related MCP servers",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.Group"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "last_updated": {
+                        "description": "LastUpdated is the timestamp when the registry was last updated, in RFC3339 format",
+                        "type": "string"
+                    },
+                    "remote_servers": {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/registry.RemoteServerMetadata"
+                        },
+                        "description": "RemoteServers is a map of server names to their corresponding remote server definitions\nThese are MCP servers accessed via HTTP/HTTPS using the thv proxy command",
+                        "type": "object"
+                    },
+                    "servers": {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/registry.ImageMetadata"
+                        },
+                        "description": "Servers is a map of server names to their corresponding server definitions",
+                        "type": "object"
+                    },
+                    "version": {
+                        "description": "Version is the schema version of the registry",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "registry.RemoteServerMetadata": {
                 "description": "Remote server details (if it's a remote server)",
                 "properties": {
@@ -4477,6 +4072,380 @@ const docTemplate = `{
                 "properties": {
                     "predicate": {},
                     "predicate_type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "remote.Config": {
+                "description": "RemoteAuthConfig contains OAuth configuration for remote MCP servers",
+                "properties": {
+                    "authorize_url": {
+                        "type": "string"
+                    },
+                    "bearer_token": {
+                        "description": "Bearer token configuration (alternative to OAuth)",
+                        "type": "string"
+                    },
+                    "bearer_token_file": {
+                        "type": "string"
+                    },
+                    "cached_cimd_client_id": {
+                        "description": "CachedCIMDClientID stores the CIMD metadata URL used as client_id when CIMD\nauthentication was used. Kept separate from CachedClientID (which holds\nDCR-issued IDs) so the two can have independent lifecycles — DCR credential\nrotation clears CachedClientID without touching the stable CIMD URL.\nRead by resolveClientCredentials to send the correct client_id on token refresh.",
+                        "type": "string"
+                    },
+                    "cached_client_id": {
+                        "description": "Cached DCR client credentials for persistence across restarts.\nThese are obtained during Dynamic Client Registration and needed to refresh tokens.\nClientID is stored as plain text since it's public information.",
+                        "type": "string"
+                    },
+                    "cached_client_secret_ref": {
+                        "type": "string"
+                    },
+                    "cached_dcr_callback_port": {
+                        "description": "CachedDCRCallbackPort is the callback port that was actually registered\nduring DCR. It may differ from CallbackPort when the requested port was\nunavailable and a fallback port was selected.",
+                        "type": "integer"
+                    },
+                    "cached_refresh_token_ref": {
+                        "description": "Cached OAuth token reference for persistence across restarts.\nThe refresh token is stored securely in the secret manager, and this field\ncontains the reference to retrieve it (e.g., \"OAUTH_REFRESH_TOKEN_workload\").\nThis enables session restoration without requiring a new browser-based login.",
+                        "type": "string"
+                    },
+                    "cached_reg_client_uri": {
+                        "description": "CachedRegClientURI is the registration_client_uri from the DCR response.\nThis is the endpoint used for RFC 7592 client read/update/delete operations.\nStored as plain text since it is not sensitive.",
+                        "type": "string"
+                    },
+                    "cached_reg_token_ref": {
+                        "description": "CachedRegTokenRef is a secret manager reference to the registration_access_token\nreturned in the DCR response. Used for RFC 7592 client update operations.\nStored as a secret reference since it's sensitive.",
+                        "type": "string"
+                    },
+                    "cached_secret_expiry": {
+                        "description": "ClientSecretExpiresAt indicates when the client secret expires (if provided by the DCR server).\nA zero value means the secret does not expire.",
+                        "type": "string"
+                    },
+                    "cached_token_auth_method": {
+                        "description": "CachedTokenEndpointAuthMethod is the auth method used for the token endpoint\n(e.g., \"client_secret_basic\", \"none\"). Persisted for RFC 7592 updates.",
+                        "type": "string"
+                    },
+                    "cached_token_expiry": {
+                        "type": "string"
+                    },
+                    "callback_port": {
+                        "type": "integer"
+                    },
+                    "client_id": {
+                        "type": "string"
+                    },
+                    "client_secret": {
+                        "type": "string"
+                    },
+                    "client_secret_file": {
+                        "type": "string"
+                    },
+                    "issuer": {
+                        "description": "OAuth endpoint configuration (from registry)",
+                        "type": "string"
+                    },
+                    "oauth_params": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "OAuth parameters for server-specific customization",
+                        "type": "object"
+                    },
+                    "resource": {
+                        "description": "Resource is the OAuth 2.0 resource indicator (RFC 8707).",
+                        "type": "string"
+                    },
+                    "scope_param_name": {
+                        "description": "ScopeParamName overrides the query parameter name used to send scopes in the\nauthorization URL. When empty, the standard \"scope\" parameter is used.\nSome providers require a non-standard name (e.g., Slack uses \"user_scope\").",
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "skip_browser": {
+                        "type": "boolean"
+                    },
+                    "timeout": {
+                        "example": "5m",
+                        "type": "string"
+                    },
+                    "token_url": {
+                        "type": "string"
+                    },
+                    "use_pkce": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "secrets.SecretParameter": {
+                "description": "Bearer token for authentication (alternative to OAuth)",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "target": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.ACLUserRunConfig": {
+                "description": "ACLUserConfig contains ACL user authentication configuration.",
+                "properties": {
+                    "password_env_var": {
+                        "description": "PasswordEnvVar is the environment variable containing the Redis password.",
+                        "type": "string"
+                    },
+                    "username_env_var": {
+                        "description": "UsernameEnvVar is the environment variable containing the Redis username.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.RedisRunConfig": {
+                "description": "RedisConfig is the Redis-specific configuration when Type is \"redis\".",
+                "properties": {
+                    "acl_user_config": {
+                        "$ref": "#/components/schemas/storage.ACLUserRunConfig"
+                    },
+                    "addr": {
+                        "description": "Addr is the Redis server address (host:port). Required for standalone and cluster modes.\nMutually exclusive with SentinelConfig.",
+                        "type": "string"
+                    },
+                    "auth_type": {
+                        "description": "AuthType must be \"aclUser\" - only ACL user authentication is supported.",
+                        "type": "string"
+                    },
+                    "cluster_mode": {
+                        "description": "ClusterMode enables the Redis Cluster protocol. Requires Addr to be set.",
+                        "type": "boolean"
+                    },
+                    "dial_timeout": {
+                        "description": "DialTimeout is the timeout for establishing connections (e.g., \"5s\").",
+                        "type": "string"
+                    },
+                    "key_prefix": {
+                        "description": "KeyPrefix for multi-tenancy, typically \"thv:auth:{ns}:{name}:\".",
+                        "type": "string"
+                    },
+                    "read_timeout": {
+                        "description": "ReadTimeout is the timeout for read operations (e.g., \"3s\").",
+                        "type": "string"
+                    },
+                    "sentinel_config": {
+                        "$ref": "#/components/schemas/storage.SentinelRunConfig"
+                    },
+                    "sentinel_tls": {
+                        "$ref": "#/components/schemas/storage.RedisTLSRunConfig"
+                    },
+                    "tls": {
+                        "$ref": "#/components/schemas/storage.RedisTLSRunConfig"
+                    },
+                    "write_timeout": {
+                        "description": "WriteTimeout is the timeout for write operations (e.g., \"3s\").",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.RedisTLSRunConfig": {
+                "description": "SentinelTLS configures TLS for Sentinel connections. Only applies when SentinelConfig is set.",
+                "properties": {
+                    "ca_cert_file": {
+                        "description": "CACertFile is the path to a PEM-encoded CA certificate file.",
+                        "type": "string"
+                    },
+                    "insecure_skip_verify": {
+                        "description": "InsecureSkipVerify skips certificate verification.",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.RunConfig": {
+                "description": "Storage configures the storage backend for the auth server.\nIf nil, defaults to in-memory storage.",
+                "properties": {
+                    "redis_config": {
+                        "$ref": "#/components/schemas/storage.RedisRunConfig"
+                    },
+                    "type": {
+                        "description": "Type specifies the storage backend type. Defaults to \"memory\".",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.SentinelRunConfig": {
+                "description": "SentinelConfig contains Sentinel-specific configuration.\nMutually exclusive with Addr.",
+                "properties": {
+                    "db": {
+                        "description": "DB is the Redis database number (default: 0).",
+                        "type": "integer"
+                    },
+                    "master_name": {
+                        "description": "MasterName is the name of the Redis Sentinel master.",
+                        "type": "string"
+                    },
+                    "sentinel_addrs": {
+                        "description": "SentinelAddrs is the list of Sentinel addresses (host:port).",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
+            "telemetry.Config": {
+                "description": "DEPRECATED: Middleware configuration.\nTelemetryConfig contains the OpenTelemetry configuration",
+                "properties": {
+                    "caCertPath": {
+                        "description": "CACertPath is the file path to a CA certificate bundle for the OTLP endpoint.\nWhen set, the OTLP exporters use this CA to verify the collector's TLS certificate\ninstead of relying solely on the system CA pool.\n+optional",
+                        "type": "string"
+                    },
+                    "customAttributes": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "CustomAttributes contains custom resource attributes to be added to all telemetry signals.\nThese are parsed from CLI flags (--otel-custom-attributes) or environment variables\n(OTEL_RESOURCE_ATTRIBUTES) as key=value pairs.\n+optional",
+                        "type": "object"
+                    },
+                    "enablePrometheusMetricsPath": {
+                        "description": "EnablePrometheusMetricsPath controls whether to expose Prometheus-style /metrics endpoint.\nThe metrics are served on the main transport port at /metrics.\nThis is separate from OTLP metrics which are sent to the Endpoint.\n+kubebuilder:default=false\n+optional",
+                        "type": "boolean"
+                    },
+                    "endpoint": {
+                        "description": "Endpoint is the OTLP endpoint URL\n+optional",
+                        "type": "string"
+                    },
+                    "environmentVariables": {
+                        "description": "EnvironmentVariables is a list of environment variable names that should be\nincluded in telemetry spans as attributes. Only variables in this list will\nbe read from the host machine and included in spans for observability.\nExample: [\"NODE_ENV\", \"DEPLOYMENT_ENV\", \"SERVICE_VERSION\"]\n+optional",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "headers": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Headers contains authentication headers for the OTLP endpoint.\n+optional",
+                        "type": "object"
+                    },
+                    "insecure": {
+                        "description": "Insecure indicates whether to use HTTP instead of HTTPS for the OTLP endpoint.\n+kubebuilder:default=false\n+optional",
+                        "type": "boolean"
+                    },
+                    "metricsEnabled": {
+                        "description": "MetricsEnabled controls whether OTLP metrics are enabled.\nWhen false, OTLP metrics are not sent even if an endpoint is configured.\nThis is independent of EnablePrometheusMetricsPath.\n+kubebuilder:default=false\n+optional",
+                        "type": "boolean"
+                    },
+                    "samplingRate": {
+                        "description": "SamplingRate is the trace sampling rate (0.0-1.0) as a string.\nOnly used when TracingEnabled is true.\nExample: \"0.05\" for 5% sampling.\n+kubebuilder:default=\"0.05\"\n+optional",
+                        "type": "string"
+                    },
+                    "serviceName": {
+                        "description": "ServiceName is the service name for telemetry.\nWhen omitted, defaults to the server name (e.g., VirtualMCPServer name).\n+optional",
+                        "type": "string"
+                    },
+                    "serviceVersion": {
+                        "description": "ServiceVersion is the service version for telemetry.\nWhen omitted, defaults to the ToolHive version.\n+optional",
+                        "type": "string"
+                    },
+                    "tracingEnabled": {
+                        "description": "TracingEnabled controls whether distributed tracing is enabled.\nWhen false, no tracer provider is created even if an endpoint is configured.\n+kubebuilder:default=false\n+optional",
+                        "type": "boolean"
+                    },
+                    "useLegacyAttributes": {
+                        "description": "UseLegacyAttributes controls whether legacy (pre-MCP OTEL semconv) attribute names\nare emitted alongside the new standard attribute names. When true, spans include both\nold and new attribute names for backward compatibility with existing dashboards.\nCurrently defaults to true; this will change to false in a future release.\n+kubebuilder:default=true\n+optional",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "templates.RuntimeConfig": {
+                "description": "RuntimeConfig allows overriding the default runtime configuration\nfor this specific workload (base images and packages)",
+                "properties": {
+                    "additional_packages": {
+                        "description": "AdditionalPackages lists extra packages to install in the builder and\nruntime stages.\nExamples for Alpine: [\"git\", \"make\", \"gcc\"]\nExamples for Debian: [\"git\", \"build-essential\"]",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "builder_image": {
+                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
+                        "type": "string"
+                    },
+                    "runtime_env": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "RuntimeEnv contains environment variables to inject into the Dockerfile's\nfinal runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),\nwhich only affects the builder stage, these variables are baked into the\nshipped image and are present in the running container's process\nenvironment at startup. Use this for values a packaged MCP server reads at\nprocess start (e.g. feature flags, cache backend selection), not for\nbuild-time package manager configuration.\nKeys must be uppercase with underscores, values are validated for safety.",
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "tokenexchange.Config": {
+                "description": "TokenExchangeConfig contains token exchange configuration for external authentication",
+                "properties": {
+                    "audience": {
+                        "description": "Audience is the target audience for the exchanged token",
+                        "type": "string"
+                    },
+                    "client_id": {
+                        "description": "ClientID is the OAuth 2.0 client identifier",
+                        "type": "string"
+                    },
+                    "client_secret": {
+                        "description": "ClientSecret is the OAuth 2.0 client secret",
+                        "type": "string"
+                    },
+                    "external_token_header_name": {
+                        "description": "ExternalTokenHeaderName is the name of the custom header to use when HeaderStrategy is \"custom\"",
+                        "type": "string"
+                    },
+                    "header_strategy": {
+                        "description": "HeaderStrategy determines how to inject the token\nValid values: HeaderStrategyReplace (default), HeaderStrategyCustom",
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "description": "Scopes is the list of scopes to request for the exchanged token",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "subject_token_type": {
+                        "description": "SubjectTokenType specifies the type of the subject token being exchanged.\nCommon values: oauthproto.TokenTypeAccessToken (default), oauthproto.TokenTypeIDToken, oauthproto.TokenTypeJWT.\nIf empty, defaults to oauthproto.TokenTypeAccessToken.",
+                        "type": "string"
+                    },
+                    "token_url": {
+                        "description": "TokenURL is the OAuth 2.0 token endpoint URL",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "types.MiddlewareConfig": {
+                "properties": {
+                    "parameters": {
+                        "description": "Parameters is a JSON object containing the middleware parameters.\nIt is stored as a raw message to allow flexible parameter types.",
+                        "type": "object"
+                    },
+                    "type": {
+                        "description": "Type is a string representing the middleware type.",
                         "type": "string"
                     }
                 },

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1,37 +1,145 @@
 {
     "components": {
         "schemas": {
-            "github_com_stacklok_toolhive-core_registry_types.Registry": {
-                "description": "Full registry data",
+            "auth.TokenValidatorConfig": {
+                "description": "DEPRECATED: Middleware configuration.\nOIDCConfig contains OIDC configuration",
                 "properties": {
-                    "groups": {
-                        "description": "Groups is a slice of group definitions containing related MCP servers",
+                    "allowPrivateIP": {
+                        "description": "AllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses",
+                        "type": "boolean"
+                    },
+                    "audience": {
+                        "description": "Audience is the expected audience for the token",
+                        "type": "string"
+                    },
+                    "authTokenFile": {
+                        "description": "AuthTokenFile is the path to file containing bearer token for authentication",
+                        "type": "string"
+                    },
+                    "cacertPath": {
+                        "description": "CACertPath is the path to the CA certificate bundle for HTTPS requests",
+                        "type": "string"
+                    },
+                    "clientID": {
+                        "description": "ClientID is the OIDC client ID",
+                        "type": "string"
+                    },
+                    "clientSecret": {
+                        "description": "ClientSecret is the optional OIDC client secret for introspection",
+                        "type": "string"
+                    },
+                    "insecureAllowHTTP": {
+                        "description": "InsecureAllowHTTP allows HTTP (non-HTTPS) OIDC issuers for development/testing\nWARNING: This is insecure and should NEVER be used in production",
+                        "type": "boolean"
+                    },
+                    "introspectionURL": {
+                        "description": "IntrospectionURL is the optional introspection endpoint for validating tokens",
+                        "type": "string"
+                    },
+                    "issuer": {
+                        "description": "Issuer is the OIDC issuer URL (e.g., https://accounts.google.com)",
+                        "type": "string"
+                    },
+                    "jwksurl": {
+                        "description": "JWKSURL is the URL to fetch the JWKS from",
+                        "type": "string"
+                    },
+                    "resourceURL": {
+                        "description": "ResourceURL is the explicit resource URL for OAuth discovery (RFC 9728)",
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "description": "Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728)\nIf empty, defaults to [\"openid\"]",
                         "items": {
-                            "$ref": "#/components/schemas/registry.Group"
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "core.Workload": {
+                "properties": {
+                    "created_at": {
+                        "description": "CreatedAt is the timestamp when the workload was created.",
+                        "type": "string"
+                    },
+                    "group": {
+                        "description": "Group is the name of the group this workload belongs to, if any.",
+                        "type": "string"
+                    },
+                    "labels": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Labels are the container labels (excluding standard ToolHive labels)",
+                        "type": "object"
+                    },
+                    "name": {
+                        "description": "Name is the name of the workload.\nIt is used as a unique identifier.",
+                        "type": "string"
+                    },
+                    "package": {
+                        "description": "Package specifies the Workload Package used to create this Workload.",
+                        "type": "string"
+                    },
+                    "port": {
+                        "description": "Port is the port on which the workload is exposed.\nThis is embedded in the URL.",
+                        "type": "integer"
+                    },
+                    "proxy_mode": {
+                        "description": "ProxyMode is the proxy mode that clients should use to connect.\nFor stdio transports, this will be the proxy mode (sse or streamable-http).\nFor direct transports (sse/streamable-http), this will be the same as TransportType.",
+                        "type": "string"
+                    },
+                    "remote": {
+                        "description": "Remote indicates whether this is a remote workload (true) or a container workload (false).",
+                        "type": "boolean"
+                    },
+                    "started_at": {
+                        "description": "StartedAt is when the container was last started (changes on restart)",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "Status is the current status of the workload.",
+                        "enum": [
+                            "running",
+                            "stopped",
+                            "error",
+                            "starting",
+                            "stopping",
+                            "unhealthy",
+                            "removing",
+                            "unknown",
+                            "unauthenticated",
+                            "auth_retrying",
+                            "policy_stopped"
+                        ],
+                        "type": "string"
+                    },
+                    "status_context": {
+                        "description": "StatusContext provides additional context about the workload's status.\nThe exact meaning is determined by the status and the underlying runtime.",
+                        "type": "string"
+                    },
+                    "tools": {
+                        "description": "ToolsFilter is the filter on tools applied to the workload.",
+                        "items": {
+                            "type": "string"
                         },
                         "type": "array",
                         "uniqueItems": false
                     },
-                    "last_updated": {
-                        "description": "LastUpdated is the timestamp when the registry was last updated, in RFC3339 format",
+                    "transport_type": {
+                        "description": "TransportType is the type of transport used for this workload.",
+                        "enum": [
+                            "stdio",
+                            "sse",
+                            "streamable-http",
+                            "inspector"
+                        ],
                         "type": "string"
                     },
-                    "remote_servers": {
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/registry.RemoteServerMetadata"
-                        },
-                        "description": "RemoteServers is a map of server names to their corresponding remote server definitions\nThese are MCP servers accessed via HTTP/HTTPS using the thv proxy command",
-                        "type": "object"
-                    },
-                    "servers": {
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/registry.ImageMetadata"
-                        },
-                        "description": "Servers is a map of server names to their corresponding server definitions",
-                        "type": "object"
-                    },
-                    "version": {
-                        "description": "Version is the schema version of the registry",
+                    "url": {
+                        "description": "URL is the URL of the workload exposed by the ToolHive proxy.",
                         "type": "string"
                     }
                 },
@@ -107,63 +215,6 @@
                 },
                 "type": "object"
             },
-            "github_com_stacklok_toolhive_pkg_auth.TokenValidatorConfig": {
-                "description": "DEPRECATED: Middleware configuration.\nOIDCConfig contains OIDC configuration",
-                "properties": {
-                    "allowPrivateIP": {
-                        "description": "AllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses",
-                        "type": "boolean"
-                    },
-                    "audience": {
-                        "description": "Audience is the expected audience for the token",
-                        "type": "string"
-                    },
-                    "authTokenFile": {
-                        "description": "AuthTokenFile is the path to file containing bearer token for authentication",
-                        "type": "string"
-                    },
-                    "cacertPath": {
-                        "description": "CACertPath is the path to the CA certificate bundle for HTTPS requests",
-                        "type": "string"
-                    },
-                    "clientID": {
-                        "description": "ClientID is the OIDC client ID",
-                        "type": "string"
-                    },
-                    "clientSecret": {
-                        "description": "ClientSecret is the optional OIDC client secret for introspection",
-                        "type": "string"
-                    },
-                    "insecureAllowHTTP": {
-                        "description": "InsecureAllowHTTP allows HTTP (non-HTTPS) OIDC issuers for development/testing\nWARNING: This is insecure and should NEVER be used in production",
-                        "type": "boolean"
-                    },
-                    "introspectionURL": {
-                        "description": "IntrospectionURL is the optional introspection endpoint for validating tokens",
-                        "type": "string"
-                    },
-                    "issuer": {
-                        "description": "Issuer is the OIDC issuer URL (e.g., https://accounts.google.com)",
-                        "type": "string"
-                    },
-                    "jwksurl": {
-                        "description": "JWKSURL is the URL to fetch the JWKS from",
-                        "type": "string"
-                    },
-                    "resourceURL": {
-                        "description": "ResourceURL is the explicit resource URL for OAuth discovery (RFC 9728)",
-                        "type": "string"
-                    },
-                    "scopes": {
-                        "description": "Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728)\nIf empty, defaults to [\"openid\"]",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    }
-                },
-                "type": "object"
-            },
             "github_com_stacklok_toolhive_pkg_auth_awssts.Config": {
                 "description": "AWSStsConfig contains AWS STS token exchange configuration for accessing AWS services",
                 "properties": {
@@ -223,111 +274,6 @@
                     "role_arn": {
                         "description": "RoleArn is the IAM role ARN to assume when this mapping matches.",
                         "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_auth_remote.Config": {
-                "description": "RemoteAuthConfig contains OAuth configuration for remote MCP servers",
-                "properties": {
-                    "authorize_url": {
-                        "type": "string"
-                    },
-                    "bearer_token": {
-                        "description": "Bearer token configuration (alternative to OAuth)",
-                        "type": "string"
-                    },
-                    "bearer_token_file": {
-                        "type": "string"
-                    },
-                    "cached_cimd_client_id": {
-                        "description": "CachedCIMDClientID stores the CIMD metadata URL used as client_id when CIMD\nauthentication was used. Kept separate from CachedClientID (which holds\nDCR-issued IDs) so the two can have independent lifecycles — DCR credential\nrotation clears CachedClientID without touching the stable CIMD URL.\nRead by resolveClientCredentials to send the correct client_id on token refresh.",
-                        "type": "string"
-                    },
-                    "cached_client_id": {
-                        "description": "Cached DCR client credentials for persistence across restarts.\nThese are obtained during Dynamic Client Registration and needed to refresh tokens.\nClientID is stored as plain text since it's public information.",
-                        "type": "string"
-                    },
-                    "cached_client_secret_ref": {
-                        "type": "string"
-                    },
-                    "cached_dcr_callback_port": {
-                        "description": "CachedDCRCallbackPort is the callback port that was actually registered\nduring DCR. It may differ from CallbackPort when the requested port was\nunavailable and a fallback port was selected.",
-                        "type": "integer"
-                    },
-                    "cached_refresh_token_ref": {
-                        "description": "Cached OAuth token reference for persistence across restarts.\nThe refresh token is stored securely in the secret manager, and this field\ncontains the reference to retrieve it (e.g., \"OAUTH_REFRESH_TOKEN_workload\").\nThis enables session restoration without requiring a new browser-based login.",
-                        "type": "string"
-                    },
-                    "cached_reg_client_uri": {
-                        "description": "CachedRegClientURI is the registration_client_uri from the DCR response.\nThis is the endpoint used for RFC 7592 client read/update/delete operations.\nStored as plain text since it is not sensitive.",
-                        "type": "string"
-                    },
-                    "cached_reg_token_ref": {
-                        "description": "CachedRegTokenRef is a secret manager reference to the registration_access_token\nreturned in the DCR response. Used for RFC 7592 client update operations.\nStored as a secret reference since it's sensitive.",
-                        "type": "string"
-                    },
-                    "cached_secret_expiry": {
-                        "description": "ClientSecretExpiresAt indicates when the client secret expires (if provided by the DCR server).\nA zero value means the secret does not expire.",
-                        "type": "string"
-                    },
-                    "cached_token_auth_method": {
-                        "description": "CachedTokenEndpointAuthMethod is the auth method used for the token endpoint\n(e.g., \"client_secret_basic\", \"none\"). Persisted for RFC 7592 updates.",
-                        "type": "string"
-                    },
-                    "cached_token_expiry": {
-                        "type": "string"
-                    },
-                    "callback_port": {
-                        "type": "integer"
-                    },
-                    "client_id": {
-                        "type": "string"
-                    },
-                    "client_secret": {
-                        "type": "string"
-                    },
-                    "client_secret_file": {
-                        "type": "string"
-                    },
-                    "issuer": {
-                        "description": "OAuth endpoint configuration (from registry)",
-                        "type": "string"
-                    },
-                    "oauth_params": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "OAuth parameters for server-specific customization",
-                        "type": "object"
-                    },
-                    "resource": {
-                        "description": "Resource is the OAuth 2.0 resource indicator (RFC 8707).",
-                        "type": "string"
-                    },
-                    "scope_param_name": {
-                        "description": "ScopeParamName overrides the query parameter name used to send scopes in the\nauthorization URL. When empty, the standard \"scope\" parameter is used.\nSome providers require a non-standard name (e.g., Slack uses \"user_scope\").",
-                        "type": "string"
-                    },
-                    "scopes": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "skip_browser": {
-                        "type": "boolean"
-                    },
-                    "timeout": {
-                        "example": "5m",
-                        "type": "string"
-                    },
-                    "token_url": {
-                        "type": "string"
-                    },
-                    "use_pkce": {
-                        "type": "boolean"
                     }
                 },
                 "type": "object"
@@ -604,7 +550,7 @@
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.SigningKeyRunConfig"
                     },
                     "storage": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RunConfig"
+                        "$ref": "#/components/schemas/storage.RunConfig"
                     },
                     "token_lifespans": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.TokenLifespanRunConfig"
@@ -766,115 +712,6 @@
                 },
                 "type": "object"
             },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.ACLUserRunConfig": {
-                "description": "ACLUserConfig contains ACL user authentication configuration.",
-                "properties": {
-                    "password_env_var": {
-                        "description": "PasswordEnvVar is the environment variable containing the Redis password.",
-                        "type": "string"
-                    },
-                    "username_env_var": {
-                        "description": "UsernameEnvVar is the environment variable containing the Redis username.",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.RedisRunConfig": {
-                "description": "RedisConfig is the Redis-specific configuration when Type is \"redis\".",
-                "properties": {
-                    "acl_user_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.ACLUserRunConfig"
-                    },
-                    "addr": {
-                        "description": "Addr is the Redis server address (host:port). Required for standalone and cluster modes.\nMutually exclusive with SentinelConfig.",
-                        "type": "string"
-                    },
-                    "auth_type": {
-                        "description": "AuthType must be \"aclUser\" - only ACL user authentication is supported.",
-                        "type": "string"
-                    },
-                    "cluster_mode": {
-                        "description": "ClusterMode enables the Redis Cluster protocol. Requires Addr to be set.",
-                        "type": "boolean"
-                    },
-                    "dial_timeout": {
-                        "description": "DialTimeout is the timeout for establishing connections (e.g., \"5s\").",
-                        "type": "string"
-                    },
-                    "key_prefix": {
-                        "description": "KeyPrefix for multi-tenancy, typically \"thv:auth:{ns}:{name}:\".",
-                        "type": "string"
-                    },
-                    "read_timeout": {
-                        "description": "ReadTimeout is the timeout for read operations (e.g., \"3s\").",
-                        "type": "string"
-                    },
-                    "sentinel_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.SentinelRunConfig"
-                    },
-                    "sentinel_tls": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RedisTLSRunConfig"
-                    },
-                    "tls": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RedisTLSRunConfig"
-                    },
-                    "write_timeout": {
-                        "description": "WriteTimeout is the timeout for write operations (e.g., \"3s\").",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.RedisTLSRunConfig": {
-                "description": "SentinelTLS configures TLS for Sentinel connections. Only applies when SentinelConfig is set.",
-                "properties": {
-                    "ca_cert_file": {
-                        "description": "CACertFile is the path to a PEM-encoded CA certificate file.",
-                        "type": "string"
-                    },
-                    "insecure_skip_verify": {
-                        "description": "InsecureSkipVerify skips certificate verification.",
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.RunConfig": {
-                "description": "Storage configures the storage backend for the auth server.\nIf nil, defaults to in-memory storage.",
-                "properties": {
-                    "redis_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RedisRunConfig"
-                    },
-                    "type": {
-                        "description": "Type specifies the storage backend type. Defaults to \"memory\".",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_authserver_storage.SentinelRunConfig": {
-                "description": "SentinelConfig contains Sentinel-specific configuration.\nMutually exclusive with Addr.",
-                "properties": {
-                    "db": {
-                        "description": "DB is the Redis database number (default: 0).",
-                        "type": "integer"
-                    },
-                    "master_name": {
-                        "description": "MasterName is the name of the Redis Sentinel master.",
-                        "type": "string"
-                    },
-                    "sentinel_addrs": {
-                        "description": "SentinelAddrs is the list of Sentinel addresses (host:port).",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    }
-                },
-                "type": "object"
-            },
             "github_com_stacklok_toolhive_pkg_authz.Config": {
                 "description": "DEPRECATED: Middleware configuration.\nAuthzConfig contains the authorization configuration",
                 "properties": {
@@ -984,149 +821,6 @@
                 },
                 "type": "object"
             },
-            "github_com_stacklok_toolhive_pkg_container_runtime.WorkloadStatus": {
-                "description": "Current status of the workload",
-                "enum": [
-                    "running",
-                    "stopped",
-                    "error",
-                    "starting",
-                    "stopping",
-                    "unhealthy",
-                    "removing",
-                    "unknown",
-                    "unauthenticated",
-                    "auth_retrying",
-                    "policy_stopped",
-                    "running",
-                    "stopped",
-                    "error",
-                    "starting",
-                    "stopping",
-                    "unhealthy",
-                    "removing",
-                    "unknown",
-                    "unauthenticated",
-                    "auth_retrying",
-                    "policy_stopped",
-                    "running",
-                    "stopped",
-                    "error",
-                    "starting",
-                    "stopping",
-                    "unhealthy",
-                    "removing",
-                    "unknown",
-                    "unauthenticated",
-                    "auth_retrying",
-                    "policy_stopped"
-                ],
-                "type": "string",
-                "x-enum-varnames": [
-                    "WorkloadStatusRunning",
-                    "WorkloadStatusStopped",
-                    "WorkloadStatusError",
-                    "WorkloadStatusStarting",
-                    "WorkloadStatusStopping",
-                    "WorkloadStatusUnhealthy",
-                    "WorkloadStatusRemoving",
-                    "WorkloadStatusUnknown",
-                    "WorkloadStatusUnauthenticated",
-                    "WorkloadStatusAuthRetrying",
-                    "WorkloadStatusPolicyStopped"
-                ]
-            },
-            "github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig": {
-                "description": "RuntimeConfig allows overriding the default runtime configuration\nfor this specific workload (base images and packages)",
-                "properties": {
-                    "additional_packages": {
-                        "description": "AdditionalPackages lists extra packages to install in the builder and\nruntime stages.\nExamples for Alpine: [\"git\", \"make\", \"gcc\"]\nExamples for Debian: [\"git\", \"build-essential\"]",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "builder_image": {
-                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
-                        "type": "string"
-                    },
-                    "runtime_env": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "RuntimeEnv contains environment variables to inject into the Dockerfile's\nfinal runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),\nwhich only affects the builder stage, these variables are baked into the\nshipped image and are present in the running container's process\nenvironment at startup. Use this for values a packaged MCP server reads at\nprocess start (e.g. feature flags, cache backend selection), not for\nbuild-time package manager configuration.\nKeys must be uppercase with underscores, values are validated for safety.",
-                        "type": "object"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_core.Workload": {
-                "properties": {
-                    "created_at": {
-                        "description": "CreatedAt is the timestamp when the workload was created.",
-                        "type": "string"
-                    },
-                    "group": {
-                        "description": "Group is the name of the group this workload belongs to, if any.",
-                        "type": "string"
-                    },
-                    "labels": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "Labels are the container labels (excluding standard ToolHive labels)",
-                        "type": "object"
-                    },
-                    "name": {
-                        "description": "Name is the name of the workload.\nIt is used as a unique identifier.",
-                        "type": "string"
-                    },
-                    "package": {
-                        "description": "Package specifies the Workload Package used to create this Workload.",
-                        "type": "string"
-                    },
-                    "port": {
-                        "description": "Port is the port on which the workload is exposed.\nThis is embedded in the URL.",
-                        "type": "integer"
-                    },
-                    "proxy_mode": {
-                        "description": "ProxyMode is the proxy mode that clients should use to connect.\nFor stdio transports, this will be the proxy mode (sse or streamable-http).\nFor direct transports (sse/streamable-http), this will be the same as TransportType.",
-                        "type": "string"
-                    },
-                    "remote": {
-                        "description": "Remote indicates whether this is a remote workload (true) or a container workload (false).",
-                        "type": "boolean"
-                    },
-                    "started_at": {
-                        "description": "StartedAt is when the container was last started (changes on restart)",
-                        "type": "string"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_runtime.WorkloadStatus"
-                    },
-                    "status_context": {
-                        "description": "StatusContext provides additional context about the workload's status.\nThe exact meaning is determined by the status and the underlying runtime.",
-                        "type": "string"
-                    },
-                    "tools": {
-                        "description": "ToolsFilter is the filter on tools applied to the workload.",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "transport_type": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.TransportType"
-                    },
-                    "url": {
-                        "description": "URL is the URL of the workload exposed by the ToolHive proxy.",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
             "github_com_stacklok_toolhive_pkg_groups.Group": {
                 "properties": {
                     "name": {
@@ -1152,62 +846,6 @@
                         },
                         "type": "array",
                         "uniqueItems": false
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_ignore.Config": {
-                "description": "IgnoreConfig contains configuration for ignore processing",
-                "properties": {
-                    "loadGlobal": {
-                        "description": "Whether to load global ignore patterns",
-                        "type": "boolean"
-                    },
-                    "printOverlays": {
-                        "description": "Whether to print resolved overlay paths for debugging",
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_oauthproto_tokenexchange.Config": {
-                "description": "TokenExchangeConfig contains token exchange configuration for external authentication",
-                "properties": {
-                    "audience": {
-                        "description": "Audience is the target audience for the exchanged token",
-                        "type": "string"
-                    },
-                    "client_id": {
-                        "description": "ClientID is the OAuth 2.0 client identifier",
-                        "type": "string"
-                    },
-                    "client_secret": {
-                        "description": "ClientSecret is the OAuth 2.0 client secret",
-                        "type": "string"
-                    },
-                    "external_token_header_name": {
-                        "description": "ExternalTokenHeaderName is the name of the custom header to use when HeaderStrategy is \"custom\"",
-                        "type": "string"
-                    },
-                    "header_strategy": {
-                        "description": "HeaderStrategy determines how to inject the token\nValid values: HeaderStrategyReplace (default), HeaderStrategyCustom",
-                        "type": "string"
-                    },
-                    "scopes": {
-                        "description": "Scopes is the list of scopes to request for the exchanged token",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "subject_token_type": {
-                        "description": "SubjectTokenType specifies the type of the subject token being exchanged.\nCommon values: oauthproto.TokenTypeAccessToken (default), oauthproto.TokenTypeIDToken, oauthproto.TokenTypeJWT.\nIf empty, defaults to oauthproto.TokenTypeAccessToken.",
-                        "type": "string"
-                    },
-                    "token_url": {
-                        "description": "TokenURL is the OAuth 2.0 token endpoint URL",
-                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -1287,7 +925,7 @@
                     "additional_middleware_configs": {
                         "description": "AdditionalMiddlewareConfigs carries pre-built middleware configs injected by\nexternal-auth handlers (reached via *[]RunConfigBuilderOption) rather than\nderived from typed RunConfig fields. PopulateMiddlewareConfigs splices these\ninto the chain in the backend-egress group — after auth and before recovery —\ninstead of discarding them. Upstream carries these configs verbatim and never\ninspects their parameters; the middleware type identity (e.g. an enterprise\nauth type) is supplied by the caller via types.MiddlewareConfig.Type.\n\nEach entry's Type is expected to be a NEW egress middleware type (e.g. OBO),\nnot one already produced from a typed RunConfig field (auth, authz, audit,\ntokenExchange, awssts, …). Dispatch in the proxyrunner is purely by Type\nstring, so an injected Type that shadows a typed-field type would add a\nsecond instance of that middleware to the chain; the seam does not validate\nagainst this.",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig"
+                            "$ref": "#/components/schemas/types.MiddlewareConfig"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -1378,7 +1016,7 @@
                         "type": "string"
                     },
                     "ignore_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_ignore.Config"
+                        "$ref": "#/components/schemas/ignore.Config"
                     },
                     "image": {
                         "description": "Image is the Docker image to run",
@@ -1403,7 +1041,7 @@
                     "middleware_configs": {
                         "description": "MiddlewareConfigs contains the list of middleware to apply to the transport\nand the configuration for each middleware.",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig"
+                            "$ref": "#/components/schemas/types.MiddlewareConfig"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -1421,7 +1059,7 @@
                         "type": "string"
                     },
                     "oidc_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_auth.TokenValidatorConfig"
+                        "$ref": "#/components/schemas/auth.TokenValidatorConfig"
                     },
                     "permission_profile_name_or_path": {
                         "description": "PermissionProfileNameOrPath is the name or path of the permission profile",
@@ -1432,7 +1070,12 @@
                         "type": "integer"
                     },
                     "proxy_mode": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.ProxyMode"
+                        "description": "ProxyMode is the effective HTTP protocol the proxy uses.\nFor stdio transports, this is the configured mode (sse or streamable-http).\nFor direct transports (sse/streamable-http), this matches the transport type.\nNote: \"sse\" is deprecated; use \"streamable-http\" instead.",
+                        "enum": [
+                            "sse",
+                            "streamable-http"
+                        ],
+                        "type": "string"
                     },
                     "publish": {
                         "description": "Publish lists ports to publish to the host in format \"hostPort:containerPort\"",
@@ -1462,14 +1105,14 @@
                         "type": "string"
                     },
                     "remote_auth_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_auth_remote.Config"
+                        "$ref": "#/components/schemas/remote.Config"
                     },
                     "remote_url": {
                         "description": "RemoteURL is the URL of the remote MCP server (if running remotely)",
                         "type": "string"
                     },
                     "runtime_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
+                        "$ref": "#/components/schemas/templates.RuntimeConfig"
                     },
                     "scaling_config": {
                         "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_runner.ScalingConfig"
@@ -1508,14 +1151,14 @@
                         "type": "integer"
                     },
                     "telemetry_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_telemetry.Config"
+                        "$ref": "#/components/schemas/telemetry.Config"
                     },
                     "thv_ca_bundle": {
                         "description": "DEPRECATED: No longer appears to be used.\nThvCABundle is the path to the CA certificate bundle for ToolHive HTTP operations",
                         "type": "string"
                     },
                     "token_exchange_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_oauthproto_tokenexchange.Config"
+                        "$ref": "#/components/schemas/tokenexchange.Config"
                     },
                     "tools_filter": {
                         "description": "DEPRECATED: Middleware configuration.\nToolsFilter is the list of tools to filter",
@@ -1533,7 +1176,14 @@
                         "type": "object"
                     },
                     "transport": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.TransportType"
+                        "description": "Transport is the transport mode (stdio, sse, or streamable-http)",
+                        "enum": [
+                            "stdio",
+                            "sse",
+                            "streamable-http",
+                            "inspector"
+                        ],
+                        "type": "string"
                     },
                     "trust_proxy_headers": {
                         "description": "TrustProxyHeaders indicates whether to trust X-Forwarded-* headers from reverse proxies",
@@ -1600,18 +1250,6 @@
                     },
                     "name": {
                         "description": "Name is the redefined name of the tool",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_secrets.SecretParameter": {
-                "description": "Bearer token for authentication (alternative to OAuth)",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "target": {
                         "type": "string"
                     }
                 },
@@ -2026,125 +1664,6 @@
                 },
                 "type": "object"
             },
-            "github_com_stacklok_toolhive_pkg_telemetry.Config": {
-                "description": "DEPRECATED: Middleware configuration.\nTelemetryConfig contains the OpenTelemetry configuration",
-                "properties": {
-                    "caCertPath": {
-                        "description": "CACertPath is the file path to a CA certificate bundle for the OTLP endpoint.\nWhen set, the OTLP exporters use this CA to verify the collector's TLS certificate\ninstead of relying solely on the system CA pool.\n+optional",
-                        "type": "string"
-                    },
-                    "customAttributes": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "CustomAttributes contains custom resource attributes to be added to all telemetry signals.\nThese are parsed from CLI flags (--otel-custom-attributes) or environment variables\n(OTEL_RESOURCE_ATTRIBUTES) as key=value pairs.\n+optional",
-                        "type": "object"
-                    },
-                    "enablePrometheusMetricsPath": {
-                        "description": "EnablePrometheusMetricsPath controls whether to expose Prometheus-style /metrics endpoint.\nThe metrics are served on the main transport port at /metrics.\nThis is separate from OTLP metrics which are sent to the Endpoint.\n+kubebuilder:default=false\n+optional",
-                        "type": "boolean"
-                    },
-                    "endpoint": {
-                        "description": "Endpoint is the OTLP endpoint URL\n+optional",
-                        "type": "string"
-                    },
-                    "environmentVariables": {
-                        "description": "EnvironmentVariables is a list of environment variable names that should be\nincluded in telemetry spans as attributes. Only variables in this list will\nbe read from the host machine and included in spans for observability.\nExample: [\"NODE_ENV\", \"DEPLOYMENT_ENV\", \"SERVICE_VERSION\"]\n+optional",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "headers": {
-                        "additionalProperties": {
-                            "type": "string"
-                        },
-                        "description": "Headers contains authentication headers for the OTLP endpoint.\n+optional",
-                        "type": "object"
-                    },
-                    "insecure": {
-                        "description": "Insecure indicates whether to use HTTP instead of HTTPS for the OTLP endpoint.\n+kubebuilder:default=false\n+optional",
-                        "type": "boolean"
-                    },
-                    "metricsEnabled": {
-                        "description": "MetricsEnabled controls whether OTLP metrics are enabled.\nWhen false, OTLP metrics are not sent even if an endpoint is configured.\nThis is independent of EnablePrometheusMetricsPath.\n+kubebuilder:default=false\n+optional",
-                        "type": "boolean"
-                    },
-                    "samplingRate": {
-                        "description": "SamplingRate is the trace sampling rate (0.0-1.0) as a string.\nOnly used when TracingEnabled is true.\nExample: \"0.05\" for 5% sampling.\n+kubebuilder:default=\"0.05\"\n+optional",
-                        "type": "string"
-                    },
-                    "serviceName": {
-                        "description": "ServiceName is the service name for telemetry.\nWhen omitted, defaults to the server name (e.g., VirtualMCPServer name).\n+optional",
-                        "type": "string"
-                    },
-                    "serviceVersion": {
-                        "description": "ServiceVersion is the service version for telemetry.\nWhen omitted, defaults to the ToolHive version.\n+optional",
-                        "type": "string"
-                    },
-                    "tracingEnabled": {
-                        "description": "TracingEnabled controls whether distributed tracing is enabled.\nWhen false, no tracer provider is created even if an endpoint is configured.\n+kubebuilder:default=false\n+optional",
-                        "type": "boolean"
-                    },
-                    "useLegacyAttributes": {
-                        "description": "UseLegacyAttributes controls whether legacy (pre-MCP OTEL semconv) attribute names\nare emitted alongside the new standard attribute names. When true, spans include both\nold and new attribute names for backward compatibility with existing dashboards.\nCurrently defaults to true; this will change to false in a future release.\n+kubebuilder:default=true\n+optional",
-                        "type": "boolean"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig": {
-                "properties": {
-                    "parameters": {
-                        "description": "Parameters is a JSON object containing the middleware parameters.\nIt is stored as a raw message to allow flexible parameter types.",
-                        "type": "object"
-                    },
-                    "type": {
-                        "description": "Type is a string representing the middleware type.",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_stacklok_toolhive_pkg_transport_types.ProxyMode": {
-                "description": "ProxyMode is the effective HTTP protocol the proxy uses.\nFor stdio transports, this is the configured mode (sse or streamable-http).\nFor direct transports (sse/streamable-http), this matches the transport type.\nNote: \"sse\" is deprecated; use \"streamable-http\" instead.",
-                "enum": [
-                    "sse",
-                    "streamable-http",
-                    "sse",
-                    "streamable-http"
-                ],
-                "type": "string",
-                "x-enum-varnames": [
-                    "ProxyModeSSE",
-                    "ProxyModeStreamableHTTP"
-                ]
-            },
-            "github_com_stacklok_toolhive_pkg_transport_types.TransportType": {
-                "description": "Transport is the transport mode (stdio, sse, or streamable-http)",
-                "enum": [
-                    "stdio",
-                    "sse",
-                    "streamable-http",
-                    "inspector",
-                    "stdio",
-                    "sse",
-                    "streamable-http",
-                    "inspector",
-                    "stdio",
-                    "sse",
-                    "streamable-http",
-                    "inspector"
-                ],
-                "type": "string",
-                "x-enum-varnames": [
-                    "TransportTypeStdio",
-                    "TransportTypeSSE",
-                    "TransportTypeStreamableHTTP",
-                    "TransportTypeInspector"
-                ]
-            },
             "github_com_stacklok_toolhive_pkg_webhook.Config": {
                 "properties": {
                     "failure_policy": {
@@ -2330,6 +1849,20 @@
                     "StatusUnknown"
                 ]
             },
+            "ignore.Config": {
+                "description": "IgnoreConfig contains configuration for ignore processing",
+                "properties": {
+                    "loadGlobal": {
+                        "description": "Whether to load global ignore patterns",
+                        "type": "boolean"
+                    },
+                    "printOverlays": {
+                        "description": "Whether to print resolved overlay paths for debugging",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
             "model.Argument": {
                 "properties": {
                     "choices": {
@@ -2386,11 +1919,15 @@
             "model.ArgumentType": {
                 "enum": [
                     "positional",
+                    "named",
+                    "positional",
                     "named"
                 ],
                 "example": "positional",
                 "type": "string",
                 "x-enum-varnames": [
+                    "ArgumentTypePositional",
+                    "ArgumentTypeNamed",
                     "ArgumentTypePositional",
                     "ArgumentTypeNamed"
                 ]
@@ -2400,10 +1937,18 @@
                     "string",
                     "number",
                     "boolean",
+                    "filepath",
+                    "string",
+                    "number",
+                    "boolean",
                     "filepath"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
+                    "FormatString",
+                    "FormatNumber",
+                    "FormatBoolean",
+                    "FormatFilePath",
                     "FormatString",
                     "FormatNumber",
                     "FormatBoolean",
@@ -3000,12 +2545,12 @@
                         "type": "string"
                     },
                     "runtime_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
+                        "$ref": "#/components/schemas/templates.RuntimeConfig"
                     },
                     "secrets": {
                         "description": "Secret parameters to inject",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter"
+                            "$ref": "#/components/schemas/secrets.SecretParameter"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -3121,7 +2666,7 @@
                         "type": "string"
                     },
                     "registry": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive-core_registry_types.Registry"
+                        "$ref": "#/components/schemas/registry.Registry"
                     },
                     "server_count": {
                         "description": "Number of servers in the registry",
@@ -3457,7 +3002,7 @@
                         "type": "string"
                     },
                     "bearer_token": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter"
+                        "$ref": "#/components/schemas/secrets.SecretParameter"
                     },
                     "callback_port": {
                         "description": "Specific port for OAuth callback server",
@@ -3468,7 +3013,7 @@
                         "type": "string"
                     },
                     "client_secret": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter"
+                        "$ref": "#/components/schemas/secrets.SecretParameter"
                     },
                     "issuer": {
                         "description": "OAuth/OIDC issuer URL (e.g., https://accounts.google.com)",
@@ -3712,12 +3257,12 @@
                         "type": "integer"
                     },
                     "runtime_config": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig"
+                        "$ref": "#/components/schemas/templates.RuntimeConfig"
                     },
                     "secrets": {
                         "description": "Secret parameters to inject",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter"
+                            "$ref": "#/components/schemas/secrets.SecretParameter"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -3894,7 +3439,7 @@
                     "workloads": {
                         "description": "List of container information for each workload",
                         "items": {
-                            "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_core.Workload"
+                            "$ref": "#/components/schemas/core.Workload"
                         },
                         "type": "array",
                         "uniqueItems": false
@@ -3906,7 +3451,21 @@
                 "description": "Response containing workload status information",
                 "properties": {
                     "status": {
-                        "$ref": "#/components/schemas/github_com_stacklok_toolhive_pkg_container_runtime.WorkloadStatus"
+                        "description": "Current status of the workload",
+                        "enum": [
+                            "running",
+                            "stopped",
+                            "error",
+                            "starting",
+                            "stopping",
+                            "unhealthy",
+                            "removing",
+                            "unknown",
+                            "unauthenticated",
+                            "auth_retrying",
+                            "policy_stopped"
+                        ],
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -4227,6 +3786,42 @@
                 },
                 "type": "object"
             },
+            "registry.Registry": {
+                "description": "Full registry data",
+                "properties": {
+                    "groups": {
+                        "description": "Groups is a slice of group definitions containing related MCP servers",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.Group"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "last_updated": {
+                        "description": "LastUpdated is the timestamp when the registry was last updated, in RFC3339 format",
+                        "type": "string"
+                    },
+                    "remote_servers": {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/registry.RemoteServerMetadata"
+                        },
+                        "description": "RemoteServers is a map of server names to their corresponding remote server definitions\nThese are MCP servers accessed via HTTP/HTTPS using the thv proxy command",
+                        "type": "object"
+                    },
+                    "servers": {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/registry.ImageMetadata"
+                        },
+                        "description": "Servers is a map of server names to their corresponding server definitions",
+                        "type": "object"
+                    },
+                    "version": {
+                        "description": "Version is the schema version of the registry",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "registry.RemoteServerMetadata": {
                 "description": "Remote server details (if it's a remote server)",
                 "properties": {
@@ -4470,6 +4065,380 @@
                 "properties": {
                     "predicate": {},
                     "predicate_type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "remote.Config": {
+                "description": "RemoteAuthConfig contains OAuth configuration for remote MCP servers",
+                "properties": {
+                    "authorize_url": {
+                        "type": "string"
+                    },
+                    "bearer_token": {
+                        "description": "Bearer token configuration (alternative to OAuth)",
+                        "type": "string"
+                    },
+                    "bearer_token_file": {
+                        "type": "string"
+                    },
+                    "cached_cimd_client_id": {
+                        "description": "CachedCIMDClientID stores the CIMD metadata URL used as client_id when CIMD\nauthentication was used. Kept separate from CachedClientID (which holds\nDCR-issued IDs) so the two can have independent lifecycles — DCR credential\nrotation clears CachedClientID without touching the stable CIMD URL.\nRead by resolveClientCredentials to send the correct client_id on token refresh.",
+                        "type": "string"
+                    },
+                    "cached_client_id": {
+                        "description": "Cached DCR client credentials for persistence across restarts.\nThese are obtained during Dynamic Client Registration and needed to refresh tokens.\nClientID is stored as plain text since it's public information.",
+                        "type": "string"
+                    },
+                    "cached_client_secret_ref": {
+                        "type": "string"
+                    },
+                    "cached_dcr_callback_port": {
+                        "description": "CachedDCRCallbackPort is the callback port that was actually registered\nduring DCR. It may differ from CallbackPort when the requested port was\nunavailable and a fallback port was selected.",
+                        "type": "integer"
+                    },
+                    "cached_refresh_token_ref": {
+                        "description": "Cached OAuth token reference for persistence across restarts.\nThe refresh token is stored securely in the secret manager, and this field\ncontains the reference to retrieve it (e.g., \"OAUTH_REFRESH_TOKEN_workload\").\nThis enables session restoration without requiring a new browser-based login.",
+                        "type": "string"
+                    },
+                    "cached_reg_client_uri": {
+                        "description": "CachedRegClientURI is the registration_client_uri from the DCR response.\nThis is the endpoint used for RFC 7592 client read/update/delete operations.\nStored as plain text since it is not sensitive.",
+                        "type": "string"
+                    },
+                    "cached_reg_token_ref": {
+                        "description": "CachedRegTokenRef is a secret manager reference to the registration_access_token\nreturned in the DCR response. Used for RFC 7592 client update operations.\nStored as a secret reference since it's sensitive.",
+                        "type": "string"
+                    },
+                    "cached_secret_expiry": {
+                        "description": "ClientSecretExpiresAt indicates when the client secret expires (if provided by the DCR server).\nA zero value means the secret does not expire.",
+                        "type": "string"
+                    },
+                    "cached_token_auth_method": {
+                        "description": "CachedTokenEndpointAuthMethod is the auth method used for the token endpoint\n(e.g., \"client_secret_basic\", \"none\"). Persisted for RFC 7592 updates.",
+                        "type": "string"
+                    },
+                    "cached_token_expiry": {
+                        "type": "string"
+                    },
+                    "callback_port": {
+                        "type": "integer"
+                    },
+                    "client_id": {
+                        "type": "string"
+                    },
+                    "client_secret": {
+                        "type": "string"
+                    },
+                    "client_secret_file": {
+                        "type": "string"
+                    },
+                    "issuer": {
+                        "description": "OAuth endpoint configuration (from registry)",
+                        "type": "string"
+                    },
+                    "oauth_params": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "OAuth parameters for server-specific customization",
+                        "type": "object"
+                    },
+                    "resource": {
+                        "description": "Resource is the OAuth 2.0 resource indicator (RFC 8707).",
+                        "type": "string"
+                    },
+                    "scope_param_name": {
+                        "description": "ScopeParamName overrides the query parameter name used to send scopes in the\nauthorization URL. When empty, the standard \"scope\" parameter is used.\nSome providers require a non-standard name (e.g., Slack uses \"user_scope\").",
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "skip_browser": {
+                        "type": "boolean"
+                    },
+                    "timeout": {
+                        "example": "5m",
+                        "type": "string"
+                    },
+                    "token_url": {
+                        "type": "string"
+                    },
+                    "use_pkce": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "secrets.SecretParameter": {
+                "description": "Bearer token for authentication (alternative to OAuth)",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "target": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.ACLUserRunConfig": {
+                "description": "ACLUserConfig contains ACL user authentication configuration.",
+                "properties": {
+                    "password_env_var": {
+                        "description": "PasswordEnvVar is the environment variable containing the Redis password.",
+                        "type": "string"
+                    },
+                    "username_env_var": {
+                        "description": "UsernameEnvVar is the environment variable containing the Redis username.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.RedisRunConfig": {
+                "description": "RedisConfig is the Redis-specific configuration when Type is \"redis\".",
+                "properties": {
+                    "acl_user_config": {
+                        "$ref": "#/components/schemas/storage.ACLUserRunConfig"
+                    },
+                    "addr": {
+                        "description": "Addr is the Redis server address (host:port). Required for standalone and cluster modes.\nMutually exclusive with SentinelConfig.",
+                        "type": "string"
+                    },
+                    "auth_type": {
+                        "description": "AuthType must be \"aclUser\" - only ACL user authentication is supported.",
+                        "type": "string"
+                    },
+                    "cluster_mode": {
+                        "description": "ClusterMode enables the Redis Cluster protocol. Requires Addr to be set.",
+                        "type": "boolean"
+                    },
+                    "dial_timeout": {
+                        "description": "DialTimeout is the timeout for establishing connections (e.g., \"5s\").",
+                        "type": "string"
+                    },
+                    "key_prefix": {
+                        "description": "KeyPrefix for multi-tenancy, typically \"thv:auth:{ns}:{name}:\".",
+                        "type": "string"
+                    },
+                    "read_timeout": {
+                        "description": "ReadTimeout is the timeout for read operations (e.g., \"3s\").",
+                        "type": "string"
+                    },
+                    "sentinel_config": {
+                        "$ref": "#/components/schemas/storage.SentinelRunConfig"
+                    },
+                    "sentinel_tls": {
+                        "$ref": "#/components/schemas/storage.RedisTLSRunConfig"
+                    },
+                    "tls": {
+                        "$ref": "#/components/schemas/storage.RedisTLSRunConfig"
+                    },
+                    "write_timeout": {
+                        "description": "WriteTimeout is the timeout for write operations (e.g., \"3s\").",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.RedisTLSRunConfig": {
+                "description": "SentinelTLS configures TLS for Sentinel connections. Only applies when SentinelConfig is set.",
+                "properties": {
+                    "ca_cert_file": {
+                        "description": "CACertFile is the path to a PEM-encoded CA certificate file.",
+                        "type": "string"
+                    },
+                    "insecure_skip_verify": {
+                        "description": "InsecureSkipVerify skips certificate verification.",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.RunConfig": {
+                "description": "Storage configures the storage backend for the auth server.\nIf nil, defaults to in-memory storage.",
+                "properties": {
+                    "redis_config": {
+                        "$ref": "#/components/schemas/storage.RedisRunConfig"
+                    },
+                    "type": {
+                        "description": "Type specifies the storage backend type. Defaults to \"memory\".",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "storage.SentinelRunConfig": {
+                "description": "SentinelConfig contains Sentinel-specific configuration.\nMutually exclusive with Addr.",
+                "properties": {
+                    "db": {
+                        "description": "DB is the Redis database number (default: 0).",
+                        "type": "integer"
+                    },
+                    "master_name": {
+                        "description": "MasterName is the name of the Redis Sentinel master.",
+                        "type": "string"
+                    },
+                    "sentinel_addrs": {
+                        "description": "SentinelAddrs is the list of Sentinel addresses (host:port).",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
+            "telemetry.Config": {
+                "description": "DEPRECATED: Middleware configuration.\nTelemetryConfig contains the OpenTelemetry configuration",
+                "properties": {
+                    "caCertPath": {
+                        "description": "CACertPath is the file path to a CA certificate bundle for the OTLP endpoint.\nWhen set, the OTLP exporters use this CA to verify the collector's TLS certificate\ninstead of relying solely on the system CA pool.\n+optional",
+                        "type": "string"
+                    },
+                    "customAttributes": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "CustomAttributes contains custom resource attributes to be added to all telemetry signals.\nThese are parsed from CLI flags (--otel-custom-attributes) or environment variables\n(OTEL_RESOURCE_ATTRIBUTES) as key=value pairs.\n+optional",
+                        "type": "object"
+                    },
+                    "enablePrometheusMetricsPath": {
+                        "description": "EnablePrometheusMetricsPath controls whether to expose Prometheus-style /metrics endpoint.\nThe metrics are served on the main transport port at /metrics.\nThis is separate from OTLP metrics which are sent to the Endpoint.\n+kubebuilder:default=false\n+optional",
+                        "type": "boolean"
+                    },
+                    "endpoint": {
+                        "description": "Endpoint is the OTLP endpoint URL\n+optional",
+                        "type": "string"
+                    },
+                    "environmentVariables": {
+                        "description": "EnvironmentVariables is a list of environment variable names that should be\nincluded in telemetry spans as attributes. Only variables in this list will\nbe read from the host machine and included in spans for observability.\nExample: [\"NODE_ENV\", \"DEPLOYMENT_ENV\", \"SERVICE_VERSION\"]\n+optional",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "headers": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Headers contains authentication headers for the OTLP endpoint.\n+optional",
+                        "type": "object"
+                    },
+                    "insecure": {
+                        "description": "Insecure indicates whether to use HTTP instead of HTTPS for the OTLP endpoint.\n+kubebuilder:default=false\n+optional",
+                        "type": "boolean"
+                    },
+                    "metricsEnabled": {
+                        "description": "MetricsEnabled controls whether OTLP metrics are enabled.\nWhen false, OTLP metrics are not sent even if an endpoint is configured.\nThis is independent of EnablePrometheusMetricsPath.\n+kubebuilder:default=false\n+optional",
+                        "type": "boolean"
+                    },
+                    "samplingRate": {
+                        "description": "SamplingRate is the trace sampling rate (0.0-1.0) as a string.\nOnly used when TracingEnabled is true.\nExample: \"0.05\" for 5% sampling.\n+kubebuilder:default=\"0.05\"\n+optional",
+                        "type": "string"
+                    },
+                    "serviceName": {
+                        "description": "ServiceName is the service name for telemetry.\nWhen omitted, defaults to the server name (e.g., VirtualMCPServer name).\n+optional",
+                        "type": "string"
+                    },
+                    "serviceVersion": {
+                        "description": "ServiceVersion is the service version for telemetry.\nWhen omitted, defaults to the ToolHive version.\n+optional",
+                        "type": "string"
+                    },
+                    "tracingEnabled": {
+                        "description": "TracingEnabled controls whether distributed tracing is enabled.\nWhen false, no tracer provider is created even if an endpoint is configured.\n+kubebuilder:default=false\n+optional",
+                        "type": "boolean"
+                    },
+                    "useLegacyAttributes": {
+                        "description": "UseLegacyAttributes controls whether legacy (pre-MCP OTEL semconv) attribute names\nare emitted alongside the new standard attribute names. When true, spans include both\nold and new attribute names for backward compatibility with existing dashboards.\nCurrently defaults to true; this will change to false in a future release.\n+kubebuilder:default=true\n+optional",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "templates.RuntimeConfig": {
+                "description": "RuntimeConfig allows overriding the default runtime configuration\nfor this specific workload (base images and packages)",
+                "properties": {
+                    "additional_packages": {
+                        "description": "AdditionalPackages lists extra packages to install in the builder and\nruntime stages.\nExamples for Alpine: [\"git\", \"make\", \"gcc\"]\nExamples for Debian: [\"git\", \"build-essential\"]",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "builder_image": {
+                        "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
+                        "type": "string"
+                    },
+                    "runtime_env": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "RuntimeEnv contains environment variables to inject into the Dockerfile's\nfinal runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),\nwhich only affects the builder stage, these variables are baked into the\nshipped image and are present in the running container's process\nenvironment at startup. Use this for values a packaged MCP server reads at\nprocess start (e.g. feature flags, cache backend selection), not for\nbuild-time package manager configuration.\nKeys must be uppercase with underscores, values are validated for safety.",
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "tokenexchange.Config": {
+                "description": "TokenExchangeConfig contains token exchange configuration for external authentication",
+                "properties": {
+                    "audience": {
+                        "description": "Audience is the target audience for the exchanged token",
+                        "type": "string"
+                    },
+                    "client_id": {
+                        "description": "ClientID is the OAuth 2.0 client identifier",
+                        "type": "string"
+                    },
+                    "client_secret": {
+                        "description": "ClientSecret is the OAuth 2.0 client secret",
+                        "type": "string"
+                    },
+                    "external_token_header_name": {
+                        "description": "ExternalTokenHeaderName is the name of the custom header to use when HeaderStrategy is \"custom\"",
+                        "type": "string"
+                    },
+                    "header_strategy": {
+                        "description": "HeaderStrategy determines how to inject the token\nValid values: HeaderStrategyReplace (default), HeaderStrategyCustom",
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "description": "Scopes is the list of scopes to request for the exchanged token",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "subject_token_type": {
+                        "description": "SubjectTokenType specifies the type of the subject token being exchanged.\nCommon values: oauthproto.TokenTypeAccessToken (default), oauthproto.TokenTypeIDToken, oauthproto.TokenTypeJWT.\nIf empty, defaults to oauthproto.TokenTypeAccessToken.",
+                        "type": "string"
+                    },
+                    "token_url": {
+                        "description": "TokenURL is the OAuth 2.0 token endpoint URL",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "types.MiddlewareConfig": {
+                "properties": {
+                    "parameters": {
+                        "description": "Parameters is a JSON object containing the middleware parameters.\nIt is stored as a raw message to allow flexible parameter types.",
+                        "type": "object"
+                    },
+                    "type": {
+                        "description": "Type is a string representing the middleware type.",
                         "type": "string"
                     }
                 },

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1,34 +1,136 @@
 components:
   schemas:
-    github_com_stacklok_toolhive-core_registry_types.Registry:
-      description: Full registry data
+    auth.TokenValidatorConfig:
+      description: |-
+        DEPRECATED: Middleware configuration.
+        OIDCConfig contains OIDC configuration
       properties:
-        groups:
-          description: Groups is a slice of group definitions containing related MCP
-            servers
+        allowPrivateIP:
+          description: AllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses
+          type: boolean
+        audience:
+          description: Audience is the expected audience for the token
+          type: string
+        authTokenFile:
+          description: AuthTokenFile is the path to file containing bearer token for
+            authentication
+          type: string
+        cacertPath:
+          description: CACertPath is the path to the CA certificate bundle for HTTPS
+            requests
+          type: string
+        clientID:
+          description: ClientID is the OIDC client ID
+          type: string
+        clientSecret:
+          description: ClientSecret is the optional OIDC client secret for introspection
+          type: string
+        insecureAllowHTTP:
+          description: |-
+            InsecureAllowHTTP allows HTTP (non-HTTPS) OIDC issuers for development/testing
+            WARNING: This is insecure and should NEVER be used in production
+          type: boolean
+        introspectionURL:
+          description: IntrospectionURL is the optional introspection endpoint for
+            validating tokens
+          type: string
+        issuer:
+          description: Issuer is the OIDC issuer URL (e.g., https://accounts.google.com)
+          type: string
+        jwksurl:
+          description: JWKSURL is the URL to fetch the JWKS from
+          type: string
+        resourceURL:
+          description: ResourceURL is the explicit resource URL for OAuth discovery
+            (RFC 9728)
+          type: string
+        scopes:
+          description: |-
+            Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728)
+            If empty, defaults to ["openid"]
           items:
-            $ref: '#/components/schemas/registry.Group'
+            type: string
+          type: array
+      type: object
+    core.Workload:
+      properties:
+        created_at:
+          description: CreatedAt is the timestamp when the workload was created.
+          type: string
+        group:
+          description: Group is the name of the group this workload belongs to, if
+            any.
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          description: Labels are the container labels (excluding standard ToolHive
+            labels)
+          type: object
+        name:
+          description: |-
+            Name is the name of the workload.
+            It is used as a unique identifier.
+          type: string
+        package:
+          description: Package specifies the Workload Package used to create this
+            Workload.
+          type: string
+        port:
+          description: |-
+            Port is the port on which the workload is exposed.
+            This is embedded in the URL.
+          type: integer
+        proxy_mode:
+          description: |-
+            ProxyMode is the proxy mode that clients should use to connect.
+            For stdio transports, this will be the proxy mode (sse or streamable-http).
+            For direct transports (sse/streamable-http), this will be the same as TransportType.
+          type: string
+        remote:
+          description: Remote indicates whether this is a remote workload (true) or
+            a container workload (false).
+          type: boolean
+        started_at:
+          description: StartedAt is when the container was last started (changes on
+            restart)
+          type: string
+        status:
+          description: Status is the current status of the workload.
+          enum:
+          - running
+          - stopped
+          - error
+          - starting
+          - stopping
+          - unhealthy
+          - removing
+          - unknown
+          - unauthenticated
+          - auth_retrying
+          - policy_stopped
+          type: string
+        status_context:
+          description: |-
+            StatusContext provides additional context about the workload's status.
+            The exact meaning is determined by the status and the underlying runtime.
+          type: string
+        tools:
+          description: ToolsFilter is the filter on tools applied to the workload.
+          items:
+            type: string
           type: array
           uniqueItems: false
-        last_updated:
-          description: LastUpdated is the timestamp when the registry was last updated,
-            in RFC3339 format
+        transport_type:
+          description: TransportType is the type of transport used for this workload.
+          enum:
+          - stdio
+          - sse
+          - streamable-http
+          - inspector
           type: string
-        remote_servers:
-          additionalProperties:
-            $ref: '#/components/schemas/registry.RemoteServerMetadata'
-          description: |-
-            RemoteServers is a map of server names to their corresponding remote server definitions
-            These are MCP servers accessed via HTTP/HTTPS using the thv proxy command
-          type: object
-        servers:
-          additionalProperties:
-            $ref: '#/components/schemas/registry.ImageMetadata'
-          description: Servers is a map of server names to their corresponding server
-            definitions
-          type: object
-        version:
-          description: Version is the schema version of the registry
+        url:
+          description: URL is the URL of the workload exposed by the ToolHive proxy.
           type: string
       type: object
     github_com_stacklok_toolhive_cmd_thv-operator_api_v1beta1.RateLimitConfig:
@@ -121,58 +223,6 @@ components:
             +optional
           type: integer
       type: object
-    github_com_stacklok_toolhive_pkg_auth.TokenValidatorConfig:
-      description: |-
-        DEPRECATED: Middleware configuration.
-        OIDCConfig contains OIDC configuration
-      properties:
-        allowPrivateIP:
-          description: AllowPrivateIP allows JWKS/OIDC endpoints on private IP addresses
-          type: boolean
-        audience:
-          description: Audience is the expected audience for the token
-          type: string
-        authTokenFile:
-          description: AuthTokenFile is the path to file containing bearer token for
-            authentication
-          type: string
-        cacertPath:
-          description: CACertPath is the path to the CA certificate bundle for HTTPS
-            requests
-          type: string
-        clientID:
-          description: ClientID is the OIDC client ID
-          type: string
-        clientSecret:
-          description: ClientSecret is the optional OIDC client secret for introspection
-          type: string
-        insecureAllowHTTP:
-          description: |-
-            InsecureAllowHTTP allows HTTP (non-HTTPS) OIDC issuers for development/testing
-            WARNING: This is insecure and should NEVER be used in production
-          type: boolean
-        introspectionURL:
-          description: IntrospectionURL is the optional introspection endpoint for
-            validating tokens
-          type: string
-        issuer:
-          description: Issuer is the OIDC issuer URL (e.g., https://accounts.google.com)
-          type: string
-        jwksurl:
-          description: JWKSURL is the URL to fetch the JWKS from
-          type: string
-        resourceURL:
-          description: ResourceURL is the explicit resource URL for OAuth discovery
-            (RFC 9728)
-          type: string
-        scopes:
-          description: |-
-            Scopes is the list of OAuth scopes to advertise in the well-known endpoint (RFC 9728)
-            If empty, defaults to ["openid"]
-          items:
-            type: string
-          type: array
-      type: object
     github_com_stacklok_toolhive_pkg_auth_awssts.Config:
       description: AWSStsConfig contains AWS STS token exchange configuration for
         accessing AWS services
@@ -240,109 +290,6 @@ components:
         role_arn:
           description: RoleArn is the IAM role ARN to assume when this mapping matches.
           type: string
-      type: object
-    github_com_stacklok_toolhive_pkg_auth_remote.Config:
-      description: RemoteAuthConfig contains OAuth configuration for remote MCP servers
-      properties:
-        authorize_url:
-          type: string
-        bearer_token:
-          description: Bearer token configuration (alternative to OAuth)
-          type: string
-        bearer_token_file:
-          type: string
-        cached_cimd_client_id:
-          description: |-
-            CachedCIMDClientID stores the CIMD metadata URL used as client_id when CIMD
-            authentication was used. Kept separate from CachedClientID (which holds
-            DCR-issued IDs) so the two can have independent lifecycles — DCR credential
-            rotation clears CachedClientID without touching the stable CIMD URL.
-            Read by resolveClientCredentials to send the correct client_id on token refresh.
-          type: string
-        cached_client_id:
-          description: |-
-            Cached DCR client credentials for persistence across restarts.
-            These are obtained during Dynamic Client Registration and needed to refresh tokens.
-            ClientID is stored as plain text since it's public information.
-          type: string
-        cached_client_secret_ref:
-          type: string
-        cached_dcr_callback_port:
-          description: |-
-            CachedDCRCallbackPort is the callback port that was actually registered
-            during DCR. It may differ from CallbackPort when the requested port was
-            unavailable and a fallback port was selected.
-          type: integer
-        cached_refresh_token_ref:
-          description: |-
-            Cached OAuth token reference for persistence across restarts.
-            The refresh token is stored securely in the secret manager, and this field
-            contains the reference to retrieve it (e.g., "OAUTH_REFRESH_TOKEN_workload").
-            This enables session restoration without requiring a new browser-based login.
-          type: string
-        cached_reg_client_uri:
-          description: |-
-            CachedRegClientURI is the registration_client_uri from the DCR response.
-            This is the endpoint used for RFC 7592 client read/update/delete operations.
-            Stored as plain text since it is not sensitive.
-          type: string
-        cached_reg_token_ref:
-          description: |-
-            CachedRegTokenRef is a secret manager reference to the registration_access_token
-            returned in the DCR response. Used for RFC 7592 client update operations.
-            Stored as a secret reference since it's sensitive.
-          type: string
-        cached_secret_expiry:
-          description: |-
-            ClientSecretExpiresAt indicates when the client secret expires (if provided by the DCR server).
-            A zero value means the secret does not expire.
-          type: string
-        cached_token_auth_method:
-          description: |-
-            CachedTokenEndpointAuthMethod is the auth method used for the token endpoint
-            (e.g., "client_secret_basic", "none"). Persisted for RFC 7592 updates.
-          type: string
-        cached_token_expiry:
-          type: string
-        callback_port:
-          type: integer
-        client_id:
-          type: string
-        client_secret:
-          type: string
-        client_secret_file:
-          type: string
-        issuer:
-          description: OAuth endpoint configuration (from registry)
-          type: string
-        oauth_params:
-          additionalProperties:
-            type: string
-          description: OAuth parameters for server-specific customization
-          type: object
-        resource:
-          description: Resource is the OAuth 2.0 resource indicator (RFC 8707).
-          type: string
-        scope_param_name:
-          description: |-
-            ScopeParamName overrides the query parameter name used to send scopes in the
-            authorization URL. When empty, the standard "scope" parameter is used.
-            Some providers require a non-standard name (e.g., Slack uses "user_scope").
-          type: string
-        scopes:
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-        skip_browser:
-          type: boolean
-        timeout:
-          example: 5m
-          type: string
-        token_url:
-          type: string
-        use_pkce:
-          type: boolean
       type: object
     github_com_stacklok_toolhive_pkg_auth_upstreamswap.Config:
       description: |-
@@ -708,7 +655,7 @@ components:
         signing_key_config:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.SigningKeyRunConfig'
         storage:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RunConfig'
+          $ref: '#/components/schemas/storage.RunConfig'
         token_lifespans:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.TokenLifespanRunConfig'
         upstreams:
@@ -874,96 +821,6 @@ components:
             If not specified, defaults to GET.
           type: string
       type: object
-    github_com_stacklok_toolhive_pkg_authserver_storage.ACLUserRunConfig:
-      description: ACLUserConfig contains ACL user authentication configuration.
-      properties:
-        password_env_var:
-          description: PasswordEnvVar is the environment variable containing the Redis
-            password.
-          type: string
-        username_env_var:
-          description: UsernameEnvVar is the environment variable containing the Redis
-            username.
-          type: string
-      type: object
-    github_com_stacklok_toolhive_pkg_authserver_storage.RedisRunConfig:
-      description: RedisConfig is the Redis-specific configuration when Type is "redis".
-      properties:
-        acl_user_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.ACLUserRunConfig'
-        addr:
-          description: |-
-            Addr is the Redis server address (host:port). Required for standalone and cluster modes.
-            Mutually exclusive with SentinelConfig.
-          type: string
-        auth_type:
-          description: AuthType must be "aclUser" - only ACL user authentication is
-            supported.
-          type: string
-        cluster_mode:
-          description: ClusterMode enables the Redis Cluster protocol. Requires Addr
-            to be set.
-          type: boolean
-        dial_timeout:
-          description: DialTimeout is the timeout for establishing connections (e.g.,
-            "5s").
-          type: string
-        key_prefix:
-          description: KeyPrefix for multi-tenancy, typically "thv:auth:{ns}:{name}:".
-          type: string
-        read_timeout:
-          description: ReadTimeout is the timeout for read operations (e.g., "3s").
-          type: string
-        sentinel_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.SentinelRunConfig'
-        sentinel_tls:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RedisTLSRunConfig'
-        tls:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RedisTLSRunConfig'
-        write_timeout:
-          description: WriteTimeout is the timeout for write operations (e.g., "3s").
-          type: string
-      type: object
-    github_com_stacklok_toolhive_pkg_authserver_storage.RedisTLSRunConfig:
-      description: SentinelTLS configures TLS for Sentinel connections. Only applies
-        when SentinelConfig is set.
-      properties:
-        ca_cert_file:
-          description: CACertFile is the path to a PEM-encoded CA certificate file.
-          type: string
-        insecure_skip_verify:
-          description: InsecureSkipVerify skips certificate verification.
-          type: boolean
-      type: object
-    github_com_stacklok_toolhive_pkg_authserver_storage.RunConfig:
-      description: |-
-        Storage configures the storage backend for the auth server.
-        If nil, defaults to in-memory storage.
-      properties:
-        redis_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_storage.RedisRunConfig'
-        type:
-          description: Type specifies the storage backend type. Defaults to "memory".
-          type: string
-      type: object
-    github_com_stacklok_toolhive_pkg_authserver_storage.SentinelRunConfig:
-      description: |-
-        SentinelConfig contains Sentinel-specific configuration.
-        Mutually exclusive with Addr.
-      properties:
-        db:
-          description: 'DB is the Redis database number (default: 0).'
-          type: integer
-        master_name:
-          description: MasterName is the name of the Redis Sentinel master.
-          type: string
-        sentinel_addrs:
-          description: SentinelAddrs is the list of Sentinel addresses (host:port).
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-      type: object
     github_com_stacklok_toolhive_pkg_authz.Config:
       description: |-
         DEPRECATED: Middleware configuration.
@@ -1060,152 +917,6 @@ components:
         name:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_client.ClientApp'
       type: object
-    github_com_stacklok_toolhive_pkg_container_runtime.WorkloadStatus:
-      description: Current status of the workload
-      enum:
-      - running
-      - stopped
-      - error
-      - starting
-      - stopping
-      - unhealthy
-      - removing
-      - unknown
-      - unauthenticated
-      - auth_retrying
-      - policy_stopped
-      - running
-      - stopped
-      - error
-      - starting
-      - stopping
-      - unhealthy
-      - removing
-      - unknown
-      - unauthenticated
-      - auth_retrying
-      - policy_stopped
-      - running
-      - stopped
-      - error
-      - starting
-      - stopping
-      - unhealthy
-      - removing
-      - unknown
-      - unauthenticated
-      - auth_retrying
-      - policy_stopped
-      type: string
-      x-enum-varnames:
-      - WorkloadStatusRunning
-      - WorkloadStatusStopped
-      - WorkloadStatusError
-      - WorkloadStatusStarting
-      - WorkloadStatusStopping
-      - WorkloadStatusUnhealthy
-      - WorkloadStatusRemoving
-      - WorkloadStatusUnknown
-      - WorkloadStatusUnauthenticated
-      - WorkloadStatusAuthRetrying
-      - WorkloadStatusPolicyStopped
-    github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig:
-      description: |-
-        RuntimeConfig allows overriding the default runtime configuration
-        for this specific workload (base images and packages)
-      properties:
-        additional_packages:
-          description: |-
-            AdditionalPackages lists extra packages to install in the builder and
-            runtime stages.
-            Examples for Alpine: ["git", "make", "gcc"]
-            Examples for Debian: ["git", "build-essential"]
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-        builder_image:
-          description: |-
-            BuilderImage is the full image reference for the builder stage.
-            An empty string signals "use the default for this transport type" during config merging.
-            Examples: "golang:1.26-alpine", "node:24-alpine", "python:3.14-slim"
-          type: string
-        runtime_env:
-          additionalProperties:
-            type: string
-          description: |-
-            RuntimeEnv contains environment variables to inject into the Dockerfile's
-            final runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),
-            which only affects the builder stage, these variables are baked into the
-            shipped image and are present in the running container's process
-            environment at startup. Use this for values a packaged MCP server reads at
-            process start (e.g. feature flags, cache backend selection), not for
-            build-time package manager configuration.
-            Keys must be uppercase with underscores, values are validated for safety.
-          type: object
-      type: object
-    github_com_stacklok_toolhive_pkg_core.Workload:
-      properties:
-        created_at:
-          description: CreatedAt is the timestamp when the workload was created.
-          type: string
-        group:
-          description: Group is the name of the group this workload belongs to, if
-            any.
-          type: string
-        labels:
-          additionalProperties:
-            type: string
-          description: Labels are the container labels (excluding standard ToolHive
-            labels)
-          type: object
-        name:
-          description: |-
-            Name is the name of the workload.
-            It is used as a unique identifier.
-          type: string
-        package:
-          description: Package specifies the Workload Package used to create this
-            Workload.
-          type: string
-        port:
-          description: |-
-            Port is the port on which the workload is exposed.
-            This is embedded in the URL.
-          type: integer
-        proxy_mode:
-          description: |-
-            ProxyMode is the proxy mode that clients should use to connect.
-            For stdio transports, this will be the proxy mode (sse or streamable-http).
-            For direct transports (sse/streamable-http), this will be the same as TransportType.
-          type: string
-        remote:
-          description: Remote indicates whether this is a remote workload (true) or
-            a container workload (false).
-          type: boolean
-        started_at:
-          description: StartedAt is when the container was last started (changes on
-            restart)
-          type: string
-        status:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_container_runtime.WorkloadStatus'
-        status_context:
-          description: |-
-            StatusContext provides additional context about the workload's status.
-            The exact meaning is determined by the status and the underlying runtime.
-          type: string
-        tools:
-          description: ToolsFilter is the filter on tools applied to the workload.
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-        transport_type:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.TransportType'
-        url:
-          description: URL is the URL of the workload exposed by the ToolHive proxy.
-          type: string
-      type: object
     github_com_stacklok_toolhive_pkg_groups.Group:
       properties:
         name:
@@ -1225,54 +936,6 @@ components:
             type: string
           type: array
           uniqueItems: false
-      type: object
-    github_com_stacklok_toolhive_pkg_ignore.Config:
-      description: IgnoreConfig contains configuration for ignore processing
-      properties:
-        loadGlobal:
-          description: Whether to load global ignore patterns
-          type: boolean
-        printOverlays:
-          description: Whether to print resolved overlay paths for debugging
-          type: boolean
-      type: object
-    github_com_stacklok_toolhive_pkg_oauthproto_tokenexchange.Config:
-      description: TokenExchangeConfig contains token exchange configuration for external
-        authentication
-      properties:
-        audience:
-          description: Audience is the target audience for the exchanged token
-          type: string
-        client_id:
-          description: ClientID is the OAuth 2.0 client identifier
-          type: string
-        client_secret:
-          description: ClientSecret is the OAuth 2.0 client secret
-          type: string
-        external_token_header_name:
-          description: ExternalTokenHeaderName is the name of the custom header to
-            use when HeaderStrategy is "custom"
-          type: string
-        header_strategy:
-          description: |-
-            HeaderStrategy determines how to inject the token
-            Valid values: HeaderStrategyReplace (default), HeaderStrategyCustom
-          type: string
-        scopes:
-          description: Scopes is the list of scopes to request for the exchanged token
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-        subject_token_type:
-          description: |-
-            SubjectTokenType specifies the type of the subject token being exchanged.
-            Common values: oauthproto.TokenTypeAccessToken (default), oauthproto.TokenTypeIDToken, oauthproto.TokenTypeJWT.
-            If empty, defaults to oauthproto.TokenTypeAccessToken.
-          type: string
-        token_url:
-          description: TokenURL is the OAuth 2.0 token endpoint URL
-          type: string
       type: object
     github_com_stacklok_toolhive_pkg_ratelimit_types.RateLimitBucket:
       description: |-
@@ -1361,7 +1024,7 @@ components:
             second instance of that middleware to the chain; the seam does not validate
             against this.
           items:
-            $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig'
+            $ref: '#/components/schemas/types.MiddlewareConfig'
           type: array
           uniqueItems: false
         allow_docker_gateway:
@@ -1448,7 +1111,7 @@ components:
           description: Host is the host for the HTTP proxy
           type: string
         ignore_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_ignore.Config'
+          $ref: '#/components/schemas/ignore.Config'
         image:
           description: Image is the Docker image to run
           type: string
@@ -1478,7 +1141,7 @@ components:
             MiddlewareConfigs contains the list of middleware to apply to the transport
             and the configuration for each middleware.
           items:
-            $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig'
+            $ref: '#/components/schemas/types.MiddlewareConfig'
           type: array
           uniqueItems: false
         mutating_webhooks:
@@ -1493,7 +1156,7 @@ components:
           description: Name is the name of the MCP server
           type: string
         oidc_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_auth.TokenValidatorConfig'
+          $ref: '#/components/schemas/auth.TokenValidatorConfig'
         permission_profile_name_or_path:
           description: PermissionProfileNameOrPath is the name or path of the permission
             profile
@@ -1502,7 +1165,15 @@ components:
           description: Port is the port for the HTTP proxy to listen on (host port)
           type: integer
         proxy_mode:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.ProxyMode'
+          description: |-
+            ProxyMode is the effective HTTP protocol the proxy uses.
+            For stdio transports, this is the configured mode (sse or streamable-http).
+            For direct transports (sse/streamable-http), this matches the transport type.
+            Note: "sse" is deprecated; use "streamable-http" instead.
+          enum:
+          - sse
+          - streamable-http
+          type: string
         publish:
           description: Publish lists ports to publish to the host in format "hostPort:containerPort"
           items:
@@ -1531,12 +1202,12 @@ components:
             Empty when the server was not discovered via registry lookup.
           type: string
         remote_auth_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_auth_remote.Config'
+          $ref: '#/components/schemas/remote.Config'
         remote_url:
           description: RemoteURL is the URL of the remote MCP server (if running remotely)
           type: string
         runtime_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig'
+          $ref: '#/components/schemas/templates.RuntimeConfig'
         scaling_config:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_runner.ScalingConfig'
         schema_version:
@@ -1583,14 +1254,14 @@ components:
             to SSE transport)
           type: integer
         telemetry_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_telemetry.Config'
+          $ref: '#/components/schemas/telemetry.Config'
         thv_ca_bundle:
           description: |-
             DEPRECATED: No longer appears to be used.
             ThvCABundle is the path to the CA certificate bundle for ToolHive HTTP operations
           type: string
         token_exchange_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_oauthproto_tokenexchange.Config'
+          $ref: '#/components/schemas/tokenexchange.Config'
         tools_filter:
           description: |-
             DEPRECATED: Middleware configuration.
@@ -1607,7 +1278,13 @@ components:
             ToolsOverride is a map from an actual tool to its overridden name and/or description
           type: object
         transport:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_transport_types.TransportType'
+          description: Transport is the transport mode (stdio, sse, or streamable-http)
+          enum:
+          - stdio
+          - sse
+          - streamable-http
+          - inspector
+          type: string
         trust_proxy_headers:
           description: TrustProxyHeaders indicates whether to trust X-Forwarded-*
             headers from reverse proxies
@@ -1670,14 +1347,6 @@ components:
           type: string
         name:
           description: Name is the redefined name of the tool
-          type: string
-      type: object
-    github_com_stacklok_toolhive_pkg_secrets.SecretParameter:
-      description: Bearer token for authentication (alternative to OAuth)
-      properties:
-        name:
-          type: string
-        target:
           type: string
       type: object
     github_com_stacklok_toolhive_pkg_skills.BuildResult:
@@ -2007,156 +1676,6 @@ components:
           type: array
           uniqueItems: false
       type: object
-    github_com_stacklok_toolhive_pkg_telemetry.Config:
-      description: |-
-        DEPRECATED: Middleware configuration.
-        TelemetryConfig contains the OpenTelemetry configuration
-      properties:
-        caCertPath:
-          description: |-
-            CACertPath is the file path to a CA certificate bundle for the OTLP endpoint.
-            When set, the OTLP exporters use this CA to verify the collector's TLS certificate
-            instead of relying solely on the system CA pool.
-            +optional
-          type: string
-        customAttributes:
-          additionalProperties:
-            type: string
-          description: |-
-            CustomAttributes contains custom resource attributes to be added to all telemetry signals.
-            These are parsed from CLI flags (--otel-custom-attributes) or environment variables
-            (OTEL_RESOURCE_ATTRIBUTES) as key=value pairs.
-            +optional
-          type: object
-        enablePrometheusMetricsPath:
-          description: |-
-            EnablePrometheusMetricsPath controls whether to expose Prometheus-style /metrics endpoint.
-            The metrics are served on the main transport port at /metrics.
-            This is separate from OTLP metrics which are sent to the Endpoint.
-            +kubebuilder:default=false
-            +optional
-          type: boolean
-        endpoint:
-          description: |-
-            Endpoint is the OTLP endpoint URL
-            +optional
-          type: string
-        environmentVariables:
-          description: |-
-            EnvironmentVariables is a list of environment variable names that should be
-            included in telemetry spans as attributes. Only variables in this list will
-            be read from the host machine and included in spans for observability.
-            Example: ["NODE_ENV", "DEPLOYMENT_ENV", "SERVICE_VERSION"]
-            +optional
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-        headers:
-          additionalProperties:
-            type: string
-          description: |-
-            Headers contains authentication headers for the OTLP endpoint.
-            +optional
-          type: object
-        insecure:
-          description: |-
-            Insecure indicates whether to use HTTP instead of HTTPS for the OTLP endpoint.
-            +kubebuilder:default=false
-            +optional
-          type: boolean
-        metricsEnabled:
-          description: |-
-            MetricsEnabled controls whether OTLP metrics are enabled.
-            When false, OTLP metrics are not sent even if an endpoint is configured.
-            This is independent of EnablePrometheusMetricsPath.
-            +kubebuilder:default=false
-            +optional
-          type: boolean
-        samplingRate:
-          description: |-
-            SamplingRate is the trace sampling rate (0.0-1.0) as a string.
-            Only used when TracingEnabled is true.
-            Example: "0.05" for 5% sampling.
-            +kubebuilder:default="0.05"
-            +optional
-          type: string
-        serviceName:
-          description: |-
-            ServiceName is the service name for telemetry.
-            When omitted, defaults to the server name (e.g., VirtualMCPServer name).
-            +optional
-          type: string
-        serviceVersion:
-          description: |-
-            ServiceVersion is the service version for telemetry.
-            When omitted, defaults to the ToolHive version.
-            +optional
-          type: string
-        tracingEnabled:
-          description: |-
-            TracingEnabled controls whether distributed tracing is enabled.
-            When false, no tracer provider is created even if an endpoint is configured.
-            +kubebuilder:default=false
-            +optional
-          type: boolean
-        useLegacyAttributes:
-          description: |-
-            UseLegacyAttributes controls whether legacy (pre-MCP OTEL semconv) attribute names
-            are emitted alongside the new standard attribute names. When true, spans include both
-            old and new attribute names for backward compatibility with existing dashboards.
-            Currently defaults to true; this will change to false in a future release.
-            +kubebuilder:default=true
-            +optional
-          type: boolean
-      type: object
-    github_com_stacklok_toolhive_pkg_transport_types.MiddlewareConfig:
-      properties:
-        parameters:
-          description: |-
-            Parameters is a JSON object containing the middleware parameters.
-            It is stored as a raw message to allow flexible parameter types.
-          type: object
-        type:
-          description: Type is a string representing the middleware type.
-          type: string
-      type: object
-    github_com_stacklok_toolhive_pkg_transport_types.ProxyMode:
-      description: |-
-        ProxyMode is the effective HTTP protocol the proxy uses.
-        For stdio transports, this is the configured mode (sse or streamable-http).
-        For direct transports (sse/streamable-http), this matches the transport type.
-        Note: "sse" is deprecated; use "streamable-http" instead.
-      enum:
-      - sse
-      - streamable-http
-      - sse
-      - streamable-http
-      type: string
-      x-enum-varnames:
-      - ProxyModeSSE
-      - ProxyModeStreamableHTTP
-    github_com_stacklok_toolhive_pkg_transport_types.TransportType:
-      description: Transport is the transport mode (stdio, sse, or streamable-http)
-      enum:
-      - stdio
-      - sse
-      - streamable-http
-      - inspector
-      - stdio
-      - sse
-      - streamable-http
-      - inspector
-      - stdio
-      - sse
-      - streamable-http
-      - inspector
-      type: string
-      x-enum-varnames:
-      - TransportTypeStdio
-      - TransportTypeSSE
-      - TransportTypeStreamableHTTP
-      - TransportTypeInspector
     github_com_stacklok_toolhive_pkg_webhook.Config:
       properties:
         failure_policy:
@@ -2318,6 +1837,16 @@ components:
       - StatusNotRegistrySourced
       - StatusServerNotFound
       - StatusUnknown
+    ignore.Config:
+      description: IgnoreConfig contains configuration for ignore processing
+      properties:
+        loadGlobal:
+          description: Whether to load global ignore patterns
+          type: boolean
+        printOverlays:
+          description: Whether to print resolved overlay paths for debugging
+          type: boolean
+      type: object
     model.Argument:
       properties:
         choices:
@@ -2358,9 +1887,13 @@ components:
       enum:
       - positional
       - named
+      - positional
+      - named
       example: positional
       type: string
       x-enum-varnames:
+      - ArgumentTypePositional
+      - ArgumentTypeNamed
       - ArgumentTypePositional
       - ArgumentTypeNamed
     model.Format:
@@ -2369,8 +1902,16 @@ components:
       - number
       - boolean
       - filepath
+      - string
+      - number
+      - boolean
+      - filepath
       type: string
       x-enum-varnames:
+      - FormatString
+      - FormatNumber
+      - FormatBoolean
+      - FormatFilePath
       - FormatString
       - FormatNumber
       - FormatBoolean
@@ -2832,11 +2373,11 @@ components:
             from (e.g. "default").
           type: string
         runtime_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig'
+          $ref: '#/components/schemas/templates.RuntimeConfig'
         secrets:
           description: Secret parameters to inject
           items:
-            $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter'
+            $ref: '#/components/schemas/secrets.SecretParameter'
           type: array
           uniqueItems: false
         server:
@@ -2928,7 +2469,7 @@ components:
           description: Name of the registry
           type: string
         registry:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive-core_registry_types.Registry'
+          $ref: '#/components/schemas/registry.Registry'
         server_count:
           description: Number of servers in the registry
           type: integer
@@ -3188,7 +2729,7 @@ components:
             non-OIDC OAuth)
           type: string
         bearer_token:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter'
+          $ref: '#/components/schemas/secrets.SecretParameter'
         callback_port:
           description: Specific port for OAuth callback server
           type: integer
@@ -3196,7 +2737,7 @@ components:
           description: OAuth client ID for authentication
           type: string
         client_secret:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter'
+          $ref: '#/components/schemas/secrets.SecretParameter'
         issuer:
           description: OAuth/OIDC issuer URL (e.g., https://accounts.google.com)
           type: string
@@ -3393,11 +2934,11 @@ components:
           description: Port for the HTTP proxy to listen on
           type: integer
         runtime_config:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_container_templates.RuntimeConfig'
+          $ref: '#/components/schemas/templates.RuntimeConfig'
         secrets:
           description: Secret parameters to inject
           items:
-            $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_secrets.SecretParameter'
+            $ref: '#/components/schemas/secrets.SecretParameter'
           type: array
           uniqueItems: false
         target_port:
@@ -3541,7 +3082,7 @@ components:
         workloads:
           description: List of container information for each workload
           items:
-            $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_core.Workload'
+            $ref: '#/components/schemas/core.Workload'
           type: array
           uniqueItems: false
       type: object
@@ -3549,7 +3090,20 @@ components:
       description: Response containing workload status information
       properties:
         status:
-          $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_container_runtime.WorkloadStatus'
+          description: Current status of the workload
+          enum:
+          - running
+          - stopped
+          - error
+          - starting
+          - stopping
+          - unhealthy
+          - removing
+          - unknown
+          - unauthenticated
+          - auth_retrying
+          - policy_stopped
+          type: string
       type: object
     registry.EnvVar:
       properties:
@@ -3849,6 +3403,37 @@ components:
         sigstore_url:
           type: string
       type: object
+    registry.Registry:
+      description: Full registry data
+      properties:
+        groups:
+          description: Groups is a slice of group definitions containing related MCP
+            servers
+          items:
+            $ref: '#/components/schemas/registry.Group'
+          type: array
+          uniqueItems: false
+        last_updated:
+          description: LastUpdated is the timestamp when the registry was last updated,
+            in RFC3339 format
+          type: string
+        remote_servers:
+          additionalProperties:
+            $ref: '#/components/schemas/registry.RemoteServerMetadata'
+          description: |-
+            RemoteServers is a map of server names to their corresponding remote server definitions
+            These are MCP servers accessed via HTTP/HTTPS using the thv proxy command
+          type: object
+        servers:
+          additionalProperties:
+            $ref: '#/components/schemas/registry.ImageMetadata'
+          description: Servers is a map of server names to their corresponding server
+            definitions
+          type: object
+        version:
+          description: Version is the schema version of the registry
+          type: string
+      type: object
     registry.RemoteServerMetadata:
       description: Remote server details (if it's a remote server)
       properties:
@@ -4068,6 +3653,394 @@ components:
       properties:
         predicate: {}
         predicate_type:
+          type: string
+      type: object
+    remote.Config:
+      description: RemoteAuthConfig contains OAuth configuration for remote MCP servers
+      properties:
+        authorize_url:
+          type: string
+        bearer_token:
+          description: Bearer token configuration (alternative to OAuth)
+          type: string
+        bearer_token_file:
+          type: string
+        cached_cimd_client_id:
+          description: |-
+            CachedCIMDClientID stores the CIMD metadata URL used as client_id when CIMD
+            authentication was used. Kept separate from CachedClientID (which holds
+            DCR-issued IDs) so the two can have independent lifecycles — DCR credential
+            rotation clears CachedClientID without touching the stable CIMD URL.
+            Read by resolveClientCredentials to send the correct client_id on token refresh.
+          type: string
+        cached_client_id:
+          description: |-
+            Cached DCR client credentials for persistence across restarts.
+            These are obtained during Dynamic Client Registration and needed to refresh tokens.
+            ClientID is stored as plain text since it's public information.
+          type: string
+        cached_client_secret_ref:
+          type: string
+        cached_dcr_callback_port:
+          description: |-
+            CachedDCRCallbackPort is the callback port that was actually registered
+            during DCR. It may differ from CallbackPort when the requested port was
+            unavailable and a fallback port was selected.
+          type: integer
+        cached_refresh_token_ref:
+          description: |-
+            Cached OAuth token reference for persistence across restarts.
+            The refresh token is stored securely in the secret manager, and this field
+            contains the reference to retrieve it (e.g., "OAUTH_REFRESH_TOKEN_workload").
+            This enables session restoration without requiring a new browser-based login.
+          type: string
+        cached_reg_client_uri:
+          description: |-
+            CachedRegClientURI is the registration_client_uri from the DCR response.
+            This is the endpoint used for RFC 7592 client read/update/delete operations.
+            Stored as plain text since it is not sensitive.
+          type: string
+        cached_reg_token_ref:
+          description: |-
+            CachedRegTokenRef is a secret manager reference to the registration_access_token
+            returned in the DCR response. Used for RFC 7592 client update operations.
+            Stored as a secret reference since it's sensitive.
+          type: string
+        cached_secret_expiry:
+          description: |-
+            ClientSecretExpiresAt indicates when the client secret expires (if provided by the DCR server).
+            A zero value means the secret does not expire.
+          type: string
+        cached_token_auth_method:
+          description: |-
+            CachedTokenEndpointAuthMethod is the auth method used for the token endpoint
+            (e.g., "client_secret_basic", "none"). Persisted for RFC 7592 updates.
+          type: string
+        cached_token_expiry:
+          type: string
+        callback_port:
+          type: integer
+        client_id:
+          type: string
+        client_secret:
+          type: string
+        client_secret_file:
+          type: string
+        issuer:
+          description: OAuth endpoint configuration (from registry)
+          type: string
+        oauth_params:
+          additionalProperties:
+            type: string
+          description: OAuth parameters for server-specific customization
+          type: object
+        resource:
+          description: Resource is the OAuth 2.0 resource indicator (RFC 8707).
+          type: string
+        scope_param_name:
+          description: |-
+            ScopeParamName overrides the query parameter name used to send scopes in the
+            authorization URL. When empty, the standard "scope" parameter is used.
+            Some providers require a non-standard name (e.g., Slack uses "user_scope").
+          type: string
+        scopes:
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        skip_browser:
+          type: boolean
+        timeout:
+          example: 5m
+          type: string
+        token_url:
+          type: string
+        use_pkce:
+          type: boolean
+      type: object
+    secrets.SecretParameter:
+      description: Bearer token for authentication (alternative to OAuth)
+      properties:
+        name:
+          type: string
+        target:
+          type: string
+      type: object
+    storage.ACLUserRunConfig:
+      description: ACLUserConfig contains ACL user authentication configuration.
+      properties:
+        password_env_var:
+          description: PasswordEnvVar is the environment variable containing the Redis
+            password.
+          type: string
+        username_env_var:
+          description: UsernameEnvVar is the environment variable containing the Redis
+            username.
+          type: string
+      type: object
+    storage.RedisRunConfig:
+      description: RedisConfig is the Redis-specific configuration when Type is "redis".
+      properties:
+        acl_user_config:
+          $ref: '#/components/schemas/storage.ACLUserRunConfig'
+        addr:
+          description: |-
+            Addr is the Redis server address (host:port). Required for standalone and cluster modes.
+            Mutually exclusive with SentinelConfig.
+          type: string
+        auth_type:
+          description: AuthType must be "aclUser" - only ACL user authentication is
+            supported.
+          type: string
+        cluster_mode:
+          description: ClusterMode enables the Redis Cluster protocol. Requires Addr
+            to be set.
+          type: boolean
+        dial_timeout:
+          description: DialTimeout is the timeout for establishing connections (e.g.,
+            "5s").
+          type: string
+        key_prefix:
+          description: KeyPrefix for multi-tenancy, typically "thv:auth:{ns}:{name}:".
+          type: string
+        read_timeout:
+          description: ReadTimeout is the timeout for read operations (e.g., "3s").
+          type: string
+        sentinel_config:
+          $ref: '#/components/schemas/storage.SentinelRunConfig'
+        sentinel_tls:
+          $ref: '#/components/schemas/storage.RedisTLSRunConfig'
+        tls:
+          $ref: '#/components/schemas/storage.RedisTLSRunConfig'
+        write_timeout:
+          description: WriteTimeout is the timeout for write operations (e.g., "3s").
+          type: string
+      type: object
+    storage.RedisTLSRunConfig:
+      description: SentinelTLS configures TLS for Sentinel connections. Only applies
+        when SentinelConfig is set.
+      properties:
+        ca_cert_file:
+          description: CACertFile is the path to a PEM-encoded CA certificate file.
+          type: string
+        insecure_skip_verify:
+          description: InsecureSkipVerify skips certificate verification.
+          type: boolean
+      type: object
+    storage.RunConfig:
+      description: |-
+        Storage configures the storage backend for the auth server.
+        If nil, defaults to in-memory storage.
+      properties:
+        redis_config:
+          $ref: '#/components/schemas/storage.RedisRunConfig'
+        type:
+          description: Type specifies the storage backend type. Defaults to "memory".
+          type: string
+      type: object
+    storage.SentinelRunConfig:
+      description: |-
+        SentinelConfig contains Sentinel-specific configuration.
+        Mutually exclusive with Addr.
+      properties:
+        db:
+          description: 'DB is the Redis database number (default: 0).'
+          type: integer
+        master_name:
+          description: MasterName is the name of the Redis Sentinel master.
+          type: string
+        sentinel_addrs:
+          description: SentinelAddrs is the list of Sentinel addresses (host:port).
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+      type: object
+    telemetry.Config:
+      description: |-
+        DEPRECATED: Middleware configuration.
+        TelemetryConfig contains the OpenTelemetry configuration
+      properties:
+        caCertPath:
+          description: |-
+            CACertPath is the file path to a CA certificate bundle for the OTLP endpoint.
+            When set, the OTLP exporters use this CA to verify the collector's TLS certificate
+            instead of relying solely on the system CA pool.
+            +optional
+          type: string
+        customAttributes:
+          additionalProperties:
+            type: string
+          description: |-
+            CustomAttributes contains custom resource attributes to be added to all telemetry signals.
+            These are parsed from CLI flags (--otel-custom-attributes) or environment variables
+            (OTEL_RESOURCE_ATTRIBUTES) as key=value pairs.
+            +optional
+          type: object
+        enablePrometheusMetricsPath:
+          description: |-
+            EnablePrometheusMetricsPath controls whether to expose Prometheus-style /metrics endpoint.
+            The metrics are served on the main transport port at /metrics.
+            This is separate from OTLP metrics which are sent to the Endpoint.
+            +kubebuilder:default=false
+            +optional
+          type: boolean
+        endpoint:
+          description: |-
+            Endpoint is the OTLP endpoint URL
+            +optional
+          type: string
+        environmentVariables:
+          description: |-
+            EnvironmentVariables is a list of environment variable names that should be
+            included in telemetry spans as attributes. Only variables in this list will
+            be read from the host machine and included in spans for observability.
+            Example: ["NODE_ENV", "DEPLOYMENT_ENV", "SERVICE_VERSION"]
+            +optional
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        headers:
+          additionalProperties:
+            type: string
+          description: |-
+            Headers contains authentication headers for the OTLP endpoint.
+            +optional
+          type: object
+        insecure:
+          description: |-
+            Insecure indicates whether to use HTTP instead of HTTPS for the OTLP endpoint.
+            +kubebuilder:default=false
+            +optional
+          type: boolean
+        metricsEnabled:
+          description: |-
+            MetricsEnabled controls whether OTLP metrics are enabled.
+            When false, OTLP metrics are not sent even if an endpoint is configured.
+            This is independent of EnablePrometheusMetricsPath.
+            +kubebuilder:default=false
+            +optional
+          type: boolean
+        samplingRate:
+          description: |-
+            SamplingRate is the trace sampling rate (0.0-1.0) as a string.
+            Only used when TracingEnabled is true.
+            Example: "0.05" for 5% sampling.
+            +kubebuilder:default="0.05"
+            +optional
+          type: string
+        serviceName:
+          description: |-
+            ServiceName is the service name for telemetry.
+            When omitted, defaults to the server name (e.g., VirtualMCPServer name).
+            +optional
+          type: string
+        serviceVersion:
+          description: |-
+            ServiceVersion is the service version for telemetry.
+            When omitted, defaults to the ToolHive version.
+            +optional
+          type: string
+        tracingEnabled:
+          description: |-
+            TracingEnabled controls whether distributed tracing is enabled.
+            When false, no tracer provider is created even if an endpoint is configured.
+            +kubebuilder:default=false
+            +optional
+          type: boolean
+        useLegacyAttributes:
+          description: |-
+            UseLegacyAttributes controls whether legacy (pre-MCP OTEL semconv) attribute names
+            are emitted alongside the new standard attribute names. When true, spans include both
+            old and new attribute names for backward compatibility with existing dashboards.
+            Currently defaults to true; this will change to false in a future release.
+            +kubebuilder:default=true
+            +optional
+          type: boolean
+      type: object
+    templates.RuntimeConfig:
+      description: |-
+        RuntimeConfig allows overriding the default runtime configuration
+        for this specific workload (base images and packages)
+      properties:
+        additional_packages:
+          description: |-
+            AdditionalPackages lists extra packages to install in the builder and
+            runtime stages.
+            Examples for Alpine: ["git", "make", "gcc"]
+            Examples for Debian: ["git", "build-essential"]
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        builder_image:
+          description: |-
+            BuilderImage is the full image reference for the builder stage.
+            An empty string signals "use the default for this transport type" during config merging.
+            Examples: "golang:1.26-alpine", "node:24-alpine", "python:3.14-slim"
+          type: string
+        runtime_env:
+          additionalProperties:
+            type: string
+          description: |-
+            RuntimeEnv contains environment variables to inject into the Dockerfile's
+            final runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),
+            which only affects the builder stage, these variables are baked into the
+            shipped image and are present in the running container's process
+            environment at startup. Use this for values a packaged MCP server reads at
+            process start (e.g. feature flags, cache backend selection), not for
+            build-time package manager configuration.
+            Keys must be uppercase with underscores, values are validated for safety.
+          type: object
+      type: object
+    tokenexchange.Config:
+      description: TokenExchangeConfig contains token exchange configuration for external
+        authentication
+      properties:
+        audience:
+          description: Audience is the target audience for the exchanged token
+          type: string
+        client_id:
+          description: ClientID is the OAuth 2.0 client identifier
+          type: string
+        client_secret:
+          description: ClientSecret is the OAuth 2.0 client secret
+          type: string
+        external_token_header_name:
+          description: ExternalTokenHeaderName is the name of the custom header to
+            use when HeaderStrategy is "custom"
+          type: string
+        header_strategy:
+          description: |-
+            HeaderStrategy determines how to inject the token
+            Valid values: HeaderStrategyReplace (default), HeaderStrategyCustom
+          type: string
+        scopes:
+          description: Scopes is the list of scopes to request for the exchanged token
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        subject_token_type:
+          description: |-
+            SubjectTokenType specifies the type of the subject token being exchanged.
+            Common values: oauthproto.TokenTypeAccessToken (default), oauthproto.TokenTypeIDToken, oauthproto.TokenTypeJWT.
+            If empty, defaults to oauthproto.TokenTypeAccessToken.
+          type: string
+        token_url:
+          description: TokenURL is the OAuth 2.0 token endpoint URL
+          type: string
+      type: object
+    types.MiddlewareConfig:
+      properties:
+        parameters:
+          description: |-
+            Parameters is a JSON object containing the middleware parameters.
+            It is stored as a raw message to allow flexible parameter types.
+          type: object
+        type:
+          description: Type is a string representing the middleware type.
           type: string
       type: object
     v0.ServerJSON:

--- a/pkg/vmcp/aggregator/aggregator.go
+++ b/pkg/vmcp/aggregator/aggregator.go
@@ -211,6 +211,25 @@ type ToolOverride interface {
 	ApplyOverrides(ctx context.Context, tools []vmcp.Tool) ([]vmcp.Tool, error)
 }
 
+// CacheInvalidator is optionally implemented by an Aggregator that memoizes
+// AggregateCapabilities results (see cachingAggregator). It lets a caller force
+// a re-sweep of all cached entries after learning, out of band, that backend
+// capabilities changed — e.g. a persistent backend connection observing
+// notifications/tools/list_changed (#5748) — rather than waiting out the TTL.
+//
+// InvalidateAll purges the ENTIRE cache (every identity's entry), not just the
+// backend that changed: the cache has no per-backend index, and coarse
+// invalidation briefly de-optimizes other identities' cached views rather than
+// leaving any identity looking at stale capabilities. Callers that type-assert
+// an Aggregator to this interface must handle the case where it is not
+// implemented (a non-caching or differently-implemented Aggregator) — see
+// core.coreVMCP.InvalidateCapabilityCache for the WARN-log fallback.
+type CacheInvalidator interface {
+	// InvalidateAll purges every cached AggregateCapabilities entry so the next
+	// call for any identity re-sweeps the backends.
+	InvalidateAll()
+}
+
 // Common aggregation errors.
 var (
 	// ErrNoBackendsFound indicates no backends were discovered.

--- a/pkg/vmcp/aggregator/caching_aggregator.go
+++ b/pkg/vmcp/aggregator/caching_aggregator.go
@@ -101,6 +101,17 @@ func (c *cachingAggregator) AggregateCapabilities(
 	return caps, nil
 }
 
+// Compile-time assertion: cachingAggregator implements CacheInvalidator.
+var _ CacheInvalidator = (*cachingAggregator)(nil)
+
+// InvalidateAll implements CacheInvalidator by purging every cached entry, so the
+// next AggregateCapabilities call for any identity re-sweeps the backends rather
+// than serving a cached view until its TTL expires. See CacheInvalidator's doc
+// for why this is coarse (whole-cache) rather than per-backend.
+func (c *cachingAggregator) InvalidateAll() {
+	c.cache.Purge()
+}
+
 // cacheKey derives a collision-resistant key from the inputs that drive backend enumeration:
 // the caller's subject, the forwarded headers (passthrough credentials/scopes), and the
 // backend ID set. Hashing keeps raw credential values out of the cache keys.

--- a/pkg/vmcp/aggregator/caching_aggregator_test.go
+++ b/pkg/vmcp/aggregator/caching_aggregator_test.go
@@ -104,6 +104,34 @@ func TestCachingAggregator_DisabledWhenTTLNonPositive(t *testing.T) {
 	assert.Nil(t, aggregator.NewCachingAggregator(nilAgg, time.Hour))
 }
 
+// TestCachingAggregator_InvalidateAll verifies the CacheInvalidator seam
+// (#5748): the returned Aggregator satisfies aggregator.CacheInvalidator, and
+// calling InvalidateAll purges the entire cache so a subsequent call for the
+// SAME identity re-sweeps rather than serving the (still TTL-fresh) cached
+// view.
+func TestCachingAggregator_InvalidateAll(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockAggregator(ctrl)
+	mock.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).
+		Return(&aggregator.AggregatedCapabilities{}, nil).Times(2)
+
+	c := aggregator.NewCachingAggregator(mock, time.Hour)
+	invalidator, ok := c.(aggregator.CacheInvalidator)
+	require.True(t, ok, "cachingAggregator must implement CacheInvalidator")
+
+	ctx := ctxWithSubject("alice")
+	_, err := c.AggregateCapabilities(ctx, testBackends)
+	require.NoError(t, err)
+
+	invalidator.InvalidateAll()
+
+	// Well within the TTL, so a hit would prove the purge did not happen; the
+	// mock's Times(2) expectation is the actual re-sweep assertion.
+	_, err = c.AggregateCapabilities(ctx, testBackends)
+	require.NoError(t, err, "the second call after InvalidateAll must re-sweep, not hit a stale entry")
+}
+
 // TestCachingAggregator_ErrorNotCached: a failed sweep is not cached, so the next call retries
 // the wrapped aggregator.
 func TestCachingAggregator_ErrorNotCached(t *testing.T) {

--- a/pkg/vmcp/aggregator/mocks/mock_interfaces.go
+++ b/pkg/vmcp/aggregator/mocks/mock_interfaces.go
@@ -272,3 +272,39 @@ func (mr *MockToolOverrideMockRecorder) ApplyOverrides(ctx, tools any) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyOverrides", reflect.TypeOf((*MockToolOverride)(nil).ApplyOverrides), ctx, tools)
 }
+
+// MockCacheInvalidator is a mock of CacheInvalidator interface.
+type MockCacheInvalidator struct {
+	ctrl     *gomock.Controller
+	recorder *MockCacheInvalidatorMockRecorder
+	isgomock struct{}
+}
+
+// MockCacheInvalidatorMockRecorder is the mock recorder for MockCacheInvalidator.
+type MockCacheInvalidatorMockRecorder struct {
+	mock *MockCacheInvalidator
+}
+
+// NewMockCacheInvalidator creates a new mock instance.
+func NewMockCacheInvalidator(ctrl *gomock.Controller) *MockCacheInvalidator {
+	mock := &MockCacheInvalidator{ctrl: ctrl}
+	mock.recorder = &MockCacheInvalidatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCacheInvalidator) EXPECT() *MockCacheInvalidatorMockRecorder {
+	return m.recorder
+}
+
+// InvalidateAll mocks base method.
+func (m *MockCacheInvalidator) InvalidateAll() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InvalidateAll")
+}
+
+// InvalidateAll indicates an expected call of InvalidateAll.
+func (mr *MockCacheInvalidatorMockRecorder) InvalidateAll() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateAll", reflect.TypeOf((*MockCacheInvalidator)(nil).InvalidateAll))
+}

--- a/pkg/vmcp/core/core.go
+++ b/pkg/vmcp/core/core.go
@@ -203,6 +203,15 @@ type VMCP interface {
 	// backend health (e.g. the /health route and periodic status reporting).
 	BackendHealth() health.Reporter
 
+	// InvalidateCapabilityCache forces the next List/Lookup/Call on every identity
+	// to re-sweep backend capabilities rather than serve a cached view. Serve's
+	// Server calls it after a backend reports notifications/tools/list_changed
+	// (#5748), before re-deriving the session's advertised tool set — otherwise
+	// the resync would immediately re-read the now-stale cached aggregation. It
+	// is a no-op (WARN-logged, not silent) when the configured Aggregator does
+	// not memoize results — see aggregator.CacheInvalidator.
+	InvalidateCapabilityCache()
+
 	// Close releases core-held resources (backend connections, the health monitor, etc.).
 	// Implementations must be idempotent: calling Close multiple times returns nil.
 	Close() error

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -482,6 +482,22 @@ func (c *coreVMCP) LookupBackend(
 	return nil, fmt.Errorf("%w: backend %q", vmcp.ErrNotFound, backendID)
 }
 
+// InvalidateCapabilityCache implements VMCP.InvalidateCapabilityCache. It
+// type-asserts the configured aggregator to aggregator.CacheInvalidator and
+// delegates; when the aggregator does not implement it, the call is a WARN-logged
+// no-op — not a silent one — because a caller relying on invalidation (the
+// list_changed resync path) needs to know the request had no effect (go-style:
+// no silent no-ops).
+func (c *coreVMCP) InvalidateCapabilityCache() {
+	invalidator, ok := c.aggregator.(aggregator.CacheInvalidator)
+	if !ok {
+		slog.Warn("capability cache invalidation requested but the configured aggregator does not support it",
+			"aggregatorType", fmt.Sprintf("%T", c.aggregator))
+		return
+	}
+	invalidator.InvalidateAll()
+}
+
 // Close stops the workflow state store's cleanup goroutine. It is idempotent:
 // the underlying Stop closes a channel that cannot be closed twice, so the work
 // is guarded by sync.Once and subsequent calls return nil.

--- a/pkg/vmcp/core/core_vmcp_test.go
+++ b/pkg/vmcp/core/core_vmcp_test.go
@@ -557,6 +557,59 @@ func TestClose_Idempotent(t *testing.T) {
 	})
 }
 
+// invalidatorAggregator is a minimal aggregator.Aggregator that also
+// implements aggregator.CacheInvalidator, so TestInvalidateCapabilityCache_*
+// can assert coreVMCP.InvalidateCapabilityCache's delegation without depending
+// on the real cachingAggregator (covered separately in the aggregator package).
+type invalidatorAggregator struct {
+	aggregator.Aggregator
+	invalidateCalls int
+}
+
+func (a *invalidatorAggregator) InvalidateAll() { a.invalidateCalls++ }
+
+var _ aggregator.CacheInvalidator = (*invalidatorAggregator)(nil)
+
+// TestInvalidateCapabilityCache_DelegatesWhenSupported verifies (#5748) that
+// InvalidateCapabilityCache type-asserts the configured aggregator to
+// aggregator.CacheInvalidator and calls InvalidateAll when it is implemented.
+func TestInvalidateCapabilityCache_DelegatesWhenSupported(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+	inv := &invalidatorAggregator{Aggregator: m.agg}
+	cfg.Aggregator = inv
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	c.InvalidateCapabilityCache()
+	assert.Equal(t, 1, inv.invalidateCalls)
+}
+
+// TestInvalidateCapabilityCache_WarnsWhenUnsupported verifies (#5748) that
+// InvalidateCapabilityCache is a WARN-logged no-op — not a silent one — when
+// the configured aggregator does not implement aggregator.CacheInvalidator
+// (baseConfig's plain MockAggregator does not).
+//
+//nolint:paralleltest // installs a global slog default + non-thread-safe buffer; must not run in parallel
+func TestInvalidateCapabilityCache_WarnsWhenUnsupported(t *testing.T) {
+	cfg, _ := baseConfig(t)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	assert.NotPanics(t, func() { c.InvalidateCapabilityCache() })
+	assert.Contains(t, buf.String(), "does not support it",
+		"unsupported aggregator must WARN-log, not silently no-op")
+}
+
 // Must run serially: it swaps the global slog default to capture output into a
 // non-thread-safe buffer, which is unsafe if other tests log concurrently.
 //

--- a/pkg/vmcp/forwarding.go
+++ b/pkg/vmcp/forwarding.go
@@ -19,6 +19,12 @@ const (
 
 	// MethodLogNotification is the notifications/message (logging) wire method.
 	MethodLogNotification = "notifications/message"
+
+	// MethodToolsListChangedNotification is the notifications/tools/list_changed
+	// wire method. Used by the persistent session-backed backend connection
+	// (pkg/vmcp/session/internal/backend) to recognize a backend's asynchronous
+	// tool-set change and trigger cache invalidation + session resync (#5748).
+	MethodToolsListChangedNotification = "notifications/tools/list_changed"
 )
 
 // SamplingRequester sends an MCP sampling (sampling/createMessage) request to the

--- a/pkg/vmcp/server/capability_regression_test.go
+++ b/pkg/vmcp/server/capability_regression_test.go
@@ -63,3 +63,59 @@ func TestRegression_InitializeAdvertisesToolsAndResourcesCapabilities(t *testing
 	assert.Contains(t, capabilities, "resources",
 		"resources capability must be advertised in initialize on the Serve path; got %v", capabilities)
 }
+
+// TestRegression_InitializeAdvertisesToolsListChanged pins #5748's capability
+// flip: tools.listChanged must now be true in the initialize response (it was
+// false — and therefore omitted, per the SDK's omitempty — before #5748).
+func TestRegression_InitializeAdvertisesToolsListChanged(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "cap-tool"}}}
+	_, _, baseURL := registerServeSession(t, fc)
+
+	initResp := postServeMCP(t, baseURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, 200, initResp.StatusCode, "initialize should succeed")
+
+	env, _ := readServeJSONRPC(t, initResp)
+	result, ok := env["result"].(map[string]any)
+	require.True(t, ok, "initialize response must have a result object; env: %v", env)
+	capabilities, ok := result["capabilities"].(map[string]any)
+	require.True(t, ok, "result.capabilities must be present; result: %v", result)
+
+	toolsCaps, ok := capabilities["tools"].(map[string]any)
+	require.True(t, ok, "tools capability must be an object; capabilities: %v", capabilities)
+	assert.Equal(t, true, toolsCaps["listChanged"],
+		"tools.listChanged must be true so downstream clients trust the resync notification (#5748)")
+}
+
+// TestRegression_SessionRegistrationDoesNotSpuriouslyInvalidateCache verifies
+// the #5748 R1 concern at the layer this PR controls: registering a session —
+// with no backend list_changed notification ever firing — must NOT invoke
+// InvalidateCapabilityCache or the resync path. Those only run from the sink
+// built in buildListChangedSink, which is invoked solely by a persistent
+// backend connection's OnNotification handler (mcp_session.go), never by
+// session registration itself.
+//
+// (go-sdk's OWN early/broadcast-scoped auto-notify behavior at registration —
+// documented in serve.go next to WithToolCapabilities(true) — is an upstream
+// SDK characteristic this PR cannot suppress; it is unrelated to whether OUR
+// code spuriously self-triggers, which is what this test pins.)
+func TestRegression_SessionRegistrationDoesNotSpuriouslyInvalidateCache(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "cap-tool"}}}
+	registerServeSession(t, fc)
+
+	assert.Equal(t, int32(0), fc.invalidateCacheCalls.Load(),
+		"session registration alone must never invalidate the capability cache")
+}

--- a/pkg/vmcp/server/context_isolation_regression_test.go
+++ b/pkg/vmcp/server/context_isolation_regression_test.go
@@ -56,7 +56,7 @@ func newPerToolSessionFactory(
 	t.Helper()
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 			mock := sessionmocks.NewMockMultiSession(ctrl)
 			mock.EXPECT().ID().Return(id).AnyTimes()
 			mock.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()

--- a/pkg/vmcp/server/context_isolation_regression_test.go
+++ b/pkg/vmcp/server/context_isolation_regression_test.go
@@ -55,8 +55,8 @@ func newPerToolSessionFactory(
 ) *sessionfactorymocks.MockMultiSessionFactory {
 	t.Helper()
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 			mock := sessionmocks.NewMockMultiSession(ctrl)
 			mock.EXPECT().ID().Return(id).AnyTimes()
 			mock.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()

--- a/pkg/vmcp/server/integration_test.go
+++ b/pkg/vmcp/server/integration_test.go
@@ -464,7 +464,7 @@ func TestIntegration_AuditLogging(t *testing.T) {
 	auditSessionFactory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	auditSessionFactory.EXPECT().
 		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 			mock := sessionmocks.NewMockMultiSession(ctrl)
 			mock.EXPECT().ID().Return(id).AnyTimes()
 			mock.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()

--- a/pkg/vmcp/server/integration_test.go
+++ b/pkg/vmcp/server/integration_test.go
@@ -463,8 +463,8 @@ func TestIntegration_AuditLogging(t *testing.T) {
 	// table needed for tool calls and resource reads to be audit-logged correctly.
 	auditSessionFactory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	auditSessionFactory.EXPECT().
-		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 			mock := sessionmocks.NewMockMultiSession(ctrl)
 			mock.EXPECT().ID().Return(id).AnyTimes()
 			mock.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -240,10 +240,38 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 	// registered dynamically, so capabilities start disabled — except resources,
 	// which advertise subscribe support so spec-compliant clients issue
 	// resources/subscribe (the handlers above answer it at ack level).
+	//
+	// tools.listChanged is now advertised (#5748): a persistent backend
+	// connection's notifications/tools/list_changed drives a session resync
+	// (serve_list_changed.go) that replaces the SDK session's tool store via
+	// SetSessionTools, and go-sdk auto-emits notifications/tools/list_changed to
+	// the downstream client whenever this capability is on.
+	//
+	// R1 (verified against toolhive-core v0.0.32 / go-sdk v1.6.1): go-sdk's own
+	// AddTool/RemoveTools call a shared changeAndNotify that debounces (10ms)
+	// and then broadcasts the notification to EVERY session currently connected
+	// to this *gosdk.Server (mcpcompat/server/server.go's srv is one instance
+	// shared across all sessions) — not just the session whose tool overlay
+	// changed. go-sdk's own bind() adds a session to that broadcast list as soon
+	// as the transport connects (Connect), before initialize/notifications
+	// initialized even round-trip; go-sdk's shared.go itself documents this as a
+	// known upstream gap ("potential spec violation... when the feature list
+	// changes before the session ... is initialized"). Concretely: every
+	// session's registration-time per-session AddTool calls (setSessionToolsDirect)
+	// now cause a list_changed broadcast to every OTHER already-connected
+	// session too, not only the one just registered — this is inherent go-sdk
+	// behavior, not something introduced by the #5748 resync sink, and there is
+	// no supported hook to scope or suppress it short of patching the vendored
+	// SDK (out of scope here). It is accepted as a benign nuisance: MCP clients
+	// treat list_changed as "you may want to refetch," so an extra notification
+	// only costs an idempotent tools/list round-trip — it never changes what a
+	// given session's tools/list actually returns (each session's advertised
+	// set still comes solely from its own overlay). See
+	// docs/arch/10-virtual-mcp-architecture.md for the propagation writeup.
 	mcpServer := server.NewMCPServer(
 		serveCfg.Name,
 		serveCfg.Version,
-		server.WithToolCapabilities(false),
+		server.WithToolCapabilities(true),
 		server.WithResourceCapabilities(true, false),
 		server.WithLogging(),
 		server.WithHooks(hooks),

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -325,6 +325,18 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 		statusReporter:   cfg.StatusReporter,
 	}
 
+	// Server-lifetime parent context for asynchronous tools/list_changed resync
+	// work (#5748). Cancelling it on Stop aborts any in-flight backend
+	// re-aggregation a late notification kicked off, so nothing outlives the
+	// server. context.Background() is the parent (not the Serve ctx, which may be
+	// request-scoped) so the resync lifetime is bounded solely by Stop.
+	resyncCtx, resyncCancel := context.WithCancel(context.Background())
+	srv.resyncBaseCtx = resyncCtx
+	srv.shutdownFuncs = append(srv.shutdownFuncs, func(context.Context) error {
+		resyncCancel()
+		return nil
+	})
+
 	if optimizerCleanup != nil {
 		srv.shutdownFuncs = append(srv.shutdownFuncs, optimizerCleanup)
 	}

--- a/pkg/vmcp/server/serve_list_changed.go
+++ b/pkg/vmcp/server/serve_list_changed.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/stacklok/toolhive-core/mcpcompat/server"
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp/headerforward"
 	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
 )
 
@@ -24,47 +26,161 @@ import (
 // connector (pkg/vmcp/session/internal/backend) does not even dispatch those
 // notification methods to this sink yet.
 
-// buildListChangedSink returns the sink passed to
-// SessionManager.CreateSession for a newly-registered session. It closes over
-// the SDK ClientSession and the caller's identity captured AT REGISTRATION
-// TIME (issue #5748, decision B1/Option 2): a later asynchronous firing reuses
-// this snapshot identity to re-derive the advertised tool set, rather than
-// resolving a fresh one.
+// listChangedResyncWorker coalesces a session's tools/list_changed resyncs.
 //
-// Token-staleness risk: if the identity's upstream tokens are refreshed after
-// registration (see #5323), this resync's core.ListTools call authorizes and
-// aggregates using the (potentially stale) captured tokens, not the live
-// per-request ones. This only affects the ACCURACY of this asynchronous
-// resync's own admission view — every live call still authenticates via the
-// fresh per-request identity through enforceSessionBinding, so a stale token
-// here cannot grant a call that would otherwise be denied.
+// The sink runs on the backend's receive-loop goroutine and must not block
+// (vmcpsession.ListChangedSink contract), so trigger() only flips a dirty flag
+// and, at most, starts ONE worker goroutine — it never does the resync inline
+// and never spawns a goroutine per notification. At most one resync is ever in
+// flight per session; notifications that arrive while one runs collapse into a
+// single follow-up run. This bounds a misbehaving backend to O(1) concurrent
+// resync work per session regardless of how fast it emits notifications.
+type listChangedResyncWorker struct {
+	// run performs exactly one resync using the given (server-lifetime) context.
+	// It is self-contained: liveness check, context reconstruction, and the
+	// re-derive-and-replace of the session's tools.
+	run func(ctx context.Context)
+	// baseCtx bounds every run to the server lifetime (cancelled on Stop) so a
+	// late notification cannot start work that outlives the server.
+	baseCtx context.Context
+
+	mu      sync.Mutex
+	running bool
+	dirty   bool
+}
+
+// trigger requests a resync. It is non-blocking and safe to call from the
+// backend receive-loop goroutine: if a resync is already running it just marks
+// the state dirty (coalescing), otherwise it starts the single worker goroutine.
+func (w *listChangedResyncWorker) trigger() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.running {
+		w.dirty = true
+		return
+	}
+	w.running = true
+	go w.loop()
+}
+
+// loop runs resyncs until no further notification arrived during the last run.
+// It is the single worker goroutine started by trigger; it exits when idle so
+// an idle session holds no goroutine.
+func (w *listChangedResyncWorker) loop() {
+	for {
+		w.run(w.baseCtx)
+
+		w.mu.Lock()
+		if !w.dirty {
+			w.running = false
+			w.mu.Unlock()
+			return
+		}
+		w.dirty = false
+		w.mu.Unlock()
+	}
+}
+
+// buildListChangedSink returns the sink passed to
+// SessionManager.CreateSession for a newly-registered session. The returned
+// sink runs on the backend receive-loop goroutine and only hands work off to a
+// per-session coalescing worker (see listChangedResyncWorker) — it never does
+// the cache purge or backend re-aggregation inline.
+//
+// It closes over the SDK ClientSession, the session ID, and the caller's
+// identity AND per-request forwarded headers captured AT REGISTRATION TIME
+// (issue #5748, decision B1/Option 2). The async resync reconstructs a context
+// carrying that identity + those headers before calling into the core, because
+// the capability cache key and the outbound backend authentication are derived
+// from the CONTEXT (auth.IdentityFromContext / headerforward.ForwardedHeaders-
+// FromContext — see pkg/vmcp/aggregator/caching_aggregator.go and
+// pkg/vmcp/client), NOT from an explicit identity argument. Without this the
+// resync would enumerate backends unauthenticated and could advertise metadata
+// the principal's own credentials would not surface (or wrongly drop
+// credential-gated tools), while replacing the correctly-scoped registration
+// set.
+//
+// Token-staleness risk: the captured identity is a snapshot. If its upstream
+// tokens are refreshed after registration (see #5323), this resync's
+// core.ListTools call authorizes/aggregates using the (possibly stale)
+// captured tokens, not the live per-request ones. This only affects the
+// accuracy of the asynchronous resync's own view — every live call still
+// authenticates via the fresh per-request identity through
+// enforceSessionBinding, so staleness here cannot grant a call that would
+// otherwise be denied.
 func (s *Server) buildListChangedSink(
-	sessionID string, session server.ClientSession, identity *auth.Identity,
+	sessionID string, session server.ClientSession, identity *auth.Identity, forwardedHeaders map[string]string,
 ) vmcpsession.ListChangedSink {
-	return func(ctx context.Context, backendWorkloadID, kind string) {
-		if kind != "tools" {
+	worker := &listChangedResyncWorker{
+		baseCtx: s.resyncBaseCtx,
+		run: func(ctx context.Context) {
+			s.runListChangedResync(ctx, sessionID, session, identity, forwardedHeaders)
+		},
+	}
+	return func(_ context.Context, backendWorkloadID string, kind vmcpsession.ChangeKind) {
+		if kind != vmcpsession.KindTools {
 			// Resources/prompts list_changed: out of scope (see file doc).
 			return
 		}
-		// Invalidate the cache FIRST so resyncSessionTools' core.ListTools call
-		// below re-sweeps the backend instead of immediately re-reading the
-		// stale cached aggregation InvalidateCapabilityCache just purged.
-		s.core.InvalidateCapabilityCache()
-		if err := s.resyncSessionTools(ctx, session, sessionID, identity); err != nil {
-			slog.Warn("failed to resync session tools after backend list_changed",
-				"session_id", sessionID, "backend_id", backendWorkloadID, "error", err)
-		}
+		slog.Debug("backend reported tools/list_changed; scheduling session resync",
+			"session_id", sessionID, "backend_id", backendWorkloadID)
+		worker.trigger()
+	}
+}
+
+// runListChangedResync performs one coalesced resync for a session. It runs on
+// the worker goroutine (off the receive loop). Order matters:
+//  1. Liveness guard — skip (and do no work) if the session was terminated, so
+//     a storm of notifications for a dead session cannot drive re-aggregation.
+//  2. Reconstruct the registration-time request context (identity + forwarded
+//     headers) atop the server-lifetime base context, so the cache key and
+//     backend auth match a real request from this principal.
+//  3. Invalidate the capability cache so the re-derivation below re-sweeps the
+//     backend rather than reading the entry it just purged.
+//  4. Re-derive and REPLACE the session's advertised tool set.
+func (s *Server) runListChangedResync(
+	baseCtx context.Context,
+	sessionID string,
+	session server.ClientSession,
+	identity *auth.Identity,
+	forwardedHeaders map[string]string,
+) {
+	// Liveness guard: if the session is gone (terminated/expired) there is
+	// nothing to resync, and doing the work would waste a full backend sweep.
+	if _, ok := s.vmcpSessionMgr.GetMultiSession(baseCtx, sessionID); !ok {
+		slog.Debug("skipping tools/list_changed resync for terminated session", "session_id", sessionID)
+		return
+	}
+
+	ctx := auth.WithIdentity(baseCtx, identity)
+	if len(forwardedHeaders) > 0 {
+		ctx = headerforward.WithForwardedHeaders(ctx, forwardedHeaders)
+	}
+
+	// Invalidate FIRST so resyncSessionTools' core.ListTools re-sweeps the
+	// backend instead of re-reading the stale cached aggregation. The purge is
+	// global (all identities) — see InvalidateCapabilityCache — but coalescing
+	// bounds it to at most once per resync burst.
+	s.core.InvalidateCapabilityCache()
+
+	if err := s.resyncSessionTools(ctx, session, sessionID, identity); err != nil {
+		slog.Warn("failed to resync session tools after backend list_changed",
+			"session_id", sessionID, "error", err)
 	}
 }
 
 // resyncSessionTools re-derives sessionID's advertised tool set (via
 // serveSessionTools — the core, cache now cold, plus optimizer meta-tools when
 // enabled) and REPLACES the SDK session's tool store with it, so a tool the
-// backend removed disappears from the advertised set rather than lingering
-// (unlike setSessionToolsDirect's registration-time MERGE, which only adds).
-// The go-sdk server auto-emits notifications/tools/list_changed to the
-// downstream client after SetSessionTools, since serve.go enables
-// WithToolCapabilities(true).
+// backend removed (and the core therefore no longer advertises) disappears
+// rather than lingering (unlike setSessionToolsDirect's registration-time
+// MERGE, which only adds). The go-sdk server then auto-emits
+// notifications/tools/list_changed to the downstream client, since serve.go
+// enables WithToolCapabilities(true).
+//
+// ctx must already carry the resyncing principal's identity and forwarded
+// headers (runListChangedResync builds it) so serveSessionTools ->
+// core.ListTools enumerates backends with the correct credentials and cache key.
 func (s *Server) resyncSessionTools(
 	ctx context.Context, session server.ClientSession, sessionID string, identity *auth.Identity,
 ) error {

--- a/pkg/vmcp/server/serve_list_changed.go
+++ b/pkg/vmcp/server/serve_list_changed.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/server"
+	"github.com/stacklok/toolhive/pkg/auth"
+	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
+)
+
+// This file holds the tools list_changed propagation added by #5748: a
+// persistent backend connection observing notifications/tools/list_changed
+// invalidates the shared capability cache and resyncs the affected session's
+// advertised tool set, so a client that already initialized eventually sees
+// the backend's change reflected in tools/list without reconnecting.
+//
+// Scope: TOOLS only. Resources/prompts list_changed propagation is a tracked
+// follow-up (see docs/arch/10-virtual-mcp-architecture.md) — the backend
+// connector (pkg/vmcp/session/internal/backend) does not even dispatch those
+// notification methods to this sink yet.
+
+// buildListChangedSink returns the sink passed to
+// SessionManager.CreateSession for a newly-registered session. It closes over
+// the SDK ClientSession and the caller's identity captured AT REGISTRATION
+// TIME (issue #5748, decision B1/Option 2): a later asynchronous firing reuses
+// this snapshot identity to re-derive the advertised tool set, rather than
+// resolving a fresh one.
+//
+// Token-staleness risk: if the identity's upstream tokens are refreshed after
+// registration (see #5323), this resync's core.ListTools call authorizes and
+// aggregates using the (potentially stale) captured tokens, not the live
+// per-request ones. This only affects the ACCURACY of this asynchronous
+// resync's own admission view — every live call still authenticates via the
+// fresh per-request identity through enforceSessionBinding, so a stale token
+// here cannot grant a call that would otherwise be denied.
+func (s *Server) buildListChangedSink(
+	sessionID string, session server.ClientSession, identity *auth.Identity,
+) vmcpsession.ListChangedSink {
+	return func(ctx context.Context, backendWorkloadID, kind string) {
+		if kind != "tools" {
+			// Resources/prompts list_changed: out of scope (see file doc).
+			return
+		}
+		// Invalidate the cache FIRST so resyncSessionTools' core.ListTools call
+		// below re-sweeps the backend instead of immediately re-reading the
+		// stale cached aggregation InvalidateCapabilityCache just purged.
+		s.core.InvalidateCapabilityCache()
+		if err := s.resyncSessionTools(ctx, session, sessionID, identity); err != nil {
+			slog.Warn("failed to resync session tools after backend list_changed",
+				"session_id", sessionID, "backend_id", backendWorkloadID, "error", err)
+		}
+	}
+}
+
+// resyncSessionTools re-derives sessionID's advertised tool set (via
+// serveSessionTools — the core, cache now cold, plus optimizer meta-tools when
+// enabled) and REPLACES the SDK session's tool store with it, so a tool the
+// backend removed disappears from the advertised set rather than lingering
+// (unlike setSessionToolsDirect's registration-time MERGE, which only adds).
+// The go-sdk server auto-emits notifications/tools/list_changed to the
+// downstream client after SetSessionTools, since serve.go enables
+// WithToolCapabilities(true).
+func (s *Server) resyncSessionTools(
+	ctx context.Context, session server.ClientSession, sessionID string, identity *auth.Identity,
+) error {
+	tools, err := s.serveSessionTools(ctx, sessionID, identity)
+	if err != nil {
+		return fmt.Errorf("resync session tools: core ListTools for session %s: %w", sessionID, err)
+	}
+
+	sessionWithTools, ok := session.(server.SessionWithTools)
+	if !ok {
+		return fmt.Errorf("resync session tools: session %s does not support per-session tools", sessionID)
+	}
+
+	toolMap := make(map[string]server.ServerTool, len(tools))
+	for _, tool := range tools {
+		toolMap[tool.Tool.Name] = tool
+	}
+	sessionWithTools.SetSessionTools(toolMap)
+
+	slog.Debug("resynced session tools after backend list_changed",
+		"session_id", sessionID, "tool_count", len(tools))
+	return nil
+}

--- a/pkg/vmcp/server/serve_list_changed_test.go
+++ b/pkg/vmcp/server/serve_list_changed_test.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	"github.com/stacklok/toolhive-core/mcpcompat/server"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// fakeToolsSession is a minimal server.ClientSession + server.SessionWithTools
+// fake used to test resyncSessionTools/buildListChangedSink without a live SDK
+// session. It records every SetSessionTools call so tests can assert
+// replacement semantics.
+type fakeToolsSession struct {
+	id string
+
+	mu                   sync.Mutex
+	tools                map[string]server.ServerTool
+	setSessionToolsCalls int
+}
+
+func (*fakeToolsSession) Initialize()                                         {}
+func (*fakeToolsSession) Initialized() bool                                   { return true }
+func (*fakeToolsSession) NotificationChannel() chan<- mcp.JSONRPCNotification { return nil }
+func (f *fakeToolsSession) SessionID() string                                 { return f.id }
+
+func (f *fakeToolsSession) GetSessionTools() map[string]server.ServerTool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]server.ServerTool, len(f.tools))
+	for k, v := range f.tools {
+		out[k] = v
+	}
+	return out
+}
+
+func (f *fakeToolsSession) SetSessionTools(tools map[string]server.ServerTool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.tools = tools
+	f.setSessionToolsCalls++
+}
+
+var _ server.ClientSession = (*fakeToolsSession)(nil)
+var _ server.SessionWithTools = (*fakeToolsSession)(nil)
+
+// TestResyncSessionTools_ReplacesRatherThanMerges verifies (#5748) that
+// resyncSessionTools REPLACES the session's tool store with the freshly
+// core-derived set — unlike setSessionToolsDirect's registration-time MERGE —
+// so a tool the backend removed (and the core therefore no longer advertises)
+// disappears rather than lingering.
+func TestResyncSessionTools_ReplacesRatherThanMerges(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "kept"}, {Name: "added"}}}
+	srv := &Server{core: fc}
+
+	sess := &fakeToolsSession{id: "sess-1", tools: map[string]server.ServerTool{
+		"kept":    {Tool: mcp.Tool{Name: "kept"}},
+		"removed": {Tool: mcp.Tool{Name: "removed"}}, // must disappear after resync
+	}}
+
+	err := srv.resyncSessionTools(context.Background(), sess, "sess-1", nil)
+	require.NoError(t, err)
+
+	got := sess.GetSessionTools()
+	assert.Len(t, got, 2)
+	assert.Contains(t, got, "kept")
+	assert.Contains(t, got, "added")
+	assert.NotContains(t, got, "removed", "resync must REPLACE the tool store, dropping a no-longer-advertised tool")
+	assert.Equal(t, 1, sess.setSessionToolsCalls)
+}
+
+// TestResyncSessionTools_SessionWithoutToolSupport verifies resyncSessionTools
+// fails loudly (rather than silently no-opping) when the session does not
+// implement server.SessionWithTools.
+func TestResyncSessionTools_SessionWithoutToolSupport(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+	srv := &Server{core: fc}
+
+	// plainSession implements only server.ClientSession, not SessionWithTools.
+	type plainSession struct{ server.ClientSession }
+	sess := plainSession{&fakeToolsSession{id: "sess-1"}}
+
+	err := srv.resyncSessionTools(context.Background(), sess, "sess-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support per-session tools")
+}
+
+// TestBuildListChangedSink_TableDriven exercises buildListChangedSink's
+// behavior (#5748): it is a no-op for anything other than kind=="tools", and
+// for kind=="tools" it invalidates the shared capability cache BEFORE
+// re-deriving and replacing the session's tool set.
+func TestBuildListChangedSink_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		kind                 string
+		wantInvalidateCalls  int32
+		wantSetSessionToolsN int
+		wantFinalToolCount   int
+	}{
+		{
+			name:                 "kind=resources is ignored (out of scope)",
+			kind:                 "resources",
+			wantInvalidateCalls:  0,
+			wantSetSessionToolsN: 0,
+			wantFinalToolCount:   1, // unchanged: only "stale" remains
+		},
+		{
+			name:                 "kind=tools invalidates cache and resyncs",
+			kind:                 "tools",
+			wantInvalidateCalls:  1,
+			wantSetSessionToolsN: 1,
+			wantFinalToolCount:   1, // replaced: only "fresh" remains
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fc := &fakeCore{tools: []vmcp.Tool{{Name: "fresh"}}}
+			srv := &Server{core: fc}
+			sess := &fakeToolsSession{id: "sess-1", tools: map[string]server.ServerTool{
+				"stale": {Tool: mcp.Tool{Name: "stale"}},
+			}}
+
+			sink := srv.buildListChangedSink("sess-1", sess, nil)
+			sink(context.Background(), "backend-1", tc.kind)
+
+			assert.Equal(t, tc.wantInvalidateCalls, fc.invalidateCacheCalls.Load())
+			assert.Equal(t, tc.wantSetSessionToolsN, sess.setSessionToolsCalls)
+			assert.Len(t, sess.GetSessionTools(), tc.wantFinalToolCount)
+		})
+	}
+}

--- a/pkg/vmcp/server/serve_list_changed_test.go
+++ b/pkg/vmcp/server/serve_list_changed_test.go
@@ -6,18 +6,23 @@ package server
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
 	"github.com/stacklok/toolhive-core/mcpcompat/server"
+	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/headerforward"
+	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
 )
 
 // fakeToolsSession is a minimal server.ClientSession + server.SessionWithTools
-// fake used to test resyncSessionTools/buildListChangedSink without a live SDK
+// fake used to test resyncSessionTools/runListChangedResync without a live SDK
 // session. It records every SetSessionTools call so tests can assert
 // replacement semantics.
 type fakeToolsSession struct {
@@ -52,6 +57,34 @@ func (f *fakeToolsSession) SetSessionTools(tools map[string]server.ServerTool) {
 
 var _ server.ClientSession = (*fakeToolsSession)(nil)
 var _ server.SessionWithTools = (*fakeToolsSession)(nil)
+
+// stubSessionManager is a minimal SessionManager for the #5748 resync tests.
+// Only GetMultiSession is meaningful (its returned liveness bool drives the
+// resync liveness guard); the rest satisfy the interface and fail loudly if a
+// test reaches them unexpectedly.
+type stubSessionManager struct {
+	alive bool
+}
+
+func (m *stubSessionManager) GetMultiSession(context.Context, string) (vmcpsession.MultiSession, bool) {
+	return nil, m.alive
+}
+func (*stubSessionManager) Generate() string { panic("stubSessionManager: Generate unexpected") }
+func (*stubSessionManager) Validate(string) (bool, error) {
+	panic("stubSessionManager: Validate unexpected")
+}
+func (*stubSessionManager) Terminate(string) (bool, error) { return false, nil }
+func (*stubSessionManager) CreateSession(
+	context.Context, string, vmcpsession.ListChangedSink,
+) (vmcpsession.MultiSession, error) {
+	panic("stubSessionManager: CreateSession unexpected")
+}
+func (*stubSessionManager) DecorateSession(string, func(vmcpsession.MultiSession) vmcpsession.MultiSession) error {
+	panic("stubSessionManager: DecorateSession unexpected")
+}
+func (*stubSessionManager) NotifyBackendExpired(string, string, map[string]string) {}
+
+var _ SessionManager = (*stubSessionManager)(nil)
 
 // TestResyncSessionTools_ReplacesRatherThanMerges verifies (#5748) that
 // resyncSessionTools REPLACES the session's tool store with the freshly
@@ -98,52 +131,143 @@ func TestResyncSessionTools_SessionWithoutToolSupport(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not support per-session tools")
 }
 
-// TestBuildListChangedSink_TableDriven exercises buildListChangedSink's
-// behavior (#5748): it is a no-op for anything other than kind=="tools", and
-// for kind=="tools" it invalidates the shared capability cache BEFORE
-// re-deriving and replacing the session's tool set.
-func TestBuildListChangedSink_TableDriven(t *testing.T) {
+// TestListChangedResyncWorker_CoalescesAndNonBlocking verifies the B-HIGH-2
+// hand-off: trigger() returns immediately, never spawns a goroutine per call,
+// runs at most one resync at a time, and coalesces concurrent triggers into a
+// single follow-up run (dirty flag).
+func TestListChangedResyncWorker_CoalescesAndNonBlocking(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name                 string
-		kind                 string
-		wantInvalidateCalls  int32
-		wantSetSessionToolsN int
-		wantFinalToolCount   int
-	}{
-		{
-			name:                 "kind=resources is ignored (out of scope)",
-			kind:                 "resources",
-			wantInvalidateCalls:  0,
-			wantSetSessionToolsN: 0,
-			wantFinalToolCount:   1, // unchanged: only "stale" remains
-		},
-		{
-			name:                 "kind=tools invalidates cache and resyncs",
-			kind:                 "tools",
-			wantInvalidateCalls:  1,
-			wantSetSessionToolsN: 1,
-			wantFinalToolCount:   1, // replaced: only "fresh" remains
+	var (
+		runs     atomic.Int32
+		inFlight atomic.Int32
+		maxSeen  atomic.Int32
+		release  = make(chan struct{})
+	)
+	firstStarted := make(chan struct{}, 1)
+
+	w := &listChangedResyncWorker{
+		baseCtx: context.Background(),
+		run: func(context.Context) {
+			n := inFlight.Add(1)
+			for {
+				m := maxSeen.Load()
+				if n <= m || maxSeen.CompareAndSwap(m, n) {
+					break
+				}
+			}
+			if runs.Add(1) == 1 {
+				firstStarted <- struct{}{}
+				<-release // hold the first run so subsequent triggers coalesce
+			}
+			inFlight.Add(-1)
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			fc := &fakeCore{tools: []vmcp.Tool{{Name: "fresh"}}}
-			srv := &Server{core: fc}
-			sess := &fakeToolsSession{id: "sess-1", tools: map[string]server.ServerTool{
-				"stale": {Tool: mcp.Tool{Name: "stale"}},
-			}}
-
-			sink := srv.buildListChangedSink("sess-1", sess, nil)
-			sink(context.Background(), "backend-1", tc.kind)
-
-			assert.Equal(t, tc.wantInvalidateCalls, fc.invalidateCacheCalls.Load())
-			assert.Equal(t, tc.wantSetSessionToolsN, sess.setSessionToolsCalls)
-			assert.Len(t, sess.GetSessionTools(), tc.wantFinalToolCount)
-		})
+	// First trigger starts the (blocked) worker goroutine.
+	w.trigger()
+	select {
+	case <-firstStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not start")
 	}
+
+	// While the first run is blocked, fire many more triggers. Each must return
+	// immediately (non-blocking) and collapse into a single dirty re-run.
+	for range 50 {
+		w.trigger()
+	}
+
+	close(release) // let the first run finish; one coalesced re-run should follow
+
+	require.Eventually(t, func() bool {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		return !w.running
+	}, 5*time.Second, 5*time.Millisecond, "worker should become idle")
+
+	assert.Equal(t, int32(1), maxSeen.Load(), "at most one resync may run at a time")
+	assert.Equal(t, int32(2), runs.Load(),
+		"50 triggers during one in-flight run must coalesce into exactly one follow-up run")
+}
+
+// TestRunListChangedResync verifies (#5748) the resync body run off the receive
+// loop: it skips terminated sessions (liveness guard), and for a live session
+// it invalidates the cache and reconstructs a context carrying the captured
+// identity + forwarded headers (B-HIGH-1) before re-deriving/replacing the
+// session's tools.
+func TestRunListChangedResync(t *testing.T) {
+	t.Parallel()
+
+	const fwdKey = "X-Tenant"
+	identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "alice"}}
+	fwd := map[string]string{fwdKey: "acme"}
+
+	t.Run("terminated session: skipped entirely", func(t *testing.T) {
+		t.Parallel()
+		fc := &fakeCore{tools: []vmcp.Tool{{Name: "fresh"}}}
+		srv := &Server{core: fc, vmcpSessionMgr: &stubSessionManager{alive: false}}
+		sess := &fakeToolsSession{id: "sess-1", tools: map[string]server.ServerTool{
+			"stale": {Tool: mcp.Tool{Name: "stale"}},
+		}}
+
+		srv.runListChangedResync(context.Background(), "sess-1", sess, identity, fwd)
+
+		assert.Equal(t, int32(0), fc.invalidateCacheCalls.Load(), "terminated session must not invalidate the cache")
+		assert.Equal(t, int32(0), fc.listToolsCalls.Load(), "terminated session must not re-aggregate")
+		assert.Equal(t, 0, sess.setSessionToolsCalls)
+	})
+
+	t.Run("live session: invalidates, reconstructs ctx, replaces tools", func(t *testing.T) {
+		t.Parallel()
+		fc := &fakeCore{tools: []vmcp.Tool{{Name: "fresh"}}}
+		srv := &Server{core: fc, vmcpSessionMgr: &stubSessionManager{alive: true}}
+		sess := &fakeToolsSession{id: "sess-1", tools: map[string]server.ServerTool{
+			"stale": {Tool: mcp.Tool{Name: "stale"}},
+		}}
+
+		srv.runListChangedResync(context.Background(), "sess-1", sess, identity, fwd)
+
+		assert.Equal(t, int32(1), fc.invalidateCacheCalls.Load(), "live session must invalidate the cache once")
+		assert.Equal(t, 1, sess.setSessionToolsCalls)
+		got := sess.GetSessionTools()
+		require.Len(t, got, 1)
+		assert.Contains(t, got, "fresh")
+		assert.NotContains(t, got, "stale", "resync must replace the stale set")
+
+		// B-HIGH-1: the resync must call the core with a context carrying the
+		// captured identity AND forwarded headers, so the cache key and outbound
+		// backend auth match a real request from this principal.
+		box := fc.lastListToolsCtx.Load()
+		require.NotNil(t, box, "ListTools must have been called")
+		resyncCtx := box.ctx
+		gotID, ok := auth.IdentityFromContext(resyncCtx)
+		require.True(t, ok, "resync context must carry the captured identity")
+		assert.Equal(t, "alice", gotID.Subject)
+		assert.Equal(t, "acme", headerforward.ForwardedHeadersFromContext(resyncCtx)[fwdKey],
+			"resync context must carry the captured forwarded headers")
+	})
+}
+
+// TestBuildListChangedSink_IgnoresNonToolsKind verifies the sink's kind gate:
+// a non-tools ChangeKind is dropped synchronously on the receive loop (no
+// worker goroutine, no cache invalidation, no resync). The gate returns before
+// worker.trigger, so the assertion is deterministic without waiting.
+func TestBuildListChangedSink_IgnoresNonToolsKind(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "fresh"}}}
+	srv := &Server{
+		core:           fc,
+		vmcpSessionMgr: &stubSessionManager{alive: true},
+		resyncBaseCtx:  context.Background(),
+	}
+	sess := &fakeToolsSession{id: "sess-1"}
+
+	sink := srv.buildListChangedSink("sess-1", sess, nil, nil)
+	// A resources list_changed (out of scope) must be ignored synchronously.
+	sink(context.Background(), "backend-1", vmcpsession.ChangeKind("resources"))
+
+	assert.Equal(t, int32(0), fc.invalidateCacheCalls.Load(), "non-tools kind must not invalidate the cache")
+	assert.Equal(t, 0, sess.setSessionToolsCalls, "non-tools kind must not resync tools")
 }

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -12,6 +12,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sort"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -48,6 +50,20 @@ import (
 // toolSessionState tracks observable behaviour of the mock session factory below.
 type toolSessionState struct {
 	makeWithIDCalled atomic.Bool
+
+	// sinkMu guards capturedSink: the sink passed to MakeSessionWithID (#5748),
+	// captured so tests can invoke it directly to simulate an asynchronous
+	// backend notification firing after registration.
+	sinkMu       sync.Mutex
+	capturedSink vmcpsession.ListChangedSink
+}
+
+// sink returns the ListChangedSink MakeSessionWithID most recently received, or
+// nil if none was supplied.
+func (s *toolSessionState) sink() vmcpsession.ListChangedSink {
+	s.sinkMu.Lock()
+	defer s.sinkMu.Unlock()
+	return s.capturedSink
 }
 
 // newToolSessionFactory creates a MockMultiSessionFactory whose MakeSessionWithID
@@ -59,9 +75,16 @@ func newToolSessionFactory(
 	t.Helper()
 	state := &toolSessionState{}
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(
+			_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, sink ...vmcpsession.ListChangedSink,
+		) (vmcpsession.MultiSession, error) {
 			state.makeWithIDCalled.Store(true)
+			if len(sink) > 0 {
+				state.sinkMu.Lock()
+				state.capturedSink = sink[0]
+				state.sinkMu.Unlock()
+			}
 			mock := sessionmocks.NewMockMultiSession(ctrl)
 			mock.EXPECT().ID().Return(id).AnyTimes()
 			mock.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()
@@ -134,6 +157,10 @@ type fakeCore struct {
 	promptErr         error // when set, GetPrompt returns it (e.g. vmcp.ErrAuthorizationFailed)
 	completeErr       error // when set, Complete returns it (e.g. vmcp.ErrAuthorizationFailed)
 	lookupResourceErr error // when set, LookupResource returns it for an ADVERTISED URI (admission denial)
+
+	// invalidateCacheCalls counts InvalidateCapabilityCache invocations, so tests
+	// covering the list_changed sink can assert the cache was re-swept (#5748).
+	invalidateCacheCalls atomic.Int32
 }
 
 var _ core.VMCP = (*fakeCore)(nil)
@@ -264,6 +291,8 @@ func (*fakeCore) LookupBackend(context.Context, *auth.Identity, string) (*vmcp.B
 func (*fakeCore) Close() error { return nil }
 
 func (*fakeCore) BackendHealth() health.Reporter { return nil }
+
+func (f *fakeCore) InvalidateCapabilityCache() { f.invalidateCacheCalls.Add(1) }
 
 // TestServeRegistersSessionHooks verifies that Serve registers the OnRegisterSession
 // hook and wires two-phase session creation: an MCP initialize triggers the hook,
@@ -701,6 +730,122 @@ func registerServeSessionWithRegistry(
 	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID); return ok },
 		2*time.Second, 10*time.Millisecond, "session should be registered")
 	return srv, sessionID, ts.URL
+}
+
+// registerServeSessionCapturingSink is registerServeSession plus the
+// toolSessionState so a test can retrieve the ListChangedSink (#5748)
+// MakeSessionWithID received for the registered session and invoke it
+// directly, simulating an asynchronous backend notification firing after
+// registration completes.
+func registerServeSessionCapturingSink(t *testing.T, fc *fakeCore) (srv *Server, sessionID, baseURL string, state *toolSessionState) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	factory, state := newToolSessionFactory(t, ctrl, fc.tools)
+
+	srv, err := Serve(context.Background(), fc, &ServerConfig{
+		SessionTTL:           time.Minute,
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	streamable := server.NewStreamableHTTPServer(
+		srv.mcpServer,
+		server.WithEndpointPath("/mcp"),
+		server.WithSessionIdManager(srv.vmcpSessionMgr),
+	)
+	ts := httptest.NewServer(streamable)
+	t.Cleanup(ts.Close)
+
+	initResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, http.StatusOK, initResp.StatusCode)
+	sessionID = initResp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+	require.Eventually(t, func() bool { _, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID); return ok },
+		2*time.Second, 10*time.Millisecond, "session should be registered")
+	require.Eventually(t, func() bool { return state.sink() != nil },
+		2*time.Second, 10*time.Millisecond, "MakeSessionWithID should have received a non-nil sink")
+	return srv, sessionID, ts.URL, state
+}
+
+// TestListChangedSink_EndToEnd_ResyncsRegisteredSession drives a real session
+// registration over HTTP, then invokes the captured sink directly (simulating
+// a backend's asynchronous notifications/tools/list_changed) and verifies,
+// via a real tools/list request, that the session's advertised set reflects
+// the core's now-changed tool set — including a REMOVED tool disappearing —
+// and that the cache was invalidated (#5748).
+func TestListChangedSink_EndToEnd_ResyncsRegisteredSession(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "kept"}, {Name: "removed"}}}
+	_, sessionID, baseURL, state := registerServeSessionCapturingSink(t, fc)
+
+	listResp := postServeMCP(t, baseURL, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{},
+	}, sessionID)
+	env, _ := readServeJSONRPC(t, listResp)
+	listResp.Body.Close()
+	before := toolNamesFromListResult(t, env)
+	assert.ElementsMatch(t, []string{"kept", "removed"}, before)
+
+	// The core's advertised set changes (as if the backend's own tool set
+	// changed): "removed" is gone, "added" is new.
+	fc.tools = []vmcp.Tool{{Name: "kept"}, {Name: "added"}}
+
+	sink := state.sink()
+	require.NotNil(t, sink)
+	sink(context.Background(), "some-backend", "tools")
+
+	require.Eventually(t, func() bool {
+		return fc.invalidateCacheCalls.Load() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "sink must invalidate the capability cache")
+
+	require.Eventually(t, func() bool {
+		listResp := postServeMCP(t, baseURL, map[string]any{
+			"jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": map[string]any{},
+		}, sessionID)
+		defer listResp.Body.Close()
+		env, _ := readServeJSONRPC(t, listResp)
+		got := toolNamesFromListResult(t, env)
+		return assert.ObjectsAreEqualValues([]string{"added", "kept"}, sortedCopy(got))
+	}, 2*time.Second, 10*time.Millisecond, "tools/list must reflect the resynced (replaced) tool set")
+}
+
+// toolNamesFromListResult extracts the tool names from a tools/list JSON-RPC
+// response envelope.
+func toolNamesFromListResult(t *testing.T, env map[string]any) []string {
+	t.Helper()
+	result, ok := env["result"].(map[string]any)
+	require.True(t, ok, "tools/list response must have a result object; env: %v", env)
+	rawTools, ok := result["tools"].([]any)
+	require.True(t, ok, "result.tools must be an array; result: %v", result)
+	names := make([]string, 0, len(rawTools))
+	for _, rt := range rawTools {
+		tm, ok := rt.(map[string]any)
+		require.True(t, ok)
+		name, _ := tm["name"].(string)
+		names = append(names, name)
+	}
+	return names
+}
+
+// sortedCopy returns a sorted copy of ss for order-independent comparison.
+func sortedCopy(ss []string) []string {
+	out := make([]string, len(ss))
+	copy(out, ss)
+	sort.Strings(out)
+	return out
 }
 
 // TestServeCoreToolHandler exercises the Serve tool handler's error/denial branches by

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -77,12 +77,12 @@ func newToolSessionFactory(
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(
-			_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, sink ...vmcpsession.ListChangedSink,
+			_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, sink vmcpsession.ListChangedSink,
 		) (vmcpsession.MultiSession, error) {
 			state.makeWithIDCalled.Store(true)
-			if len(sink) > 0 {
+			if sink != nil {
 				state.sinkMu.Lock()
-				state.capturedSink = sink[0]
+				state.capturedSink = sink
 				state.sinkMu.Unlock()
 			}
 			mock := sessionmocks.NewMockMultiSession(ctrl)
@@ -161,12 +161,23 @@ type fakeCore struct {
 	// invalidateCacheCalls counts InvalidateCapabilityCache invocations, so tests
 	// covering the list_changed sink can assert the cache was re-swept (#5748).
 	invalidateCacheCalls atomic.Int32
+
+	// lastListToolsCtx records the context ListTools last received, so #5748
+	// tests can assert the async resync reconstructed a context carrying the
+	// registration-time identity + forwarded headers (B-HIGH-1). Wrapped in a
+	// fixed struct type because atomic.Value panics when Store sees differing
+	// concrete context types across calls (HTTP request ctx vs Background).
+	lastListToolsCtx atomic.Pointer[ctxBox]
 }
+
+// ctxBox wraps a context.Context for atomic.Pointer storage on fakeCore.
+type ctxBox struct{ ctx context.Context }
 
 var _ core.VMCP = (*fakeCore)(nil)
 
-func (f *fakeCore) ListTools(context.Context, *auth.Identity) ([]vmcp.Tool, error) {
+func (f *fakeCore) ListTools(ctx context.Context, _ *auth.Identity) ([]vmcp.Tool, error) {
 	f.listToolsCalls.Add(1)
+	f.lastListToolsCtx.Store(&ctxBox{ctx: ctx})
 	return f.tools, nil
 }
 

--- a/pkg/vmcp/server/serve_test.go
+++ b/pkg/vmcp/server/serve_test.go
@@ -84,6 +84,7 @@ func (*stubVMCP) LookupBackend(context.Context, *auth.Identity, string) (*vmcp.B
 }
 func (s *stubVMCP) Close() error                 { s.closed = true; return nil }
 func (*stubVMCP) BackendHealth() health.Reporter { return nil }
+func (*stubVMCP) InvalidateCapabilityCache()     {}
 
 // stubWatcher is a non-nil Watcher for the drift-guard test; its behavior is not
 // exercised there.

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -336,6 +336,13 @@ type Server struct {
 	// Populated during Start() initialization before blocking; no mutex needed
 	// since Stop() is only called after Start()'s select returns.
 	shutdownFuncs []func(context.Context) error
+
+	// resyncBaseCtx is the server-lifetime parent context for asynchronous
+	// tools/list_changed resync work (#5748). It is cancelled by a shutdownFunc
+	// on Stop, so an in-flight backend re-aggregation triggered by a late
+	// notification cannot outlive the server. Set by Serve; nil for direct-Serve
+	// callers that never register a list_changed sink.
+	resyncBaseCtx context.Context
 }
 
 // buildSessionDataStorage constructs the DataStorage backend from cfg.
@@ -1214,8 +1221,15 @@ func (s *Server) handleSessionRegistrationImpl(ctx context.Context, session serv
 	//
 	// The list_changed sink is built here, before CreateSession, so it can be
 	// threaded through to every backend connector this session opens (#5748).
+	// Capture BOTH the caller identity AND the per-request forwarded headers from
+	// the registration context: the asynchronous resync re-enumerates backends
+	// through the same identity+header-keyed path a live request uses (cache key
+	// and outbound backend auth are derived from the context, not passed
+	// explicitly), so it must reconstruct a faithful context or it would
+	// enumerate unauthenticated. See buildListChangedSink.
 	identity, _ := auth.IdentityFromContext(ctx)
-	sink := s.buildListChangedSink(sessionID, session, identity)
+	forwardedHeaders := headerforward.ForwardedHeadersFromContext(ctx)
+	sink := s.buildListChangedSink(sessionID, session, identity, forwardedHeaders)
 	if _, retErr = s.vmcpSessionMgr.CreateSession(ctx, sessionID, sink); retErr != nil {
 		slog.Error("failed to create session-scoped backends",
 			"session_id", sessionID,

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -1211,7 +1211,12 @@ func (s *Server) handleSessionRegistrationImpl(ctx context.Context, session serv
 	// after initialize may receive a "tool not found" error before AddSessionTools
 	// completes. Conforming MCP clients call tools/list before tools/call, so this
 	// window is expected to be harmless in practice.
-	if _, retErr = s.vmcpSessionMgr.CreateSession(ctx, sessionID); retErr != nil {
+	//
+	// The list_changed sink is built here, before CreateSession, so it can be
+	// threaded through to every backend connector this session opens (#5748).
+	identity, _ := auth.IdentityFromContext(ctx)
+	sink := s.buildListChangedSink(sessionID, session, identity)
+	if _, retErr = s.vmcpSessionMgr.CreateSession(ctx, sessionID, sink); retErr != nil {
 		slog.Error("failed to create session-scoped backends",
 			"session_id", sessionID,
 			"error", retErr)

--- a/pkg/vmcp/server/session_management_integration_test.go
+++ b/pkg/vmcp/server/session_management_integration_test.go
@@ -47,8 +47,8 @@ func newNoopMockFactory(t *testing.T) *sessionfactorymocks.MockMultiSessionFacto
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 			mock := sessionmocks.NewMockMultiSession(ctrl)
 			mock.EXPECT().ID().Return(id).AnyTimes()
 			mock.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()
@@ -89,8 +89,8 @@ func newMockFactory(t *testing.T, ctrl *gomock.Controller, tools []vmcp.Tool) (*
 	t.Helper()
 	state := &mockFactoryState{}
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 			state.makeWithIDCalled.Store(true)
 			// All sessions carry MetadataKeyIdentityBinding so Terminate takes the
 			// Phase 2 (storage.Delete) path. The sentinel value is sufficient for

--- a/pkg/vmcp/server/session_management_integration_test.go
+++ b/pkg/vmcp/server/session_management_integration_test.go
@@ -48,7 +48,7 @@ func newNoopMockFactory(t *testing.T) *sessionfactorymocks.MockMultiSessionFacto
 	ctrl := gomock.NewController(t)
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 			mock := sessionmocks.NewMockMultiSession(ctrl)
 			mock.EXPECT().ID().Return(id).AnyTimes()
 			mock.EXPECT().UpdatedAt().Return(time.Time{}).AnyTimes()
@@ -90,7 +90,7 @@ func newMockFactory(t *testing.T, ctrl *gomock.Controller, tools []vmcp.Tool) (*
 	state := &mockFactoryState{}
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+		DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 			state.makeWithIDCalled.Store(true)
 			// All sessions carry MetadataKeyIdentityBinding so Terminate takes the
 			// Phase 2 (storage.Delete) path. The sentinel value is sufficient for

--- a/pkg/vmcp/server/session_manager_interface.go
+++ b/pkg/vmcp/server/session_manager_interface.go
@@ -24,7 +24,15 @@ type SessionManager interface {
 	// CreateSession completes Phase 2 of the two-phase session creation pattern.
 	// Called from OnRegisterSession hook once context is available; creates backend
 	// connections and replaces the placeholder with a fully-formed MultiSession.
-	CreateSession(ctx context.Context, sessionID string) (vmcpsession.MultiSession, error)
+	//
+	// sink is a trailing variadic parameter (at most the first value is used) so
+	// the many pre-existing 2-argument call sites in the session-manager test
+	// suite continue to compile unchanged. When supplied, it is threaded to
+	// MultiSessionFactory.MakeSessionWithID and reaches every backend connector
+	// opened for this session (#5748).
+	CreateSession(
+		ctx context.Context, sessionID string, sink ...vmcpsession.ListChangedSink,
+	) (vmcpsession.MultiSession, error)
 
 	// GetMultiSession retrieves the fully-formed MultiSession for the given session ID.
 	// Returns (nil, false) if the session does not exist or is still a placeholder.

--- a/pkg/vmcp/server/session_manager_interface.go
+++ b/pkg/vmcp/server/session_manager_interface.go
@@ -25,13 +25,11 @@ type SessionManager interface {
 	// Called from OnRegisterSession hook once context is available; creates backend
 	// connections and replaces the placeholder with a fully-formed MultiSession.
 	//
-	// sink is a trailing variadic parameter (at most the first value is used) so
-	// the many pre-existing 2-argument call sites in the session-manager test
-	// suite continue to compile unchanged. When supplied, it is threaded to
-	// MultiSessionFactory.MakeSessionWithID and reaches every backend connector
-	// opened for this session (#5748).
+	// sink, when non-nil, is threaded to MultiSessionFactory.MakeSessionWithID and
+	// reaches every backend connector opened for this session (#5748). Pass nil to
+	// disable asynchronous list_changed consumption for this session.
 	CreateSession(
-		ctx context.Context, sessionID string, sink ...vmcpsession.ListChangedSink,
+		ctx context.Context, sessionID string, sink vmcpsession.ListChangedSink,
 	) (vmcpsession.MultiSession, error)
 
 	// GetMultiSession retrieves the fully-formed MultiSession for the given session ID.

--- a/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
+++ b/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
@@ -89,7 +89,7 @@ func createSession(t *testing.T, sm *Manager, identity *auth.Identity) string {
 	if identity != nil {
 		ctx = auth.WithIdentity(ctx, identity)
 	}
-	_, err := sm.CreateSession(ctx, sessionID)
+	_, err := sm.CreateSession(ctx, sessionID, nil)
 	require.NoError(t, err)
 	return sessionID
 }

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -277,15 +277,15 @@ func (sm *Manager) Generate() string {
 //  4. Persists session metadata to storage and caches the live MultiSession
 //     in the node-local map.
 //
-// sink, when supplied (at most the first value is used), is threaded to
-// MultiSessionFactory.MakeSessionWithID so every backend connector opened for
-// this session can report an asynchronous backend notification (#5748).
+// sink, when non-nil, is threaded to MultiSessionFactory.MakeSessionWithID so
+// every backend connector opened for this session can report an asynchronous
+// backend notification (#5748); pass nil to disable that consumption.
 //
 // The returned MultiSession can be retrieved later via GetMultiSession().
 func (sm *Manager) CreateSession(
 	ctx context.Context,
 	sessionID string,
-	sink ...vmcpsession.ListChangedSink,
+	sink vmcpsession.ListChangedSink,
 ) (vmcpsession.MultiSession, error) {
 	if sessionID == "" {
 		return nil, fmt.Errorf("Manager.CreateSession: session ID must not be empty")
@@ -323,7 +323,7 @@ func (sm *Manager) CreateSession(
 	backends := sm.listAllBackends(ctx)
 
 	// Build the fully-formed MultiSession using the SDK-assigned session ID.
-	sess, err := sm.factory.MakeSessionWithID(ctx, sessionID, identity, backends, sink...)
+	sess, err := sm.factory.MakeSessionWithID(ctx, sessionID, identity, backends, sink)
 	if err != nil {
 		sm.cleanupFailedPlaceholder(sessionID, placeholder)
 		return nil, fmt.Errorf("Manager.CreateSession: failed to create multi-session: %w", err)

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -277,10 +277,15 @@ func (sm *Manager) Generate() string {
 //  4. Persists session metadata to storage and caches the live MultiSession
 //     in the node-local map.
 //
+// sink, when supplied (at most the first value is used), is threaded to
+// MultiSessionFactory.MakeSessionWithID so every backend connector opened for
+// this session can report an asynchronous backend notification (#5748).
+//
 // The returned MultiSession can be retrieved later via GetMultiSession().
 func (sm *Manager) CreateSession(
 	ctx context.Context,
 	sessionID string,
+	sink ...vmcpsession.ListChangedSink,
 ) (vmcpsession.MultiSession, error) {
 	if sessionID == "" {
 		return nil, fmt.Errorf("Manager.CreateSession: session ID must not be empty")
@@ -318,7 +323,7 @@ func (sm *Manager) CreateSession(
 	backends := sm.listAllBackends(ctx)
 
 	// Build the fully-formed MultiSession using the SDK-assigned session ID.
-	sess, err := sm.factory.MakeSessionWithID(ctx, sessionID, identity, backends)
+	sess, err := sm.factory.MakeSessionWithID(ctx, sessionID, identity, backends, sink...)
 	if err != nil {
 		sm.cleanupFailedPlaceholder(sessionID, placeholder)
 		return nil, fmt.Errorf("Manager.CreateSession: failed to create multi-session: %w", err)

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -64,7 +64,7 @@ func newMockFactory(t *testing.T, ctrl *gomock.Controller, sess vmcpsession.Mult
 	t.Helper()
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	factory.EXPECT().
-		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(sess, nil).AnyTimes()
 	return factory
 }
@@ -74,7 +74,7 @@ func newMockFactoryWithError(t *testing.T, ctrl *gomock.Controller, err error) *
 	t.Helper()
 	factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	factory.EXPECT().
-		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, err).AnyTimes()
 	return factory
 }
@@ -299,8 +299,8 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		var createdSess *sessionmocks.MockMultiSession
 		factory.EXPECT().
-			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				createdSess = newMockSession(t, ctrl, id, tools)
 				return createdSess, nil
 			}).AnyTimes()
@@ -366,8 +366,8 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		factoryCalled := false
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
-			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				factoryCalled = true
 				sess := newMockSession(t, ctrl, id, tools)
 				return sess, nil
@@ -401,8 +401,8 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		factoryCalled := false
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
-			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				factoryCalled = true
 				sess := newMockSession(t, ctrl, id, tools)
 				return sess, nil
@@ -439,8 +439,8 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		var createdSess *sessionmocks.MockMultiSession
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
-			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				// Sleep to simulate slow backend initialization, creating a window
 				// where the client can terminate the session after the first check passes.
 				time.Sleep(50 * time.Millisecond)
@@ -616,8 +616,8 @@ func TestSessionManager_Terminate(t *testing.T) {
 		var createdSess *sessionmocks.MockMultiSession
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
-			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				createdSess = sessionmocks.NewMockMultiSession(ctrl)
 				createdSess.EXPECT().ID().Return(id).AnyTimes()
 				createdSess.EXPECT().GetMetadata().Return(bindingMeta).AnyTimes()
@@ -670,8 +670,8 @@ func TestSessionManager_Terminate(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
-			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				sess := newMockSession(t, ctrl, id, nil)
 				// Close is called by onEvict when Terminate removes the cache entry.
 				sess.EXPECT().Close().Return(nil).AnyTimes()
@@ -851,8 +851,8 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
-			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				sess := newMockSession(t, ctrl, id, tools)
 				return sess, nil
 			}).Times(1)
@@ -906,7 +906,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		// MakeSessionWithID is only for Phase 2; unused in the restore path.
-		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Times(0)
 
 		sessionID := "restore-zero-backend-session"
@@ -946,7 +946,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		// RestoreSession. This test documents that backward-compat behaviour.
 		ctrl := gomock.NewController(t)
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Times(0)
 
 		sessionID := "restore-legacy-session"
@@ -982,7 +982,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		// that stale per-backend session IDs do not persist indefinitely in storage.
 		ctrl := gomock.NewController(t)
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Times(0)
 
 		sessionID := "restore-metadata-persist-session"
@@ -1033,7 +1033,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		// restored session.
 		ctrl := gomock.NewController(t)
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Times(0)
 
 		sessionID := "restore-concurrent-delete-session"
@@ -1079,7 +1079,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		// metadata drift on the next liveness check and evict if necessary.
 		ctrl := gomock.NewController(t)
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Times(0)
 
 		sessionID := "restore-update-error-session"
@@ -1185,8 +1185,8 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
-			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				return newMockSession(t, ctrl, id, tools), nil
 			}).Times(1)
 
@@ -1254,8 +1254,8 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 		// 2. Terminate sees the key and takes the Phase 2 path (storage.Delete).
 		bindingMeta := map[string]string{sessiontypes.MetadataKeyIdentityBinding: "unauthenticated"}
 		factory.EXPECT().
-			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend) (vmcpsession.MultiSession, error) {
+			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				sess := sessionmocks.NewMockMultiSession(ctrl)
 				sess.EXPECT().ID().Return(id).AnyTimes()
 				sess.EXPECT().GetMetadata().Return(bindingMeta).AnyTimes()
@@ -1308,7 +1308,7 @@ func TestSessionManager_CheckSession(t *testing.T) {
 		t.Helper()
 		ctrl := gomock.NewController(t)
 		f := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-		f.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		f.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			AnyTimes().Return(nil, nil)
 		f.EXPECT().RestoreSession(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			AnyTimes().Return(nil, nil)
@@ -1792,7 +1792,7 @@ func TestLoadSession_Phase2Marker_UsesIdentityBindingKey(t *testing.T) {
 		tools := []vmcp.Tool{{Name: "restored-tool", Description: "a restored tool"}}
 		ctrl := gomock.NewController(t)
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
-		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		factory.EXPECT().MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Times(0)
 
 		sessionID := "identity-binding-session"

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -300,7 +300,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		var createdSess *sessionmocks.MockMultiSession
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				createdSess = newMockSession(t, ctrl, id, tools)
 				return createdSess, nil
 			}).AnyTimes()
@@ -313,7 +313,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		require.NotEmpty(t, sessionID)
 
 		// Upgrade to full MultiSession.
-		multiSess, err := sm.CreateSession(context.Background(), sessionID)
+		multiSess, err := sm.CreateSession(context.Background(), sessionID, nil)
 		require.NoError(t, err)
 		require.NotNil(t, multiSess)
 		assert.Equal(t, sessionID, multiSess.ID())
@@ -332,7 +332,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		registry := newFakeRegistry()
 		sm, _ := newTestSessionManager(t, factory, registry)
 
-		_, err := sm.CreateSession(context.Background(), "")
+		_, err := sm.CreateSession(context.Background(), "", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "session ID must not be empty")
 	})
@@ -351,7 +351,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
 
-		_, err := sm.CreateSession(context.Background(), sessionID)
+		_, err := sm.CreateSession(context.Background(), sessionID, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "failed to create multi-session")
 	})
@@ -367,7 +367,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				factoryCalled = true
 				sess := newMockSession(t, ctrl, id, tools)
 				return sess, nil
@@ -383,7 +383,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		require.NoError(t, storage.Delete(context.Background(), sessionID))
 
 		// CreateSession must fail fast before opening any backend connections.
-		_, createErr := sm.CreateSession(context.Background(), sessionID)
+		_, createErr := sm.CreateSession(context.Background(), sessionID, nil)
 		require.Error(t, createErr)
 		assert.ErrorContains(t, createErr, "not found")
 
@@ -402,7 +402,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				factoryCalled = true
 				sess := newMockSession(t, ctrl, id, tools)
 				return sess, nil
@@ -421,7 +421,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 
 		// CreateSession must fail fast (terminated=true) before opening any
 		// backend connections.
-		_, createErr := sm.CreateSession(context.Background(), sessionID)
+		_, createErr := sm.CreateSession(context.Background(), sessionID, nil)
 		require.Error(t, createErr)
 		assert.ErrorContains(t, createErr, "was terminated")
 
@@ -440,7 +440,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				// Sleep to simulate slow backend initialization, creating a window
 				// where the client can terminate the session after the first check passes.
 				time.Sleep(50 * time.Millisecond)
@@ -461,7 +461,7 @@ func TestSessionManager_CreateSession(t *testing.T) {
 		// check and then sleep during MakeSessionWithID.
 		errChan := make(chan error, 1)
 		go func() {
-			_, err := sm.CreateSession(context.Background(), sessionID)
+			_, err := sm.CreateSession(context.Background(), sessionID, nil)
 			errChan <- err
 		}()
 
@@ -617,7 +617,7 @@ func TestSessionManager_Terminate(t *testing.T) {
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				createdSess = sessionmocks.NewMockMultiSession(ctrl)
 				createdSess.EXPECT().ID().Return(id).AnyTimes()
 				createdSess.EXPECT().GetMetadata().Return(bindingMeta).AnyTimes()
@@ -643,7 +643,7 @@ func TestSessionManager_Terminate(t *testing.T) {
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
 
-		_, err := sm.CreateSession(context.Background(), sessionID)
+		_, err := sm.CreateSession(context.Background(), sessionID, nil)
 		require.NoError(t, err)
 		require.NotNil(t, createdSess)
 
@@ -671,7 +671,7 @@ func TestSessionManager_Terminate(t *testing.T) {
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				sess := newMockSession(t, ctrl, id, nil)
 				// Close is called by onEvict when Terminate removes the cache entry.
 				sess.EXPECT().Close().Return(nil).AnyTimes()
@@ -684,7 +684,7 @@ func TestSessionManager_Terminate(t *testing.T) {
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
 
-		_, err := sm.CreateSession(context.Background(), sessionID)
+		_, err := sm.CreateSession(context.Background(), sessionID, nil)
 		require.NoError(t, err)
 
 		// Seed MetadataKeyIdentityBinding into storage so Terminate recognises this
@@ -852,7 +852,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				sess := newMockSession(t, ctrl, id, tools)
 				return sess, nil
 			}).Times(1)
@@ -863,7 +863,7 @@ func TestSessionManager_GetMultiSession(t *testing.T) {
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
 
-		_, err := sm.CreateSession(context.Background(), sessionID)
+		_, err := sm.CreateSession(context.Background(), sessionID, nil)
 		require.NoError(t, err)
 
 		multiSess, ok := sm.GetMultiSession(t.Context(), sessionID)
@@ -1186,7 +1186,7 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 		factory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				return newMockSession(t, ctrl, id, tools), nil
 			}).Times(1)
 
@@ -1195,7 +1195,7 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
-		_, err := sm.CreateSession(context.Background(), sessionID)
+		_, err := sm.CreateSession(context.Background(), sessionID, nil)
 		require.NoError(t, err)
 
 		// Apply a decorator that wraps with an extra tool.
@@ -1255,7 +1255,7 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 		bindingMeta := map[string]string{sessiontypes.MetadataKeyIdentityBinding: "unauthenticated"}
 		factory.EXPECT().
 			MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
+			DoAndReturn(func(_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink) (vmcpsession.MultiSession, error) {
 				sess := sessionmocks.NewMockMultiSession(ctrl)
 				sess.EXPECT().ID().Return(id).AnyTimes()
 				sess.EXPECT().GetMetadata().Return(bindingMeta).AnyTimes()
@@ -1278,7 +1278,7 @@ func TestSessionManager_DecorateSession(t *testing.T) {
 
 		sessionID := sm.Generate()
 		require.NotEmpty(t, sessionID)
-		_, err := sm.CreateSession(context.Background(), sessionID)
+		_, err := sm.CreateSession(context.Background(), sessionID, nil)
 		require.NoError(t, err)
 
 		err = sm.DecorateSession(sessionID, func(sess sessiontypes.MultiSession) sessiontypes.MultiSession {
@@ -1498,7 +1498,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 		sm, storage := newTestSessionManager(t, factory, registry)
 
 		sessionID := sm.Generate()
-		_, err := sm.CreateSession(t.Context(), sessionID)
+		_, err := sm.CreateSession(t.Context(), sessionID, nil)
 		require.NoError(t, err)
 
 		meta := seedBackendMetadata(t, storage, sessionID,
@@ -1530,7 +1530,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 		sm, storage := newTestSessionManager(t, factory, registry)
 
 		sessionID := sm.Generate()
-		_, err := sm.CreateSession(t.Context(), sessionID)
+		_, err := sm.CreateSession(t.Context(), sessionID, nil)
 		require.NoError(t, err)
 
 		meta := seedBackendMetadata(t, storage, sessionID,
@@ -1619,7 +1619,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 		sm, storage := newTestSessionManager(t, factory, registry)
 
 		sessionID := sm.Generate()
-		_, err := sm.CreateSession(t.Context(), sessionID)
+		_, err := sm.CreateSession(t.Context(), sessionID, nil)
 		require.NoError(t, err)
 
 		// Seed MetadataKeyIdentityBinding into storage so Terminate recognises this
@@ -1659,7 +1659,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 		sm, storage := newTestSessionManager(t, factory, registry)
 
 		sessionID := sm.Generate()
-		_, err := sm.CreateSession(t.Context(), sessionID)
+		_, err := sm.CreateSession(t.Context(), sessionID, nil)
 		require.NoError(t, err)
 
 		meta := seedBackendMetadata(t, storage, sessionID,
@@ -1693,7 +1693,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 		sm, storage := newTestSessionManager(t, factory, registry)
 
 		sessionID := sm.Generate()
-		_, err := sm.CreateSession(t.Context(), sessionID)
+		_, err := sm.CreateSession(t.Context(), sessionID, nil)
 		require.NoError(t, err)
 
 		meta := seedBackendMetadata(t, storage, sessionID,
@@ -1727,7 +1727,7 @@ func TestNotifyBackendExpired(t *testing.T) {
 		sm, storage := newTestSessionManager(t, factory, registry)
 
 		sessionID := sm.Generate()
-		_, err := sm.CreateSession(t.Context(), sessionID)
+		_, err := sm.CreateSession(t.Context(), sessionID, nil)
 		require.NoError(t, err)
 
 		// Session must be in cache after CreateSession.

--- a/pkg/vmcp/server/telemetry_integration_test.go
+++ b/pkg/vmcp/server/telemetry_integration_test.go
@@ -83,7 +83,7 @@ func newBackendAwareTestFactory(tools []vmcp.Tool, rt *vmcp.RoutingTable) *backe
 }
 
 func (f *backendAwareTestFactory) MakeSessionWithID(
-	_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink,
+	_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink,
 ) (vmcpsession.MultiSession, error) {
 	return f.newSession(id), nil
 }

--- a/pkg/vmcp/server/telemetry_integration_test.go
+++ b/pkg/vmcp/server/telemetry_integration_test.go
@@ -83,7 +83,7 @@ func newBackendAwareTestFactory(tools []vmcp.Tool, rt *vmcp.RoutingTable) *backe
 }
 
 func (f *backendAwareTestFactory) MakeSessionWithID(
-	_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend,
+	_ context.Context, id string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink,
 ) (vmcpsession.MultiSession, error) {
 	return f.newSession(id), nil
 }

--- a/pkg/vmcp/server/testfactory_test.go
+++ b/pkg/vmcp/server/testfactory_test.go
@@ -28,7 +28,7 @@ type minimalTestFactory struct{}
 var _ vmcpsession.MultiSessionFactory = (*minimalTestFactory)(nil)
 
 func (*minimalTestFactory) MakeSessionWithID(
-	_ context.Context, _ string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink,
+	_ context.Context, _ string, _ *auth.Identity, _ []*vmcp.Backend, _ vmcpsession.ListChangedSink,
 ) (vmcpsession.MultiSession, error) {
 	return nil, fmt.Errorf("minimalTestFactory: MakeSessionWithID not implemented in test helper")
 }

--- a/pkg/vmcp/server/testfactory_test.go
+++ b/pkg/vmcp/server/testfactory_test.go
@@ -28,7 +28,7 @@ type minimalTestFactory struct{}
 var _ vmcpsession.MultiSessionFactory = (*minimalTestFactory)(nil)
 
 func (*minimalTestFactory) MakeSessionWithID(
-	_ context.Context, _ string, _ *auth.Identity, _ []*vmcp.Backend,
+	_ context.Context, _ string, _ *auth.Identity, _ []*vmcp.Backend, _ ...vmcpsession.ListChangedSink,
 ) (vmcpsession.MultiSession, error) {
 	return nil, fmt.Errorf("minimalTestFactory: MakeSessionWithID not implemented in test helper")
 }

--- a/pkg/vmcp/session/connector_integration_test.go
+++ b/pkg/vmcp/session/connector_integration_test.go
@@ -263,7 +263,7 @@ func TestIdentityBinding_CallerRejection(t *testing.T) {
 	}
 
 	// No backend connector needed: auth validation fires before any routing.
-	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, nil
 	}
 	factory := newSessionFactoryWithConnector(connector)
@@ -372,7 +372,7 @@ func TestIdentityBinding_RestoreSession_RoundTrip(t *testing.T) {
 		},
 	}
 
-	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, nil
 	}
 	factory := newSessionFactoryWithConnector(connector)

--- a/pkg/vmcp/session/connector_integration_test.go
+++ b/pkg/vmcp/session/connector_integration_test.go
@@ -114,7 +114,7 @@ func TestSessionFactory_Integration_CapabilityDiscovery(t *testing.T) {
 	}
 
 	factory := NewSessionFactory(newUnauthenticatedRegistry(t))
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, sess)
 	t.Cleanup(func() { require.NoError(t, sess.Close()) })
@@ -143,7 +143,7 @@ func TestSessionFactory_Integration_CallTool(t *testing.T) {
 	}
 
 	factory := NewSessionFactory(newUnauthenticatedRegistry(t))
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, sess.Close()) })
 
@@ -166,7 +166,7 @@ func TestSessionFactory_Integration_ReadResource(t *testing.T) {
 	}
 
 	factory := NewSessionFactory(newUnauthenticatedRegistry(t))
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, sess.Close()) })
 
@@ -189,7 +189,7 @@ func TestSessionFactory_Integration_GetPrompt(t *testing.T) {
 	}
 
 	factory := NewSessionFactory(newUnauthenticatedRegistry(t))
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, sess.Close()) })
 
@@ -218,7 +218,7 @@ func TestSessionFactory_Integration_MultipleBackends(t *testing.T) {
 	}
 
 	factory := NewSessionFactory(newUnauthenticatedRegistry(t))
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends)
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, sess.Close()) })
 
@@ -267,7 +267,7 @@ func TestIdentityBinding_CallerRejection(t *testing.T) {
 		return nil, nil, nil
 	}
 	factory := newSessionFactoryWithConnector(connector)
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), alice, nil)
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), alice, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sess.Close() })
 
@@ -328,7 +328,7 @@ func TestIdentityBinding_ReadResource_And_GetPrompt_WithRealBackend(t *testing.T
 	}
 
 	factory := NewSessionFactory(newUnauthenticatedRegistry(t))
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), identity, []*vmcp.Backend{backend})
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), identity, []*vmcp.Backend{backend}, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, sess.Close()) })
 
@@ -376,7 +376,7 @@ func TestIdentityBinding_RestoreSession_RoundTrip(t *testing.T) {
 		return nil, nil, nil
 	}
 	factory := newSessionFactoryWithConnector(connector)
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), identity, nil)
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), identity, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sess.Close() })
 
@@ -478,7 +478,7 @@ func TestSessionFactory_Integration_RestoreSession_SendsStoredSessionHintToBacke
 
 	// Create the original session — the backend assigns a session ID over
 	// streamable-HTTP and we store it in metadata.
-	orig, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+	orig, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = orig.Close() })
 

--- a/pkg/vmcp/session/decorating_factory.go
+++ b/pkg/vmcp/session/decorating_factory.go
@@ -52,8 +52,9 @@ func (f *decoratingMultiSessionFactory) MakeSessionWithID(
 	id string,
 	identity *auth.Identity,
 	backends []*vmcp.Backend,
+	sink ...ListChangedSink,
 ) (MultiSession, error) {
-	sess, err := f.base.MakeSessionWithID(ctx, id, identity, backends)
+	sess, err := f.base.MakeSessionWithID(ctx, id, identity, backends, sink...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vmcp/session/decorating_factory.go
+++ b/pkg/vmcp/session/decorating_factory.go
@@ -52,9 +52,9 @@ func (f *decoratingMultiSessionFactory) MakeSessionWithID(
 	id string,
 	identity *auth.Identity,
 	backends []*vmcp.Backend,
-	sink ...ListChangedSink,
+	sink ListChangedSink,
 ) (MultiSession, error) {
-	sess, err := f.base.MakeSessionWithID(ctx, id, identity, backends, sink...)
+	sess, err := f.base.MakeSessionWithID(ctx, id, identity, backends, sink)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vmcp/session/decorating_factory_test.go
+++ b/pkg/vmcp/session/decorating_factory_test.go
@@ -34,7 +34,7 @@ func TestNewDecoratingFactory_DecoratorsAppliedInOrder(t *testing.T) {
 	sess := sessionmocks.NewMockMultiSession(ctrl)
 	base := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	base.EXPECT().
-		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(sess, nil)
 
 	var order []int
@@ -48,7 +48,7 @@ func TestNewDecoratingFactory_DecoratorsAppliedInOrder(t *testing.T) {
 	}
 
 	factory := session.NewDecoratingFactory(base, dec1, dec2)
-	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil)
+	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []int{1, 2}, order)
 }
@@ -62,7 +62,7 @@ func TestNewDecoratingFactory_DecoratorError_ClosesSession(t *testing.T) {
 
 	base := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	base.EXPECT().
-		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(sess, nil)
 
 	decErr := errors.New("decorator boom")
@@ -70,7 +70,7 @@ func TestNewDecoratingFactory_DecoratorError_ClosesSession(t *testing.T) {
 		return nil, decErr
 	})
 
-	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil)
+	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil, nil)
 	require.ErrorIs(t, err, decErr)
 }
 
@@ -85,7 +85,7 @@ func TestNewDecoratingFactory_SecondDecoratorError_ClosesCurrentSession(t *testi
 
 	base := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	base.EXPECT().
-		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(sess, nil)
 
 	decErr := errors.New("second decorator boom")
@@ -93,7 +93,7 @@ func TestNewDecoratingFactory_SecondDecoratorError_ClosesCurrentSession(t *testi
 	dec2 := func(_ context.Context, _ session.MultiSession) (session.MultiSession, error) { return nil, decErr }
 
 	factory := session.NewDecoratingFactory(base, dec1, dec2)
-	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil)
+	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil, nil)
 	require.ErrorIs(t, err, decErr)
 }
 
@@ -106,14 +106,14 @@ func TestNewDecoratingFactory_NilReturnWithNoError_ClosesSession(t *testing.T) {
 
 	base := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	base.EXPECT().
-		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(sess, nil)
 
 	factory := session.NewDecoratingFactory(base, func(_ context.Context, _ session.MultiSession) (session.MultiSession, error) {
 		return nil, nil // buggy decorator
 	})
 
-	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil)
+	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nil session")
 }
@@ -127,7 +127,7 @@ func TestNewDecoratingFactory_CloseErrorOnDecoratorFailure_DoesNotSuppressOrigin
 
 	base := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	base.EXPECT().
-		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(sess, nil)
 
 	decErr := errors.New("decorator error")
@@ -135,7 +135,7 @@ func TestNewDecoratingFactory_CloseErrorOnDecoratorFailure_DoesNotSuppressOrigin
 		return nil, decErr
 	})
 
-	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil)
+	_, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil, nil)
 	// The original decorator error, not the close error, is returned.
 	require.ErrorIs(t, err, decErr)
 }
@@ -149,14 +149,14 @@ func TestNewDecoratingFactory_HappyPath_ReturnsFinalSession(t *testing.T) {
 
 	base := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
 	base.EXPECT().
-		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		MakeSessionWithID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(sess, nil)
 
 	factory := session.NewDecoratingFactory(base,
 		func(_ context.Context, _ session.MultiSession) (session.MultiSession, error) { return finalSess, nil },
 	)
 
-	got, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil)
+	got, err := factory.MakeSessionWithID(context.Background(), "id", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, finalSess, got)
 }

--- a/pkg/vmcp/session/default_session_test.go
+++ b/pkg/vmcp/session/default_session_test.go
@@ -549,7 +549,7 @@ func TestNewSessionFactory_MakeSession(t *testing.T) {
 		t.Parallel()
 
 		factory := newSessionFactoryWithConnector(successConnector)
-		sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+		sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 		require.NoError(t, err)
 		require.NotNil(t, sess)
 
@@ -567,9 +567,9 @@ func TestNewSessionFactory_MakeSession(t *testing.T) {
 		t.Parallel()
 
 		factory := newSessionFactoryWithConnector(successConnector)
-		s1, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+		s1, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 		require.NoError(t, err)
-		s2, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+		s2, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 		require.NoError(t, err)
 
 		assert.NotEqual(t, s1.ID(), s2.ID())
@@ -582,7 +582,7 @@ func TestNewSessionFactory_MakeSession(t *testing.T) {
 		t.Parallel()
 
 		factory := newSessionFactoryWithConnector(successConnector)
-		sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, nil)
+		sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, sess)
 
@@ -598,7 +598,7 @@ func TestNewSessionFactory_MakeSession(t *testing.T) {
 		factory := newSessionFactoryWithConnector(successConnector)
 		// Mix of valid and nil entries; nil must not cause a panic.
 		backends := []*vmcp.Backend{nil, backend, nil}
-		sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends)
+		sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends, nil)
 		require.NoError(t, err)
 		require.NotNil(t, sess)
 
@@ -626,7 +626,7 @@ func TestNewSessionFactory_PartialInitialisation(t *testing.T) {
 	}
 
 	factory := newSessionFactoryWithConnector(connector)
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends)
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends, nil)
 	require.NoError(t, err, "partial init must not return an error")
 	require.NotNil(t, sess)
 
@@ -685,7 +685,7 @@ func TestNewSessionFactory_ConnectorReturnsNilWithoutError(t *testing.T) {
 			}
 
 			factory := newSessionFactoryWithConnector(wrappedConnector)
-			sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+			sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 			require.NoError(t, err)
 			require.NotNil(t, sess)
 			assert.Empty(t, sess.Tools())
@@ -712,7 +712,7 @@ func TestNewSessionFactory_ConnectorReturnsConnWithError(t *testing.T) {
 	}
 
 	factory := newSessionFactoryWithConnector(connector)
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 	require.NoError(t, err, "partial failure must not abort the session")
 	require.NotNil(t, sess)
 	assert.Empty(t, sess.Tools())
@@ -741,7 +741,7 @@ func TestNewSessionFactory_CapabilityNameConflictIsResolvedDeterministically(t *
 	}
 
 	factory := newSessionFactoryWithConnector(connector)
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends)
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends, nil)
 	require.NoError(t, err)
 	require.NotNil(t, sess)
 	defer func() { require.NoError(t, sess.Close()) }()
@@ -771,7 +771,7 @@ func TestNewSessionFactory_AllBackendsFail(t *testing.T) {
 	}
 
 	factory := newSessionFactoryWithConnector(connector)
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 	require.NoError(t, err, "all-fail must still return a valid (empty) session")
 	require.NotNil(t, sess)
 
@@ -795,7 +795,7 @@ func TestNewSessionFactory_BackendInitTimeout(t *testing.T) {
 	}
 
 	factory := newSessionFactoryWithConnector(connector, WithBackendInitTimeout(50*time.Millisecond))
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend})
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
 	require.NoError(t, err, "timeout is a partial failure, not a hard error")
 	require.NotNil(t, sess)
 
@@ -844,7 +844,7 @@ func TestNewSessionFactory_ParallelInit(t *testing.T) {
 	}
 
 	factory := newSessionFactoryWithConnector(connector, WithMaxBackendInitConcurrency(3))
-	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends)
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends, nil)
 	require.NoError(t, err)
 
 	// All backends must have been initialised.
@@ -928,7 +928,7 @@ func TestNewSessionFactory_MakeSession_Metadata(t *testing.T) {
 			t.Parallel()
 
 			factory := newSessionFactoryWithConnector(tt.connector)
-			sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), tt.identity, tt.backends)
+			sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), tt.identity, tt.backends, nil)
 			require.NoError(t, err)
 			require.NotNil(t, sess)
 			defer func() { require.NoError(t, sess.Close()) }()
@@ -1142,11 +1142,11 @@ func TestMakeSessionWithID_InvalidIDReturnsError(t *testing.T) {
 		return nil, nil, nil
 	})
 
-	_, err := f.MakeSessionWithID(context.Background(), "", nil, nil)
+	_, err := f.MakeSessionWithID(context.Background(), "", nil, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not be empty")
 
-	_, err = f.MakeSessionWithID(context.Background(), "bad id", nil, nil)
+	_, err = f.MakeSessionWithID(context.Background(), "bad id", nil, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid character")
 }

--- a/pkg/vmcp/session/default_session_test.go
+++ b/pkg/vmcp/session/default_session_test.go
@@ -537,7 +537,7 @@ func TestNewSessionFactory_MakeSession(t *testing.T) {
 	}
 
 	//nolint:unparam // second return is always nil by design in the success-path connector
-	successConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	successConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return &mockConnectedBackend{sessID: "bs-1"}, &vmcp.CapabilityList{
 			Tools:     []vmcp.Tool{tool},
 			Resources: []vmcp.Resource{resource},
@@ -616,7 +616,7 @@ func TestNewSessionFactory_PartialInitialisation(t *testing.T) {
 		{ID: "fail", Name: "fail", BaseURL: "http://fail:9999", TransportType: "streamable-http"},
 	}
 
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		if target.WorkloadID == "fail" {
 			return nil, nil, errors.New("backend unavailable")
 		}
@@ -650,20 +650,20 @@ func TestNewSessionFactory_ConnectorReturnsNilWithoutError(t *testing.T) {
 	}{
 		{
 			name: "nil conn with nil caps",
-			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 				return nil, nil, nil
 			},
 		},
 		{
 			name: "nil conn with non-nil caps",
-			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 				return nil, &vmcp.CapabilityList{}, nil
 			},
 		},
 		{
 			name:          "non-nil conn with nil caps must close conn to avoid leak",
 			wantConnClose: true,
-			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+			connector: func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 				return &mockConnectedBackend{}, nil, nil
 			},
 		},
@@ -676,8 +676,8 @@ func TestNewSessionFactory_ConnectorReturnsNilWithoutError(t *testing.T) {
 			// Replace the connector with one that captures the mock so we can
 			// inspect closeCalled after MakeSession returns.
 			var captured *mockConnectedBackend
-			wrappedConnector := func(ctx context.Context, target *vmcp.BackendTarget, id *auth.Identity, hint string) (internalbk.Session, *vmcp.CapabilityList, error) {
-				conn, caps, err := tt.connector(ctx, target, id, hint)
+			wrappedConnector := func(ctx context.Context, target *vmcp.BackendTarget, id *auth.Identity, hint string, sink internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
+				conn, caps, err := tt.connector(ctx, target, id, hint, sink)
 				if m, ok := conn.(*mockConnectedBackend); ok {
 					captured = m
 				}
@@ -707,7 +707,7 @@ func TestNewSessionFactory_ConnectorReturnsConnWithError(t *testing.T) {
 	backend := &vmcp.Backend{ID: "b1", Name: "b1", BaseURL: "http://x:9", TransportType: "streamable-http"}
 	leaked := &mockConnectedBackend{}
 
-	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return leaked, nil, errors.New("init failed but conn was partially opened")
 	}
 
@@ -732,7 +732,7 @@ func TestNewSessionFactory_CapabilityNameConflictIsResolvedDeterministically(t *
 		{ID: "alpha", Name: "alpha", BaseURL: "http://alpha:9", TransportType: "streamable-http"},
 	}
 
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return &mockConnectedBackend{sessID: target.WorkloadID}, &vmcp.CapabilityList{
 			Tools:     []vmcp.Tool{{Name: "fetch", BackendID: target.WorkloadID}},
 			Resources: []vmcp.Resource{{URI: "file://data", BackendID: target.WorkloadID}},
@@ -766,7 +766,7 @@ func TestNewSessionFactory_AllBackendsFail(t *testing.T) {
 	t.Parallel()
 
 	backend := &vmcp.Backend{ID: "b1", Name: "b1", BaseURL: "http://x:9", TransportType: "streamable-http"}
-	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, errors.New("down")
 	}
 
@@ -785,7 +785,7 @@ func TestNewSessionFactory_BackendInitTimeout(t *testing.T) {
 	backend := &vmcp.Backend{ID: "slow", Name: "slow", BaseURL: "http://x:9", TransportType: "streamable-http"}
 
 	released := make(chan struct{})
-	connector := func(ctx context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(ctx context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		select {
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
@@ -823,7 +823,7 @@ func TestNewSessionFactory_ParallelInit(t *testing.T) {
 	var mu sync.Mutex
 	var maxConcurrent, current int32
 
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		mu.Lock()
 		current++
 		if current > maxConcurrent {
@@ -864,10 +864,10 @@ func TestNewSessionFactory_MakeSession_Metadata(t *testing.T) {
 	backend2 := &vmcp.Backend{ID: "b2", Name: "backend-2", BaseURL: "http://localhost:9002", TransportType: "streamable-http"}
 
 	//nolint:unparam // error return is always nil by design in the success-path connector
-	successConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	successConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return &mockConnectedBackend{}, &vmcp.CapabilityList{}, nil
 	}
-	failConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	failConnector := func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, errors.New("connection refused")
 	}
 
@@ -1138,7 +1138,7 @@ func TestValidateSessionID(t *testing.T) {
 func TestMakeSessionWithID_InvalidIDReturnsError(t *testing.T) {
 	t.Parallel()
 
-	f := newSessionFactoryWithConnector(func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	f := newSessionFactoryWithConnector(func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, nil
 	})
 

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -55,11 +55,20 @@ type MultiSessionFactory interface {
 	//
 	// All other behaviour (partial initialisation, bounded concurrency, etc.)
 	// is identical to MakeSession.
+	//
+	// sink is a trailing variadic parameter (at most the first value is used) so
+	// the many pre-existing 4-argument call sites across the session/server test
+	// suites continue to compile unchanged. When a value is supplied, it is
+	// threaded to every backend connector for this session and invoked
+	// (best-effort) when a backend emits a notification consumed asynchronously
+	// — currently only notifications/tools/list_changed (#5748). Pass no value,
+	// or nil, to leave that consumption disabled for this session.
 	MakeSessionWithID(
 		ctx context.Context,
 		id string,
 		identity *auth.Identity,
 		backends []*vmcp.Backend,
+		sink ...ListChangedSink,
 	) (MultiSession, error)
 
 	// RestoreSession reconstructs a live MultiSession from persisted metadata.
@@ -96,6 +105,12 @@ type MultiSessionFactory interface {
 // Mcp-Session-Id hint during Initialize so the backend can resume rather than
 // re-initialize. Pass an empty string for brand-new sessions.
 //
+// sink, when non-nil, is invoked (best-effort, possibly from a receive-loop
+// goroutine) whenever this backend emits a notification the connector consumes
+// asynchronously (currently only notifications/tools/list_changed). Pass nil to
+// leave that consumption disabled; a connector that does not support it may
+// ignore the parameter entirely. See backend.ListChangedSink.
+//
 // The returned backend.Session owns the underlying transport connection and
 // must be closed when the session ends. The returned CapabilityList is used
 // to populate the session's routing table and capability lists.
@@ -107,6 +122,7 @@ type backendConnector func(
 	target *vmcp.BackendTarget,
 	identity *auth.Identity,
 	sessionHint string,
+	sink backend.ListChangedSink,
 ) (backend.Session, *vmcp.CapabilityList, error)
 
 // defaultMultiSessionFactory is the production MultiSessionFactory implementation.
@@ -177,12 +193,13 @@ func (f *defaultMultiSessionFactory) initOneBackend(
 	b *vmcp.Backend,
 	identity *auth.Identity,
 	sessionHint string,
+	sink backend.ListChangedSink,
 ) *initResult {
 	bCtx, cancel := context.WithTimeout(ctx, f.backendInitTimeout)
 	defer cancel()
 
 	target := vmcp.BackendToTarget(b)
-	conn, caps, err := f.connector(bCtx, target, identity, sessionHint)
+	conn, caps, err := f.connector(bCtx, target, identity, sessionHint, sink)
 	if err != nil {
 		if conn != nil {
 			_ = conn.Close()
@@ -249,11 +266,21 @@ func (f *defaultMultiSessionFactory) MakeSessionWithID(
 	id string,
 	identity *auth.Identity,
 	backends []*vmcp.Backend,
+	sink ...ListChangedSink,
 ) (MultiSession, error) {
 	if err := validateSessionID(id); err != nil {
 		return nil, err
 	}
-	return f.makeSession(ctx, id, identity, backends)
+	return f.makeSession(ctx, id, identity, backends, firstSink(sink))
+}
+
+// firstSink returns the first sink in a variadic slice, or nil. See
+// MultiSessionFactory.MakeSessionWithID's doc comment for why sink is variadic.
+func firstSink(sink []ListChangedSink) ListChangedSink {
+	if len(sink) == 0 {
+		return nil
+	}
+	return sink[0]
 }
 
 // validateSessionID checks that id is non-empty and contains only visible
@@ -302,6 +329,7 @@ func (f *defaultMultiSessionFactory) makeBaseSession(
 	identity *auth.Identity,
 	backends []*vmcp.Backend,
 	sessionHints map[string]string,
+	sink backend.ListChangedSink,
 ) *defaultMultiSession {
 	filtered := make([]*vmcp.Backend, 0, len(backends))
 	for _, b := range backends {
@@ -322,7 +350,7 @@ func (f *defaultMultiSessionFactory) makeBaseSession(
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			rawResults[i] = f.initOneBackend(ctx, b, identity, sessionHints[b.ID])
+			rawResults[i] = f.initOneBackend(ctx, b, identity, sessionHints[b.ID], sink)
 		}(i, b)
 	}
 	wg.Wait()
@@ -377,8 +405,9 @@ func (f *defaultMultiSessionFactory) makeSession(
 	sessID string,
 	identity *auth.Identity,
 	backends []*vmcp.Backend,
+	sink backend.ListChangedSink,
 ) (MultiSession, error) {
-	baseSession := f.makeBaseSession(ctx, sessID, identity, backends, nil)
+	baseSession := f.makeBaseSession(ctx, sessID, identity, backends, nil, sink)
 
 	// Apply session binding: extracts the (iss, sub) identity tuple, stores it in
 	// session metadata under MetadataKeyIdentityBinding, and wraps the session with
@@ -460,8 +489,12 @@ func (f *defaultMultiSessionFactory) RestoreSession(
 	}
 
 	// Build the base session (backend connections + routing table) without the
-	// security wrapper. Pass nil identity — see comment above.
-	baseSession := f.makeBaseSession(ctx, id, nil, filteredBackends, sessionHints)
+	// security wrapper. Pass nil identity — see comment above. Pass nil sink: a
+	// cross-pod restore has no SDK ClientSession to resync (the restoring pod may
+	// not be the one serving the client's connection), so tools list_changed
+	// propagation on this path is a follow-up (#5748 scope: the CreateSession
+	// path only).
+	baseSession := f.makeBaseSession(ctx, id, nil, filteredBackends, sessionHints, nil)
 
 	// Restore only the identity-binding key from stored metadata. The other
 	// keys (MetadataKeyBackendIDs, MetadataKeyBackendSessionPrefix.*) are

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -56,19 +56,17 @@ type MultiSessionFactory interface {
 	// All other behaviour (partial initialisation, bounded concurrency, etc.)
 	// is identical to MakeSession.
 	//
-	// sink is a trailing variadic parameter (at most the first value is used) so
-	// the many pre-existing 4-argument call sites across the session/server test
-	// suites continue to compile unchanged. When a value is supplied, it is
-	// threaded to every backend connector for this session and invoked
-	// (best-effort) when a backend emits a notification consumed asynchronously
-	// — currently only notifications/tools/list_changed (#5748). Pass no value,
-	// or nil, to leave that consumption disabled for this session.
+	// sink, when non-nil, is threaded to every backend connector for this
+	// session and invoked (best-effort, on the backend receive-loop goroutine)
+	// when a backend emits a notification consumed asynchronously — currently
+	// only notifications/tools/list_changed (#5748). Pass nil to leave that
+	// consumption disabled for this session.
 	MakeSessionWithID(
 		ctx context.Context,
 		id string,
 		identity *auth.Identity,
 		backends []*vmcp.Backend,
-		sink ...ListChangedSink,
+		sink ListChangedSink,
 	) (MultiSession, error)
 
 	// RestoreSession reconstructs a live MultiSession from persisted metadata.
@@ -266,21 +264,12 @@ func (f *defaultMultiSessionFactory) MakeSessionWithID(
 	id string,
 	identity *auth.Identity,
 	backends []*vmcp.Backend,
-	sink ...ListChangedSink,
+	sink ListChangedSink,
 ) (MultiSession, error) {
 	if err := validateSessionID(id); err != nil {
 		return nil, err
 	}
-	return f.makeSession(ctx, id, identity, backends, firstSink(sink))
-}
-
-// firstSink returns the first sink in a variadic slice, or nil. See
-// MultiSessionFactory.MakeSessionWithID's doc comment for why sink is variadic.
-func firstSink(sink []ListChangedSink) ListChangedSink {
-	if len(sink) == 0 {
-		return nil
-	}
-	return sink[0]
+	return f.makeSession(ctx, id, identity, backends, sink)
 }
 
 // validateSessionID checks that id is non-empty and contains only visible

--- a/pkg/vmcp/session/factory_metadata_test.go
+++ b/pkg/vmcp/session/factory_metadata_test.go
@@ -24,7 +24,7 @@ func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
 	t.Run("two backends: both session IDs written to metadata", func(t *testing.T) {
 		t.Parallel()
 
-		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 			ids := map[string]string{
 				"backend-a": "sess-a",
 				"backend-b": "sess-b",
@@ -72,7 +72,7 @@ func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
 	t.Run("partial failure: only successful backend written", func(t *testing.T) {
 		t.Parallel()
 
-		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+		connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 			if target.WorkloadID == "backend-ok" {
 				return &mockConnectedBackend{sessID: "sess-ok"}, &vmcp.CapabilityList{}, nil
 			}
@@ -103,7 +103,7 @@ func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
 func TestRestoreSession_FreshlyPopulatesMetadataKeyBackendIDs(t *testing.T) {
 	t.Parallel()
 
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		ids := map[string]string{
 			"backend-a": "sess-a",
 			"backend-b": "sess-b",
@@ -181,7 +181,7 @@ func TestRestoreSession_PassesStoredSessionHintToConnector(t *testing.T) {
 	// connector records the session hint it receives for each backend.
 	// It always returns a stable session ID so that the original session
 	// has predictable per-backend metadata to store.
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, sessionHint string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, sessionHint string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		mu.Lock()
 		hintsReceived[target.WorkloadID] = sessionHint
 		mu.Unlock()
@@ -224,6 +224,72 @@ func TestRestoreSession_PassesStoredSessionHintToConnector(t *testing.T) {
 		"RestoreSession must pass stored backend-b session ID as hint to connector")
 }
 
+// TestMakeSession_ThreadsListChangedSinkToConnector verifies (#5748) that a
+// sink passed to MakeSessionWithID reaches the connector for every backend in
+// the session, and that a session created WITHOUT a sink argument (the
+// pre-existing 4-arg call shape) passes nil — so existing callers are
+// unaffected.
+func TestMakeSession_ThreadsListChangedSinkToConnector(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sink threaded to every backend connector", func(t *testing.T) {
+		t.Parallel()
+
+		var mu sync.Mutex
+		received := map[string]internalbk.ListChangedSink{}
+
+		connector := func(
+			_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string, sink internalbk.ListChangedSink,
+		) (internalbk.Session, *vmcp.CapabilityList, error) {
+			mu.Lock()
+			received[target.WorkloadID] = sink
+			mu.Unlock()
+			return &mockConnectedBackend{sessID: "sess-" + target.WorkloadID}, &vmcp.CapabilityList{}, nil
+		}
+
+		factory := newSessionFactoryWithConnector(connector)
+		backends := []*vmcp.Backend{{ID: "backend-a"}, {ID: "backend-b"}}
+
+		var sinkCalls int
+		sink := internalbk.ListChangedSink(func(context.Context, string, string) { sinkCalls++ })
+
+		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, backends, sink)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = sess.Close() })
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, received, 2)
+		for _, id := range []string{"backend-a", "backend-b"} {
+			require.NotNil(t, received[id], "connector for %s must receive a non-nil sink", id)
+			received[id](context.Background(), id, "tools")
+		}
+		assert.Equal(t, 2, sinkCalls, "the same sink function must reach every backend's connector call")
+	})
+
+	t.Run("no sink argument passes nil (pre-existing call shape unaffected)", func(t *testing.T) {
+		t.Parallel()
+
+		var receivedSink internalbk.ListChangedSink
+		var sinkWasNonNil bool
+		connector := func(
+			_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, sink internalbk.ListChangedSink,
+		) (internalbk.Session, *vmcp.CapabilityList, error) {
+			receivedSink = sink
+			sinkWasNonNil = sink != nil
+			return &mockConnectedBackend{sessID: "sess"}, &vmcp.CapabilityList{}, nil
+		}
+
+		factory := newSessionFactoryWithConnector(connector)
+		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, []*vmcp.Backend{{ID: "backend-a"}})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = sess.Close() })
+
+		assert.False(t, sinkWasNonNil, "omitting the variadic sink argument must pass nil to the connector")
+		assert.Nil(t, receivedSink)
+	})
+}
+
 // TestMakeSession_PassesEmptySessionHintToConnector verifies that MakeSession
 // (creating a new session, not restoring) passes an empty hint so that the
 // backend always creates a fresh session.
@@ -233,7 +299,7 @@ func TestMakeSession_PassesEmptySessionHintToConnector(t *testing.T) {
 	var mu sync.Mutex
 	hintsReceived := map[string]string{}
 
-	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, sessionHint string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	connector := func(_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, sessionHint string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		mu.Lock()
 		hintsReceived[target.WorkloadID] = sessionHint
 		mu.Unlock()

--- a/pkg/vmcp/session/factory_metadata_test.go
+++ b/pkg/vmcp/session/factory_metadata_test.go
@@ -41,7 +41,7 @@ func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
 			{ID: "backend-a"},
 			{ID: "backend-b"},
 		}
-		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, backends)
+		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, backends, nil)
 		require.NoError(t, err)
 
 		meta := sess.GetMetadata()
@@ -56,7 +56,7 @@ func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
 		t.Parallel()
 
 		factory := newSessionFactoryWithConnector(nilBackendConnector())
-		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, nil)
+		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, nil, nil)
 		require.NoError(t, err)
 
 		meta := sess.GetMetadata()
@@ -85,7 +85,7 @@ func TestMakeSession_PersistsBackendSessionIDs(t *testing.T) {
 			{ID: "backend-ok"},
 			{ID: "backend-fail"},
 		}
-		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, backends)
+		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, backends, nil)
 		require.NoError(t, err)
 
 		meta := sess.GetMetadata()
@@ -123,7 +123,7 @@ func TestRestoreSession_FreshlyPopulatesMetadataKeyBackendIDs(t *testing.T) {
 	sessionID := "restore-test-session"
 
 	// Create the initial session so we have a real token hash in metadata.
-	original, err := factory.MakeSessionWithID(t.Context(), sessionID, nil, backends)
+	original, err := factory.MakeSessionWithID(t.Context(), sessionID, nil, backends, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = original.Close() })
 
@@ -195,7 +195,7 @@ func TestRestoreSession_PassesStoredSessionHintToConnector(t *testing.T) {
 	}
 
 	// Create the original session — connector receives empty hints.
-	original, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, backends)
+	original, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, backends, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = original.Close() })
 
@@ -251,7 +251,7 @@ func TestMakeSession_ThreadsListChangedSinkToConnector(t *testing.T) {
 		backends := []*vmcp.Backend{{ID: "backend-a"}, {ID: "backend-b"}}
 
 		var sinkCalls int
-		sink := internalbk.ListChangedSink(func(context.Context, string, string) { sinkCalls++ })
+		sink := internalbk.ListChangedSink(func(context.Context, string, internalbk.ChangeKind) { sinkCalls++ })
 
 		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, backends, sink)
 		require.NoError(t, err)
@@ -262,7 +262,7 @@ func TestMakeSession_ThreadsListChangedSinkToConnector(t *testing.T) {
 		require.Len(t, received, 2)
 		for _, id := range []string{"backend-a", "backend-b"} {
 			require.NotNil(t, received[id], "connector for %s must receive a non-nil sink", id)
-			received[id](context.Background(), id, "tools")
+			received[id](context.Background(), id, internalbk.KindTools)
 		}
 		assert.Equal(t, 2, sinkCalls, "the same sink function must reach every backend's connector call")
 	})
@@ -281,7 +281,7 @@ func TestMakeSession_ThreadsListChangedSinkToConnector(t *testing.T) {
 		}
 
 		factory := newSessionFactoryWithConnector(connector)
-		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, []*vmcp.Backend{{ID: "backend-a"}})
+		sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, []*vmcp.Backend{{ID: "backend-a"}}, nil)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = sess.Close() })
 
@@ -307,7 +307,7 @@ func TestMakeSession_PassesEmptySessionHintToConnector(t *testing.T) {
 	}
 
 	factory := newSessionFactoryWithConnector(connector)
-	sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, []*vmcp.Backend{{ID: "backend-a"}})
+	sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, []*vmcp.Backend{{ID: "backend-a"}}, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sess.Close() })
 

--- a/pkg/vmcp/session/identity_binding_test.go
+++ b/pkg/vmcp/session/identity_binding_test.go
@@ -24,7 +24,7 @@ import (
 // backend to be skipped during init. This lets us exercise session-metadata
 // logic without real backend connections.
 func nilBackendConnector() backendConnector {
-	return func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string) (internalbk.Session, *vmcp.CapabilityList, error) {
+	return func(_ context.Context, _ *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink) (internalbk.Session, *vmcp.CapabilityList, error) {
 		return nil, nil, nil
 	}
 }
@@ -226,6 +226,7 @@ func TestRestoreSession_PassesNilIdentityToConnector(t *testing.T) {
 		_ *vmcp.BackendTarget,
 		id *auth.Identity,
 		_ string,
+		_ internalbk.ListChangedSink,
 	) (internalbk.Session, *vmcp.CapabilityList, error) {
 		connectorCalled = true
 		capturedIdentity = id

--- a/pkg/vmcp/session/identity_binding_test.go
+++ b/pkg/vmcp/session/identity_binding_test.go
@@ -79,7 +79,7 @@ func TestMakeSession_StoresIdentityBinding(t *testing.T) {
 
 			factory := newSessionFactoryWithConnector(nilBackendConnector())
 			sess, err := factory.MakeSessionWithID(
-				t.Context(), uuid.New().String(), tt.identity, nil,
+				t.Context(), uuid.New().String(), tt.identity, nil, nil,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, sess)
@@ -104,7 +104,7 @@ func TestMakeSession_RejectsBoundSessionWithoutIdentifyingClaims(t *testing.T) {
 	// Token is present but Claims are empty, so BindSession's extractBindingID fails.
 	identity := identityWithClaims("x", map[string]any{})
 
-	_, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), identity, nil)
+	_, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), identity, nil, nil)
 	require.Error(t, err, "session creation must fail when bound identity lacks identifying claims")
 }
 
@@ -240,7 +240,7 @@ func TestRestoreSession_PassesNilIdentityToConnector(t *testing.T) {
 	})
 
 	factory := newSessionFactoryWithConnector(capturingConnector)
-	multiSess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), originalIdentity, nil)
+	multiSess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), originalIdentity, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = multiSess.Close() })
 

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -39,6 +39,44 @@ const (
 	defaultBackendRequestTimeout = 30 * time.Second
 )
 
+// ListChangedSink is invoked when a persistent backend connection observes a
+// notification this package consumes asynchronously (outside any in-flight
+// call) — currently only notifications/tools/list_changed, reported with
+// kind="tools". Resources/prompts list_changed are out of scope for #5748 (a
+// tracked follow-up); this package does not dispatch them to sink.
+//
+// Implementations must be best-effort and non-blocking: the handler that
+// invokes sink runs on the mcpcompat client's receive-loop goroutine (see
+// Client.dispatch in toolhive-core), so a slow or blocking sink stalls that
+// backend's notification delivery. ctx carries no request-scoped values (the
+// notification can arrive long after any particular client request
+// completed) — see createMCPClient.
+type ListChangedSink func(ctx context.Context, backendWorkloadID, kind string)
+
+// newListChangedNotificationHandler builds the OnNotification handler
+// registered by createMCPClient when sink is non-nil. It dispatches
+// notifications/tools/list_changed to sink (kind="tools") and log-only handles
+// notifications/message; every other notification method is ignored — this
+// handler is not the mid-call server->client relay (that is
+// pkg/vmcp/client's per-call notification forwarder), it only feeds the
+// session-registration resync path.
+func newListChangedNotificationHandler(workloadID string, sink ListChangedSink) func(mcp.JSONRPCNotification) {
+	return func(n mcp.JSONRPCNotification) {
+		switch n.Method {
+		case vmcp.MethodToolsListChangedNotification:
+			sink(context.Background(), workloadID, "tools")
+		case vmcp.MethodLogNotification:
+			// Out-of-call backend log messages are not relayed to the downstream
+			// client on this path; log so the signal is visible rather than
+			// silently dropped.
+			slog.Debug("backend log notification received outside call", "backendID", workloadID)
+		default:
+			// Other notification types (resources/prompts list_changed, resource
+			// subscription updates, ...) are out of scope here (#5748 follow-up).
+		}
+	}
+}
+
 // httpRoundTripperFunc adapts a plain function to http.RoundTripper.
 type httpRoundTripperFunc func(*http.Request) (*http.Response, error)
 
@@ -236,11 +274,18 @@ func (c *mcpSession) GetPrompt(
 // shared across every session it creates; its lifetime matches the connector's.
 // It is consumed by BuildHeaderForwardTripper to resolve secret-backed entries
 // in target.HeaderForward.
+//
+// The returned function's sink parameter, when non-nil, enables persistent
+// backend-notification consumption for this backend connection — see
+// createMCPClient for what that does and does not enable (nil-sink callers are
+// completely unaffected: no OnNotification handler is registered and no
+// standalone GET stream is opened).
 func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
 	identity *auth.Identity,
 	sessionHint string,
+	sink ListChangedSink,
 ) (Session, *vmcp.CapabilityList, error) {
 	provider := secrets.NewEnvironmentProvider()
 	return func(
@@ -248,8 +293,9 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 		target *vmcp.BackendTarget,
 		identity *auth.Identity,
 		sessionHint string,
+		sink ListChangedSink,
 	) (Session, *vmcp.CapabilityList, error) {
-		c, err := createMCPClient(ctx, target, identity, registry, sessionHint, provider)
+		c, err := createMCPClient(ctx, target, identity, registry, sessionHint, provider, sink)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create MCP client for backend %s: %w", target.WorkloadID, err)
 		}
@@ -283,6 +329,18 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 // ctx is used only to resolve secret-backed entries in target.HeaderForward at
 // client-creation time; the transport itself is started with context.Background()
 // as described above. provider supplies values for those secret-backed headers.
+//
+// sink is gated STRICTLY on non-nil: when nil, this function's behavior is
+// byte-for-byte identical to before sink existed (no OnNotification handler is
+// registered, and the streamable-HTTP branch does not enable continuous
+// listening). When non-nil, an OnNotification handler is registered (before
+// c.Start, per the mcpcompat client's registration contract) that invokes sink
+// on notifications/tools/list_changed and log-only handles notifications/message.
+// For the streamable-HTTP transport, a non-nil sink also enables
+// mcptransport.WithContinuousListening() — required for the backend's
+// asynchronous (outside any in-flight call) notifications to reach this client
+// at all — since some backends hang when a standalone GET stream is opened
+// against them, this must stay opt-in (#5748 R3).
 func createMCPClient(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
@@ -290,6 +348,7 @@ func createMCPClient(
 	registry vmcpauth.OutgoingAuthRegistry,
 	sessionHint string,
 	provider secrets.Provider,
+	sink ListChangedSink,
 ) (*mcpclient.Client, error) {
 	// Resolve and validate the auth strategy once at client creation time.
 	strategyName := authtypes.StrategyTypeUnauthenticated
@@ -379,6 +438,14 @@ func createMCPClient(
 		if sessionHint != "" {
 			streamableOpts = append(streamableOpts, mcptransport.WithSession(sessionHint))
 		}
+		if sink != nil {
+			// A standalone GET stream is the only way this client can receive a
+			// notification the backend emits outside an in-flight call (e.g.
+			// tools/list_changed after a registration-time capability change).
+			// Gated strictly on sink != nil: some backends hang when this stream
+			// is opened against them (#5748 R3), so it must stay opt-in.
+			streamableOpts = append(streamableOpts, mcptransport.WithContinuousListening())
+		}
 		c, err = mcpclient.NewStreamableHttpClient(target.BaseURL, streamableOpts...)
 	case "sse":
 		// For SSE, the entire session is delivered as one long-lived HTTP
@@ -400,6 +467,16 @@ func createMCPClient(
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create %s client: %w", target.TransportType, err)
+	}
+
+	// Register the notification handler before Start (mirrors the per-call
+	// client in pkg/vmcp/client, and matches the mcpcompat client's own
+	// registration contract): the handler dispatches
+	// notifications/tools/list_changed to sink and logs notifications/message.
+	// Strictly gated on sink != nil so a nil-sink caller registers no handler at
+	// all — this function's behavior for that caller is unchanged.
+	if sink != nil {
+		c.OnNotification(newListChangedNotificationHandler(target.WorkloadID, sink))
 	}
 
 	// Start the transport with context.Background() so that the transport's

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -39,23 +39,35 @@ const (
 	defaultBackendRequestTimeout = 30 * time.Second
 )
 
+// ChangeKind identifies which capability class a backend reported changed via
+// ListChangedSink. Using a typed constant (rather than a bare string) means a
+// typo is a compile error at the producer and consumer instead of a silent
+// no-op, and gives the resources/prompts follow-up (#5748) an obvious extension
+// point (KindResources/KindPrompts).
+type ChangeKind string
+
+// KindTools is reported when a backend emits notifications/tools/list_changed.
+const KindTools ChangeKind = "tools"
+
 // ListChangedSink is invoked when a persistent backend connection observes a
 // notification this package consumes asynchronously (outside any in-flight
 // call) — currently only notifications/tools/list_changed, reported with
-// kind="tools". Resources/prompts list_changed are out of scope for #5748 (a
+// kind=KindTools. Resources/prompts list_changed are out of scope for #5748 (a
 // tracked follow-up); this package does not dispatch them to sink.
 //
-// Implementations must be best-effort and non-blocking: the handler that
-// invokes sink runs on the mcpcompat client's receive-loop goroutine (see
-// Client.dispatch in toolhive-core), so a slow or blocking sink stalls that
-// backend's notification delivery. ctx carries no request-scoped values (the
-// notification can arrive long after any particular client request
-// completed) — see createMCPClient.
-type ListChangedSink func(ctx context.Context, backendWorkloadID, kind string)
+// The sink is invoked on the mcpcompat client's receive-loop goroutine (see
+// Client.dispatch in toolhive-core), so implementations MUST be non-blocking:
+// they must hand the work off (e.g. set a dirty flag / signal a worker) and
+// return immediately. A sink that does real work (network I/O, cache purges)
+// inline stalls that backend's entire notification delivery and lets a
+// misbehaving backend amplify one notification into unbounded work. The ctx
+// passed here is only for the hand-off; long-lived resync work must run under
+// a caller-owned, cancellable context, not this one.
+type ListChangedSink func(ctx context.Context, backendWorkloadID string, kind ChangeKind)
 
 // newListChangedNotificationHandler builds the OnNotification handler
 // registered by createMCPClient when sink is non-nil. It dispatches
-// notifications/tools/list_changed to sink (kind="tools") and log-only handles
+// notifications/tools/list_changed to sink (kind=KindTools) and log-only handles
 // notifications/message; every other notification method is ignored — this
 // handler is not the mid-call server->client relay (that is
 // pkg/vmcp/client's per-call notification forwarder), it only feeds the
@@ -64,7 +76,7 @@ func newListChangedNotificationHandler(workloadID string, sink ListChangedSink) 
 	return func(n mcp.JSONRPCNotification) {
 		switch n.Method {
 		case vmcp.MethodToolsListChangedNotification:
-			sink(context.Background(), workloadID, "tools")
+			sink(context.Background(), workloadID, KindTools)
 		case vmcp.MethodLogNotification:
 			// Out-of-call backend log messages are not relayed to the downstream
 			// client on this path; log so the signal is visible rather than

--- a/pkg/vmcp/session/internal/backend/mcp_session_header_forward_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_header_forward_test.go
@@ -112,7 +112,7 @@ func TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests(t *testing.T) 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		sess, _, err := connector(ctx, target, nil, "")
+		sess, _, err := connector(ctx, target, nil, "", nil)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = sess.Close() })
 
@@ -155,7 +155,7 @@ func TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests(t *testing.T) 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		_, _, err := connector(ctx, target, nil, "")
+		_, _, err := connector(ctx, target, nil, "", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "restricted",
 			"connector must reject restricted header names in HeaderForward config")
@@ -216,7 +216,7 @@ func connectAndCallEcho(t *testing.T, target *vmcp.BackendTarget) Session {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	sess, caps, err := connector(ctx, target, nil, "")
+	sess, caps, err := connector(ctx, target, nil, "", nil)
 	require.NoError(t, err, "connector must initialise the backend successfully")
 	require.NotNil(t, sess, "connector returned nil session")
 	require.NotNil(t, caps, "connector returned nil capability list")

--- a/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
@@ -85,7 +85,7 @@ func TestHTTPSession_PerRequestIdentity_DrivesUpstreamAuthHeader(t *testing.T) {
 	initCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	sess, _, err := connector(initCtx, target, staleIdentity, "")
+	sess, _, err := connector(initCtx, target, staleIdentity, "", nil)
 	require.NoError(t, err, "connector must initialise the backend successfully")
 	t.Cleanup(func() { _ = sess.Close() })
 
@@ -161,7 +161,7 @@ func TestHTTPSession_FallbackIdentity_UsedWhenContextHasNoIdentity(t *testing.T)
 	initCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	sess, _, err := connector(initCtx, target, fallbackIdentity, "")
+	sess, _, err := connector(initCtx, target, fallbackIdentity, "", nil)
 	require.NoError(t, err, "connector must initialise the backend successfully")
 	t.Cleanup(func() { _ = sess.Close() })
 

--- a/pkg/vmcp/session/internal/backend/mcp_session_meta_propagation_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_meta_propagation_test.go
@@ -56,7 +56,7 @@ func TestHTTPSession_CallTool_InjectsTraceparent(t *testing.T) { //nolint:parall
 	initCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	sess, _, err := connector(initCtx, target, nil, "")
+	sess, _, err := connector(initCtx, target, nil, "", nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sess.Close() })
 

--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -190,7 +190,7 @@ func TestCreateMCPClient_ContinuousListeningGatedOnSink(t *testing.T) {
 		{name: "nil sink disables continuous listening", sink: nil, wantContinuous: false},
 		{
 			name:           "non-nil sink enables continuous listening",
-			sink:           func(context.Context, string, string) {},
+			sink:           func(context.Context, string, ChangeKind) {},
 			wantContinuous: true,
 		},
 	}
@@ -229,10 +229,11 @@ func TestCreateMCPClient_ListChangedSink_FiresOnBackendNotification(t *testing.T
 	}
 
 	type firedCall struct {
-		backendWorkloadID, kind string
+		backendWorkloadID string
+		kind              ChangeKind
 	}
 	fired := make(chan firedCall, 4)
-	sink := func(_ context.Context, backendWorkloadID, kind string) {
+	sink := func(_ context.Context, backendWorkloadID string, kind ChangeKind) {
 		fired <- firedCall{backendWorkloadID: backendWorkloadID, kind: kind}
 	}
 
@@ -258,8 +259,86 @@ func TestCreateMCPClient_ListChangedSink_FiresOnBackendNotification(t *testing.T
 	select {
 	case got := <-fired:
 		assert.Equal(t, "list-changed-backend", got.backendWorkloadID)
-		assert.Equal(t, "tools", got.kind)
+		assert.Equal(t, KindTools, got.kind)
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for the list_changed sink to fire")
 	}
+}
+
+// TestCreateMCPClient_ListChangedSink_DoesNotStallInFlightCall is the F9
+// corroborated-concern regression: firing a real backend tools/list_changed —
+// whose sink is (deliberately, for the test) slow — must NOT stall an in-flight
+// call on the same backend session. The sink runs on the client's
+// notification-dispatch goroutine, which is independent of the request path, so
+// a CallTool issued while the sink is still working completes promptly. This
+// validates the no-deadlock conclusion behind moving the real resync off the
+// receive loop (#5748 B-HIGH-2).
+func TestCreateMCPClient_ListChangedSink_DoesNotStallInFlightCall(t *testing.T) {
+	t.Parallel()
+
+	b := newListChangedTestBackend(t)
+	target := &vmcp.BackendTarget{
+		WorkloadID:    "list-changed-backend",
+		WorkloadName:  "list-changed-backend",
+		BaseURL:       b.url,
+		TransportType: "streamable-http",
+	}
+
+	sinkEntered := make(chan struct{}, 1)
+	releaseSink := make(chan struct{})
+	sink := func(_ context.Context, _ string, kind ChangeKind) {
+		if kind != KindTools {
+			return
+		}
+		select {
+		case sinkEntered <- struct{}{}:
+		default:
+		}
+		// Simulate a slow resync body running on the dispatch goroutine to prove
+		// it does not hold anything the request path needs.
+		<-releaseSink
+	}
+
+	c, err := createMCPClient(
+		context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), sink,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.Initialize(context.Background(), mcpmcp.InitializeRequest{
+		Params: mcpmcp.InitializeParams{
+			ProtocolVersion: mcpmcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcpmcp.Implementation{Name: "test-client", Version: "1.0"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Trigger a real tools/list_changed and wait until the (slow) sink is running.
+	b.addTool(t, "added_tool")
+	select {
+	case <-sinkEntered:
+	case <-time.After(10 * time.Second):
+		close(releaseSink)
+		t.Fatal("sink never fired")
+	}
+
+	// With the sink still blocked, an in-flight call on the same session must
+	// complete promptly (independent dispatch vs request paths).
+	callDone := make(chan error, 1)
+	go func() {
+		_, callErr := c.CallTool(context.Background(), mcpmcp.CallToolRequest{
+			Params: mcpmcp.CallToolParams{Name: "initial_tool"},
+		})
+		callDone <- callErr
+	}()
+
+	select {
+	case callErr := <-callDone:
+		require.NoError(t, callErr, "in-flight call must succeed while a resync sink is running")
+	case <-time.After(10 * time.Second):
+		close(releaseSink)
+		t.Fatal("in-flight call stalled while the list_changed sink was running")
+	}
+
+	close(releaseSink)
 }

--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -5,11 +5,18 @@ package backend
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	mcptransport "github.com/stacklok/toolhive-core/mcpcompat/client/transport"
+	mcpmcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	mcpserver "github.com/stacklok/toolhive-core/mcpcompat/server"
 	"github.com/stacklok/toolhive/pkg/secrets"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
@@ -46,10 +53,213 @@ func TestCreateMCPClient_UnsupportedTransport(t *testing.T) {
 				TransportType: transport,
 			}
 
-			_, err := createMCPClient(context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider())
+			_, err := createMCPClient(context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), nil)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, vmcp.ErrUnsupportedTransport,
 				"transport %q should return ErrUnsupportedTransport", transport)
 		})
+	}
+}
+
+// listChangedTestBackend is a real mcpcompat MCP server (streamable-HTTP) with
+// WithToolCapabilities(true). It captures its one connected session (via
+// OnRegisterSession) and exposes addTool, which appends a per-session tool via
+// SessionWithTools.SetSessionTools — the same mechanism ToolHive's own vMCP
+// Server uses (setSessionToolsDirect/resyncSessionTools) — which is what
+// actually drives the underlying go-sdk server's real
+// notifications/tools/list_changed broadcast. (The mcpcompat-wrapper-level
+// MCPServer.AddTool called AFTER the server starts serving does NOT do this:
+// it only mutates the wrapper's pre-serve tool set, registered once at
+// buildServer time, so it has no effect on an already-connected session.)
+type listChangedTestBackend struct {
+	url string
+
+	// ready closes once OnRegisterSession has captured session, decoupling
+	// addTool from the client-side race noted below.
+	ready chan struct{}
+
+	mu      sync.Mutex
+	session mcpserver.ClientSession
+	tools   map[string]mcpserver.ServerTool
+}
+
+func newListChangedTool(name string) mcpserver.ServerTool {
+	return mcpserver.ServerTool{
+		Tool: mcpmcp.NewTool(name, mcpmcp.WithDescription("a list_changed test tool")),
+		Handler: func(_ context.Context, _ mcpmcp.CallToolRequest) (*mcpmcp.CallToolResult, error) {
+			return mcpmcp.NewToolResultText("ok"), nil
+		},
+	}
+}
+
+// newListChangedTestBackend starts the backend; its OnRegisterSession hook
+// captures the connecting session and closes ready.
+func newListChangedTestBackend(t *testing.T) *listChangedTestBackend {
+	t.Helper()
+	b := &listChangedTestBackend{
+		ready: make(chan struct{}),
+		tools: map[string]mcpserver.ServerTool{
+			"initial_tool": newListChangedTool("initial_tool"),
+		},
+	}
+
+	hooks := &mcpserver.Hooks{}
+	hooks.AddOnRegisterSession(func(_ context.Context, session mcpserver.ClientSession) {
+		b.mu.Lock()
+		b.session = session
+		tools := make(map[string]mcpserver.ServerTool, len(b.tools))
+		for k, v := range b.tools {
+			tools[k] = v
+		}
+		b.mu.Unlock()
+		sessionWithTools, ok := session.(mcpserver.SessionWithTools)
+		if !ok {
+			t.Errorf("listChangedTestBackend: session does not support per-session tools")
+			return
+		}
+		sessionWithTools.SetSessionTools(tools)
+		close(b.ready)
+	})
+
+	srv := mcpserver.NewMCPServer("list-changed-backend", "1.0.0",
+		mcpserver.WithToolCapabilities(true),
+		mcpserver.WithHooks(hooks),
+	)
+	streamableSrv := mcpserver.NewStreamableHTTPServer(srv)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", streamableSrv)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	b.url = ts.URL + "/mcp"
+	return b
+}
+
+// addTool adds name to the connected session's per-session tool set via
+// SetSessionTools, reconciling it onto the live go-sdk server and (since
+// WithToolCapabilities(true) is set) triggering a real, asynchronous
+// notifications/tools/list_changed broadcast — independent of any in-flight
+// call.
+//
+// It waits on b.ready first: the mcpcompat/go-sdk client's Initialize sends
+// notifications/initialized and returns as soon as the SEND succeeds, without
+// waiting for the SERVER to finish processing it (registerAndSync, which is
+// where OnRegisterSession/b.session-capture runs) — so a caller cannot safely
+// call addTool immediately after Initialize returns without this explicit
+// synchronization.
+func (b *listChangedTestBackend) addTool(t *testing.T, name string) {
+	t.Helper()
+	select {
+	case <-b.ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listChangedTestBackend: timed out waiting for session registration")
+	}
+
+	b.mu.Lock()
+	session := b.session
+	b.tools[name] = newListChangedTool(name)
+	tools := make(map[string]mcpserver.ServerTool, len(b.tools))
+	for k, v := range b.tools {
+		tools[k] = v
+	}
+	b.mu.Unlock()
+	sessionWithTools, ok := session.(mcpserver.SessionWithTools)
+	require.True(t, ok, "listChangedTestBackend: session does not support per-session tools")
+	sessionWithTools.SetSessionTools(tools)
+}
+
+// TestCreateMCPClient_ContinuousListeningGatedOnSink verifies createMCPClient
+// only enables the streamable-HTTP standalone GET stream (WithContinuousListening)
+// when a non-nil sink is supplied. Some backends hang when this stream is opened
+// against them (#5748 R3), so it must stay strictly opt-in.
+func TestCreateMCPClient_ContinuousListeningGatedOnSink(t *testing.T) {
+	t.Parallel()
+
+	b := newListChangedTestBackend(t)
+	target := &vmcp.BackendTarget{
+		WorkloadID:    "list-changed-backend",
+		WorkloadName:  "list-changed-backend",
+		BaseURL:       b.url,
+		TransportType: "streamable-http",
+	}
+
+	tests := []struct {
+		name           string
+		sink           ListChangedSink
+		wantContinuous bool
+	}{
+		{name: "nil sink disables continuous listening", sink: nil, wantContinuous: false},
+		{
+			name:           "non-nil sink enables continuous listening",
+			sink:           func(context.Context, string, string) {},
+			wantContinuous: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, err := createMCPClient(
+				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), tc.sink,
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = c.Close() })
+
+			sh, ok := c.GetTransport().(*mcptransport.StreamableHTTP)
+			require.True(t, ok, "expected a streamable-HTTP transport")
+			assert.Equal(t, tc.wantContinuous, sh.ContinuousListening())
+		})
+	}
+}
+
+// TestCreateMCPClient_ListChangedSink_FiresOnBackendNotification is the
+// end-to-end regression for #5748: a non-nil sink fires with the backend's
+// WorkloadID and kind="tools" when the real backend emits
+// notifications/tools/list_changed asynchronously (outside any in-flight
+// call), and the nil-sink path never panics or opens the standalone stream.
+func TestCreateMCPClient_ListChangedSink_FiresOnBackendNotification(t *testing.T) {
+	t.Parallel()
+
+	b := newListChangedTestBackend(t)
+	target := &vmcp.BackendTarget{
+		WorkloadID:    "list-changed-backend",
+		WorkloadName:  "list-changed-backend",
+		BaseURL:       b.url,
+		TransportType: "streamable-http",
+	}
+
+	type firedCall struct {
+		backendWorkloadID, kind string
+	}
+	fired := make(chan firedCall, 4)
+	sink := func(_ context.Context, backendWorkloadID, kind string) {
+		fired <- firedCall{backendWorkloadID: backendWorkloadID, kind: kind}
+	}
+
+	c, err := createMCPClient(
+		context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), sink,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.Initialize(context.Background(), mcpmcp.InitializeRequest{
+		Params: mcpmcp.InitializeParams{
+			ProtocolVersion: mcpmcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcpmcp.Implementation{Name: "test-client", Version: "1.0"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Backend asynchronously changes its (per-session) tool set — a real
+	// tools/list_changed trigger, independent of any in-flight call from this
+	// client.
+	b.addTool(t, "added_tool")
+
+	select {
+	case got := <-fired:
+		assert.Equal(t, "list-changed-backend", got.backendWorkloadID)
+		assert.Equal(t, "tools", got.kind)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the list_changed sink to fire")
 	}
 }

--- a/pkg/vmcp/session/mocks/mock_factory.go
+++ b/pkg/vmcp/session/mocks/mock_factory.go
@@ -44,18 +44,23 @@ func (m *MockMultiSessionFactory) EXPECT() *MockMultiSessionFactoryMockRecorder 
 }
 
 // MakeSessionWithID mocks base method.
-func (m *MockMultiSessionFactory) MakeSessionWithID(ctx context.Context, id string, identity *auth.Identity, backends []*vmcp.Backend) (session.MultiSession, error) {
+func (m *MockMultiSessionFactory) MakeSessionWithID(ctx context.Context, id string, identity *auth.Identity, backends []*vmcp.Backend, sink ...session.ListChangedSink) (session.MultiSession, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeSessionWithID", ctx, id, identity, backends)
+	varargs := []any{ctx, id, identity, backends}
+	for _, a := range sink {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MakeSessionWithID", varargs...)
 	ret0, _ := ret[0].(session.MultiSession)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeSessionWithID indicates an expected call of MakeSessionWithID.
-func (mr *MockMultiSessionFactoryMockRecorder) MakeSessionWithID(ctx, id, identity, backends any) *gomock.Call {
+func (mr *MockMultiSessionFactoryMockRecorder) MakeSessionWithID(ctx, id, identity, backends any, sink ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeSessionWithID", reflect.TypeOf((*MockMultiSessionFactory)(nil).MakeSessionWithID), ctx, id, identity, backends)
+	varargs := append([]any{ctx, id, identity, backends}, sink...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeSessionWithID", reflect.TypeOf((*MockMultiSessionFactory)(nil).MakeSessionWithID), varargs...)
 }
 
 // RestoreSession mocks base method.

--- a/pkg/vmcp/session/mocks/mock_factory.go
+++ b/pkg/vmcp/session/mocks/mock_factory.go
@@ -44,23 +44,18 @@ func (m *MockMultiSessionFactory) EXPECT() *MockMultiSessionFactoryMockRecorder 
 }
 
 // MakeSessionWithID mocks base method.
-func (m *MockMultiSessionFactory) MakeSessionWithID(ctx context.Context, id string, identity *auth.Identity, backends []*vmcp.Backend, sink ...session.ListChangedSink) (session.MultiSession, error) {
+func (m *MockMultiSessionFactory) MakeSessionWithID(ctx context.Context, id string, identity *auth.Identity, backends []*vmcp.Backend, sink session.ListChangedSink) (session.MultiSession, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{ctx, id, identity, backends}
-	for _, a := range sink {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "MakeSessionWithID", varargs...)
+	ret := m.ctrl.Call(m, "MakeSessionWithID", ctx, id, identity, backends, sink)
 	ret0, _ := ret[0].(session.MultiSession)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeSessionWithID indicates an expected call of MakeSessionWithID.
-func (mr *MockMultiSessionFactoryMockRecorder) MakeSessionWithID(ctx, id, identity, backends any, sink ...any) *gomock.Call {
+func (mr *MockMultiSessionFactoryMockRecorder) MakeSessionWithID(ctx, id, identity, backends, sink any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, id, identity, backends}, sink...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeSessionWithID", reflect.TypeOf((*MockMultiSessionFactory)(nil).MakeSessionWithID), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeSessionWithID", reflect.TypeOf((*MockMultiSessionFactory)(nil).MakeSessionWithID), ctx, id, identity, backends, sink)
 }
 
 // RestoreSession mocks base method.

--- a/pkg/vmcp/session/session.go
+++ b/pkg/vmcp/session/session.go
@@ -5,6 +5,7 @@ package session
 
 import (
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp/session/internal/backend"
 	"github.com/stacklok/toolhive/pkg/vmcp/session/internal/security"
 	sessiontypes "github.com/stacklok/toolhive/pkg/vmcp/session/types"
 )
@@ -12,6 +13,12 @@ import (
 // MultiSession is an alias for sessiontypes.MultiSession, re-exported here for
 // backward compatibility and convenience.
 type MultiSession = sessiontypes.MultiSession
+
+// ListChangedSink is an alias for backend.ListChangedSink, re-exported here so
+// callers outside the pkg/vmcp/session/internal/backend package (e.g.
+// pkg/vmcp/server, which builds the session-registration sink) can reference it
+// without importing the internal package directly.
+type ListChangedSink = backend.ListChangedSink
 
 // ValidateCaller checks caller against a stored identity-binding string (the
 // value persisted under MetadataKeyIdentityBinding) and returns nil when the

--- a/pkg/vmcp/session/session.go
+++ b/pkg/vmcp/session/session.go
@@ -20,6 +20,14 @@ type MultiSession = sessiontypes.MultiSession
 // without importing the internal package directly.
 type ListChangedSink = backend.ListChangedSink
 
+// ChangeKind is an alias for backend.ChangeKind, re-exported for the same
+// reason as ListChangedSink.
+type ChangeKind = backend.ChangeKind
+
+// KindTools re-exports backend.KindTools so out-of-tree callers can match on it
+// without importing the internal package.
+const KindTools = backend.KindTools
+
 // ValidateCaller checks caller against a stored identity-binding string (the
 // value persisted under MetadataKeyIdentityBinding) and returns nil when the
 // caller is permitted, or ErrNilCaller / ErrUnauthorizedCaller / ErrSessionOwnerUnknown


### PR DESCRIPTION
## Summary

vMCP registered **no persistent notification handler** on its per-session backend connections, so backend `tools/list_changed` was silently dropped. Aggregated tool views went stale until the short-TTL cache happened to expire, and because vMCP advertised `tools.listChanged: false`, nothing was ever pushed to downstream clients. This closes that 2025-11-25 compliance gap (Workstream B of #5743).

What changed:

- **Consume backend `tools/list_changed`.** The persistent per-session backend connection (`mcpSession`) now registers an `OnNotification` handler (with `WithContinuousListening()` for streamable-HTTP), gated strictly on a non-nil sink so the nil-sink path is byte-for-byte unchanged.
- **Invalidate + re-sync on change.** On a backend `tools/list_changed`, the aggregation cache is invalidated and the session's advertised tool set is re-derived and pushed via a **full-replacement** `SetSessionTools`, so removed backend tools disappear. The per-session go-sdk server then auto-emits `tools/list_changed` to the client.
- **Flip the advertised capability** to `tools.listChanged: true`, now that emission is actually backed.
- **Authenticated re-aggregation.** The async resync reconstructs the principal's context (identity + forwarded headers) so backend enumeration and the cache key match a real request from that session's principal — not an anonymous sweep.
- **Bounded, non-blocking propagation.** The receive-loop callback is a non-blocking hand-off to a per-session coalescing worker (dirty-flag, at most one in-flight resync, cancellable on server shutdown, liveness-guarded), so a noisy or malicious backend cannot block the receive loop or amplify work across backends/sessions.
- **`notifications/message`** received out-of-call is log-only.

Fixes #5748

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`) — full suite green except two pre-existing, environment-only failures unrelated to this change (`pkg/api` needs a container runtime; `pkg/secrets/keyring` needs a keyring backend); verified identical on a clean baseline. All `pkg/vmcp/...` packages pass under `-race`.
- [x] Linting (`task lint-fix`) — 0 issues; `task license-check` clean.

New/extended tests: sink fires on a real backend `tools/list_changed` (`mcp_session_test.go`); nil-sink opens no standalone GET stream; a concurrent `tools/call` is **not** stalled while a slow resync runs on the dispatch goroutine; coalescing worker collapses 50 concurrent triggers into one re-run with max-in-flight = 1; resync context carries the reconstructed identity + forwarded headers; full-replacement `SetSessionTools` drops removed tools; cache invalidation delegates (WARN, not silent no-op, when unsupported); `initialize` advertises `tools.listChanged: true` with no spurious emit at registration.

## API Compatibility

- [x] This PR does not break the `v1beta1` API (no operator API surface touched).

## Does this introduce a user-facing change?

Yes. vMCP now reflects backend tool-set changes to connected clients in near-real-time: when a backend adds or removes tools, clients receive `notifications/tools/list_changed` and a subsequent `tools/list` returns the updated set, instead of seeing a stale view until the cache TTL expired.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Architected by an Opus agent, implemented by a Sonnet worker, then reviewed by a four-Opus panel (security, MCP protocol correctness, code quality, concurrency + test rigor). Two blocking security findings (unauthenticated resync context; unbounded blocking fan-out on the receive-loop goroutine) were raised and fixed, then re-verified as resolved by the same reviewers.

- Register a persistent `ListChangedSink` on the per-session backend connection, gated on a non-nil sink; enable `WithContinuousListening()` only for streamable-HTTP + non-nil sink.
- Thread the sink through the connector → factory → session-manager seams to `handleSessionRegistrationImpl`, which captures the downstream `ClientSession`, the session identity, and the forwarded headers.
- Add cache invalidation via a narrow `CacheInvalidator` capability interface + `core.InvalidateCapabilityCache()` (WARN fallback, not a silent no-op).
- On backend `tools/list_changed`: non-blocking `trigger()` → per-session coalescing worker → invalidate cache → re-derive tools (with reconstructed principal context) → full-replacement `SetSessionTools` → go-sdk auto-emits to the client.
- Flip `WithToolCapabilities(true)`.

</details>

## Special notes for reviewers

**Scope / size.** Production code is ~476 lines across 14 files (the bulk is one new file, `serve_list_changed.go`); the rest of the diff is tests (~1055), generated mocks, and docs. This is over the repo's 400-line / 10-file guideline, but the change is one cohesive unit — the capability flip cannot land safely without both the plumbing and the async safety machinery the security review required, so a split would produce non-functional intermediate PRs. Happy to split if preferred.

**R1 — pre-`initialize` broadcast (accepted, documented).** go-sdk's shared server broadcasts `list_changed` to all connected sessions, and a session is broadcast-eligible from `Connect` (before `initialize`). The MCP reviewer confirmed this is not a spec violation (the 2025-11-25 SHOULD-NOT covers *requests*, not notifications) and carries no payload, so it is not a data leak. It is inherent upstream behavior with no supported suppression hook; a regression test pins that *our* code never self-triggers a resync at registration.

**Invalidation strategy.** The resync uses a coalesced global cache purge rather than targeted per-backend invalidation, because the LRU key is a hash of (identity + forwarded headers + backend set) and per-backend invalidation would need a reverse index disproportionate to this PR. Coalescing bounds the purge to at most once per resync burst per session.

**Deferred follow-ups (not in this PR):** resources/prompts `list_changed` propagation; `resources.subscribe` → `resources/updated` emission (pre-existing gap); a per-backend continuous-listening opt-out knob; targeted cache invalidation; joining the resync worker on `Stop` (currently cancel-only — benign).

Generated with [Claude Code](https://claude.com/claude-code)