### PR TITLE
Preserve inner error codes through the skills lock-state wrap

### DIFF
--- a/pkg/skills/skillsvc/install.go
+++ b/pkg/skills/skillsvc/install.go
@@ -5,6 +5,7 @@ package skillsvc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -267,10 +268,17 @@ func (s *service) installAndRegister(
 		updated, err := s.recordLockState(ctx, opts, originalName, result.Skill)
 		if err != nil {
 			rollback()
-			return nil, httperr.WithCode(
-				fmt.Errorf("recording skill in project lock file: %w", err),
-				http.StatusInternalServerError,
-			)
+			// Preserve a specific code already attached deeper in the chain
+			// — dependency materialization runs inside recordLockState, so a
+			// dep's 502 (git resolve) or 404 (registry miss) must reach the
+			// API boundary as itself, not masked to 500. Only a code-less
+			// failure (e.g. an actual lock write error) defaults to 500.
+			wrapped := fmt.Errorf("recording skill in project lock file: %w", err)
+			var coded *httperr.CodedError
+			if !errors.As(err, &coded) {
+				wrapped = httperr.WithCode(wrapped, http.StatusInternalServerError)
+			}
+			return nil, wrapped
 		}
 		result.Skill = updated
 	}

--- a/pkg/skills/skillsvc/lock_test.go
+++ b/pkg/skills/skillsvc/lock_test.go
@@ -6,6 +6,7 @@ package skillsvc
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/stacklok/toolhive-core/httperr"
 	"github.com/stacklok/toolhive/pkg/groups"
 	groupmocks "github.com/stacklok/toolhive/pkg/groups/mocks"
 	"github.com/stacklok/toolhive/pkg/skills"
@@ -353,6 +355,8 @@ func TestInstallProjectScope_LockWriteFailureRollsBackInstall(t *testing.T) {
 		Name: ref, Scope: skills.ScopeProject, ProjectRoot: projectRoot, Clients: []string{"claude-code"},
 	})
 	require.Error(t, err, "install must fail when the lock file cannot be written")
+	assert.Equal(t, http.StatusInternalServerError, httperr.Code(err),
+		"a code-less lock-write failure still defaults to 500")
 
 	_, err = svc.Info(t.Context(), skills.InfoOptions{Name: "my-skill", Scope: skills.ScopeProject, ProjectRoot: projectRoot})
 	require.Error(t, err, "the DB record must be rolled back so a retry starts fresh")
@@ -556,4 +560,27 @@ func TestUninstall_LockWriteFailureAbortsBeforeDestruction(t *testing.T) {
 	skillMD := filepath.Join(projectRoot, ".claude", "skills", "my-skill", "SKILL.md")
 	_, statErr := os.Stat(skillMD)
 	require.NoError(t, statErr, "on-disk files must be untouched")
+}
+
+// TestInstallProjectScope_DependencyFailureCodePreserved: a dependency's
+// specific failure code must reach the API boundary as itself. Dependency
+// materialization runs inside recordLockState, whose failures used to be
+// blanket-wrapped as 500 — masking a git resolver's 502 (and turning the
+// typed sync failure reason into "unknown" instead of
+// "registry-unreachable").
+//
+//nolint:paralleltest // uses t.Setenv via newLockTestService, incompatible with t.Parallel
+func TestInstallProjectScope_DependencyFailureCodePreserved(t *testing.T) {
+	gr, fx := newGitResolverMock(t)
+	missingDepRef, _ := gitRef("missing-dep") // never registered — Resolve fails with 502
+	fx.register("parent-skill", gitSkill("parent-skill", missingDepRef))
+	svc, projectRoot := newLockTestService(t, gr)
+
+	ref, _ := gitRef("parent-skill")
+	_, err := svc.Install(t.Context(), skills.InstallOptions{
+		Name: ref, Scope: skills.ScopeProject, ProjectRoot: projectRoot, Clients: []string{"claude-code"},
+	})
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadGateway, httperr.Code(err),
+		"the dependency's 502 must not be masked to 500 by the lock-state wrap")
 }


### PR DESCRIPTION
## Summary

- Follow-up to the #5894 panel review (deferred minor, promised in the review reply; tracked under #5899). `installAndRegister` wrapped every `recordLockState` failure as HTTP 500 — but dependency materialization runs *inside* `recordLockState`, so a dependency's specific failure (502 from a git resolve, 404 from a registry miss) was masked to 500 at the API boundary, and `classifySyncFailure` reported `unknown` instead of the typed reason (`registry-unreachable`/`digest-missing`) that CI automation keys on.
- The wrap now attaches 500 only when the inner chain carries no `httperr` code. Code-less failures — e.g. an actual lock file write error — keep defaulting to 500, and the `errLockWrite` sentinel classification is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] New unit test: an install whose declared dependency fails to resolve surfaces the resolver's 502 through `Install` (was 500 before the fix)
- [x] Extended existing test: a pure lock-write failure still surfaces as 500
- [x] `task test` and `task lint-fix` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)