### PR TITLE
Extract shared source-dispatch skeleton for skill sources

### DIFF
--- a/pkg/skills/skillsvc/install.go
+++ b/pkg/skills/skillsvc/install.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"strings"
 
+	nameref "github.com/google/go-containerregistry/pkg/name"
+
 	"github.com/stacklok/toolhive-core/httperr"
 	"github.com/stacklok/toolhive/pkg/groups"
 	"github.com/stacklok/toolhive/pkg/skills"
@@ -39,63 +41,45 @@ func (s *service) Install(ctx context.Context, opts skills.InstallOptions) (*ski
 	// the same lock key and DB record.
 	opts.ProjectRoot = projectRoot
 
-	// Git references (git://host/owner/repo[@ref][#path]) are dispatched first;
-	// the prefix is unambiguous and cannot collide with OCI references.
-	if gitresolver.IsGitReference(opts.Name) {
-		result, err := s.installFromGit(ctx, opts, scope)
-		if err != nil {
-			return nil, err
-		}
-		return s.installAndRegister(ctx, opts, originalName, result, opts.Group, result.Skill.Metadata.Name, scope)
-	}
-
 	// When the caller supplies `version` separately and the name is a tag-less
 	// OCI-like reference (contains '/' but no ':' or '@'), splice the version
 	// in as the tag. Without this, parseOCIReference + qualifiedOCIRef would
 	// default the pull to ":latest" and silently drop opts.Version. An
 	// explicit tag in the name still wins (we only splice when none is set).
+	// Git references are unaffected: the git:// prefix contains "://".
 	if opts.Version != "" &&
+		!gitresolver.IsGitReference(opts.Name) &&
 		strings.ContainsRune(opts.Name, '/') &&
 		!strings.ContainsAny(opts.Name, ":@") {
 		opts.Name = opts.Name + ":" + opts.Version
 	}
 
-	ref, isOCI, err := parseOCIReference(opts.Name)
-	if err != nil {
-		return nil, httperr.WithCode(
-			fmt.Errorf("invalid OCI reference %q: %w", opts.Name, err),
-			http.StatusBadRequest,
-		)
-	}
-	if isOCI {
-		result, ociErr := s.installFromOCI(ctx, opts, scope, ref)
-		if ociErr == nil {
+	// Route through the shared source-dispatch skeleton (git, direct OCI
+	// with registry fallback, plain name) — the same sequence upgrade's
+	// re-resolution uses, so the two cannot drift.
+	return dispatchSource(ctx, s, opts.Name, sourceOps[*skills.InstallResult]{
+		git: func(ctx context.Context, _ string) (*skills.InstallResult, error) {
+			result, err := s.installFromGit(ctx, opts, scope)
+			if err != nil {
+				return nil, err
+			}
+			return s.installAndRegister(ctx, opts, originalName, result, opts.Group, result.Skill.Metadata.Name, scope)
+		},
+		oci: func(ctx context.Context, ref nameref.Reference) (*skills.InstallResult, error) {
+			result, err := s.installFromOCI(ctx, opts, scope, ref)
+			if err != nil {
+				slog.Debug("OCI pull failed, registry fallback may apply", "name", opts.Name, "error", err)
+				return nil, err
+			}
 			return s.installAndRegister(ctx, opts, originalName, result, opts.Group, opts.Name, scope)
-		}
-		// OCI pull failed — fall back to registry lookup for names that look
-		// like a qualified "namespace/name". Names that are unambiguously OCI
-		// (digest, explicit tag, or multi-segment path) must not trigger a
-		// registry search. See isUnambiguousOCIRef for the full rule set.
-		if isUnambiguousOCIRef(opts.Name, ref) {
-			return nil, ociErr
-		}
-		slog.Debug("OCI pull failed, attempting registry fallback", "name", opts.Name, "error", ociErr)
-		resolved, regErr := s.resolveFromRegistry(opts.Name)
-		if regErr != nil {
-			return nil, regErr
-		}
-		if resolved != nil {
+		},
+		registry: func(ctx context.Context, resolved *registryResolveResult) (*skills.InstallResult, error) {
 			return s.installFromResolvedRegistry(ctx, opts, originalName, scope, resolved)
-		}
-		return nil, ociErr
-	}
-
-	// Plain skill name — validate and proceed with existing flow.
-	if err := skills.ValidateSkillName(opts.Name); err != nil {
-		return nil, httperr.WithCode(err, http.StatusBadRequest)
-	}
-
-	return s.installByName(ctx, opts, originalName, scope)
+		},
+		plainName: func(ctx context.Context, _ string) (*skills.InstallResult, error) {
+			return s.installByName(ctx, opts, originalName, scope)
+		},
+	})
 }
 
 // installByName handles installation for a validated plain skill name. It

--- a/pkg/skills/skillsvc/source_dispatch.go
+++ b/pkg/skills/skillsvc/source_dispatch.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skillsvc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	nameref "github.com/google/go-containerregistry/pkg/name"
+
+	"github.com/stacklok/toolhive-core/httperr"
+	"github.com/stacklok/toolhive/pkg/skills"
+	"github.com/stacklok/toolhive/pkg/skills/gitresolver"
+)
+
+// sourceOps are the per-kind leaf operations dispatchSource routes a skill
+// source to.
+type sourceOps[T any] struct {
+	// git handles a git:// reference.
+	git func(ctx context.Context, gitURL string) (T, error)
+	// oci handles a direct OCI reference.
+	oci func(ctx context.Context, ref nameref.Reference) (T, error)
+	// registry handles a source resolved through the registry catalogue
+	// (either the OCI ambiguity fallback or a plain-name lookup).
+	registry func(ctx context.Context, resolved *registryResolveResult) (T, error)
+	// plainName, when non-nil, handles a validated bare skill name instead
+	// of the default registry lookup — for callers with a richer flow
+	// (Install checks the local OCI store and takes a per-name lock).
+	plainName func(ctx context.Context, name string) (T, error)
+}
+
+// dispatchSource is the single source of truth for how a skill source
+// string is routed: git prefix first (unambiguous), then OCI-shaped
+// references — with a registry-catalogue fallback when a direct OCI
+// operation fails for an *ambiguous* "namespace/name" (see
+// isUnambiguousOCIRef) — and finally validated plain skill names via the
+// registry. Install and upgrade's re-resolution previously each maintained
+// their own copy of this sequence, and the two drifted (the upgrade copy
+// lost the fallback branch entirely); every consumer must go through this
+// function so they cannot diverge again.
+//
+// Fallback error precedence: when the direct OCI operation fails and the
+// registry lookup itself errors, the registry error wins (it is the more
+// actionable signal); when the registry simply has no match, the original
+// OCI error is returned.
+func dispatchSource[T any](ctx context.Context, s *service, source string, ops sourceOps[T]) (T, error) {
+	var zero T
+
+	if gitresolver.IsGitReference(source) {
+		return ops.git(ctx, source)
+	}
+
+	ref, isOCI, err := parseOCIReference(source)
+	if err != nil {
+		return zero, httperr.WithCode(
+			fmt.Errorf("invalid OCI reference %q: %w", source, err),
+			http.StatusBadRequest,
+		)
+	}
+	if isOCI {
+		result, ociErr := ops.oci(ctx, ref)
+		if ociErr == nil {
+			return result, nil
+		}
+		// Direct OCI failed — an ambiguous "namespace/name" may be a
+		// registry catalogue name. Names that are unambiguously OCI
+		// (digest, explicit tag, or multi-segment path) must not trigger a
+		// registry search.
+		if isUnambiguousOCIRef(source, ref) {
+			return zero, ociErr
+		}
+		resolved, regErr := s.resolveFromRegistry(source)
+		if regErr != nil {
+			return zero, regErr
+		}
+		if resolved == nil {
+			return zero, ociErr
+		}
+		return ops.registry(ctx, resolved)
+	}
+
+	if err := skills.ValidateSkillName(source); err != nil {
+		return zero, httperr.WithCode(err, http.StatusBadRequest)
+	}
+	if ops.plainName != nil {
+		return ops.plainName(ctx, source)
+	}
+	resolved, regErr := s.resolveFromRegistry(source)
+	if regErr != nil {
+		return zero, regErr
+	}
+	if resolved == nil {
+		return zero, httperr.WithCode(
+			fmt.Errorf("skill %q not found in registry", source),
+			http.StatusNotFound,
+		)
+	}
+	return ops.registry(ctx, resolved)
+}

--- a/pkg/skills/skillsvc/source_dispatch_test.go
+++ b/pkg/skills/skillsvc/source_dispatch_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skillsvc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	nameref "github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive-core/httperr"
+	regtypes "github.com/stacklok/toolhive-core/registry/types"
+	regmocks "github.com/stacklok/toolhive/pkg/registry/mocks"
+	storemocks "github.com/stacklok/toolhive/pkg/storage/mocks"
+)
+
+// dispatchProbe records which leaf dispatchSource routed to.
+type dispatchProbe struct {
+	gitURL    string
+	ociRef    string
+	registry  *registryResolveResult
+	plainName string
+}
+
+// probeOps returns ops whose leaves record the routing into probe and
+// return the given leaf results.
+func probeOps(probe *dispatchProbe, ociErr error) sourceOps[string] {
+	return sourceOps[string]{
+		git: func(_ context.Context, gitURL string) (string, error) {
+			probe.gitURL = gitURL
+			return "git", nil
+		},
+		oci: func(_ context.Context, ref nameref.Reference) (string, error) {
+			probe.ociRef = ref.String()
+			if ociErr != nil {
+				return "", ociErr
+			}
+			return "oci", nil
+		},
+		registry: func(_ context.Context, resolved *registryResolveResult) (string, error) {
+			probe.registry = resolved
+			return "registry", nil
+		},
+		plainName: func(_ context.Context, name string) (string, error) {
+			probe.plainName = name
+			return "plain", nil
+		},
+	}
+}
+
+func newDispatchTestService(t *testing.T, lookup *regmocks.MockProvider) *service {
+	t.Helper()
+	opts := []Option{}
+	if lookup != nil {
+		opts = append(opts, WithSkillLookup(lookup))
+	}
+	svc := New(storemocks.NewMockSkillStore(gomock.NewController(t)), opts...)
+	return svc.(*service) //nolint:forcetypeassert // white-box test in the same package
+}
+
+func TestDispatchSourceRouting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("git reference routes to git", func(t *testing.T) {
+		t.Parallel()
+		svc := newDispatchTestService(t, nil)
+		var probe dispatchProbe
+		got, err := dispatchSource(t.Context(), svc, "git://github.com/org/skill@main", probeOps(&probe, nil))
+		require.NoError(t, err)
+		assert.Equal(t, "git", got)
+		assert.Equal(t, "git://github.com/org/skill@main", probe.gitURL)
+	})
+
+	t.Run("OCI reference routes to oci", func(t *testing.T) {
+		t.Parallel()
+		svc := newDispatchTestService(t, nil)
+		var probe dispatchProbe
+		got, err := dispatchSource(t.Context(), svc, "ghcr.io/org/skill:v1", probeOps(&probe, nil))
+		require.NoError(t, err)
+		assert.Equal(t, "oci", got)
+		assert.Equal(t, "ghcr.io/org/skill:v1", probe.ociRef)
+	})
+
+	t.Run("plain name routes to plainName leaf when set", func(t *testing.T) {
+		t.Parallel()
+		svc := newDispatchTestService(t, nil)
+		var probe dispatchProbe
+		got, err := dispatchSource(t.Context(), svc, "my-skill", probeOps(&probe, nil))
+		require.NoError(t, err)
+		assert.Equal(t, "plain", got)
+		assert.Equal(t, "my-skill", probe.plainName)
+	})
+
+	t.Run("plain name without plainName leaf resolves via registry", func(t *testing.T) {
+		t.Parallel()
+		lookup := regmocks.NewMockProvider(gomock.NewController(t))
+		lookup.EXPECT().SearchSkills("my-skill").Return([]regtypes.Skill{
+			{Name: "my-skill", Packages: []regtypes.SkillPackage{
+				{RegistryType: "oci", Identifier: "ghcr.io/test/my-skill:v1"},
+			}},
+		}, nil)
+		svc := newDispatchTestService(t, lookup)
+		var probe dispatchProbe
+		ops := probeOps(&probe, nil)
+		ops.plainName = nil
+		got, err := dispatchSource(t.Context(), svc, "my-skill", ops)
+		require.NoError(t, err)
+		assert.Equal(t, "registry", got)
+		require.NotNil(t, probe.registry)
+	})
+
+	t.Run("invalid plain name is rejected", func(t *testing.T) {
+		t.Parallel()
+		svc := newDispatchTestService(t, nil)
+		var probe dispatchProbe
+		_, err := dispatchSource(t.Context(), svc, "Not_A_Name", probeOps(&probe, nil))
+		require.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, httperr.Code(err))
+	})
+}
+
+// TestDispatchSourceOCIFallback pins the ambiguity-fallback rules whose
+// hand-copied divergence caused the upgrade-path majors: a failed direct
+// OCI operation falls back to the registry catalogue only for ambiguous
+// names, and the error precedence is fixed (registry error wins over the
+// OCI error; a registry miss returns the original OCI error).
+func TestDispatchSourceOCIFallback(t *testing.T) {
+	t.Parallel()
+	ociFailure := errors.New("name unknown")
+
+	t.Run("ambiguous name falls back to registry on OCI failure", func(t *testing.T) {
+		t.Parallel()
+		lookup := regmocks.NewMockProvider(gomock.NewController(t))
+		lookup.EXPECT().SearchSkills("my-skill").Return([]regtypes.Skill{
+			{Namespace: "io.github.test", Name: "my-skill", Packages: []regtypes.SkillPackage{
+				{RegistryType: "oci", Identifier: "ghcr.io/test/my-skill:v2"},
+			}},
+		}, nil)
+		svc := newDispatchTestService(t, lookup)
+		var probe dispatchProbe
+		got, err := dispatchSource(t.Context(), svc, "io.github.test/my-skill", probeOps(&probe, ociFailure))
+		require.NoError(t, err)
+		assert.Equal(t, "registry", got)
+		require.NotNil(t, probe.registry)
+		assert.NotNil(t, probe.registry.OCIRef)
+	})
+
+	t.Run("unambiguous reference never falls back", func(t *testing.T) {
+		t.Parallel()
+		svc := newDispatchTestService(t, nil) // no lookup: a fallback attempt would nil-panic expectations
+		var probe dispatchProbe
+		_, err := dispatchSource(t.Context(), svc, "ghcr.io/org/skill:v1", probeOps(&probe, ociFailure))
+		require.ErrorIs(t, err, ociFailure)
+	})
+
+	t.Run("registry miss returns the original OCI error", func(t *testing.T) {
+		t.Parallel()
+		lookup := regmocks.NewMockProvider(gomock.NewController(t))
+		lookup.EXPECT().SearchSkills("my-skill").Return(nil, nil)
+		svc := newDispatchTestService(t, lookup)
+		var probe dispatchProbe
+		_, err := dispatchSource(t.Context(), svc, "io.github.test/my-skill", probeOps(&probe, ociFailure))
+		require.ErrorIs(t, err, ociFailure)
+	})
+}

--- a/pkg/skills/skillsvc/upgrade.go
+++ b/pkg/skills/skillsvc/upgrade.go
@@ -199,43 +199,27 @@ func (s *service) applyUpgrade(ctx context.Context, opts skills.UpgradeOptions, 
 // the RFC's "preview is not side-effect-free" note; git sources resolve
 // without touching disk.
 func (s *service) resolveLatestState(ctx context.Context, source string) (resolvedRef, digestStr string, err error) {
-	if gitresolver.IsGitReference(source) {
-		return s.resolveGitLatest(ctx, source)
-	}
+	// resolvedState carries the two return values through the shared
+	// source-dispatch skeleton, which routes exactly like Install does
+	// (git, direct OCI with registry fallback, plain registry name) so the
+	// two can never drift again.
+	type resolvedState struct{ ref, digest string }
 
-	ref, isOCI, err := parseOCIReference(source)
-	if err != nil {
-		return "", "", httperr.WithCode(fmt.Errorf("invalid OCI reference %q: %w", source, err), http.StatusBadRequest)
-	}
-	if isOCI {
-		newRef, newDigest, ociErr := s.resolveOCILatest(ctx, ref)
-		if ociErr == nil {
-			return newRef, newDigest, nil
-		}
-		// Mirror Install's fallback: an ambiguous "namespace/name" that
-		// fails as a direct OCI pull may be a registry catalogue name — the
-		// path the skill was originally installed through. Without this
-		// branch, a skill that installs cleanly via the registry fallback
-		// could never be upgraded (its source fails the direct pull exactly
-		// as it did at install time).
-		if isUnambiguousOCIRef(source, ref) {
-			return "", "", ociErr
-		}
-		resolved, regErr := s.resolveFromRegistry(source)
-		if regErr != nil || resolved == nil {
-			return "", "", ociErr
-		}
-		return s.resolveRegistryLatest(ctx, source, resolved)
-	}
-
-	resolved, regErr := s.resolveFromRegistry(source)
-	if regErr != nil {
-		return "", "", regErr
-	}
-	if resolved == nil {
-		return "", "", httperr.WithCode(fmt.Errorf("skill %q not found in registry", source), http.StatusNotFound)
-	}
-	return s.resolveRegistryLatest(ctx, source, resolved)
+	state, err := dispatchSource(ctx, s, source, sourceOps[resolvedState]{
+		git: func(ctx context.Context, gitURL string) (resolvedState, error) {
+			r, d, gitErr := s.resolveGitLatest(ctx, gitURL)
+			return resolvedState{r, d}, gitErr
+		},
+		oci: func(ctx context.Context, ref nameref.Reference) (resolvedState, error) {
+			r, d, ociErr := s.resolveOCILatest(ctx, ref)
+			return resolvedState{r, d}, ociErr
+		},
+		registry: func(ctx context.Context, resolved *registryResolveResult) (resolvedState, error) {
+			r, d, regErr := s.resolveRegistryLatest(ctx, source, resolved)
+			return resolvedState{r, d}, regErr
+		},
+	})
+	return state.ref, state.digest, err
 }
 
 // resolveRegistryLatest resolves the latest state of a registry catalogue


### PR DESCRIPTION
## Summary

- Follow-up to the #5896 panel review (deferred minor, promised in the review reply; tracked under #5899). `Install` and upgrade's `resolveLatestState` each hand-maintained the same routing sequence — git prefix → direct OCI with a registry-catalogue fallback for ambiguous names (`isUnambiguousOCIRef`) → plain registry name — with no shared source of truth. The two copies drifted, which is exactly what produced the broken OCI upgrade path fixed pre-merge in #5896 (unqualified reference comparison + a dropped fallback branch).
- New `dispatchSource[T]` (`pkg/skills/skillsvc/source_dispatch.go`) owns the branch structure and the fallback error precedence; `Install` and `resolveLatestState` inject only their leaf operations, so the sequence cannot diverge again.
- One deliberate alignment: on a registry-fallback lookup *error*, both consumers now return the registry error (Install's existing behavior); previously `resolveLatestState` swallowed it in favor of the original OCI error. A registry *miss* still returns the original OCI error in both.

## Type of change

- [x] Refactoring (no functional changes beyond the alignment noted above)

## Test plan

- [x] Entire existing skills test suite passes unchanged (install git/OCI/registry-fallback tests, the `upgrade_oci_test.go` matrix including its registry-fallback case — these pin the behavior the refactor must preserve)
- [x] New routing-table unit test for `dispatchSource` itself: four routing outcomes plus the ambiguity-fallback error precedence
- [x] `task test` and `task lint-fix` pass locally

## Special notes for reviewers

`Install` keeps its pre-dispatch specifics (version splicing, `originalName` capture) and its richer plain-name flow (local OCI store check + per-name locking) via the optional `plainName` leaf; upgrade uses the skeleton's default registry-lookup path for plain names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)