### PR TITLE
Propagate backend list_changed through vMCP

### DIFF
--- a/pkg/vmcp/aggregator/caching_aggregator.go
+++ b/pkg/vmcp/aggregator/caching_aggregator.go
@@ -54,9 +54,28 @@ type cachingAggregator struct {
 	cache *lru.Cache[string, cacheEntry]
 }
 
+var _ CacheInvalidator = (*cachingAggregator)(nil)
+
 type cacheEntry struct {
 	caps *AggregatedCapabilities
 	at   time.Time
+	// backendIDs is the set of backend IDs that contributed to caps, captured at
+	// AggregateCapabilities time from the backends argument. It lets
+	// InvalidateBackend scope eviction to only the cache entries a given backend
+	// actually contributed to.
+	backendIDs map[string]struct{}
+}
+
+// CacheInvalidator lets a caller evict every cached capability view that a
+// specific backend contributed to, without waiting for the TTL to expire. The
+// list_changed coordinator (pkg/vmcp/server) uses this so a backend's
+// notifications/{tools,resources,prompts}/list_changed forces a fresh sweep of
+// just that backend on the next AggregateCapabilities call, instead of serving
+// a stale cached view for up to ttl.
+type CacheInvalidator interface {
+	// InvalidateBackend evicts every cache entry whose backend set includes
+	// backendID. It is a no-op if no cached entry references backendID.
+	InvalidateBackend(backendID string)
 }
 
 // NewCachingAggregator wraps next so AggregateCapabilities results are memoized per identity
@@ -97,8 +116,34 @@ func (c *cachingAggregator) AggregateCapabilities(
 	if err != nil {
 		return nil, err
 	}
-	c.cache.Add(key, cacheEntry{caps: caps, at: time.Now()})
+	backendIDs := make(map[string]struct{}, len(backends))
+	for _, b := range backends {
+		backendIDs[b.ID] = struct{}{}
+	}
+	c.cache.Add(key, cacheEntry{caps: caps, at: time.Now(), backendIDs: backendIDs})
 	return caps, nil
+}
+
+// InvalidateBackend implements CacheInvalidator. It scans the cache (bounded to
+// capabilityCacheMaxEntries) rather than maintaining a backend->keys reverse
+// index: hashicorp/golang-lru's base Cache has no eviction callback (see
+// NewCachingAggregator), so a reverse index kept in sync via NewWithEvict would
+// need its own lock, and updating it from evictions while InvalidateBackend
+// holds no cache-wide lock of its own would invert lock order against the
+// cache's internal lock. A full scan under only the LRU's own internal
+// locking (Keys/Peek/Remove are each independently locked) avoids that
+// entirely, at O(cache size) — bounded by capabilityCacheMaxEntries (1024),
+// cheap relative to the backend sweep it triggers.
+func (c *cachingAggregator) InvalidateBackend(backendID string) {
+	for _, key := range c.cache.Keys() {
+		e, ok := c.cache.Peek(key)
+		if !ok {
+			continue
+		}
+		if _, hit := e.backendIDs[backendID]; hit {
+			c.cache.Remove(key)
+		}
+	}
 }
 
 // cacheKey derives a collision-resistant key from the inputs that drive backend enumeration:

--- a/pkg/vmcp/aggregator/caching_aggregator_test.go
+++ b/pkg/vmcp/aggregator/caching_aggregator_test.go
@@ -124,3 +124,101 @@ func TestCachingAggregator_ErrorNotCached(t *testing.T) {
 	_, err = c.AggregateCapabilities(ctx, testBackends)
 	require.NoError(t, err, "the error must not have been cached")
 }
+
+// TestCachingAggregator_InvalidateBackend_ScopedEviction verifies that
+// InvalidateBackend evicts only the cache entries whose backend set includes
+// the invalidated backend, leaving entries scoped to unrelated backends
+// (or unrelated identities over the SAME backend set) untouched.
+func TestCachingAggregator_InvalidateBackend_ScopedEviction(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockAggregator(ctrl)
+
+	b1, b2 := []vmcp.Backend{{ID: "b1"}}, []vmcp.Backend{{ID: "b2"}}
+	aliceB1 := ctxWithSubject("alice")
+	bobB2 := ctxWithSubject("bob")
+
+	// One sweep to populate each of the two distinct cache entries; a second
+	// sweep per key proves the corresponding entry was (or was not) evicted.
+	mock.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).
+		Return(&aggregator.AggregatedCapabilities{}, nil).Times(3)
+
+	c := aggregator.NewCachingAggregator(mock, time.Hour)
+	inv, ok := c.(aggregator.CacheInvalidator)
+	require.True(t, ok, "cachingAggregator must implement CacheInvalidator")
+
+	// Populate both entries.
+	_, err := c.AggregateCapabilities(aliceB1, b1)
+	require.NoError(t, err)
+	_, err = c.AggregateCapabilities(bobB2, b2)
+	require.NoError(t, err)
+
+	// Invalidate only b1's entry.
+	inv.InvalidateBackend("b1")
+
+	// alice/b1 must re-sweep (evicted) — this is the 3rd AggregateCapabilities call.
+	_, err = c.AggregateCapabilities(aliceB1, b1)
+	require.NoError(t, err)
+
+	// bob/b2 must still be a cache hit — no further AggregateCapabilities call is
+	// permitted by the mock (Times(3) is already exhausted), so gomock fails the
+	// test if this call reaches the wrapped aggregator instead of hitting cache.
+	_, err = c.AggregateCapabilities(bobB2, b2)
+	require.NoError(t, err)
+}
+
+// TestCachingAggregator_InvalidateBackend_MultiBackendEntry verifies the
+// multi-member backendIDs lookup: an entry aggregated over {b1,b2} is evicted
+// when EITHER of its member backends is invalidated (here b1), exercising the
+// set-membership branch that a single-backend entry does not.
+func TestCachingAggregator_InvalidateBackend_MultiBackendEntry(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockAggregator(ctrl)
+
+	// One sweep to populate the {b1,b2} entry, plus one more after eviction.
+	mock.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).
+		Return(&aggregator.AggregatedCapabilities{}, nil).Times(2)
+
+	c := aggregator.NewCachingAggregator(mock, time.Hour)
+	inv, ok := c.(aggregator.CacheInvalidator)
+	require.True(t, ok)
+
+	ctx := ctxWithSubject("alice")
+	multi := []vmcp.Backend{{ID: "b1"}, {ID: "b2"}}
+
+	_, err := c.AggregateCapabilities(ctx, multi)
+	require.NoError(t, err)
+
+	// Invalidating a member (b1) of the {b1,b2} entry must evict it.
+	inv.InvalidateBackend("b1")
+
+	// Re-sweep required (this is the 2nd AggregateCapabilities call).
+	_, err = c.AggregateCapabilities(ctx, multi)
+	require.NoError(t, err)
+}
+
+// TestCachingAggregator_InvalidateBackend_NoMatchIsNoop verifies that
+// invalidating a backend ID no cached entry references is a harmless no-op:
+// the existing entry survives and the next call is still a cache hit.
+func TestCachingAggregator_InvalidateBackend_NoMatchIsNoop(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mock := mocks.NewMockAggregator(ctrl)
+	mock.EXPECT().AggregateCapabilities(gomock.Any(), gomock.Any()).
+		Return(&aggregator.AggregatedCapabilities{}, nil).Times(1)
+
+	c := aggregator.NewCachingAggregator(mock, time.Hour)
+	inv, ok := c.(aggregator.CacheInvalidator)
+	require.True(t, ok)
+
+	ctx := ctxWithSubject("alice")
+	_, err := c.AggregateCapabilities(ctx, testBackends)
+	require.NoError(t, err)
+
+	inv.InvalidateBackend("unrelated-backend")
+
+	// Still a cache hit: the mock's Times(1) would fail this test otherwise.
+	_, err = c.AggregateCapabilities(ctx, testBackends)
+	require.NoError(t, err)
+}

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -348,9 +348,18 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 		slog.Debug("VMCP_SESSION_HMAC_SECRET is set but no longer used after #5306; ignoring",
 			"env_var", "VMCP_SESSION_HMAC_SECRET")
 	}
+	// listChangedHolder resolves the construction-order inversion between the
+	// session factory (built here, needs a non-nil BackendListChangedNotifier to
+	// hand to the persistent backend connector) and server.New's list_changed
+	// coordinator (constructed later, inside Serve). It is bound to the real
+	// coordinator once srv exists, below.
+	listChangedHolder := vmcp.NewLateBoundListChangedNotifier()
+
 	// The factory never aggregates — the core is the single source of capability
 	// aggregation (agg feeds it via Config.Aggregator below).
-	sessionFactory := vmcpsession.NewSessionFactory(outgoingRegistry)
+	sessionFactory := vmcpsession.NewSessionFactory(
+		outgoingRegistry, vmcpsession.WithBackendListChangedNotifier(listChangedHolder),
+	)
 
 	// When the optimizer is enabled, its meta-tools are pass-through tools.
 	// Authz uses this for optimizer-aware authorization/filtering.
@@ -464,6 +473,12 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to create Virtual MCP Server: %w", err)
 	}
+
+	// Bind the late-bound holder to the server's real list_changed coordinator
+	// now that it exists, so the session factory's persistent backend
+	// connections (already built above, holding listChangedHolder) start
+	// reporting real backend list_changed notifications.
+	listChangedHolder.Bind(srv.BackendListChangedNotifier())
 
 	slog.Info(fmt.Sprintf("Starting Virtual MCP Server at %s", srv.Address()))
 	return srv.Start(ctx)

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -623,11 +623,12 @@ func (h *httpBackendClient) defaultClientFactory(
 	}
 
 	// Register the notification forwarder before Initialize (the caller runs it
-	// after this factory returns) so a backend's mid-call progress/logging
-	// notifications are relayed to the downstream client. OnNotification is a
-	// post-construction method, so it applies to both transports.
-	if fwd != nil && forwarding && fwd.notifier != nil {
-		c.OnNotification(newNotificationForwarder(ctx, fwd.notifier))
+	// after this factory returns) so a backend's mid-call progress/logging and
+	// list_changed notifications are relayed to the downstream client / reported
+	// to the list_changed coordinator. OnNotification is a post-construction
+	// method, so it applies to both transports.
+	if fwd != nil && forwarding && (fwd.notifier != nil || fwd.listChanged != nil) {
+		c.OnNotification(newNotificationForwarder(ctx, fwd.notifier, fwd.listChanged, target.WorkloadID))
 	}
 
 	// Start the client connection

--- a/pkg/vmcp/client/client_test.go
+++ b/pkg/vmcp/client/client_test.go
@@ -1722,6 +1722,7 @@ func TestDefaultClientFactory_SSEForwarding(t *testing.T) {
 					&stubElicitationRequester{},
 					&stubSamplingRequester{},
 					nil,
+					nil,
 				)
 			}
 

--- a/pkg/vmcp/client/forwarding.go
+++ b/pkg/vmcp/client/forwarding.go
@@ -24,22 +24,25 @@ type boundForwarders struct {
 	elicitation vmcp.ElicitationRequester
 	sampling    vmcp.SamplingRequester
 	notifier    vmcp.ClientNotifier
+	listChanged vmcp.BackendListChangedNotifier
 }
 
 // BindForwarders implements vmcp.ClientForwarderBinder. server.New calls it once,
 // after Serve builds the mcp-go server the adapters wrap and before serving
 // begins, so the backend clients created per call can relay a backend's mid-call
-// server->client traffic (elicitation, sampling, progress/logging) to the
-// downstream client.
+// server->client traffic (elicitation, sampling, progress/logging, list_changed)
+// to the downstream client.
 func (h *httpBackendClient) BindForwarders(
 	elicitation vmcp.ElicitationRequester,
 	sampling vmcp.SamplingRequester,
 	notifier vmcp.ClientNotifier,
+	listChanged vmcp.BackendListChangedNotifier,
 ) {
 	h.forwarders.Store(&boundForwarders{
 		elicitation: elicitation,
 		sampling:    sampling,
 		notifier:    notifier,
+		listChanged: listChanged,
 	})
 }
 
@@ -92,9 +95,18 @@ func (h *httpBackendClient) enableBackendLogging(
 // for enqueued handlers to finish (jsonrpc2.Connection.Close drains the handler
 // queue), so the forward completes before teardown.
 //
-// Only runs when server->client forwarding is bound (fwd.notifier != nil, the
-// same condition under which the notification forwarder is registered); other
-// deployments keep the pre-forwarding fast path with no extra round-trip.
+// Only runs when the progress/logging notifier is bound (fwd.notifier != nil).
+// The notification forwarder itself is now registered under the broader
+// condition fwd.notifier != nil || fwd.listChanged != nil, so the gate here is
+// deliberately narrower: it exists to drain fire-and-forget progress/logging
+// notifications that would otherwise be lost at Close. A mid-call
+// list_changed rides the same FIFO handler queue, so this barrier drains it too
+// when the notifier is bound; and even without the barrier a mid-call
+// list_changed is redundant — the persistent session connector
+// (pkg/vmcp/session/internal/backend) delivers backend list_changed on its own
+// standalone stream, and the TTL-bounded re-sweep would pick up any missed one.
+// So a deployment with only listChanged bound (no notifier) intentionally keeps
+// the pre-forwarding fast path with no extra round-trip.
 // Best-effort: a ping failure only forgoes the barrier — the tool result is
 // already in hand, so it must not fail the call.
 func (h *httpBackendClient) drainServerToClientNotifications(ctx context.Context, c *client.Client) {
@@ -209,15 +221,26 @@ func newSamplingForwarder(callCtx context.Context, req vmcp.SamplingRequester) c
 // newNotificationForwarder builds an OnNotification handler that relays a
 // backend's mid-call notifications/progress and notifications/message to the
 // downstream client via the bound notifier, using the captured per-call
-// downstream context. Forwarding is best-effort: a missing downstream session
-// (the notifier no-ops) or a forwarding error is logged at debug and dropped,
-// never surfaced to the backend. Other notification methods are ignored (the
-// go-sdk server re-emits list-changed notifications automatically).
-func newNotificationForwarder(callCtx context.Context, notifier vmcp.ClientNotifier) func(mcp.JSONRPCNotification) {
+// downstream context, and reports a backend's list_changed notifications
+// (tools/resources/prompts) to listChanged, keyed by backendID. Forwarding is
+// best-effort: a missing downstream session (the notifier no-ops) or a
+// forwarding error is logged at debug and dropped, never surfaced to the
+// backend. Either notifier or listChanged may be nil — a nil notifier disables
+// the progress/logging path, a nil listChanged disables the list_changed path —
+// so this handler can be registered when only one of the two is bound. The
+// list_changed notify call is non-blocking (map-write + non-blocking channel
+// send in the coordinator), so it never stalls this receive-loop-invoked
+// handler or the drain-ping barrier. Any other notification method is ignored.
+func newNotificationForwarder(
+	callCtx context.Context, notifier vmcp.ClientNotifier, listChanged vmcp.BackendListChangedNotifier, backendID string,
+) func(mcp.JSONRPCNotification) {
 	return func(n mcp.JSONRPCNotification) {
 		fields := n.Params.AdditionalFields
 		switch n.Method {
 		case vmcp.MethodProgressNotification:
+			if notifier == nil {
+				return
+			}
 			err := notifier.NotifyProgress(callCtx, vmcp.ProgressNotification{
 				ProgressToken: fields["progressToken"],
 				Progress:      toFloat(fields["progress"]),
@@ -228,6 +251,9 @@ func newNotificationForwarder(callCtx context.Context, notifier vmcp.ClientNotif
 				slog.Debug("failed to forward progress notification", "error", err)
 			}
 		case vmcp.MethodLogNotification:
+			if notifier == nil {
+				return
+			}
 			err := notifier.NotifyLog(callCtx, vmcp.LogMessage{
 				Level:  toString(fields["level"]),
 				Logger: toString(fields["logger"]),
@@ -237,8 +263,12 @@ func newNotificationForwarder(callCtx context.Context, notifier vmcp.ClientNotif
 				slog.Debug("failed to forward log notification", "error", err)
 			}
 		default:
-			// Other notifications (list_changed, resources/updated, ...) are not
-			// mid-call server->client traffic this forwarder relays.
+			if listChanged == nil {
+				return
+			}
+			if kind, ok := vmcp.ListChangedKindForMethod(n.Method); ok {
+				listChanged.NotifyBackendListChanged(backendID, kind)
+			}
 		}
 	}
 }

--- a/pkg/vmcp/client/forwarding_test.go
+++ b/pkg/vmcp/client/forwarding_test.go
@@ -145,7 +145,7 @@ func TestNewNotificationForwarder_ForwardsProgress(t *testing.T) {
 			return nil
 		})
 
-	handler := newNotificationForwarder(callCtx, notifier)
+	handler := newNotificationForwarder(callCtx, notifier, nil, "backend-1")
 	handler(progressNotification("tok-1", 0.5, 1.0, "halfway"))
 }
 
@@ -164,7 +164,7 @@ func TestNewNotificationForwarder_ForwardsLog(t *testing.T) {
 			return nil
 		})
 
-	handler := newNotificationForwarder(t.Context(), notifier)
+	handler := newNotificationForwarder(t.Context(), notifier, nil, "backend-1")
 	handler(mcp.JSONRPCNotification{
 		Notification: mcp.Notification{
 			Method: vmcp.MethodLogNotification,
@@ -176,7 +176,8 @@ func TestNewNotificationForwarder_ForwardsLog(t *testing.T) {
 }
 
 // TestNewNotificationForwarder_IgnoresUnknownMethod verifies that a notification
-// method the forwarder does not relay does not reach the notifier.
+// method the forwarder does not relay does not reach the notifier and, when
+// listChanged is nil, is silently dropped rather than panicking.
 func TestNewNotificationForwarder_IgnoresUnknownMethod(t *testing.T) {
 	t.Parallel()
 
@@ -184,9 +185,9 @@ func TestNewNotificationForwarder_IgnoresUnknownMethod(t *testing.T) {
 	notifier := mocks.NewMockClientNotifier(ctrl)
 	// No EXPECT calls: any invocation fails the test.
 
-	handler := newNotificationForwarder(t.Context(), notifier)
+	handler := newNotificationForwarder(t.Context(), notifier, nil, "backend-1")
 	handler(mcp.JSONRPCNotification{
-		Notification: mcp.Notification{Method: "notifications/tools/list_changed"},
+		Notification: mcp.Notification{Method: "notifications/some/other"},
 	})
 }
 
@@ -201,9 +202,50 @@ func TestNewNotificationForwarder_SwallowsError(t *testing.T) {
 		NotifyProgress(gomock.Any(), gomock.Any()).
 		Return(errors.New("transport closed"))
 
-	handler := newNotificationForwarder(t.Context(), notifier)
+	handler := newNotificationForwarder(t.Context(), notifier, nil, "backend-1")
 	assert.NotPanics(t, func() {
 		handler(progressNotification("tok", 1, 0, ""))
+	})
+}
+
+// TestNewNotificationForwarder_ListChanged verifies that a backend's
+// list_changed notification is routed to the bound BackendListChangedNotifier,
+// keyed by backendID, for each of the three kinds, and that an unrecognized
+// method with a non-nil listChanged still does not fire it.
+func TestNewNotificationForwarder_ListChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		want   vmcp.ListChangedKind
+	}{
+		{"tools", vmcp.MethodToolListChanged, vmcp.ListChangedTools},
+		{"resources", vmcp.MethodResourceListChanged, vmcp.ListChangedResources},
+		{"prompts", vmcp.MethodPromptListChanged, vmcp.ListChangedPrompts},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			listChanged := mocks.NewMockBackendListChangedNotifier(ctrl)
+			listChanged.EXPECT().NotifyBackendListChanged("backend-1", tt.want)
+
+			handler := newNotificationForwarder(t.Context(), nil, listChanged, "backend-1")
+			handler(mcp.JSONRPCNotification{Notification: mcp.Notification{Method: tt.method}})
+		})
+	}
+}
+
+// TestNewNotificationForwarder_ListChangedNilSafe verifies that a nil
+// listChanged does not panic on an unrecognized (or list_changed) method.
+func TestNewNotificationForwarder_ListChangedNilSafe(t *testing.T) {
+	t.Parallel()
+
+	handler := newNotificationForwarder(t.Context(), nil, nil, "backend-1")
+	assert.NotPanics(t, func() {
+		handler(mcp.JSONRPCNotification{Notification: mcp.Notification{Method: vmcp.MethodToolListChanged}})
 	})
 }
 
@@ -214,17 +256,19 @@ func TestBindForwarders_StoresSnapshot(t *testing.T) {
 	elicit := mocks.NewMockElicitationRequester(ctrl)
 	sampling := mocks.NewMockSamplingRequester(ctrl)
 	notifier := mocks.NewMockClientNotifier(ctrl)
+	listChanged := mocks.NewMockBackendListChangedNotifier(ctrl)
 
 	h := &httpBackendClient{}
 	assert.Nil(t, h.forwarders.Load())
 
-	h.BindForwarders(elicit, sampling, notifier)
+	h.BindForwarders(elicit, sampling, notifier, listChanged)
 
 	fwd := h.forwarders.Load()
 	require.NotNil(t, fwd)
 	assert.Same(t, elicit, fwd.elicitation)
 	assert.Same(t, sampling, fwd.sampling)
 	assert.Same(t, notifier, fwd.notifier)
+	assert.Same(t, listChanged, fwd.listChanged)
 }
 
 // TestDeriveForwardCtx_CancelsOnHandlerCancel verifies that the derived context

--- a/pkg/vmcp/forwarding.go
+++ b/pkg/vmcp/forwarding.go
@@ -19,7 +19,59 @@ const (
 
 	// MethodLogNotification is the notifications/message (logging) wire method.
 	MethodLogNotification = "notifications/message"
+
+	// MethodToolListChanged is the notifications/tools/list_changed wire method.
+	MethodToolListChanged = "notifications/tools/list_changed"
+
+	// MethodResourceListChanged is the notifications/resources/list_changed wire method.
+	MethodResourceListChanged = "notifications/resources/list_changed"
+
+	// MethodPromptListChanged is the notifications/prompts/list_changed wire method.
+	MethodPromptListChanged = "notifications/prompts/list_changed"
 )
+
+// ListChangedKind identifies which capability list changed on a backend.
+type ListChangedKind int
+
+const (
+	// ListChangedTools indicates a backend's tools/list_changed notification.
+	ListChangedTools ListChangedKind = iota
+	// ListChangedResources indicates a backend's resources/list_changed notification.
+	ListChangedResources
+	// ListChangedPrompts indicates a backend's prompts/list_changed notification.
+	ListChangedPrompts
+)
+
+// ListChangedKindForMethod maps a wire notification method to its ListChangedKind.
+// It returns false for any method that is not one of the three list_changed
+// notifications, so callers (the backend client's OnNotification handler and the
+// persistent session connector's notification handler) share one classification.
+func ListChangedKindForMethod(method string) (ListChangedKind, bool) {
+	switch method {
+	case MethodToolListChanged:
+		return ListChangedTools, true
+	case MethodResourceListChanged:
+		return ListChangedResources, true
+	case MethodPromptListChanged:
+		return ListChangedPrompts, true
+	default:
+		return 0, false
+	}
+}
+
+// BackendListChangedNotifier receives notice that a backend's tool, resource, or
+// prompt list changed (a notifications/{tools,resources,prompts}/list_changed
+// notification from that backend). Implementations MUST be non-blocking: this is
+// called directly from a backend client's OnNotification handler, which runs on
+// the client's receive loop — a blocking implementation would stall that loop
+// (and, on the mid-call path, the drain-ping barrier in
+// drainServerToClientNotifications).
+type BackendListChangedNotifier interface {
+	// NotifyBackendListChanged records that backendID's capability list of the
+	// given kind changed. It must return without blocking on I/O or downstream
+	// locks.
+	NotifyBackendListChanged(backendID string, kind ListChangedKind)
+}
 
 // SamplingRequester sends an MCP sampling (sampling/createMessage) request to the
 // client and blocks for the response.
@@ -75,9 +127,14 @@ type ClientNotifier interface {
 type ClientForwarderBinder interface {
 	// BindForwarders installs the elicitation, sampling, and notification
 	// requesters used to relay a backend's mid-call server->client traffic to the
-	// downstream client. It is called exactly once, before serving begins. Any of
-	// the arguments may be nil to leave that forwarding path disabled.
-	BindForwarders(elicitation ElicitationRequester, sampling SamplingRequester, notifier ClientNotifier)
+	// downstream client, plus the sink that receives a backend's list_changed
+	// notifications (mid-call and, on the persistent session connector, idle). It
+	// is called exactly once, before serving begins. Any of the arguments may be
+	// nil to leave that forwarding path disabled: a nil listChanged means backend
+	// list_changed notifications are dropped rather than propagated downstream.
+	BindForwarders(
+		elicitation ElicitationRequester, sampling SamplingRequester, notifier ClientNotifier, listChanged BackendListChangedNotifier,
+	)
 }
 
 // SamplingRequest is the domain-typed sampling (sampling/createMessage) request.

--- a/pkg/vmcp/forwarding_test.go
+++ b/pkg/vmcp/forwarding_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestListChangedKindForMethod covers the shared method->kind classification
+// used by both the backend client's OnNotification handler
+// (pkg/vmcp/client/forwarding.go) and the persistent session connector
+// (pkg/vmcp/session/internal/backend/mcp_session.go).
+func TestListChangedKindForMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		method   string
+		wantKind ListChangedKind
+		wantOK   bool
+	}{
+		{"tools list_changed", MethodToolListChanged, ListChangedTools, true},
+		{"resources list_changed", MethodResourceListChanged, ListChangedResources, true},
+		{"prompts list_changed", MethodPromptListChanged, ListChangedPrompts, true},
+		{"progress notification is not a list_changed kind", MethodProgressNotification, 0, false},
+		{"log notification is not a list_changed kind", MethodLogNotification, 0, false},
+		{"unknown method", "notifications/resources/updated", 0, false},
+		{"empty method", "", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			kind, ok := ListChangedKindForMethod(tt.method)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantKind, kind)
+			}
+		})
+	}
+}

--- a/pkg/vmcp/listchanged_latebound.go
+++ b/pkg/vmcp/listchanged_latebound.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmcp
+
+import "sync"
+
+// LateBoundListChangedNotifier is a BackendListChangedNotifier whose backing
+// target is set once, after the real coordinator exists.
+//
+// The composition root (pkg/vmcp/cli) builds the session factory — which needs a
+// non-nil BackendListChangedNotifier to hand to the backend connector — before
+// server.Serve constructs the coordinator that will actually receive the
+// notifications. Bind resolves that construction-order inversion: the factory is
+// given this holder up front, and the composition root calls Bind once the
+// server's coordinator exists, before any session starts sending real traffic.
+// This mirrors lateBoundElicitationRequester in pkg/vmcp/server/elicitation_latebound.go.
+//
+// While unbound, NotifyBackendListChanged is a silent no-op: a notification that
+// arrives before Bind (impossible in practice, since no backend connection is
+// opened before the composition root finishes wiring) is simply dropped rather
+// than panicking or blocking.
+//
+// Safe for concurrent use: Bind happens once during construction (before serving
+// begins), NotifyBackendListChanged reads under the same lock.
+type LateBoundListChangedNotifier struct {
+	mu     sync.RWMutex
+	target BackendListChangedNotifier
+}
+
+var _ BackendListChangedNotifier = (*LateBoundListChangedNotifier)(nil)
+
+// NewLateBoundListChangedNotifier returns an unbound notifier. Bind must be
+// called before any backend connection that carries a reference to it starts
+// receiving list_changed notifications, or they are silently dropped.
+func NewLateBoundListChangedNotifier() *LateBoundListChangedNotifier {
+	return &LateBoundListChangedNotifier{}
+}
+
+// Bind sets the backing notifier. The composition root calls it exactly once,
+// after the server's list_changed coordinator is constructed and before serving
+// begins.
+func (l *LateBoundListChangedNotifier) Bind(target BackendListChangedNotifier) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.target = target
+}
+
+// NotifyBackendListChanged forwards to the bound target, or no-ops when called
+// before Bind.
+func (l *LateBoundListChangedNotifier) NotifyBackendListChanged(backendID string, kind ListChangedKind) {
+	l.mu.RLock()
+	target := l.target
+	l.mu.RUnlock()
+	if target == nil {
+		return
+	}
+	target.NotifyBackendListChanged(backendID, kind)
+}

--- a/pkg/vmcp/listchanged_latebound_test.go
+++ b/pkg/vmcp/listchanged_latebound_test.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vmcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// recordingListChangedNotifier records every NotifyBackendListChanged call.
+type recordingListChangedNotifier struct {
+	calls []struct {
+		backendID string
+		kind      ListChangedKind
+	}
+}
+
+func (r *recordingListChangedNotifier) NotifyBackendListChanged(backendID string, kind ListChangedKind) {
+	r.calls = append(r.calls, struct {
+		backendID string
+		kind      ListChangedKind
+	}{backendID, kind})
+}
+
+// TestLateBoundListChangedNotifier_UnboundIsNoop verifies that a notification
+// delivered before Bind is silently dropped rather than panicking.
+func TestLateBoundListChangedNotifier_UnboundIsNoop(t *testing.T) {
+	t.Parallel()
+
+	l := NewLateBoundListChangedNotifier()
+	assert.NotPanics(t, func() {
+		l.NotifyBackendListChanged("backend-1", ListChangedTools)
+	})
+}
+
+// TestLateBoundListChangedNotifier_BoundForwards verifies that once Bind is
+// called, notifications are forwarded to the bound target with the exact
+// arguments.
+func TestLateBoundListChangedNotifier_BoundForwards(t *testing.T) {
+	t.Parallel()
+
+	l := NewLateBoundListChangedNotifier()
+	target := &recordingListChangedNotifier{}
+	l.Bind(target)
+
+	l.NotifyBackendListChanged("backend-1", ListChangedResources)
+	l.NotifyBackendListChanged("backend-2", ListChangedPrompts)
+
+	require := assert.New(t)
+	require.Len(target.calls, 2)
+	require.Equal("backend-1", target.calls[0].backendID)
+	require.Equal(ListChangedResources, target.calls[0].kind)
+	require.Equal("backend-2", target.calls[1].backendID)
+	require.Equal(ListChangedPrompts, target.calls[1].kind)
+}

--- a/pkg/vmcp/mocks/mock_forwarding.go
+++ b/pkg/vmcp/mocks/mock_forwarding.go
@@ -17,6 +17,42 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+// MockBackendListChangedNotifier is a mock of BackendListChangedNotifier interface.
+type MockBackendListChangedNotifier struct {
+	ctrl     *gomock.Controller
+	recorder *MockBackendListChangedNotifierMockRecorder
+	isgomock struct{}
+}
+
+// MockBackendListChangedNotifierMockRecorder is the mock recorder for MockBackendListChangedNotifier.
+type MockBackendListChangedNotifierMockRecorder struct {
+	mock *MockBackendListChangedNotifier
+}
+
+// NewMockBackendListChangedNotifier creates a new mock instance.
+func NewMockBackendListChangedNotifier(ctrl *gomock.Controller) *MockBackendListChangedNotifier {
+	mock := &MockBackendListChangedNotifier{ctrl: ctrl}
+	mock.recorder = &MockBackendListChangedNotifierMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockBackendListChangedNotifier) EXPECT() *MockBackendListChangedNotifierMockRecorder {
+	return m.recorder
+}
+
+// NotifyBackendListChanged mocks base method.
+func (m *MockBackendListChangedNotifier) NotifyBackendListChanged(backendID string, kind vmcp.ListChangedKind) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyBackendListChanged", backendID, kind)
+}
+
+// NotifyBackendListChanged indicates an expected call of NotifyBackendListChanged.
+func (mr *MockBackendListChangedNotifierMockRecorder) NotifyBackendListChanged(backendID, kind any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyBackendListChanged", reflect.TypeOf((*MockBackendListChangedNotifier)(nil).NotifyBackendListChanged), backendID, kind)
+}
+
 // MockSamplingRequester is a mock of SamplingRequester interface.
 type MockSamplingRequester struct {
 	ctrl     *gomock.Controller
@@ -133,13 +169,13 @@ func (m *MockClientForwarderBinder) EXPECT() *MockClientForwarderBinderMockRecor
 }
 
 // BindForwarders mocks base method.
-func (m *MockClientForwarderBinder) BindForwarders(elicitation vmcp.ElicitationRequester, sampling vmcp.SamplingRequester, notifier vmcp.ClientNotifier) {
+func (m *MockClientForwarderBinder) BindForwarders(elicitation vmcp.ElicitationRequester, sampling vmcp.SamplingRequester, notifier vmcp.ClientNotifier, listChanged vmcp.BackendListChangedNotifier) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "BindForwarders", elicitation, sampling, notifier)
+	m.ctrl.Call(m, "BindForwarders", elicitation, sampling, notifier, listChanged)
 }
 
 // BindForwarders indicates an expected call of BindForwarders.
-func (mr *MockClientForwarderBinderMockRecorder) BindForwarders(elicitation, sampling, notifier any) *gomock.Call {
+func (mr *MockClientForwarderBinderMockRecorder) BindForwarders(elicitation, sampling, notifier, listChanged any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindForwarders", reflect.TypeOf((*MockClientForwarderBinder)(nil).BindForwarders), elicitation, sampling, notifier)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindForwarders", reflect.TypeOf((*MockClientForwarderBinder)(nil).BindForwarders), elicitation, sampling, notifier, listChanged)
 }

--- a/pkg/vmcp/server/context_isolation_regression_test.go
+++ b/pkg/vmcp/server/context_isolation_regression_test.go
@@ -69,6 +69,8 @@ func newPerToolSessionFactory(
 			}).AnyTimes()
 			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyIdentityBinding).
 				Return("unauthenticated", true).AnyTimes()
+			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyBackendIDs).
+				Return("", true).AnyTimes()
 			mock.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).AnyTimes()
 			toolsCopy := make([]vmcp.Tool, len(tools))
 			copy(toolsCopy, tools)

--- a/pkg/vmcp/server/forwarding_realbackend_integration_test.go
+++ b/pkg/vmcp/server/forwarding_realbackend_integration_test.go
@@ -126,7 +126,10 @@ func startForwardingBackend(t *testing.T) string {
 	mux.Handle("/mcp", streamableSrv)
 
 	ts := httptest.NewServer(mux)
-	t.Cleanup(ts.Close)
+	// Force-close active connections before Close: the persistent session
+	// connector holds a standalone SSE GET stream open for the whole session
+	// (see cleanupBackendServer), which Close would otherwise block on.
+	cleanupBackendServer(t, ts)
 	return ts.URL + "/mcp"
 }
 

--- a/pkg/vmcp/server/integration_test.go
+++ b/pkg/vmcp/server/integration_test.go
@@ -478,6 +478,10 @@ func TestIntegration_AuditLogging(t *testing.T) {
 			// Serve-path enforceSessionBinding reads the binding via GetMetadataValue.
 			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyIdentityBinding).
 				Return("unauthenticated", true).AnyTimes()
+			// handleSessionRegistrationImpl reads the backend ID set for the
+			// list_changed coordinator's registry.
+			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyBackendIDs).
+				Return("", true).AnyTimes()
 			mock.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).AnyTimes()
 			mock.EXPECT().Tools().Return(auditTools).AnyTimes()
 			mock.EXPECT().Resources().Return(nil).AnyTimes()

--- a/pkg/vmcp/server/list_changed.go
+++ b/pkg/vmcp/server/list_changed.go
@@ -1,0 +1,503 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/server"
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+	"github.com/stacklok/toolhive/pkg/vmcp/headerforward"
+)
+
+// listChangedDebounce coalesces a burst of NotifyBackendListChanged calls
+// (multiple sessions' listeners plus the mid-call path firing for the same
+// underlying backend mutation) into a single invalidate+re-sweep cycle. It is
+// the default for the per-coordinator debounce; tests shorten it via the
+// coordinator's atomic debounce field to avoid real quarter-second sleeps.
+const listChangedDebounce = 250 * time.Millisecond
+
+// listChangedSweepTimeout bounds the re-derivation of a single session's
+// capability set (core re-list + optimizer rebuild) during a re-sweep. It is
+// generous relative to the per-request deadlines elsewhere in this package
+// because a re-sweep runs off the request path, in the background, on the
+// coordinator's own goroutine.
+const listChangedSweepTimeout = 30 * time.Second
+
+// kindSet is a bitmask over vmcp.ListChangedKind, letting the coordinator
+// accumulate "which capability lists changed" for a backend (or the union
+// across backends affecting one session) without repeated slice scans.
+type kindSet uint8
+
+const (
+	kindTools kindSet = 1 << iota
+	kindResources
+	kindPrompts
+)
+
+// kindBit maps a vmcp.ListChangedKind to its bit. An unrecognized kind (should
+// be unreachable — vmcp.ListChangedKindForMethod is the only producer) maps to
+// 0, which every kindSet.has check reports as absent.
+func kindBit(k vmcp.ListChangedKind) kindSet {
+	switch k {
+	case vmcp.ListChangedTools:
+		return kindTools
+	case vmcp.ListChangedResources:
+		return kindResources
+	case vmcp.ListChangedPrompts:
+		return kindPrompts
+	default:
+		return 0
+	}
+}
+
+func (s kindSet) has(bit kindSet) bool { return s&bit != 0 }
+
+// trackedSession is the coordinator's per-session record, captured once at
+// session registration (handleSessionRegistrationImpl) and consulted on every
+// re-sweep.
+type trackedSession struct {
+	// sess is the live SDK session. SetSessionTools/SetSessionResources/
+	// SetSessionPrompts on it reconcile the per-session overlay onto the live
+	// go-sdk server and (for tools) auto-notify the downstream client.
+	sess server.ClientSession
+
+	// identity is the caller's identity at registration time. It is immutable
+	// (see pkg/auth/identity.go) so retaining it is safe, but it can go stale
+	// relative to a refreshed upstream token (#5323) — the re-swept core calls
+	// below are therefore best-effort with respect to identity freshness, same
+	// as any other background (non-request-path) use of a captured identity.
+	identity *auth.Identity
+
+	// fwdHeaders is the headerforward snapshot captured at registration
+	// (headerforward.ForwardedHeadersFromContext on the registration request).
+	// It must be replayed on the re-sweep context so the cache key the
+	// re-derivation computes (aggregator.cacheKey) matches the one the original
+	// registration populated — otherwise the re-sweep would miss the just-
+	// invalidated cache entry and silently serve a second, freshly-swept but
+	// differently-keyed entry.
+	fwdHeaders map[string]string
+
+	// backendIDs is this session's connected backend set (from the session's
+	// MultiSession metadata at registration). A backend's list_changed only
+	// affects sessions whose backendIDs contains that backend.
+	backendIDs map[string]struct{}
+}
+
+// listChangedCoordinator consumes backend list_changed notifications (from both
+// the per-call and persistent-session paths, see vmcp.BackendListChangedNotifier)
+// and propagates them to every affected, still-live session by invalidating the
+// per-identity capability cache and re-deriving + re-applying that session's
+// capability set.
+//
+// Concurrency model: dirty and tracked are the coordinator's only mutable state
+// besides invalidator, all guarded by mu. NotifyBackendListChanged (called
+// directly from a backend client's receive loop) only ever does a map write
+// under mu plus a non-blocking channel send — it never blocks on I/O or takes
+// any lock this type does not already own, so it cannot stall the receive loop
+// it runs on or the drain-ping barrier (pkg/vmcp/client's
+// drainServerToClientNotifications). All the heavy lifting — cache invalidation,
+// snapshotting tracked, and the per-session core re-derivation — happens on the
+// single worker goroutine started by Serve, well clear of any request path.
+type listChangedCoordinator struct {
+	srv *Server
+
+	mu sync.Mutex
+	// invalidator evicts per-identity capability cache entries scoped to one
+	// backend. Nil when response caching is disabled (aggregator.
+	// NewCachingAggregator returns the aggregator unwrapped for ttl<=0), in
+	// which case invalidation is skipped — there is no cache to go stale.
+	invalidator aggregator.CacheInvalidator
+	// dirty accumulates backendID -> which capability kinds changed, since the
+	// last sweep drained it.
+	dirty map[string]kindSet
+	// tracked holds the coordinator's own sessionID -> trackedSession registry.
+	// This is deliberately NOT layered onto the session Manager or the
+	// validating cache (pkg/cache/validating_cache.go) — neither is designed to
+	// be enumerated (Range is intentionally absent, see their docs), and adding
+	// that capability purely to support this coordinator would widen a stable
+	// interface for one caller.
+	//
+	// Entries are removed on two paths:
+	//   1. Graceful termination (client DELETE, or any internal Terminate): the
+	//      Manager's SetOnTerminate hook calls untrack synchronously — see
+	//      Serve's wiring and terminateOnBindingFailure.
+	//   2. Sweep-time discovery: a sweep that finds Manager.Validate reports a
+	//      tracked session terminated prunes it then (covers, e.g., a session
+	//      that expired without a DELETE but is later revisited by a sweep).
+	//
+	// UNBOUNDED-GROWTH GAP: a session whose client vanishes WITHOUT a DELETE
+	// (ungraceful transport drop) fires neither path unless a later sweep happens
+	// to revisit it — and a sweep only revisits sessions whose backend set
+	// intersects a dirty backend, so an idle session on an otherwise-quiet
+	// backend is never revisited. There is no unregister hook to catch this:
+	// mcpcompat's server.Hooks exposes only OnRegisterSession, and go-sdk's
+	// session-disconnect path is internal (no consumer-settable close callback,
+	// verified against toolhive-core@v0.0.32 / go-sdk@v1.6.1). So such an entry
+	// (a live server.ClientSession, identity, and two small maps) leaks until the
+	// process exits — the SAME class of leak mcpcompat itself documents for its
+	// own session maps (issue #156 finding 5). Bounding this needs an upstream
+	// close hook; tracked as a follow-up, not added to toolhive-core in this PR.
+	tracked map[string]*trackedSession
+
+	// wake is a buffered(1) signal from NotifyBackendListChanged to the worker.
+	// Buffering at 1 means a storm of notifications collapses to a single
+	// pending wake-up rather than queuing one per notification.
+	wake chan struct{}
+	// done is closed by stop to terminate the worker goroutine. Its close is
+	// guarded by stopOnce so a second Server.Stop cannot panic on close-of-closed.
+	done     chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+
+	// baseCtx is the root context for every background re-sweep; cancel cancels it
+	// inside stop() so an in-flight sweep's core calls abort promptly instead of
+	// blocking shutdown for up to the sweep timeout per affected session.
+	baseCtx context.Context
+	cancel  context.CancelFunc
+
+	// debounceNanos is the coalescing window in nanoseconds, read atomically by
+	// the worker on each wake. It defaults to listChangedDebounce; tests store a
+	// far smaller value to avoid real quarter-second sleeps under -race.
+	debounceNanos atomic.Int64
+}
+
+var _ vmcp.BackendListChangedNotifier = (*listChangedCoordinator)(nil)
+
+// newListChangedCoordinator constructs a coordinator bound to srv. The caller
+// (Serve) must call start() once before any session can register, and must
+// arrange for stop to run during shutdown.
+func newListChangedCoordinator(srv *Server) *listChangedCoordinator {
+	baseCtx, cancel := context.WithCancel(context.Background())
+	c := &listChangedCoordinator{
+		srv:     srv,
+		dirty:   make(map[string]kindSet),
+		tracked: make(map[string]*trackedSession),
+		wake:    make(chan struct{}, 1),
+		done:    make(chan struct{}),
+		baseCtx: baseCtx,
+		cancel:  cancel,
+	}
+	c.debounceNanos.Store(int64(listChangedDebounce))
+	return c
+}
+
+// setInvalidator installs the cache invalidator once the caching aggregator
+// (built in server.New) is known. Called before the server begins accepting
+// connections, so there is no concurrent sweep in progress the first time it
+// runs; later reads of invalidator by the worker take the same mu.
+func (c *listChangedCoordinator) setInvalidator(inv aggregator.CacheInvalidator) {
+	c.mu.Lock()
+	c.invalidator = inv
+	c.mu.Unlock()
+}
+
+// NotifyBackendListChanged implements vmcp.BackendListChangedNotifier. It is
+// invoked directly from a backend client's OnNotification handler (both the
+// per-call and persistent-session paths), so it MUST NOT block: it does a
+// single guarded map write plus a non-blocking wake signal, nothing else.
+func (c *listChangedCoordinator) NotifyBackendListChanged(backendID string, kind vmcp.ListChangedKind) {
+	bit := kindBit(kind)
+	if bit == 0 {
+		return
+	}
+	c.mu.Lock()
+	c.dirty[backendID] |= bit
+	c.mu.Unlock()
+
+	select {
+	case c.wake <- struct{}{}:
+	default:
+	}
+}
+
+// track registers sessionID's coordinator entry. Called once, after a session's
+// capabilities have been successfully injected at registration.
+func (c *listChangedCoordinator) track(sessionID string, entry *trackedSession) {
+	c.mu.Lock()
+	c.tracked[sessionID] = entry
+	c.mu.Unlock()
+}
+
+// untrack removes sessionID's coordinator entry. Called on session termination
+// (including binding-failure termination) and when a sweep discovers the
+// session manager reports it terminated.
+func (c *listChangedCoordinator) untrack(sessionID string) {
+	c.mu.Lock()
+	delete(c.tracked, sessionID)
+	c.mu.Unlock()
+}
+
+// start launches the single coordinator worker goroutine. Serve calls it
+// exactly once, before the server begins accepting connections.
+func (c *listChangedCoordinator) start() {
+	c.wg.Add(1)
+	go c.run()
+}
+
+// stop signals the worker to exit and waits for it, bounded by ctx. It is
+// registered on Server.shutdownFuncs. It is idempotent (stopOnce guards the
+// channel close and context cancel) so a second Server.Stop cannot panic.
+// Cancelling baseCtx first aborts any in-flight re-sweep's core calls promptly,
+// so shutdown does not block for up to the sweep timeout per affected session.
+//
+// It stops ONLY the coordinator goroutine and clears the tracked registry's
+// worker; it does NOT close the per-session persistent backend connections /
+// standalone list_changed streams — those MultiSessions are owned by the session
+// Manager's cache and are released on eviction (see the lifecycle note in
+// backend.NewHTTPConnector), not here. Eager close-on-Stop is a documented
+// follow-up.
+func (c *listChangedCoordinator) stop(ctx context.Context) error {
+	c.stopOnce.Do(func() {
+		c.cancel()
+		close(c.done)
+	})
+	waited := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(waited)
+	}()
+	select {
+	case <-waited:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// run is the coordinator's sole worker goroutine: wait for a wake-up (or
+// shutdown), debounce briefly to coalesce a notification storm, then drain and
+// process dirty backends until none remain (re-checking after each sweep, since
+// a notification may have arrived mid-sweep). It aborts promptly on shutdown at
+// every blocking or loop boundary.
+func (c *listChangedCoordinator) run() {
+	defer c.wg.Done()
+	for {
+		select {
+		case <-c.wake:
+		case <-c.done:
+			return
+		}
+
+		timer := time.NewTimer(time.Duration(c.debounceNanos.Load()))
+		select {
+		case <-timer.C:
+		case <-c.done:
+			timer.Stop()
+			return
+		}
+
+		for {
+			// Abort promptly on shutdown rather than draining the whole dirty set.
+			select {
+			case <-c.done:
+				return
+			default:
+			}
+			dirty := c.drainDirty()
+			if len(dirty) == 0 {
+				break
+			}
+			c.sweep(dirty)
+		}
+	}
+}
+
+// drainDirty atomically swaps out the dirty map, returning the previous
+// contents (or nil if empty) and leaving an empty map in place.
+func (c *listChangedCoordinator) drainDirty() map[string]kindSet {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.dirty) == 0 {
+		return nil
+	}
+	d := c.dirty
+	c.dirty = make(map[string]kindSet)
+	return d
+}
+
+// sweep invalidates the capability cache for every dirty backend, then
+// re-derives and re-applies the capability set for every tracked session that
+// backend set affects.
+func (c *listChangedCoordinator) sweep(dirty map[string]kindSet) {
+	c.mu.Lock()
+	inv := c.invalidator
+	sessions := make(map[string]*trackedSession, len(c.tracked))
+	for id, e := range c.tracked {
+		sessions[id] = e
+	}
+	c.mu.Unlock()
+
+	if inv != nil {
+		for backendID := range dirty {
+			inv.InvalidateBackend(backendID)
+		}
+	}
+
+	// Sequential, not parallel: the first affected session's re-sweep for a
+	// given (identity, forwarded-headers, backend-set) cache key repopulates
+	// the just-invalidated aggregator cache entry; any other tracked session
+	// sharing that exact key then hits the warm cache instead of re-sweeping
+	// the backends itself.
+	for sessionID, entry := range sessions {
+		// Bail between sessions on shutdown so stop() is not held up by the
+		// remaining sessions' re-sweeps (baseCtx is already cancelled too).
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+		kinds := affectedKinds(entry.backendIDs, dirty)
+		if kinds == 0 {
+			continue
+		}
+		c.resweepSession(sessionID, entry, kinds)
+	}
+}
+
+// affectedKinds unions the dirty kindSets of every backend in backendIDs,
+// returning 0 when none of dirty's backends belong to this session.
+func affectedKinds(backendIDs map[string]struct{}, dirty map[string]kindSet) kindSet {
+	var union kindSet
+	for id := range backendIDs {
+		if k, ok := dirty[id]; ok {
+			union |= k
+		}
+	}
+	return union
+}
+
+// resweepSession re-derives and re-applies sessionID's capability set for the
+// dirty kinds, after confirming the session is still live.
+func (c *listChangedCoordinator) resweepSession(sessionID string, entry *trackedSession, kinds kindSet) {
+	// Manager.Validate is storage-only (no restore/reconnect side effects),
+	// unlike GetMultiSession which can trigger a full backend reconnect on a
+	// cache miss — exactly the kind of expensive, request-shaped work this
+	// background sweep must not trigger incidentally. Validate is sufficient
+	// here: we only need to know whether the session still exists.
+	terminated, err := c.srv.vmcpSessionMgr.Validate(sessionID)
+	if err != nil {
+		slog.Debug("list_changed: skipping session re-sweep; validate failed",
+			"session_id", sessionID, "error", err)
+		return
+	}
+	if terminated {
+		c.untrack(sessionID)
+		return
+	}
+
+	// c.baseCtx, not context.Background(): this runs on the coordinator's own
+	// goroutine, well after the (long-gone) registration request completed, but
+	// it must still abort promptly when stop() cancels baseCtx (otherwise
+	// shutdown blocks up to the sweep timeout per affected session). Carrying
+	// identity + forwarded headers reproduces the exact cache key
+	// (aggregator.cacheKey) the original registration populated, so the
+	// invalidated entry is genuinely refreshed rather than missed.
+	ctx := auth.WithIdentity(c.baseCtx, entry.identity)
+	ctx = headerforward.WithForwardedHeaders(ctx, entry.fwdHeaders)
+	ctx, cancel := context.WithTimeout(ctx, listChangedSweepTimeout)
+	defer cancel()
+
+	if kinds.has(kindTools) {
+		c.resweepTools(ctx, sessionID, entry)
+	}
+	if kinds.has(kindResources) {
+		c.resweepResources(ctx, sessionID, entry)
+	}
+	if kinds.has(kindPrompts) {
+		c.resweepPrompts(ctx, sessionID, entry)
+	}
+}
+
+// resweepTools re-derives sessionID's advertised tool set and REPLACES the
+// session's tool overlay with it (setSessionToolsReplace, not the
+// registration-time merge helper), so a tool the backend removed actually
+// disappears — the merge helper can only ever add. On a re-derivation error
+// the previous tool set is left untouched (never shrunk to empty on a
+// transient failure); the next backend notification retries.
+func (c *listChangedCoordinator) resweepTools(ctx context.Context, sessionID string, entry *trackedSession) {
+	tools, err := c.srv.serveSessionTools(ctx, sessionID, entry.identity)
+	if err != nil {
+		slog.Warn("list_changed: failed to re-list tools for session; retaining previous set",
+			"session_id", sessionID, "error", err)
+		return
+	}
+	if err := setSessionToolsReplace(entry.sess, tools); err != nil {
+		slog.Warn("list_changed: failed to apply re-swept tools",
+			"session_id", sessionID, "error", err)
+	}
+}
+
+// resweepResources re-derives sessionID's advertised resources and resource
+// templates and applies them via the ADD-ONLY setSessionResourcesDirect /
+// setSessionResourceTemplatesDirect helpers.
+//
+// Removal gap (documented, not fixed here): unlike tools, the underlying
+// go-sdk-facing sync (mcpcompat's syncSessionResources / syncSessionResourceTemplates)
+// only ever ADDS — it has no RemoveResources/RemoveResourceTemplates
+// reconciliation the way syncSessionTools has RemoveTools. So a resource or
+// resource template a backend REMOVES stays advertised on already-registered
+// sessions until the session ends; only additions propagate. Closing this gap
+// needs a toolhive-core change (making those two sync functions reconciling,
+// like syncSessionTools) plus a version bump, which is out of scope for this
+// PR — tracked as a toolhive-core follow-up (see the PR description).
+func (c *listChangedCoordinator) resweepResources(ctx context.Context, sessionID string, entry *trackedSession) {
+	resources, err := c.srv.coreSessionResources(ctx, sessionID, entry.identity)
+	if err != nil {
+		slog.Warn("list_changed: failed to re-list resources for session",
+			"session_id", sessionID, "error", err)
+	} else if len(resources) > 0 {
+		if err := setSessionResourcesDirect(entry.sess, resources); err != nil {
+			slog.Warn("list_changed: failed to apply re-swept resources",
+				"session_id", sessionID, "error", err)
+		}
+	}
+
+	templates, err := c.srv.coreSessionResourceTemplates(ctx, sessionID, entry.identity)
+	if err != nil {
+		slog.Warn("list_changed: failed to re-list resource templates for session",
+			"session_id", sessionID, "error", err)
+	} else if len(templates) > 0 {
+		if err := setSessionResourceTemplatesDirect(entry.sess, templates); err != nil {
+			slog.Warn("list_changed: failed to apply re-swept resource templates",
+				"session_id", sessionID, "error", err)
+		}
+	}
+}
+
+// resweepPrompts re-derives sessionID's advertised prompts and applies them via
+// the ADD-ONLY setSessionPromptsDirect helper. See resweepResources for the
+// same add-only / toolhive-core-follow-up caveat, which applies identically to
+// prompts (mcpcompat's syncSessionPrompts is also add-only).
+func (c *listChangedCoordinator) resweepPrompts(ctx context.Context, sessionID string, entry *trackedSession) {
+	prompts, err := c.srv.coreSessionPrompts(ctx, sessionID, entry.identity)
+	if err != nil {
+		slog.Warn("list_changed: failed to re-list prompts for session",
+			"session_id", sessionID, "error", err)
+		return
+	}
+	if len(prompts) > 0 {
+		if err := setSessionPromptsDirect(entry.sess, prompts); err != nil {
+			slog.Warn("list_changed: failed to apply re-swept prompts",
+				"session_id", sessionID, "error", err)
+		}
+	}
+}
+
+// BackendListChangedNotifier returns the server's list_changed coordinator as
+// the narrow interface backend clients/connectors depend on. It returns a true
+// nil interface value (not a non-nil interface wrapping a nil *listChangedCoordinator)
+// when the server has no coordinator, so callers' nil checks behave correctly.
+func (s *Server) BackendListChangedNotifier() vmcp.BackendListChangedNotifier {
+	if s.listChanged == nil {
+		return nil
+	}
+	return s.listChanged
+}

--- a/pkg/vmcp/server/list_changed_realbackend_integration_test.go
+++ b/pkg/vmcp/server/list_changed_realbackend_integration_test.go
@@ -1,0 +1,424 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mcpmcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
+)
+
+// listChangedRealBackendTimeout bounds each real-backend list_changed test, for
+// the same reason as forwardingRealBackendTimeout (see forwarding_realbackend_
+// integration_test.go): these exercise an async backend -> vMCP coordinator ->
+// downstream relay (with a 250ms coordinator debounce on top), which can take
+// several seconds under a loaded, -race CI run.
+const listChangedRealBackendTimeout = 60 * time.Second
+
+// mutableBackend wraps a raw go-sdk (not mcpcompat) MCP server so the test can
+// mutate its OWN tool/resource/prompt set at will — including from a plain test
+// goroutine with no vMCP call in flight (the "idle" list_changed path) or from
+// inside a tool handler (the "mid-call" path). It deliberately bypasses
+// toolhive-core's mcpcompat shim: mcpcompat's MCPServer.AddTool only feeds the
+// ONE underlying gosdk.Server the shim's StreamableHTTPServer builds lazily on
+// first request, with no supported way to mutate that already-built server
+// afterwards (see the comment in pkg/vmcp/session/internal/backend/
+// mcp_session_listchanged_test.go). The raw go-sdk *Server has no such
+// limitation: AddTool/RemoveTools (and their Resource/Prompt counterparts) work
+// against the live server and emit real notifications/*/list_changed traffic,
+// exactly as a genuine third-party backend built directly on go-sdk would.
+type mutableBackend struct {
+	srv *gosdk.Server
+}
+
+// addTool registers a trivial tool that returns "ok" when called.
+func (m *mutableBackend) addTool(name string) {
+	gosdk.AddTool[any, any](m.srv, &gosdk.Tool{Name: name},
+		func(context.Context, *gosdk.CallToolRequest, any) (*gosdk.CallToolResult, any, error) {
+			return &gosdk.CallToolResult{Content: []gosdk.Content{&gosdk.TextContent{Text: "ok"}}}, nil, nil
+		})
+}
+
+// addSelfMutatingTool registers a tool whose handler adds newToolName to the
+// SAME backend server before returning — the "mid-call" scenario: the
+// backend's own tools/call handler triggers its own list_changed notification
+// while vMCP's tools/call to it is still in flight.
+func (m *mutableBackend) addSelfMutatingTool(name, newToolName string) {
+	gosdk.AddTool[any, any](m.srv, &gosdk.Tool{Name: name},
+		func(context.Context, *gosdk.CallToolRequest, any) (*gosdk.CallToolResult, any, error) {
+			m.addTool(newToolName)
+			return &gosdk.CallToolResult{Content: []gosdk.Content{&gosdk.TextContent{Text: "mutated"}}}, nil, nil
+		})
+}
+
+func (m *mutableBackend) removeTool(name string) { m.srv.RemoveTools(name) }
+
+func (m *mutableBackend) addResource(uri, name string) {
+	m.srv.AddResource(&gosdk.Resource{URI: uri, Name: name},
+		func(context.Context, *gosdk.ReadResourceRequest) (*gosdk.ReadResourceResult, error) {
+			return &gosdk.ReadResourceResult{
+				Contents: []*gosdk.ResourceContents{{URI: uri, Text: "resource-body"}},
+			}, nil
+		})
+}
+
+func (m *mutableBackend) removeResource(uri string) { m.srv.RemoveResources(uri) }
+
+func (m *mutableBackend) addPrompt(name string) {
+	m.srv.AddPrompt(&gosdk.Prompt{Name: name},
+		func(context.Context, *gosdk.GetPromptRequest) (*gosdk.GetPromptResult, error) {
+			return &gosdk.GetPromptResult{
+				Messages: []*gosdk.PromptMessage{{
+					Role:    "user",
+					Content: &gosdk.TextContent{Text: "prompt-body"},
+				}},
+			}, nil
+		})
+}
+
+// startMutableBackend starts a raw go-sdk streamable-HTTP backend seeded with
+// one tool (so it advertises SOME capability at startup) and returns the
+// mutableBackend handle plus its /mcp URL.
+func startMutableBackend(t *testing.T) (*mutableBackend, string) {
+	t.Helper()
+
+	srv := gosdk.NewServer(&gosdk.Implementation{Name: "mutable-backend", Version: "1.0.0"}, nil)
+	mb := &mutableBackend{srv: srv}
+	mb.addTool("seed_tool")
+
+	handler := gosdk.NewStreamableHTTPHandler(func(*http.Request) *gosdk.Server { return srv }, nil)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", handler)
+	ts := httptest.NewServer(mux)
+	// Force-close active connections before Close: vMCP holds a standalone SSE GET
+	// stream open against this backend for the whole session (see
+	// cleanupBackendServer), which Close would otherwise block on.
+	cleanupBackendServer(t, ts)
+	return mb, ts.URL + "/mcp"
+}
+
+// drainNotifications consumes every pending forwarded notification plus any that
+// arrive within a short quiet window, so a subsequent waitNotification proves an
+// emission caused by a LATER action rather than the benign registration-time
+// tools/list_changed (go-sdk emits one ~10ms after a session's tools are first
+// projected — see the W0 capability-flip note in serve.go). The presence
+// backstops already keep these tests sound; this tightens the notification
+// assertion to the mutation-caused emission.
+func (dc *downstreamClient) drainNotifications() {
+	const quiet = 300 * time.Millisecond
+	for {
+		select {
+		case <-dc.notifCh:
+		case <-time.After(quiet):
+			return
+		}
+	}
+}
+
+// waitToolPresence polls tools/list on the downstream client's session until
+// wantName's presence matches want, or the context is done.
+func waitToolPresence(ctx context.Context, t *testing.T, dc *downstreamClient, wantName string, want bool) {
+	t.Helper()
+	for {
+		res, err := dc.c.ListTools(ctx, mcpmcp.ListToolsRequest{})
+		if err == nil {
+			found := false
+			for _, tl := range res.Tools {
+				if tl.Name == wantName {
+					found = true
+					break
+				}
+			}
+			if found == want {
+				return
+			}
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for tool %q presence=%v: %v", wantName, want, err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// TestListChanged_MidCallMutate_RealBackend covers scenario 1 from the spec: a
+// backend mutates its OWN tool set from inside a tools/call handler (mid-call).
+// vMCP must relay the resulting notifications/tools/list_changed to the
+// downstream client, and a subsequent tools/list must show the new tool and
+// hide nothing that wasn't removed.
+func TestListChanged_MidCallMutate_RealBackend(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(t.Context(), listChangedRealBackendTimeout)
+	defer cancel()
+
+	mb, backendURL := startMutableBackend(t)
+	mb.addSelfMutatingTool("mutate_add", "added_midcall")
+
+	vmcpTS := newRealTestServer(t, backendURL)
+	dc := newDownstreamClient(ctx, t, vmcpTS.URL+"/mcp", false)
+
+	// Wait for registration to complete (mutate_add advertised) and drain the
+	// benign registration-time tools/list_changed, so the assertion below proves
+	// the MID-CALL mutation emission.
+	waitToolPresence(ctx, t, dc, "mutate_add", true)
+	dc.drainNotifications()
+
+	res, err := dc.c.CallTool(ctx, mcpCallToolParams("mutate_add", nil))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	dc.waitNotification(ctx, t, "notifications/tools/list_changed")
+	waitToolPresence(ctx, t, dc, "added_midcall", true)
+}
+
+// TestListChanged_IdleMutate_RealBackend covers scenario 2 from the spec: the
+// backend mutates its tool set from a plain test goroutine with NO vMCP call in
+// flight. Delivery for this case depends entirely on the PERSISTENT session
+// connector's continuous-listening stream (pkg/vmcp/session/internal/backend),
+// not the per-call forwarding path.
+func TestListChanged_IdleMutate_RealBackend(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(t.Context(), listChangedRealBackendTimeout)
+	defer cancel()
+
+	mb, backendURL := startMutableBackend(t)
+	vmcpTS := newRealTestServer(t, backendURL)
+	dc := newDownstreamClient(ctx, t, vmcpTS.URL+"/mcp", false)
+
+	// Establish the session (and its persistent backend connection) before
+	// mutating, and confirm the seed tool is visible first.
+	waitToolPresence(ctx, t, dc, "seed_tool", true)
+	dc.drainNotifications()
+
+	mb.addTool("added_idle")
+
+	dc.waitNotification(ctx, t, "notifications/tools/list_changed")
+	waitToolPresence(ctx, t, dc, "added_idle", true)
+
+	// Removal, unlike resources/prompts, IS supported for tools (setSessionToolsReplace):
+	// prove the removed tool actually disappears downstream, not just that
+	// additions propagate.
+	dc.drainNotifications()
+	mb.removeTool("added_idle")
+	dc.waitNotification(ctx, t, "notifications/tools/list_changed")
+	waitToolPresence(ctx, t, dc, "added_idle", false)
+}
+
+// TestListChanged_FanOut_RealBackend covers scenario 3: two concurrent
+// downstream sessions against the same vMCP instance must BOTH observe an idle
+// backend mutation.
+func TestListChanged_FanOut_RealBackend(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(t.Context(), listChangedRealBackendTimeout)
+	defer cancel()
+
+	mb, backendURL := startMutableBackend(t)
+	vmcpTS := newRealTestServer(t, backendURL)
+
+	dcA := newDownstreamClient(ctx, t, vmcpTS.URL+"/mcp", false)
+	dcB := newDownstreamClient(ctx, t, vmcpTS.URL+"/mcp", false)
+
+	waitToolPresence(ctx, t, dcA, "seed_tool", true)
+	waitToolPresence(ctx, t, dcB, "seed_tool", true)
+	dcA.drainNotifications()
+	dcB.drainNotifications()
+
+	mb.addTool("added_fanout")
+
+	dcA.waitNotification(ctx, t, "notifications/tools/list_changed")
+	dcB.waitNotification(ctx, t, "notifications/tools/list_changed")
+	waitToolPresence(ctx, t, dcA, "added_fanout", true)
+	waitToolPresence(ctx, t, dcB, "added_fanout", true)
+}
+
+// TestListChanged_ResourcesAndPromptsAdd_RealBackend covers scenario 4: a
+// backend ADDING a resource or a prompt propagates a list_changed notification
+// and the new item appears downstream. Removal propagation for
+// resources/prompts is an explicit, documented toolhive-core follow-up (see
+// listChangedCoordinator.resweepResources), so it is intentionally NOT
+// asserted here.
+func TestListChanged_ResourcesAndPromptsAdd_RealBackend(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(t.Context(), listChangedRealBackendTimeout)
+	defer cancel()
+
+	mb, backendURL := startMutableBackend(t)
+	vmcpTS := newRealTestServer(t, backendURL)
+	dc := newDownstreamClient(ctx, t, vmcpTS.URL+"/mcp", false)
+
+	waitToolPresence(ctx, t, dc, "seed_tool", true)
+	dc.drainNotifications()
+
+	mb.addResource("file:///new-resource.txt", "new-resource")
+	dc.waitNotification(ctx, t, "notifications/resources/list_changed")
+
+	require.Eventually(t, func() bool {
+		res, err := dc.c.ListResources(ctx, mcpmcp.ListResourcesRequest{})
+		if err != nil {
+			return false
+		}
+		for _, r := range res.Resources {
+			if r.URI == "file:///new-resource.txt" {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond, "the added resource must appear in resources/list")
+
+	dc.drainNotifications()
+	mb.addPrompt("new-prompt")
+	dc.waitNotification(ctx, t, "notifications/prompts/list_changed")
+
+	require.Eventually(t, func() bool {
+		res, err := dc.c.ListPrompts(ctx, mcpmcp.ListPromptsRequest{})
+		if err != nil {
+			return false
+		}
+		for _, p := range res.Prompts {
+			if p.Name == "new-prompt" {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond, "the added prompt must appear in prompts/list")
+}
+
+// TestListChanged_CapabilityRegression is scenario 5: the initialize response
+// must advertise tools.listChanged, resources.subscribe+listChanged, and
+// prompts.listChanged, all true (W0's capability flip).
+func TestListChanged_CapabilityRegression(t *testing.T) {
+	t.Parallel()
+
+	backendURL := startRealMCPBackend(t)
+	vmcpTS := newRealTestServer(t, backendURL)
+
+	resp := postMCP(t, vmcpTS.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var rpc struct {
+		Result struct {
+			Capabilities struct {
+				Tools *struct {
+					ListChanged bool `json:"listChanged"`
+				} `json:"tools"`
+				Resources *struct {
+					Subscribe   bool `json:"subscribe"`
+					ListChanged bool `json:"listChanged"`
+				} `json:"resources"`
+				Prompts *struct {
+					ListChanged bool `json:"listChanged"`
+				} `json:"prompts"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&rpc))
+
+	require.NotNil(t, rpc.Result.Capabilities.Tools, "tools capability must be advertised")
+	assert.True(t, rpc.Result.Capabilities.Tools.ListChanged, "tools.listChanged must be true")
+
+	require.NotNil(t, rpc.Result.Capabilities.Resources, "resources capability must be advertised")
+	assert.True(t, rpc.Result.Capabilities.Resources.Subscribe, "resources.subscribe must be true")
+	assert.True(t, rpc.Result.Capabilities.Resources.ListChanged, "resources.listChanged must be true")
+
+	require.NotNil(t, rpc.Result.Capabilities.Prompts, "prompts capability must be advertised")
+	assert.True(t, rpc.Result.Capabilities.Prompts.ListChanged, "prompts.listChanged must be true")
+}
+
+// TestListChanged_ResourceRemovalNotPropagated_RegressionGuard locks in the
+// CURRENT add-only limitation for resources (and, by the same mechanism,
+// prompts): a resource a backend REMOVES stays advertised in the downstream
+// resources/list until the session ends, because the per-session resource
+// overlay sync (mcpcompat's syncSessionResources) only ever ADDS — it has no
+// RemoveResources reconciliation the way tools' syncSessionTools has RemoveTools.
+//
+// This is intentional for THIS PR (see listChangedCoordinator.resweepResources).
+// When the toolhive-core follow-up makes resource/prompt sync reconciling, this
+// test WILL start failing — that failure is the intended signal to update it to
+// assert removal now propagates (and to flip the coordinator's resource/prompt
+// path to setSessionToolsReplace-style semantics). Note reads are unaffected:
+// coreResourceHandler routes every resources/read through core.ReadResource,
+// which re-derives admission per call, so a stale overlay entry cannot be READ
+// once the backend/admission drops it — only listed.
+func TestListChanged_ResourceRemovalNotPropagated_RegressionGuard(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(t.Context(), listChangedRealBackendTimeout)
+	defer cancel()
+
+	mb, backendURL := startMutableBackend(t)
+	vmcpTS := newRealTestServer(t, backendURL)
+	dc := newDownstreamClient(ctx, t, vmcpTS.URL+"/mcp", false)
+
+	waitToolPresence(ctx, t, dc, "seed_tool", true)
+	dc.drainNotifications()
+
+	// Keep a second resource present for the whole test so removing `uri` never
+	// drops the backend to ZERO resources: a go-sdk backend infers its resource
+	// capability from registered resources, so removing the last one would leave
+	// no resources capability and emit NO resources/list_changed — the re-sweep
+	// would never fire and the guard would pass vacuously. With `keep` remaining,
+	// the removal still emits a real notification and drives an actual re-sweep.
+	const (
+		keep = "file:///keep.txt"
+		uri  = "file:///removable.txt"
+	)
+	mb.addResource(keep, "keep")
+	mb.addResource(uri, "removable")
+	dc.waitNotification(ctx, t, "notifications/resources/list_changed")
+
+	resourcePresent := func() bool {
+		res, err := dc.c.ListResources(ctx, mcpmcp.ListResourcesRequest{})
+		if err != nil {
+			return false
+		}
+		for _, r := range res.Resources {
+			if r.URI == uri {
+				return true
+			}
+		}
+		return false
+	}
+	require.Eventually(t, resourcePresent, 10*time.Second, 100*time.Millisecond,
+		"the added resource must first appear before we can assert removal is NOT propagated")
+
+	// Remove it on the backend; `keep` remains, so the backend emits
+	// resources/list_changed and vMCP re-sweeps — but the add-only overlay cannot
+	// drop the stale entry.
+	dc.drainNotifications()
+	mb.removeResource(uri)
+	dc.waitNotification(ctx, t, "notifications/resources/list_changed")
+
+	// Settle past the re-sweep, then assert the removed resource STILL lists
+	// (the documented add-only gap). Flip this to require absence when the
+	// toolhive-core follow-up lands.
+	time.Sleep(500 * time.Millisecond)
+	assert.True(t, resourcePresent(),
+		"KNOWN add-only limitation: a removed resource stays advertised until session end "+
+			"(update this guard when the toolhive-core resource/prompt removal follow-up lands)")
+}
+
+// mcpCallToolParams builds a mcpmcp.CallToolRequest for name/args, mirroring the
+// shape forwarding_realbackend_integration_test.go's tests build inline. Small
+// helper to avoid repeating the Params wrapper at each call site in this file.
+func mcpCallToolParams(name string, args map[string]any) mcpmcp.CallToolRequest {
+	return mcpmcp.CallToolRequest{Params: mcpmcp.CallToolParams{Name: name, Arguments: args}}
+}

--- a/pkg/vmcp/server/list_changed_test.go
+++ b/pkg/vmcp/server/list_changed_test.go
@@ -1,0 +1,356 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	"github.com/stacklok/toolhive-core/mcpcompat/server"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// bareSession implements only server.ClientSession (not SessionWithTools),
+// used to exercise setSessionToolsReplace's unsupported-session error branch.
+type bareSession struct{ id string }
+
+var _ server.ClientSession = (*bareSession)(nil)
+
+func (b *bareSession) SessionID() string                                 { return b.id }
+func (*bareSession) Initialize()                                         {}
+func (*bareSession) Initialized() bool                                   { return true }
+func (*bareSession) NotificationChannel() chan<- mcp.JSONRPCNotification { return nil }
+
+// TestSetSessionToolsReplace covers the REPLACE (not merge) semantics that
+// distinguish it from setSessionToolsDirect: a tool present in the session's
+// existing overlay but absent from the new set must disappear, and a session
+// that does not implement SessionWithTools is rejected.
+func TestSetSessionToolsReplace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes a tool no longer present", func(t *testing.T) {
+		t.Parallel()
+		sess := &fakeSDKSession{id: "s1", tools: map[string]server.ServerTool{
+			"old": {Tool: mcp.Tool{Name: "old"}},
+		}}
+		err := setSessionToolsReplace(sess, []server.ServerTool{{Tool: mcp.Tool{Name: "new"}}})
+		require.NoError(t, err)
+		assert.NotContains(t, sess.tools, "old", "replace must remove a tool no longer present")
+		assert.Contains(t, sess.tools, "new")
+	})
+
+	t.Run("empty replacement clears the session's tools", func(t *testing.T) {
+		t.Parallel()
+		sess := &fakeSDKSession{id: "s2", tools: map[string]server.ServerTool{
+			"old": {Tool: mcp.Tool{Name: "old"}},
+		}}
+		err := setSessionToolsReplace(sess, nil)
+		require.NoError(t, err)
+		assert.Empty(t, sess.tools)
+	})
+
+	t.Run("rejects a session without SessionWithTools", func(t *testing.T) {
+		t.Parallel()
+		err := setSessionToolsReplace(&bareSession{id: "s3"}, nil)
+		require.Error(t, err)
+	})
+}
+
+// trackedBackendIDs replaces sessionID's coordinator entry's backendIDs, used
+// to simulate the session having connected to specific backends (the mock
+// session factories in this package register sessions with no real backend
+// metadata).
+func trackedBackendIDs(t *testing.T, srv *Server, sessionID string, backendIDs ...string) {
+	t.Helper()
+	ids := make(map[string]struct{}, len(backendIDs))
+	for _, id := range backendIDs {
+		ids[id] = struct{}{}
+	}
+	srv.listChanged.mu.Lock()
+	entry, ok := srv.listChanged.tracked[sessionID]
+	srv.listChanged.mu.Unlock()
+	require.True(t, ok, "session must already be tracked by the coordinator")
+	entry.backendIDs = ids
+}
+
+func isTracked(srv *Server, sessionID string) bool {
+	srv.listChanged.mu.Lock()
+	defer srv.listChanged.mu.Unlock()
+	_, ok := srv.listChanged.tracked[sessionID]
+	return ok
+}
+
+// fastDebounce shrinks the coordinator's coalescing window so tests do not sleep
+// a real quarter-second per assertion (which flakes under -race CI load). The
+// field is atomic and read by the worker on each wake, and callers set it before
+// sending any notification, so there is no race with the running worker.
+func fastDebounce(srv *Server) {
+	srv.listChanged.debounceNanos.Store(int64(time.Millisecond))
+}
+
+// TestListChangedCoordinator_RegistersAndUntracksOnBindingFailure verifies
+// track() is populated by a normal registration and untrack() is invoked by
+// terminateOnBindingFailure.
+func TestListChangedCoordinator_RegistersAndUntracksOnBindingFailure(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+	srv, sessionID, _ := registerServeSession(t, fc)
+
+	assert.True(t, isTracked(srv, sessionID), "a successfully registered session must be tracked")
+
+	srv.terminateOnBindingFailure(sessionID, "t", errors.New("boom"))
+	assert.False(t, isTracked(srv, sessionID), "terminateOnBindingFailure must untrack the session")
+}
+
+// TestListChangedCoordinator_UntracksOnTerminate verifies the normal
+// session-termination path (Manager.Terminate, the SDK DELETE / internal path)
+// promptly removes the session from the coordinator's registry via the
+// SetOnTerminate hook — not only lazily on a later sweep — so entries do not
+// accumulate for the lifetime of the process.
+func TestListChangedCoordinator_UntracksOnTerminate(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+	srv, sessionID, _ := registerServeSession(t, fc)
+	require.True(t, isTracked(srv, sessionID), "a successfully registered session must be tracked")
+
+	_, err := srv.vmcpSessionMgr.Terminate(sessionID)
+	require.NoError(t, err)
+
+	// Prompt (synchronous with Terminate via the onTerminate hook), not on a sweep.
+	assert.False(t, isTracked(srv, sessionID),
+		"a normally-terminated session must be untracked promptly, without waiting for a sweep")
+}
+
+// TestListChangedCoordinator_CoalescesBurst verifies a burst of
+// NotifyBackendListChanged calls for the same backend, well within the
+// debounce window, collapses into exactly one re-sweep.
+func TestListChangedCoordinator_CoalescesBurst(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+	srv, sessionID, _ := registerServeSession(t, fc)
+	fastDebounce(srv)
+	trackedBackendIDs(t, srv, sessionID, "backend-1")
+
+	before := fc.listToolsCalls.Load()
+	for i := 0; i < 5; i++ {
+		srv.listChanged.NotifyBackendListChanged("backend-1", vmcp.ListChangedTools)
+	}
+
+	require.Eventually(t, func() bool {
+		return fc.listToolsCalls.Load() > before
+	}, 2*time.Second, 5*time.Millisecond, "a re-sweep should occur after the debounce window")
+
+	// Give any incorrect extra resweep time to occur, then assert exactly one
+	// happened for the whole burst.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, before+1, fc.listToolsCalls.Load(),
+		"a burst of notifications for one backend must coalesce into exactly one re-sweep")
+}
+
+// TestListChangedCoordinator_KindRouting verifies that only the dirty kind's
+// core re-list is invoked: a resources notification re-lists resources (and
+// resource templates, which share the same capability gate) but not tools or
+// prompts, and vice versa for a tools notification.
+func TestListChangedCoordinator_KindRouting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		kind          vmcp.ListChangedKind
+		wantTools     bool
+		wantResources bool
+		wantPrompts   bool
+	}{
+		{"tools", vmcp.ListChangedTools, true, false, false},
+		{"resources", vmcp.ListChangedResources, false, true, false},
+		{"prompts", vmcp.ListChangedPrompts, false, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+			srv, sessionID, _ := registerServeSession(t, fc)
+			fastDebounce(srv)
+			trackedBackendIDs(t, srv, sessionID, "backend-1")
+
+			toolsBefore := fc.listToolsCalls.Load()
+			resourcesBefore := fc.listResourcesCalls.Load()
+			promptsBefore := fc.listPromptsCalls.Load()
+
+			srv.listChanged.NotifyBackendListChanged("backend-1", tt.kind)
+
+			// Wait for whichever counter this kind is expected to bump; then assert
+			// none of the others moved.
+			require.Eventually(t, func() bool {
+				switch {
+				case tt.wantTools:
+					return fc.listToolsCalls.Load() > toolsBefore
+				case tt.wantResources:
+					return fc.listResourcesCalls.Load() > resourcesBefore
+				default:
+					return fc.listPromptsCalls.Load() > promptsBefore
+				}
+			}, 2*time.Second, 5*time.Millisecond, "expected re-sweep did not occur")
+
+			// A short settle so a wrongly-routed call would have had time to land.
+			time.Sleep(150 * time.Millisecond)
+			assert.Equal(t, tt.wantTools, fc.listToolsCalls.Load() > toolsBefore, "tools re-list routing")
+			assert.Equal(t, tt.wantResources, fc.listResourcesCalls.Load() > resourcesBefore, "resources re-list routing")
+			assert.Equal(t, tt.wantPrompts, fc.listPromptsCalls.Load() > promptsBefore, "prompts re-list routing")
+		})
+	}
+}
+
+// TestListChangedCoordinator_UnaffectedSessionNotSwept verifies a session
+// whose backendIDs do not intersect the dirty backend is left alone.
+func TestListChangedCoordinator_UnaffectedSessionNotSwept(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+	srv, sessionID, _ := registerServeSession(t, fc)
+	fastDebounce(srv)
+	trackedBackendIDs(t, srv, sessionID, "backend-unrelated")
+
+	before := fc.listToolsCalls.Load()
+	srv.listChanged.NotifyBackendListChanged("backend-1", vmcp.ListChangedTools)
+
+	// There is nothing to wait ON for a negative assertion, so sleep well past the
+	// (now ~1ms) debounce window and confirm no re-sweep happened.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, before, fc.listToolsCalls.Load(),
+		"a backend not in this session's backendIDs must not trigger a re-sweep")
+}
+
+// TestListChangedCoordinator_PrunesTerminatedSession verifies that a sweep
+// discovering (via Manager.Validate) that a tracked session was terminated by
+// some other path removes it from the coordinator's registry.
+func TestListChangedCoordinator_PrunesTerminatedSession(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+	srv, sessionID, _ := registerServeSession(t, fc)
+	fastDebounce(srv)
+	trackedBackendIDs(t, srv, sessionID, "backend-1")
+	require.True(t, isTracked(srv, sessionID))
+
+	// Isolate the sweep's lazy Validate-based prune (distinct from the synchronous
+	// Terminate untrack hook, which TestListChangedCoordinator_UntracksOnTerminate
+	// covers): Terminate deletes the session from storage AND fires the hook that
+	// removes the coordinator entry, so re-insert a stale entry afterwards to force
+	// the next sweep to discover — via Manager.Validate — that the session is gone.
+	_, err := srv.vmcpSessionMgr.Terminate(sessionID)
+	require.NoError(t, err)
+	srv.listChanged.track(sessionID, &trackedSession{
+		sess:       &fakeSDKSession{id: sessionID, tools: map[string]server.ServerTool{}},
+		backendIDs: map[string]struct{}{"backend-1": {}},
+	})
+	require.True(t, isTracked(srv, sessionID))
+
+	srv.listChanged.NotifyBackendListChanged("backend-1", vmcp.ListChangedTools)
+
+	require.Eventually(t, func() bool {
+		return !isTracked(srv, sessionID)
+	}, 2*time.Second, 5*time.Millisecond, "a terminated session must be pruned from the coordinator's registry on sweep")
+}
+
+// TestListChangedCoordinator_ToolsErrorRetainsPreviousSet verifies that a
+// failed re-derivation of the tool set (core.ListTools erroring) leaves the
+// session's previously-applied tools untouched rather than shrinking them.
+func TestListChangedCoordinator_ToolsErrorRetainsPreviousSet(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+	srv, sessionID, baseURL := registerServeSession(t, fc)
+	fastDebounce(srv)
+	trackedBackendIDs(t, srv, sessionID, "backend-1")
+
+	listErr := errors.New("backend unavailable")
+	fc.listToolsErr.Store(&listErr)
+
+	before := fc.listToolsCalls.Load()
+	srv.listChanged.NotifyBackendListChanged("backend-1", vmcp.ListChangedTools)
+	require.Eventually(t, func() bool {
+		return fc.listToolsCalls.Load() > before
+	}, 2*time.Second, 5*time.Millisecond, "the failed re-sweep attempt must still run")
+
+	// Give the (failed) sweep time to have applied any (incorrect) change.
+	time.Sleep(150 * time.Millisecond)
+
+	resp := postServeMCP(t, baseURL, map[string]any{
+		"jsonrpc": "2.0", "id": 99, "method": "tools/list", "params": map[string]any{},
+	}, sessionID)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"t"`,
+		"a failed re-sweep must retain the previously-applied tool set, not shrink it")
+}
+
+// TestListChangedCoordinator_StartStop verifies the worker goroutine starts
+// and stops cleanly, and that stop is safe to call from Server.shutdownFuncs
+// (its actual signature).
+func TestListChangedCoordinator_StartStop(t *testing.T) {
+	t.Parallel()
+
+	c := newListChangedCoordinator(&Server{})
+	c.start()
+
+	err := c.stop(context.Background())
+	require.NoError(t, err)
+
+	// A notification after stop must not panic (best-effort: the worker is gone,
+	// so it is simply never processed).
+	assert.NotPanics(t, func() {
+		c.NotifyBackendListChanged("backend-1", vmcp.ListChangedTools)
+	})
+}
+
+// TestListChangedCoordinator_SetInvalidatorInvokedOnSweep verifies that the
+// installed CacheInvalidator is called with the dirty backend ID during a
+// sweep, and is safely skipped (nil) when caching is disabled.
+func TestListChangedCoordinator_SetInvalidatorInvokedOnSweep(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{tools: []vmcp.Tool{{Name: "t"}}}
+	srv, sessionID, _ := registerServeSession(t, fc)
+	fastDebounce(srv)
+	trackedBackendIDs(t, srv, sessionID, "backend-1")
+
+	inv := &recordingInvalidator{done: make(chan string, 8)}
+	srv.listChanged.setInvalidator(inv)
+
+	srv.listChanged.NotifyBackendListChanged("backend-1", vmcp.ListChangedTools)
+
+	select {
+	case id := <-inv.done:
+		assert.Equal(t, "backend-1", id)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for InvalidateBackend to be called")
+	}
+}
+
+// recordingInvalidator is a minimal aggregator.CacheInvalidator that reports
+// every InvalidateBackend call on a channel.
+type recordingInvalidator struct {
+	done chan string
+}
+
+func (r *recordingInvalidator) InvalidateBackend(backendID string) {
+	select {
+	case r.done <- backendID:
+	default:
+	}
+}

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -236,15 +236,27 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 		return srv.coreSubscribeHandler(ctx, "resources/unsubscribe", uri)
 	}
 
-	// Build the mcp-go server (mirrors server.New): tools and resources are
-	// registered dynamically, so capabilities start disabled — except resources,
-	// which advertise subscribe support so spec-compliant clients issue
-	// resources/subscribe (the handlers above answer it at ack level).
+	// Build the mcp-go server (mirrors server.New): tools, resources, and
+	// prompts are registered dynamically (per session, after initialize), so
+	// their capabilities are declared up front with listChanged=true —
+	// resources additionally advertise subscribe support so spec-compliant
+	// clients issue resources/subscribe (the handlers above answer it at ack
+	// level). These flags gate BOTH the initialize advertisement AND go-sdk's
+	// own auto-emission of notifications/{tools,resources,prompts}/list_changed
+	// (shouldSendListChangedNotification): they are what makes the list_changed
+	// coordinator's re-projection (setSessionToolsReplace et al., see
+	// list_changed.go) actually reach the downstream client. One side effect: a
+	// session's registration-time setSessionToolsDirect now also triggers an
+	// initial post-initialize notifications/tools/list_changed (go-sdk's
+	// notificationDelay, ~10ms after registerAndSync) even though nothing
+	// changed after advertisement — benign, but tests that assert on downstream
+	// notification traffic must tolerate/consume it.
 	mcpServer := server.NewMCPServer(
 		serveCfg.Name,
 		serveCfg.Version,
-		server.WithToolCapabilities(false),
-		server.WithResourceCapabilities(true, false),
+		server.WithToolCapabilities(true),
+		server.WithResourceCapabilities(true, true),
+		server.WithPromptCapabilities(true),
 		server.WithLogging(),
 		server.WithHooks(hooks),
 		server.WithCompletionHandler(completionHandler),
@@ -300,6 +312,22 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 	if optimizerCleanup != nil {
 		srv.shutdownFuncs = append(srv.shutdownFuncs, optimizerCleanup)
 	}
+
+	// The list_changed coordinator consumes backend list_changed notifications
+	// (see vmcp.BackendListChangedNotifier / list_changed.go) and propagates them
+	// to every affected, still-live session. Its invalidator is set later, by
+	// server.New, once the caching aggregator is known; its worker goroutine is
+	// started here so it is running before any session can register.
+	srv.listChanged = newListChangedCoordinator(srv)
+	srv.listChanged.start()
+	srv.shutdownFuncs = append(srv.shutdownFuncs, srv.listChanged.stop)
+
+	// Drop a session from the coordinator's registry the moment it is terminated
+	// (SDK DELETE or internal termination), rather than only lazily on the next
+	// sweep — mcpcompat has no OnUnregisterSession hook, so the session manager's
+	// Terminate is the explicit unregister point. TTL expiry does not flow through
+	// Terminate, so the coordinator still prunes lazily via Validate as a backstop.
+	vmcpSessMgr.SetOnTerminate(srv.listChanged.untrack)
 
 	// Serve owns the injected core's lifecycle: release its backend connections
 	// when the server stops. core.VMCP.Close is idempotent, so this is safe even

--- a/pkg/vmcp/server/serve_handlers.go
+++ b/pkg/vmcp/server/serve_handlers.go
@@ -583,6 +583,7 @@ func (s *Server) terminateOnBindingFailure(sessionID, capability string, err err
 		slog.Error("failed to terminate session after auth failure",
 			"session_id", sessionID, "error", termErr)
 	}
+	s.listChanged.untrack(sessionID)
 }
 
 // backendDisplayName resolves a logical backend ID to its human-readable name via

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -77,6 +77,11 @@ func newToolSessionFactory(
 			// enforceSessionBinding reads the binding via the single-key accessor.
 			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyIdentityBinding).
 				Return("unauthenticated", true).AnyTimes()
+			// handleSessionRegistrationImpl reads the backend ID set for the
+			// list_changed coordinator's registry; this fake session has no real
+			// backends, so an empty (but present) value is the accurate answer.
+			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyBackendIDs).
+				Return("", true).AnyTimes()
 			mock.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).AnyTimes()
 			toolsCopy := make([]vmcp.Tool, len(tools))
 			copy(toolsCopy, tools)
@@ -134,12 +139,21 @@ type fakeCore struct {
 	promptErr         error // when set, GetPrompt returns it (e.g. vmcp.ErrAuthorizationFailed)
 	completeErr       error // when set, Complete returns it (e.g. vmcp.ErrAuthorizationFailed)
 	lookupResourceErr error // when set, LookupResource returns it for an ADVERTISED URI (admission denial)
+
+	// listToolsErr, when non-nil (via Store), makes ListTools return it instead of
+	// f.tools. An atomic.Pointer so tests can toggle it AFTER initial session
+	// registration succeeded, concurrently with the list_changed coordinator's
+	// background re-sweep goroutine, without a data race.
+	listToolsErr atomic.Pointer[error]
 }
 
 var _ core.VMCP = (*fakeCore)(nil)
 
 func (f *fakeCore) ListTools(context.Context, *auth.Identity) ([]vmcp.Tool, error) {
 	f.listToolsCalls.Add(1)
+	if p := f.listToolsErr.Load(); p != nil && *p != nil {
+		return nil, *p
+	}
 	return f.tools, nil
 }
 

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"os"
@@ -323,6 +324,13 @@ type Server struct {
 	// vmcpSessionMgr manages session-scoped backend client lifecycle.
 	vmcpSessionMgr SessionManager
 
+	// listChanged consumes backend list_changed notifications and propagates
+	// them to affected, still-live sessions (see list_changed.go). Serve always
+	// constructs and starts it; server.New sets its cache invalidator once the
+	// caching aggregator is known. Nil only for a *Server built by a test that
+	// bypasses Serve entirely.
+	listChanged *listChangedCoordinator
+
 	// Ready channel signals when the server is ready to accept connections.
 	// Closed once the listener is created and serving.
 	ready     chan struct{}
@@ -515,17 +523,31 @@ func New(
 	elicitAdapter := NewSDKElicitationAdapter(srv.MCPServer())
 	elicitation.bind(elicitAdapter)
 
+	// Give the list_changed coordinator its cache invalidator now that the
+	// caching aggregator is known. cachedAgg is the exact instance the core
+	// calls into; type-asserting it here (rather than threading a second
+	// collaborator through core.New/Serve) keeps CacheInvalidator scoped to
+	// this one wiring point. cachedAgg implements it whenever caching is
+	// enabled (ttl > 0); when disabled, NewCachingAggregator returns cfg.Aggregator
+	// unwrapped, which does not implement it, and invalidation is skipped —
+	// there is no cache to go stale.
+	if inv, ok := cachedAgg.(aggregator.CacheInvalidator); ok {
+		srv.listChanged.setInvalidator(inv)
+	}
+
 	// Bind the server->client forwarders onto the concrete backend client so a
-	// backend's mid-call elicitation, sampling, and progress/logging traffic is
-	// relayed to the downstream client on the same session. This mirrors the
-	// elicitation late-binding above (the SDK adapters wrap the mcp-go server Serve
-	// just built, so they cannot exist before this point); a backend client that
-	// does not implement the binder simply does not forward server->client traffic.
+	// backend's mid-call elicitation, sampling, progress/logging, and
+	// list_changed traffic is relayed to the downstream client on the same
+	// session. This mirrors the elicitation late-binding above (the SDK adapters
+	// wrap the mcp-go server Serve just built, so they cannot exist before this
+	// point); a backend client that does not implement the binder simply does
+	// not forward server->client traffic.
 	if binder, ok := backendClient.(vmcp.ClientForwarderBinder); ok {
 		binder.BindForwarders(
 			elicitAdapter,
 			NewSDKSamplingAdapter(srv.MCPServer()),
 			NewSDKNotifierAdapter(srv.MCPServer()),
+			srv.BackendListChangedNotifier(),
 		)
 	}
 
@@ -1105,6 +1127,30 @@ func setSessionToolsDirect(session server.ClientSession, tools []server.ServerTo
 	return nil
 }
 
+// setSessionToolsReplace sets tools directly on the session via the
+// SessionWithTools interface, REPLACING any existing session tools rather than
+// merging with them (compare setSessionToolsDirect, used at registration, which
+// merges to preserve tools set by earlier calls). The list_changed coordinator
+// uses this to re-project a session's tool set after a backend's tools changed:
+// a tool the backend removed must actually disappear from the session, which a
+// merge could never achieve. SetSessionTools itself does the add/remove
+// reconciliation against the live go-sdk server (session.go's syncSessionTools),
+// including the RemoveTools call for names that dropped out — that reconciliation
+// is what emits the downstream notifications/tools/list_changed.
+func setSessionToolsReplace(session server.ClientSession, tools []server.ServerTool) error {
+	sessionWithTools, ok := session.(server.SessionWithTools)
+	if !ok {
+		return fmt.Errorf("session does not support per-session tools")
+	}
+
+	toolMap := make(map[string]server.ServerTool, len(tools))
+	for _, tool := range tools {
+		toolMap[tool.Tool.Name] = tool
+	}
+	sessionWithTools.SetSessionTools(toolMap)
+	return nil
+}
+
 // lazyInjectSessionTools injects tools into the SDK ephemeral session for sessions
 // that were reconstructed from Redis on a different pod (cross-pod session sharing).
 //
@@ -1211,7 +1257,8 @@ func (s *Server) handleSessionRegistrationImpl(ctx context.Context, session serv
 	// after initialize may receive a "tool not found" error before AddSessionTools
 	// completes. Conforming MCP clients call tools/list before tools/call, so this
 	// window is expected to be harmless in practice.
-	if _, retErr = s.vmcpSessionMgr.CreateSession(ctx, sessionID); retErr != nil {
+	var multiSess vmcpsession.MultiSession
+	if multiSess, retErr = s.vmcpSessionMgr.CreateSession(ctx, sessionID); retErr != nil {
 		slog.Error("failed to create session-scoped backends",
 			"session_id", sessionID,
 			"error", retErr)
@@ -1223,7 +1270,50 @@ func (s *Server) handleSessionRegistrationImpl(ctx context.Context, session serv
 	// handlers that route through the core. CreateSession above still establishes the bound
 	// session record (identity binding, TTL, Validate). The returned error becomes retErr
 	// (named return), so the defer terminates the session on failure.
-	return s.injectCoreSessionCapabilities(ctx, session)
+	if retErr = s.injectCoreSessionCapabilities(ctx, session); retErr != nil {
+		return retErr
+	}
+
+	// Register with the list_changed coordinator only once capability injection
+	// has succeeded, so a session that never fully registered is never tracked.
+	// backendIDs comes from the MultiSession's own metadata (populated by the
+	// factory at CreateSession) rather than being re-derived here, so it always
+	// matches the backends this session actually connected to. fwdHeaders is
+	// cloned: it is retained for the whole session lifetime off the request path,
+	// so defense-in-depth against a caller mutating the request-scoped map after
+	// this returns (copy-before-mutate). identity is immutable (safe to retain)
+	// and backendIDs is a fresh map, so neither needs cloning.
+	identity, _ := auth.IdentityFromContext(ctx)
+	s.listChanged.track(sessionID, &trackedSession{
+		sess:       session,
+		identity:   identity,
+		fwdHeaders: maps.Clone(headerforward.ForwardedHeadersFromContext(ctx)),
+		backendIDs: backendIDSetFromMetadata(multiSess),
+	})
+	return nil
+}
+
+// backendIDSetFromMetadata extracts the session's connected backend ID set from
+// its MultiSession metadata (vmcpsession.MetadataKeyBackendIDs, a comma-separated
+// sorted list written by the session factory). Returns an empty, non-nil set
+// when the key is absent or empty rather than nil, so
+// list_changed.affectedKinds's range-over-nil-map degrades to "no backends",
+// not a panic.
+func backendIDSetFromMetadata(sess vmcpsession.MultiSession) map[string]struct{} {
+	ids := make(map[string]struct{})
+	if sess == nil {
+		return ids
+	}
+	raw, ok := sess.GetMetadataValue(vmcpsession.MetadataKeyBackendIDs)
+	if !ok || raw == "" {
+		return ids
+	}
+	for _, id := range strings.Split(raw, ",") {
+		if id = strings.TrimSpace(id); id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	return ids
 }
 
 // backendHealth returns the core-owned backend health reporter, or nil when health

--- a/pkg/vmcp/server/session_management_integration_test.go
+++ b/pkg/vmcp/server/session_management_integration_test.go
@@ -57,6 +57,13 @@ func newNoopMockFactory(t *testing.T) *sessionfactorymocks.MockMultiSessionFacto
 			mock.EXPECT().GetData().Return(nil).AnyTimes()
 			mock.EXPECT().SetData(gomock.Any()).AnyTimes()
 			mock.EXPECT().GetMetadata().Return(map[string]string{}).AnyTimes()
+			// The Serve-path enforceSessionBinding / handleSessionRegistrationImpl
+			// read individual keys via GetMetadataValue rather than the full-map
+			// GetMetadata; a "noop" session is anonymous with no real backends.
+			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyIdentityBinding).
+				Return("unauthenticated", true).AnyTimes()
+			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyBackendIDs).
+				Return("", true).AnyTimes()
 			mock.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).AnyTimes()
 			mock.EXPECT().Tools().Return(nil).AnyTimes()
 			mock.EXPECT().AllTools().Return(nil).AnyTimes()
@@ -109,6 +116,10 @@ func newMockFactory(t *testing.T, ctrl *gomock.Controller, tools []vmcp.Tool) (*
 			// GetMetadataValue (not the full-map GetMetadata); return the same sentinel.
 			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyIdentityBinding).
 				Return("unauthenticated", true).AnyTimes()
+			// handleSessionRegistrationImpl reads the backend ID set for the
+			// list_changed coordinator's registry.
+			mock.EXPECT().GetMetadataValue(vmcpsession.MetadataKeyBackendIDs).
+				Return("", true).AnyTimes()
 			mock.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).AnyTimes()
 			toolsCopy := make([]vmcp.Tool, len(tools))
 			copy(toolsCopy, tools)

--- a/pkg/vmcp/server/session_management_realbackend_integration_test.go
+++ b/pkg/vmcp/server/session_management_realbackend_integration_test.go
@@ -65,7 +65,12 @@ func newRealTestHandler(t *testing.T, backendURL string) http.Handler {
 		authtypes.StrategyTypeUnauthenticated,
 		strategies.NewUnauthenticatedStrategy(),
 	))
-	factory := vmcpsession.NewSessionFactory(authReg)
+
+	// Mirrors the composition root's (pkg/vmcp/cli) late-bound wiring: the
+	// factory needs a non-nil BackendListChangedNotifier before server.New's
+	// list_changed coordinator exists.
+	listChangedHolder := vmcp.NewLateBoundListChangedNotifier()
+	factory := vmcpsession.NewSessionFactory(authReg, vmcpsession.WithBackendListChangedNotifier(listChangedHolder))
 
 	// Real backend client + aggregator: server.New routes through core.New + Serve, so the
 	// core sources the advertised set by querying the real backend through this client and
@@ -93,6 +98,8 @@ func newRealTestHandler(t *testing.T, backendURL string) http.Handler {
 		nil,
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+	listChangedHolder.Bind(srv.BackendListChangedNotifier())
 
 	handler, err := srv.Handler(context.Background())
 	require.NoError(t, err)

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -89,6 +89,17 @@ type Manager struct {
 	// path can build a per-session optimizer over the core's tools. The store and
 	// cleanup remain owned by this Manager (cleanup returned from New).
 	optimizerFactory func(context.Context, []mcpserver.ServerTool) (optimizer.Optimizer, error)
+
+	// onTerminate, when set via SetOnTerminate, is invoked with the session ID on
+	// every SUCCESSFUL Terminate (the SDK's DELETE path and internal
+	// terminations). It is the explicit unregister hook the list_changed
+	// coordinator needs to drop a session from its registry promptly, since
+	// mcpcompat exposes no OnUnregisterSession hook. Best-effort, idempotent
+	// bookkeeping only — it must not block or take Manager locks. TTL expiry does
+	// NOT flow through Terminate (it is handled by the storage cleanup goroutine),
+	// so observers must still tolerate a session vanishing without this callback
+	// (the coordinator additionally prunes lazily via Validate during a sweep).
+	onTerminate func(sessionID string)
 }
 
 // New creates a Manager backed by the given SessionDataStorage and backend
@@ -158,6 +169,14 @@ func New(
 		return optimizerCleanup(ctx)
 	}
 	return sm, cleanup, nil
+}
+
+// SetOnTerminate installs a callback invoked with the session ID on every
+// successful Terminate (see the onTerminate field). It is wired once at
+// composition time (Serve), before the server accepts connections, so no
+// concurrent Terminate can race the assignment. Passing nil clears it.
+func (m *Manager) SetOnTerminate(fn func(sessionID string)) {
+	m.onTerminate = fn
 }
 
 // OptimizerFactory returns the resolved (telemetry-wrapped) optimizer factory, or
@@ -489,6 +508,20 @@ func (sm *Manager) Validate(sessionID string) (isTerminated bool, err error) {
 func (sm *Manager) Terminate(sessionID string) (isNotAllowed bool, err error) {
 	if sessionID == "" {
 		return false, fmt.Errorf("Manager.Terminate: empty session ID")
+	}
+
+	// Fire the unregister hook only on a SUCCESSFUL termination (err == nil):
+	// a transient storage error may leave the session alive, so dropping it from
+	// observers (e.g. the list_changed coordinator) then would silently stop
+	// delivering to a still-live session. The "already gone" success path DOES
+	// fire it, which correctly prunes an observer entry for a racily-removed
+	// session.
+	if sm.onTerminate != nil {
+		defer func() {
+			if err == nil {
+				sm.onTerminate(sessionID)
+			}
+		}()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), terminateTimeout)

--- a/pkg/vmcp/server/testutil_test.go
+++ b/pkg/vmcp/server/testutil_test.go
@@ -47,8 +47,28 @@ func startRealMCPBackend(t *testing.T) string {
 	mux.Handle("/mcp", streamableSrv)
 
 	ts := httptest.NewServer(mux)
-	t.Cleanup(ts.Close)
+	cleanupBackendServer(t, ts)
 	return ts.URL + "/mcp"
+}
+
+// cleanupBackendServer tears down an in-process backend httptest.Server used as
+// a vMCP backend. It force-closes active client connections BEFORE Close.
+//
+// vMCP's persistent session connector opens a standalone SSE GET stream and
+// holds it open for the whole session (continuous listening, enabled whenever a
+// list_changed sink is wired — which the real-backend test harness now does).
+// That stream is a StateActive inbound request on this backend server, and
+// httptest.Server.Close blocks until outstanding requests complete — nothing
+// else closes that stream during a test, so a plain Close would hang until the
+// package test timeout. CloseClientConnections force-drops the active
+// connections first (the connector does not reconnect, matching the Phase-1
+// no-reconnect behavior), so the subsequent Close returns promptly.
+func cleanupBackendServer(t *testing.T, ts *httptest.Server) {
+	t.Helper()
+	t.Cleanup(func() {
+		ts.CloseClientConnections()
+		ts.Close()
+	})
 }
 
 // MCPTestClient provides higher-level test utilities for MCP protocol interactions.

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -114,6 +114,12 @@ type defaultMultiSessionFactory struct {
 	connector          backendConnector
 	maxConcurrency     int
 	backendInitTimeout time.Duration
+
+	// listChangedSink receives a backend's list_changed notifications from the
+	// persistent per-backend connections this factory opens (see
+	// backend.NewHTTPConnector). Nil disables the idle (no-call-in-flight)
+	// list_changed delivery path entirely; set via WithBackendListChangedNotifier.
+	listChangedSink vmcp.BackendListChangedNotifier
 }
 
 // MultiSessionFactoryOption configures a defaultMultiSessionFactory.
@@ -139,10 +145,31 @@ func WithBackendInitTimeout(d time.Duration) MultiSessionFactoryOption {
 	}
 }
 
+// WithBackendListChangedNotifier sets the sink that receives a backend's
+// list_changed notifications delivered over this factory's persistent backend
+// connections (the idle, no-call-in-flight path; the mid-call path is wired
+// separately onto the per-call backend client). Nil (the default) disables it.
+func WithBackendListChangedNotifier(sink vmcp.BackendListChangedNotifier) MultiSessionFactoryOption {
+	return func(f *defaultMultiSessionFactory) {
+		f.listChangedSink = sink
+	}
+}
+
 // NewSessionFactory creates a MultiSessionFactory that connects to backends
 // over HTTP using the given outgoing auth registry.
 func NewSessionFactory(registry vmcpauth.OutgoingAuthRegistry, opts ...MultiSessionFactoryOption) MultiSessionFactory {
-	return newSessionFactoryWithConnector(backend.NewHTTPConnector(registry), opts...)
+	f := &defaultMultiSessionFactory{
+		maxConcurrency:     defaultMaxBackendInitConcurrency,
+		backendInitTimeout: defaultBackendInitTimeout,
+	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	// Built AFTER options are applied: the connector needs f.listChangedSink,
+	// which WithBackendListChangedNotifier sets above. Building it eagerly
+	// (before opts) would permanently bind a nil sink regardless of options.
+	f.connector = backend.NewHTTPConnector(registry, f.listChangedSink)
+	return f
 }
 
 // newSessionFactoryWithConnector creates a MultiSessionFactory backed by an

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -232,11 +232,20 @@ func (c *mcpSession) GetPrompt(
 // registry provides the authentication strategy for outgoing backend requests.
 // Pass a registry configured with the "unauthenticated" strategy to disable auth.
 //
+// listChanged, when non-nil, is reported a backend's tools/resources/prompts
+// list_changed notifications for as long as this session's client is open —
+// unlike the per-call client in pkg/vmcp/client, which only observes such
+// notifications during an in-flight tools/call, this session-backed client is
+// persistent, so it is the delivery path for a backend list_changed that fires
+// while no call is in flight (the "idle" path). Nil disables it entirely: no
+// continuous-listening stream is opened and no OnNotification handler is
+// registered, reproducing the pre-list_changed construction exactly.
+//
 // A single secrets.EnvironmentProvider is constructed once per connector and
 // shared across every session it creates; its lifetime matches the connector's.
 // It is consumed by BuildHeaderForwardTripper to resolve secret-backed entries
 // in target.HeaderForward.
-func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
+func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry, listChanged vmcp.BackendListChangedNotifier) func(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
 	identity *auth.Identity,
@@ -249,9 +258,36 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 		identity *auth.Identity,
 		sessionHint string,
 	) (Session, *vmcp.CapabilityList, error) {
-		c, err := createMCPClient(ctx, target, identity, registry, sessionHint, provider)
+		c, err := createMCPClient(ctx, target, identity, registry, sessionHint, provider, listChanged)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create MCP client for backend %s: %w", target.WorkloadID, err)
+		}
+
+		// Register the persistent list_changed listener before the Initialize
+		// handshake / capability queries below so a notification that arrives
+		// during (or immediately after) initialization is never missed. The
+		// handler only reports notifications; it does not block the receive
+		// loop it runs on (see vmcp.BackendListChangedNotifier).
+		//
+		// Lifecycle: this handler (and the standalone GET stream + go-sdk reader
+		// goroutine behind it) lives as long as the underlying client connection.
+		// mcpSession.Close tears it down — but Close is only reached when the
+		// MultiSession is EVICTED from the session Manager's ValidatingCache, and
+		// that eviction is LAZY: the cache has no background TTL sweeper, so an
+		// entry is dropped only on a cache hit that returns ErrExpired (i.e. the
+		// session is re-accessed after its TTL) or under LRU capacity pressure. An
+		// idle session that is never re-accessed and never evicted by capacity thus
+		// keeps this stream and its reader goroutine open until the process exits.
+		// There is also no reconnection on transport drop (Phase-1 limitation
+		// documented on mcpSession), so a dropped connection simply stops delivering
+		// list_changed notifications for that backend until a new session is created.
+		if listChanged != nil {
+			workloadID := target.WorkloadID
+			c.OnNotification(func(n mcp.JSONRPCNotification) {
+				if kind, ok := vmcp.ListChangedKindForMethod(n.Method); ok {
+					listChanged.NotifyBackendListChanged(workloadID, kind)
+				}
+			})
 		}
 
 		caps, err := initAndQueryCapabilities(ctx, c, target)
@@ -274,6 +310,88 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 	}
 }
 
+// newStreamableClient builds (but does not start) a streamable-HTTP mcpcompat
+// client over base for target.
+//
+// For streamable-HTTP each MCP call is normally a single bounded HTTP
+// request/response pair, so a per-response body size limit is safe and correct.
+// http.Client.Timeout provides a hard wall-clock deadline; WithHTTPTimeout
+// additionally wraps each SDK request in a context.WithTimeout so the mcpcompat
+// transport surfaces a descriptive error before the stdlib deadline fires. Both
+// are set to defaultBackendRequestTimeout: defense-in-depth.
+//
+// EXCEPTION — continuousListening (i.e. this connector has a list_changed sink):
+// to receive a backend's idle list_changed the go-sdk holds a standalone SSE GET
+// stream open for the WHOLE session. That long-lived stream must not be bounded
+// like a single request: http.Client.Timeout caps the entire body read (it would
+// tear the stream down after defaultBackendRequestTimeout and then churn
+// reconnects, silently losing idle notifications in each ~30s gap), and the
+// cumulative io.LimitReader would EOF the stream after maxBackendResponseSize
+// TOTAL bytes. This mirrors newSSEClient's rationale. So when continuous
+// listening is on: no client Timeout, no WithHTTPTimeout (the mcpcompat shim maps
+// WithHTTPTimeout straight onto http.Client.Timeout — it has no per-request
+// timeout separate from the stream), and the size limit is applied only to the
+// JSON-RPC POST responses, never the standalone GET stream. Per-request calls
+// stay bounded by their context deadline (the init handshake via
+// backendInitTimeout; runtime calls via the request context), exactly as the SSE
+// transport already relies on.
+//
+// TRADEOFF (intentional): dropping BOTH timeouts means the POST calls on a
+// continuous-listening client (CallTool/ReadResource/GetPrompt) have NO
+// client-level wall-clock backstop — they rely solely on the caller's request
+// context deadline. This is the same accepted tradeoff as the SSE branch
+// (newSSEClient), which likewise omits http.Client.Timeout so its long-lived
+// stream survives. A caller that invokes these with a deadline-less context would
+// have no timeout; in practice runtime calls carry the incoming request's
+// deadline and the init path carries backendInitTimeout.
+func newStreamableClient(
+	target *vmcp.BackendTarget, base http.RoundTripper, sessionHint string, continuousListening bool,
+) (*mcpclient.Client, error) {
+	sizeLimited := httpRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		resp, err := base.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+		// The standalone SSE stream is a GET; capping its cumulative length would
+		// kill a long-lived stream (see the EXCEPTION note above).
+		if continuousListening && req.Method == http.MethodGet {
+			return resp, nil
+		}
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{
+			Reader: io.LimitReader(resp.Body, maxBackendResponseSize),
+			Closer: resp.Body,
+		}
+		return resp, nil
+	})
+	httpClient := &http.Client{Transport: sizeLimited}
+	streamableOpts := []mcptransport.StreamableHTTPCOption{
+		mcptransport.WithHTTPBasicClient(httpClient),
+	}
+	if !continuousListening {
+		// No standalone stream to keep alive: retain the defense-in-depth wall-clock
+		// bound on every request at both the http.Client and SDK layers, as before.
+		httpClient.Timeout = defaultBackendRequestTimeout
+		streamableOpts = append(streamableOpts, mcptransport.WithHTTPTimeout(defaultBackendRequestTimeout))
+	}
+	if sessionHint != "" {
+		streamableOpts = append(streamableOpts, mcptransport.WithSession(sessionHint))
+	}
+	if continuousListening {
+		// A backend's idle list_changed notification is routed by the go-sdk onto
+		// the standalone SSE stream, so the client must hold it open to receive it —
+		// mirroring the per-call client's forwarding path (see
+		// httpBackendClient.newStreamableHTTPClient). A backend without a standalone
+		// GET stream answers the GET with 405, which the go-sdk treats as a clean
+		// "no stream" (closes the body and returns; no retry spin) — see
+		// streamableClientConn.connectStandaloneSSE.
+		streamableOpts = append(streamableOpts, mcptransport.WithContinuousListening())
+	}
+	return mcpclient.NewStreamableHttpClient(target.BaseURL, streamableOpts...)
+}
+
 // createMCPClient builds and starts a mcpcompat MCP client for target.
 // The transport is started with context.Background() so its lifetime is bound
 // to client.Close(), not to any caller-supplied init context.
@@ -283,6 +401,10 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 // ctx is used only to resolve secret-backed entries in target.HeaderForward at
 // client-creation time; the transport itself is started with context.Background()
 // as described above. provider supplies values for those secret-backed headers.
+// listChanged is non-nil only to decide whether the streamable-HTTP transport
+// needs a continuous-listening standalone stream open (see the streamable-HTTP
+// case below); the OnNotification handler itself is registered by the caller
+// (NewHTTPConnector) after this function returns.
 func createMCPClient(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
@@ -290,6 +412,7 @@ func createMCPClient(
 	registry vmcpauth.OutgoingAuthRegistry,
 	sessionHint string,
 	provider secrets.Provider,
+	listChanged vmcp.BackendListChangedNotifier,
 ) (*mcpclient.Client, error) {
 	// Resolve and validate the auth strategy once at client creation time.
 	strategyName := authtypes.StrategyTypeUnauthenticated
@@ -346,40 +469,7 @@ func createMCPClient(
 	switch target.TransportType {
 	case "streamable-http", "streamable":
 		// "streamable" is a legacy alias for "streamable-http".
-		//
-		// For streamable-HTTP, each MCP call is a single bounded HTTP
-		// request/response pair, so a per-response body size limit is safe and
-		// correct. http.Client.Timeout provides a hard wall-clock deadline;
-		// WithHTTPTimeout additionally wraps each SDK request in a
-		// context.WithTimeout so the mcpcompat transport surfaces a descriptive
-		// error before the stdlib deadline fires. Both are set to
-		// defaultBackendRequestTimeout: defense-in-depth.
-		sizeLimited := httpRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			resp, err := base.RoundTrip(req)
-			if err != nil {
-				return nil, err
-			}
-			resp.Body = struct {
-				io.Reader
-				io.Closer
-			}{
-				Reader: io.LimitReader(resp.Body, maxBackendResponseSize),
-				Closer: resp.Body,
-			}
-			return resp, nil
-		})
-		httpClient := &http.Client{
-			Transport: sizeLimited,
-			Timeout:   defaultBackendRequestTimeout,
-		}
-		streamableOpts := []mcptransport.StreamableHTTPCOption{
-			mcptransport.WithHTTPTimeout(defaultBackendRequestTimeout),
-			mcptransport.WithHTTPBasicClient(httpClient),
-		}
-		if sessionHint != "" {
-			streamableOpts = append(streamableOpts, mcptransport.WithSession(sessionHint))
-		}
-		c, err = mcpclient.NewStreamableHttpClient(target.BaseURL, streamableOpts...)
+		c, err = newStreamableClient(target, base, sessionHint, listChanged != nil)
 	case "sse":
 		// For SSE, the entire session is delivered as one long-lived HTTP
 		// response body. Applying io.LimitReader to that body would silently

--- a/pkg/vmcp/session/internal/backend/mcp_session_header_forward_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_header_forward_test.go
@@ -108,7 +108,7 @@ func TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests(t *testing.T) 
 			},
 		}
 
-		connector := NewHTTPConnector(registry)
+		connector := NewHTTPConnector(registry, nil)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
@@ -151,7 +151,7 @@ func TestHTTPSession_AppliesHeaderForwardToPostInitializeRequests(t *testing.T) 
 		}
 
 		registry := newTestRegistry(t)
-		connector := NewHTTPConnector(registry)
+		connector := NewHTTPConnector(registry, nil)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
@@ -211,7 +211,7 @@ func connectAndCallEcho(t *testing.T, target *vmcp.BackendTarget) Session {
 	t.Helper()
 
 	registry := newTestRegistry(t)
-	connector := NewHTTPConnector(registry)
+	connector := NewHTTPConnector(registry, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)

--- a/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_identity_refresh_test.go
@@ -81,7 +81,7 @@ func TestHTTPSession_PerRequestIdentity_DrivesUpstreamAuthHeader(t *testing.T) {
 		UpstreamTokens: map[string]string{providerName: staleToken},
 	}
 
-	connector := NewHTTPConnector(registry)
+	connector := NewHTTPConnector(registry, nil)
 	initCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
@@ -157,7 +157,7 @@ func TestHTTPSession_FallbackIdentity_UsedWhenContextHasNoIdentity(t *testing.T)
 		UpstreamTokens: map[string]string{providerName: fallbackTokenVal},
 	}
 
-	connector := NewHTTPConnector(registry)
+	connector := NewHTTPConnector(registry, nil)
 	initCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 

--- a/pkg/vmcp/session/internal/backend/mcp_session_listchanged_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_listchanged_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mcptransport "github.com/stacklok/toolhive-core/mcpcompat/client/transport"
+	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// stubListChangedNotifier is a minimal vmcp.BackendListChangedNotifier that
+// records every call, safe for concurrent use from a client's receive loop.
+type stubListChangedNotifier struct {
+	mu    sync.Mutex
+	calls []struct {
+		backendID string
+		kind      vmcp.ListChangedKind
+	}
+	notify chan struct{}
+}
+
+func newStubListChangedNotifier() *stubListChangedNotifier {
+	return &stubListChangedNotifier{notify: make(chan struct{}, 8)}
+}
+
+func (s *stubListChangedNotifier) NotifyBackendListChanged(backendID string, kind vmcp.ListChangedKind) {
+	s.mu.Lock()
+	s.calls = append(s.calls, struct {
+		backendID string
+		kind      vmcp.ListChangedKind
+	}{backendID, kind})
+	s.mu.Unlock()
+	select {
+	case s.notify <- struct{}{}:
+	default:
+	}
+}
+
+// TestNewHTTPConnector_ContinuousListening verifies that a non-nil listChanged
+// makes the streamable-HTTP connector open the standalone continuous-listening
+// stream (needed to receive an idle list_changed notification), while a nil
+// listChanged reproduces the pre-list_changed construction (no continuous
+// listening).
+func TestNewHTTPConnector_ContinuousListening(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		listChanged vmcp.BackendListChangedNotifier
+		want        bool
+	}{
+		{"nil listChanged: no continuous listening", nil, false},
+		{"bound listChanged: continuous listening enabled", newStubListChangedNotifier(), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fb := &fakeBackend{advertiseTools: true, tools: []mcp.Tool{{Name: "echo"}}}
+			url := newFakeBackend(t, fb)
+			target := &vmcp.BackendTarget{
+				WorkloadID:    "backend-1",
+				WorkloadName:  "backend-1",
+				BaseURL:       url,
+				TransportType: "streamable-http",
+			}
+
+			connector := NewHTTPConnector(newTestRegistry(t), tt.listChanged)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			sess, _, err := connector(ctx, target, nil, "")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = sess.Close() })
+
+			ms, ok := sess.(*mcpSession)
+			require.True(t, ok)
+			st, ok := ms.client.GetTransport().(*mcptransport.StreamableHTTP)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, st.ContinuousListening())
+		})
+	}
+}
+
+// Real idle-path delivery (a backend mutating its OWN tool set with no call in
+// flight, and vMCP's persistent connector receiving the resulting
+// notifications/tools/list_changed) is covered end-to-end at the server layer
+// by TestListChanged_IdleMutate_RealBackend, which drives a raw go-sdk backend
+// (bypassing the mcpcompat shim, whose MCPServer.AddTool only feeds the ONE
+// gosdk.Server built lazily by StreamableHTTPServer and has no supported way to
+// mutate it afterwards) — the same reason this package does not duplicate that
+// scenario at the connector level.

--- a/pkg/vmcp/session/internal/backend/mcp_session_meta_propagation_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_meta_propagation_test.go
@@ -51,7 +51,7 @@ func TestHTTPSession_CallTool_InjectsTraceparent(t *testing.T) { //nolint:parall
 	}
 
 	registry := newTestRegistry(t)
-	connector := NewHTTPConnector(registry)
+	connector := NewHTTPConnector(registry, nil)
 
 	initCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -46,7 +46,7 @@ func TestCreateMCPClient_UnsupportedTransport(t *testing.T) {
 				TransportType: transport,
 			}
 
-			_, err := createMCPClient(context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider())
+			_, err := createMCPClient(context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), nil)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, vmcp.ErrUnsupportedTransport,
 				"transport %q should return ErrUnsupportedTransport", transport)


### PR DESCRIPTION
## Summary

vMCP already consumed backend `notifications/progress` and `notifications/message`, but **dropped `*/list_changed`** and advertised `listChanged: false` toward clients. As a result, aggregated tool/resource/prompt views went stale until the short-TTL cache happened to expire, and nothing was ever pushed to clients — the core complaint in #5748.

This wires the `list_changed` path end-to-end so backend capability changes converge to clients promptly:

- **Consume** backend `notifications/{tools,resources,prompts}/list_changed` on **both** the per-call client (`pkg/vmcp/client`) and a **new persistent (idle) listener** on the session-backed connector (`pkg/vmcp/session/internal/backend`), so changes are caught whether or not a call is in flight.
- **Coordinator** (`pkg/vmcp/server/list_changed.go`): on a backend change, invalidate **only that backend's** aggregation-cache entries (scoped, not whole-cache) and **re-project each affected session's** capabilities. The per-session go-sdk server then auto-emits `list_changed` downstream, so a subsequent `tools/list` reflects the new set.
- **Flip** the advertised `listChanged` capability to `true` for tools, resources, and prompts (`pkg/vmcp/server/serve.go`).
- **Storm coalescing**: a debounce keyed by backend collapses the per-session×backend notification fan-in into one sweep. Notification handlers are non-blocking (map-write + non-blocking channel send); the coordinator does heavy work off the receive loop under a shutdown-tied context, and untracks sessions on graceful termination.

Closes #5748

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

`task lint-fix` reports 0 issues; `go build`/`go vet` clean. `go test -race` (Taskfile ldflags) across `./pkg/vmcp/...` + `./pkg/cache/...`: **44 packages pass, 0 fail**. Coverage added:
- **Unit**: `ListChangedKindForMethod`, `LateBoundListChangedNotifier`, per-call + persistent handler routing (method→sink with backendID), scoped `CacheInvalidator.InvalidateBackend` (incl. multi-backend entries), coordinator coalescing/kind-routing/terminated-prune/`ListTools`-error-retains-old-set/start-stop/untrack-on-terminate, `setSessionToolsReplace` removal.
- **Integration** (real go-sdk backend, `list_changed_realbackend_integration_test.go`): mid-call mutation, **idle** mutation (proves the persistent listener), two concurrent sessions (fan-out), resources/prompts additions, capability-regression assertions, and a regression guard pinning the documented resources/prompts removal gap.

## Does this introduce a user-facing change?

Yes (observability/correctness): with vMCP, backend tool/resource/prompt changes now propagate to connected clients as `list_changed` notifications (and updated `*/list` results) promptly, instead of only after the aggregation cache's TTL expires. vMCP now advertises `listChanged: true`. Clients that ignore the notifications continue to work via polling/TTL.

## Special notes for reviewers

Reviewed by a 5-axis Opus panel (security, MCP-correctness, code-quality, observability/concurrency, test-coverage). The concurrency axis initially flagged three MAJOR lifecycle bugs (a 30s client timeout that capped the idle stream, a session-registry leak on normal termination, and a shutdown hang); all were fixed and independently re-verified.

**Known limitations — tracked follow-ups (not blockers):**
1. **Resources/prompts *removal* does not propagate** (additions do). mcpcompat's per-session `syncSessionResources`/`syncSessionPrompts` are add-only (unlike `syncSessionTools`, which fully reconciles). Advertising `listChanged: true` is still correct for additions; removal propagation needs a reconciling change in `stacklok/toolhive-core` (mcpcompat) + a version bump. Documented at the coordinator's resource/prompt apply path and pinned by a regression-guard test. **Read-time access is not affected** — `ReadResource` re-derives admission per call, so a removed/deadmitted resource is denied at read time even while it lingers in the advertised list.
2. **In-process `Stop()` does not eagerly close the new persistent backend streams**, and the coordinator's session-tracking map is **unbounded for ungracefully-dropped sessions** never revisited by a sweep. This is bounded to the embed-and-`Stop`-without-process-exit and client-crash scenarios (the normal `serve` path reclaims everything at process exit), and closing it eagerly is blocked today by the absence of a public *unregister-session* hook in mcpcompat/go-sdk (only `AddOnRegisterSession` exists). A shim `AddOnUnregisterSession` in toolhive-core is the clean fix — follow-up.

Both follow-ups are in `stacklok/toolhive-core` (which we own); I can file them.

**Size:** larger than the usual limit (~33 files; the diff includes substantial docs/tests and generated mocks) — the maintainer approved a single comprehensive PR for this feature.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Architected in two passes (Opus gap-analysis, then a Fable architect finalized the authoritative single-PR spec). Key design points, all grounded in the current tree:

- Reuse the existing forwarding seams; the backend `OnNotification` handler and progress/message forwarding already existed — this adds the `list_changed` arm + a persistent idle listener.
- W0 capability flip; W1 domain types (`BackendListChangedNotifier`, `ListChangedKind`, late-bound holder); W2 per-call handler; W3 persistent listener (`WithContinuousListening`, no client timeout so the standalone GET stream isn't capped); W4 factory threading; W5 per-backend scoped cache invalidation via a bounded scan (a reverse index would deadlock against the LRU evict path); W6 coordinator (debounce, sessionID→ClientSession registry, fan-out) — enumerating the session cache was rejected (wrong object type; would require forbidden new cache API), so the coordinator keeps its own registry populated at registration and pruned via `SetOnTerminate` + sweep-time `Validate`; W7 REPLACE tool setter (so removals propagate); W8 wiring.
- No `toolhive-core` change in this PR (tools propagate fully; resources/prompts removal is the documented follow-up).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRh394VZgnqbYjJwjrcJWm