### PR TITLE
Regenerate swagger docs to drop duplicate enums

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1926,15 +1926,11 @@ const docTemplate = `{
             "model.ArgumentType": {
                 "enum": [
                     "positional",
-                    "named",
-                    "positional",
                     "named"
                 ],
                 "example": "positional",
                 "type": "string",
                 "x-enum-varnames": [
-                    "ArgumentTypePositional",
-                    "ArgumentTypeNamed",
                     "ArgumentTypePositional",
                     "ArgumentTypeNamed"
                 ]
@@ -1944,18 +1940,10 @@ const docTemplate = `{
                     "string",
                     "number",
                     "boolean",
-                    "filepath",
-                    "string",
-                    "number",
-                    "boolean",
                     "filepath"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
-                    "FormatString",
-                    "FormatNumber",
-                    "FormatBoolean",
-                    "FormatFilePath",
                     "FormatString",
                     "FormatNumber",
                     "FormatBoolean",

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1919,15 +1919,11 @@
             "model.ArgumentType": {
                 "enum": [
                     "positional",
-                    "named",
-                    "positional",
                     "named"
                 ],
                 "example": "positional",
                 "type": "string",
                 "x-enum-varnames": [
-                    "ArgumentTypePositional",
-                    "ArgumentTypeNamed",
                     "ArgumentTypePositional",
                     "ArgumentTypeNamed"
                 ]
@@ -1937,18 +1933,10 @@
                     "string",
                     "number",
                     "boolean",
-                    "filepath",
-                    "string",
-                    "number",
-                    "boolean",
                     "filepath"
                 ],
                 "type": "string",
                 "x-enum-varnames": [
-                    "FormatString",
-                    "FormatNumber",
-                    "FormatBoolean",
-                    "FormatFilePath",
                     "FormatString",
                     "FormatNumber",
                     "FormatBoolean",

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1887,13 +1887,9 @@ components:
       enum:
       - positional
       - named
-      - positional
-      - named
       example: positional
       type: string
       x-enum-varnames:
-      - ArgumentTypePositional
-      - ArgumentTypeNamed
       - ArgumentTypePositional
       - ArgumentTypeNamed
     model.Format:
@@ -1902,16 +1898,8 @@ components:
       - number
       - boolean
       - filepath
-      - string
-      - number
-      - boolean
-      - filepath
       type: string
       x-enum-varnames:
-      - FormatString
-      - FormatNumber
-      - FormatBoolean
-      - FormatFilePath
       - FormatString
       - FormatNumber
       - FormatBoolean


### PR DESCRIPTION
## Summary

The committed OpenAPI docs (`docs/server/swagger.yaml`, `swagger.json`, `docs.go`) list every value of `model.ArgumentType` and `model.Format` **twice** — each enum block repeats `positional`/`named` (and the matching `x-enum-varnames`) and `string`/`number`/`boolean`/`filepath` over again.

`swag` v2.0.0 emits these enum blocks **non-deterministically**, and a doubled variant was committed. The result is that the **`Verify Swagger Documentation`** CI check is flaky: it fails on any branch where a fresh regeneration happens to produce the correct de-duplicated form (which is what surfaced it — a rebased feature branch regenerated the single-value form and diffed against the committed doubled form).

This regenerates the docs to the canonical single-value enums so the committed artifact matches a clean generation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Regenerated via the documented target: `swag init -g pkg/api/server.go --v3.1 -o docs/server --parseDependencyLevel 1`
- [x] Verified the diff is deletions only (36 lines across the 3 generated files) — every removed line is a duplicated enum value or `x-enum-varname`; no schema content changed.

## Does this introduce a user-facing change?

No — generated API documentation only; the deduplicated enums describe the identical accepted values.

## Special notes for reviewers

Generated-docs-only change. The underlying non-determinism in `swag` v2.0.0 (why the doubled variant can be produced at all) is a separate flaky-codegen concern not addressed here; this just restores the correct committed artifact. Unblocks the `Verify Swagger Documentation` check on branches rebased onto current `main`.

Generated with [Claude Code](https://claude.com/claude-code)