### PR TITLE
Propagate backend resources/prompts list_changed in vMCP

### DIFF
--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -178,9 +178,9 @@ Beyond tools, vMCP aggregates and serves the full complement of MCP capabilities
 | Capability | Served? | Notes |
 |------------|---------|-------|
 | Tools (`tools/list`, `tools/call`) | Yes | Aggregated, conflict-resolved, admission-filtered; a backend's asynchronous `notifications/tools/list_changed` is propagated to already-registered sessions — see below |
-| Resources (`resources/list`, `resources/read`) | Yes | Admission-filtered per identity |
-| Resource templates (`resources/templates/list`) | Yes | Templated reads route through the same `ReadResource` path; the router matches an expanded URI against the aggregated templates, and an exact template-string key routes to its backend |
-| Prompts (`prompts/list`, `prompts/get`) | Yes | Served per-session |
+| Resources (`resources/list`, `resources/read`) | Yes | Admission-filtered per identity; a backend's asynchronous `notifications/resources/list_changed` propagates ADDITIONS (not removals) to already-registered sessions — see below |
+| Resource templates (`resources/templates/list`) | Yes | Templated reads route through the same `ReadResource` path; the router matches an expanded URI against the aggregated templates, and an exact template-string key routes to its backend; covered by the same `notifications/resources/list_changed` propagation as resources (MCP 2025-11-25 has no separate wire method for template changes) |
+| Prompts (`prompts/list`, `prompts/get`) | Yes | Served per-session; a backend's asynchronous `notifications/prompts/list_changed` propagates ADDITIONS (not removals) to already-registered sessions — see below |
 | Completions (`completion/complete`) | Yes | A `ref/prompt` routes via the prompts table; a `ref/resource` carries the URI-template string per the spec and routes via the resource-templates table (exact template-string key, with exact-resource and template-expansion fallbacks). Unroutable refs return an empty result (lenient completion); admission denial returns an error |
 | Resource subscriptions (`resources/subscribe`, `resources/unsubscribe`) | Ack-level only | vMCP accepts and records the subscription (after session-binding and resource-admission checks) but does **not** yet forward backend `notifications/resources/updated` — see the limitation below |
 
@@ -190,7 +190,7 @@ The completion handler is a single global handler installed via `WithCompletionH
 
 vMCP advertises `resources.subscribe: true` and answers `resources/subscribe` / `resources/unsubscribe` at **ack level**: the request is accepted (enforcing session binding and validating the URI is an advertised, admitted resource), and go-sdk records the subscription. vMCP does **not** currently propagate backend `notifications/resources/updated` to the subscribed client — doing so requires persistent per-session backend connections, which is out of scope. Clients that subscribe will receive a success ack but no update stream yet.
 
-### Tools list_changed propagation (#5748)
+### Tools/resources/prompts list_changed propagation (#5748, #5969)
 
 Unlike the per-call backend client (`pkg/vmcp/client`), the **persistent**
 per-session backend connection (`pkg/vmcp/session/internal/backend`) stays
@@ -203,10 +203,13 @@ non-nil `ListChangedSink` is supplied at connection time, the connector:
   backends hang when this stream is opened against them. SSE backends need no
   extra option: their whole session is already one continuous stream.
 - Registers an `OnNotification` handler that dispatches
-  `notifications/tools/list_changed` to the sink (`kind=KindTools`, a typed
-  `ChangeKind` constant rather than a bare string so a typo is a compile
-  error) and logs `notifications/message` received out-of-call (log-only; no
-  relay).
+  `notifications/tools/list_changed` (`kind=KindTools`),
+  `notifications/resources/list_changed` (`kind=KindResources` — also covers
+  resource templates, since MCP 2025-11-25 has no separate wire method for
+  template changes), and `notifications/prompts/list_changed`
+  (`kind=KindPrompts`) to the sink — `ChangeKind` is a typed constant rather
+  than a bare string so a typo is a compile error — and logs
+  `notifications/message` received out-of-call (log-only; no relay).
 
 The sink is built once per session, at registration (`pkg/vmcp/server`'s
 `buildListChangedSink`), closing over the SDK `ClientSession`, the session ID,
@@ -217,20 +220,27 @@ the token-staleness note below). It is threaded through
 single nilable `ListChangedSink` parameter) down to every backend connector
 opened for that session.
 
+`buildListChangedSink` builds **one coalescing worker per `ChangeKind`**
+(`KindTools`, `KindResources`, `KindPrompts`) rather than a single shared
+worker: a tools notification resyncs only the session's tool store, without
+forcing a redundant re-apply (and possible spurious downstream
+`list_changed`) of its resources or prompts overlay, and vice versa.
+
 **The sink is non-blocking (runs on the backend receive-loop goroutine).** It
 must not do real work inline: the mcpcompat client dispatches notifications
 synchronously on its receive loop, so a blocking sink would stall that
 backend's notification delivery and let a misbehaving backend amplify one
-notification into unbounded work. The sink therefore only hands off to a
-**per-session coalescing worker** (`listChangedResyncWorker`): `trigger()`
-sets a dirty flag and, at most, starts **one** worker goroutine — never one
-goroutine per notification. At most one resync runs at a time per session;
-notifications that arrive while a resync is in flight collapse into a single
-follow-up run, so a notification storm is bounded to O(1) concurrent work per
-session. The worker goroutine exits when idle, so an idle session holds no
-goroutine.
+notification into unbounded work. The sink therefore only hands off to the
+matching **per-(session, kind) coalescing worker** (`listChangedResyncWorker`):
+`trigger()` sets a dirty flag and, at most, starts **one** worker goroutine —
+never one goroutine per notification. At most one resync runs at a time per
+(session, kind); notifications that arrive while a resync is in flight
+collapse into a single follow-up run, so a notification storm is bounded to
+O(1) concurrent work per (session, kind) — up to 3 concurrent resyncs per
+session in the worst case, one per kind. Each worker goroutine exits when
+idle, so an idle session holds no goroutine.
 
-The worker's resync body (`runListChangedResync`), off the receive loop:
+Each worker's resync body (`runListChangedResync`), off the receive loop:
 
 1. **Liveness guard** — looks the session up via `GetMultiSession` and returns
    immediately if it was terminated/expired, so a storm of notifications for a
@@ -243,67 +253,100 @@ The worker's resync body (`runListChangedResync`), off the receive loop:
    capability cache key and the outbound backend authentication are derived
    from the **context** (not from an explicit identity argument), so without
    this the resync would enumerate backends *unauthenticated* — advertising
-   tool metadata the principal's own credentials would not surface, or wrongly
-   dropping credential-gated tools, while replacing the correctly-scoped
-   registration-time set.
+   metadata the principal's own credentials would not surface, or wrongly
+   dropping credential-gated tools/resources/prompts, while replacing the
+   correctly-scoped registration-time set.
 3. Calls `core.InvalidateCapabilityCache()`, which purges the **entire**
-   per-identity capability cache (`aggregator.CacheInvalidator`). This is
-   coarse (not scoped to the one backend that changed): the LRU key is a hash
-   of identity + forwarded headers + backend-set, so per-backend invalidation
-   would need a reverse index that is disproportionate here. The coalescing
-   above already bounds the purge to at most once per resync burst, and a
-   purge only forces the next call per identity to re-sweep — an accepted
-   de-opt / follow-up. An aggregator that does not implement `CacheInvalidator`
+   per-identity capability cache (`aggregator.CacheInvalidator`), covering all
+   capability kinds together (tools, resources, resource templates, prompts
+   share one cached `AggregatedCapabilities` per identity). This is coarse (not
+   scoped to the one backend that changed): the LRU key is a hash of identity +
+   forwarded headers + backend-set, so per-backend invalidation would need a
+   reverse index that is disproportionate here. The coalescing above already
+   bounds the purge to at most once per resync burst per kind, and a purge
+   only forces the next call per identity to re-sweep — an accepted de-opt /
+   follow-up. An aggregator that does not implement `CacheInvalidator`
    WARN-logs instead of silently no-opping.
-4. Re-derives the session's advertised tool set from the (now cold) cache via
-   the same `serveSessionTools` helper session registration uses, and
-   **replaces** — not merges — the SDK session's tool store
-   (`SessionWithTools.SetSessionTools`), so a tool the backend removed
-   disappears rather than lingering from the registration-time merge.
+4. Re-derives and **replaces** — not merges — the session's advertised set for
+   the notification's kind, from the (now cold) cache: `KindTools` re-derives
+   via `serveSessionTools` and replaces the tool store
+   (`SessionWithTools.SetSessionTools`); `KindResources` re-derives via
+   `coreSessionResources`/`coreSessionResourceTemplates` and replaces BOTH the
+   resource store (`SessionWithResources.SetSessionResources`) and the
+   resource-template store
+   (`SessionWithResourceTemplates.SetSessionResourceTemplates`) — one
+   notification method covers both, per MCP 2025-11-25; `KindPrompts`
+   re-derives via `coreSessionPrompts` and replaces the prompt store
+   (`SessionWithPrompts.SetSessionPrompts`). Replacing (rather than merging)
+   means a tool the backend removed disappears rather than lingering from the
+   registration-time merge — but see the add-only caveat below for resources
+   and prompts.
 
-The go-sdk server auto-emits `notifications/tools/list_changed` to the
-downstream client whenever `SetSessionTools` changes something, now that
-`WithToolCapabilities(true)` is set (`pkg/vmcp/server/serve.go`).
+The go-sdk server auto-emits the corresponding `list_changed` notification
+(`notifications/tools/list_changed`, `notifications/resources/list_changed`,
+or `notifications/prompts/list_changed`) to the downstream client whenever the
+matching `SetSession*` call changes something, now that
+`WithToolCapabilities(true)`, `WithResourceCapabilities(true, true)`, and
+`WithPromptCapabilities(true)` are all set (`pkg/vmcp/server/serve.go`).
 
-**Identity staleness (B1)**: the sink reuses the identity captured at
+**Identity staleness (B1)**: each worker reuses the identity captured at
 registration for its re-aggregation and admission view. If that identity's
-upstream tokens are refreshed later (see #5323), the resync's `core.ListTools`
-call authorizes/aggregates against the (potentially stale) captured tokens,
-not the live per-request ones. This only affects the *accuracy of the
-asynchronous resync's own view* — every live call still authenticates via the
-fresh per-request identity through `enforceSessionBinding`, so staleness here
-cannot grant a call that would otherwise be denied.
+upstream tokens are refreshed later (see #5323), the resync's
+`core.ListTools`/`ListResources`/`ListPrompts` call authorizes/aggregates
+against the (potentially stale) captured tokens, not the live per-request
+ones. This only affects the *accuracy of the asynchronous resync's own view*
+— every live call still authenticates via the fresh per-request identity
+through `enforceSessionBinding`, so staleness here cannot grant a call that
+would otherwise be denied.
 
-**Registration-time emission (R1)**: go-sdk's own `AddTool`/`RemoveTools`
-debounce (10ms) and then broadcast `notifications/tools/list_changed` to
-**every** session currently connected to the shared `*gosdk.Server` — not
-only the session whose tool overlay changed — and a session is eligible for
-that broadcast from the moment its transport connects (`Server.bind`), before
-its own `initialize`/`notifications/initialized` round-trip completes.
-go-sdk's own source documents this as a known upstream gap ("potential spec
-violation... when the feature list changes before the session ... is
-initialized"). This means every session's registration-time per-session
-`AddTool` calls (`setSessionToolsDirect`) now cause a broadcast to every other
-already-connected session too. There is no supported hook to scope or
-suppress this without patching the vendored SDK, so it is accepted as a
-benign nuisance: MCP notifications are inherently a "you may want to refetch"
-hint, so an extra one only costs an idempotent `tools/list` round-trip — it
-never changes what any given session's own `tools/list` actually returns.
+**Registration-time emission (R1)**: go-sdk's own `AddTool`/`RemoveTools` (and
+the resource/prompt equivalents) debounce (10ms) and then broadcast the
+corresponding `list_changed` notification to **every** session currently
+connected to the shared `*gosdk.Server` — not only the session whose overlay
+changed — and a session is eligible for that broadcast from the moment its
+transport connects (`Server.bind`), before its own
+`initialize`/`notifications/initialized` round-trip completes. go-sdk's own
+source documents this as a known upstream gap ("potential spec violation...
+when the feature list changes before the session ... is initialized"). This
+means every session's registration-time per-session `AddTool`/resource/prompt
+calls (`setSessionToolsDirect`/`setSessionResourcesDirect`/
+`setSessionResourceTemplatesDirect`/`setSessionPromptsDirect`) now cause a
+broadcast to every other already-connected session too. There is no supported
+hook to scope or suppress this without patching the vendored SDK, so it is
+accepted as a benign nuisance for all three capability kinds: MCP
+notifications are inherently a "you may want to refetch" hint, so an extra one
+only costs an idempotent list round-trip — it never changes what any given
+session's own list actually returns.
 
-**Scope**: tools only. Resources/prompts `list_changed` propagation is a
-tracked follow-up — the backend connector does not dispatch those
-notification methods to the sink yet, and cross-pod session restore
-(`RestoreSession`) does not thread a sink at all (no live `ClientSession` to
-resync there).
+**Scope**: additions AND removals propagate for tools. For resources
+(including resource templates) and prompts, only **additions** propagate
+today: toolhive-core's mcpcompat per-session sync for resources/resource
+templates/prompts (`syncSessionResources`/`syncSessionResourceTemplates`/
+`syncSessionPrompts` in `mcpcompat/server/session.go`) is add-only — unlike
+`syncSessionTools`, which also calls `RemoveTools` — so a backend-removed
+resource/template/prompt stays registered on the session's go-sdk server
+(listed until re-initialize) even though the overlay this PR replaces no
+longer contains it. `resyncSessionResources`/`resyncSessionPrompts` still
+REPLACE (not merge) their overlay, so once toolhive-core gains removal
+reconciliation ([stacklok/toolhive-core#184](https://github.com/stacklok/toolhive-core/issues/184)),
+removals start propagating with no change needed on the vMCP side. Advertising
+`listChanged: true` stays honest in the meantime — notifications ARE emitted on
+change (except that a pure removal which EMPTIES the overlay issues no `Add*`
+and therefore triggers no downstream `list_changed`, since go-sdk notifies only
+via `Add*`/`RemoveTools`); `listChanged` promises notification, not list
+minimization — but until that follow-up lands, a refetch after a pure removal
+returns a stale superset for resources/templates/prompts. Cross-pod session
+restore (`RestoreSession`) does not thread a sink at all for any kind (no live
+`ClientSession` to resync there).
 
 **Implementation**: `pkg/vmcp/session/internal/backend/mcp_session.go`
-(`ChangeKind`/`KindTools`, `ListChangedSink`, connector wiring),
-`pkg/vmcp/aggregator/aggregator.go` and `caching_aggregator.go`
-(`CacheInvalidator`), `pkg/vmcp/core/core_vmcp.go`
+(`ChangeKind`/`KindTools`/`KindResources`/`KindPrompts`, `ListChangedSink`,
+connector wiring), `pkg/vmcp/aggregator/aggregator.go` and
+`caching_aggregator.go` (`CacheInvalidator`), `pkg/vmcp/core/core_vmcp.go`
 (`InvalidateCapabilityCache`), `pkg/vmcp/server/serve_list_changed.go`
 (`listChangedResyncWorker` coalescing, `buildListChangedSink`,
-`runListChangedResync`, `resyncSessionTools`) with `Server.resyncBaseCtx`
-cancelled on `Stop`.
+`runListChangedResync`, `resyncSessionTools`, `resyncSessionResources`,
+`resyncSessionPrompts`) with `Server.resyncBaseCtx` cancelled on `Stop`.
 
 ### Mid-call forwarding (elicitation / sampling / progress / logging)
 

--- a/pkg/vmcp/forwarding.go
+++ b/pkg/vmcp/forwarding.go
@@ -25,6 +25,22 @@ const (
 	// (pkg/vmcp/session/internal/backend) to recognize a backend's asynchronous
 	// tool-set change and trigger cache invalidation + session resync (#5748).
 	MethodToolsListChangedNotification = "notifications/tools/list_changed"
+
+	// MethodResourcesListChangedNotification is the notifications/resources/list_changed
+	// wire method. Per MCP 2025-11-25 there is no separate wire method for resource
+	// TEMPLATE changes, so this method also covers a backend's resource-template-set
+	// change. Used by the persistent session-backed backend connection
+	// (pkg/vmcp/session/internal/backend) to recognize a backend's asynchronous
+	// resource (and resource-template) set change and trigger cache invalidation +
+	// session resync (#5969, mirroring #5748's tools handling).
+	MethodResourcesListChangedNotification = "notifications/resources/list_changed"
+
+	// MethodPromptsListChangedNotification is the notifications/prompts/list_changed
+	// wire method. Used by the persistent session-backed backend connection
+	// (pkg/vmcp/session/internal/backend) to recognize a backend's asynchronous
+	// prompt-set change and trigger cache invalidation + session resync (#5969,
+	// mirroring #5748's tools handling).
+	MethodPromptsListChangedNotification = "notifications/prompts/list_changed"
 )
 
 // SamplingRequester sends an MCP sampling (sampling/createMessage) request to the

--- a/pkg/vmcp/server/capability_regression_test.go
+++ b/pkg/vmcp/server/capability_regression_test.go
@@ -62,12 +62,18 @@ func TestRegression_InitializeAdvertisesToolsAndResourcesCapabilities(t *testing
 		"tools capability must be advertised in initialize on the Serve path; got %v", capabilities)
 	assert.Contains(t, capabilities, "resources",
 		"resources capability must be advertised in initialize on the Serve path; got %v", capabilities)
+	assert.Contains(t, capabilities, "prompts",
+		"prompts capability must be advertised in initialize on the Serve path (#5969 fixes a latent bug"+
+			" where it was never advertised even though per-session prompts were served); got %v", capabilities)
 }
 
-// TestRegression_InitializeAdvertisesToolsListChanged pins #5748's capability
-// flip: tools.listChanged must now be true in the initialize response (it was
-// false — and therefore omitted, per the SDK's omitempty — before #5748).
-func TestRegression_InitializeAdvertisesToolsListChanged(t *testing.T) {
+// TestRegression_InitializeAdvertisesListChanged pins the #5748 (tools) and
+// #5969 (resources/prompts) capability flips: tools.listChanged,
+// resources.listChanged, and prompts.listChanged must all be true in the
+// initialize response (they were false — and therefore omitted, per the
+// SDK's omitempty — before these changes). resources.subscribe must remain
+// true throughout (unrelated to listChanged, pinned pre-existing behavior).
+func TestRegression_InitializeAdvertisesListChanged(t *testing.T) {
 	t.Parallel()
 
 	fc := &fakeCore{tools: []vmcp.Tool{{Name: "cap-tool"}}}
@@ -96,6 +102,17 @@ func TestRegression_InitializeAdvertisesToolsListChanged(t *testing.T) {
 	require.True(t, ok, "tools capability must be an object; capabilities: %v", capabilities)
 	assert.Equal(t, true, toolsCaps["listChanged"],
 		"tools.listChanged must be true so downstream clients trust the resync notification (#5748)")
+
+	resourcesCaps, ok := capabilities["resources"].(map[string]any)
+	require.True(t, ok, "resources capability must be an object; capabilities: %v", capabilities)
+	assert.Equal(t, true, resourcesCaps["subscribe"], "resources.subscribe must remain true")
+	assert.Equal(t, true, resourcesCaps["listChanged"],
+		"resources.listChanged must be true so downstream clients trust the resync notification (#5969)")
+
+	promptsCaps, ok := capabilities["prompts"].(map[string]any)
+	require.True(t, ok, "prompts capability must be an object; capabilities: %v", capabilities)
+	assert.Equal(t, true, promptsCaps["listChanged"],
+		"prompts.listChanged must be true so downstream clients trust the resync notification (#5969)")
 }
 
 // TestRegression_SessionRegistrationDoesNotSpuriouslyInvalidateCache verifies

--- a/pkg/vmcp/server/serve.go
+++ b/pkg/vmcp/server/serve.go
@@ -236,43 +236,57 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 		return srv.coreSubscribeHandler(ctx, "resources/unsubscribe", uri)
 	}
 
-	// Build the mcp-go server (mirrors server.New): tools and resources are
-	// registered dynamically, so capabilities start disabled — except resources,
-	// which advertise subscribe support so spec-compliant clients issue
-	// resources/subscribe (the handlers above answer it at ack level).
+	// Build the mcp-go server (mirrors server.New): tools, resources, and
+	// prompts are registered dynamically, so capabilities start disabled —
+	// except resources, which additionally advertise subscribe support so
+	// spec-compliant clients issue resources/subscribe (the handlers above
+	// answer it at ack level).
 	//
-	// tools.listChanged is now advertised (#5748): a persistent backend
-	// connection's notifications/tools/list_changed drives a session resync
-	// (serve_list_changed.go) that replaces the SDK session's tool store via
-	// SetSessionTools, and go-sdk auto-emits notifications/tools/list_changed to
-	// the downstream client whenever this capability is on.
+	// tools.listChanged (#5748) and resources.listChanged/prompts.listChanged
+	// (#5969) are now advertised: a persistent backend connection's
+	// notifications/tools/list_changed, notifications/resources/list_changed,
+	// or notifications/prompts/list_changed drives a per-kind session resync
+	// (serve_list_changed.go) that replaces the SDK session's tool, resource
+	// (+ resource-template), or prompt store via SetSessionTools/
+	// SetSessionResources/SetSessionResourceTemplates/SetSessionPrompts, and
+	// go-sdk auto-emits the corresponding list_changed notification to the
+	// downstream client whenever that capability is on. WithPromptCapabilities
+	// also fixes a spec-conformance defect: vMCP already served prompts per
+	// session (SessionWithPrompts) but never declared the prompts capability at
+	// initialize, violating MCP 2025-11-25's "Servers that support prompts MUST
+	// declare the prompts capability during initialization".
 	//
 	// R1 (verified against toolhive-core v0.0.32 / go-sdk v1.6.1): go-sdk's own
-	// AddTool/RemoveTools call a shared changeAndNotify that debounces (10ms)
-	// and then broadcasts the notification to EVERY session currently connected
-	// to this *gosdk.Server (mcpcompat/server/server.go's srv is one instance
-	// shared across all sessions) — not just the session whose tool overlay
-	// changed. go-sdk's own bind() adds a session to that broadcast list as soon
-	// as the transport connects (Connect), before initialize/notifications
-	// initialized even round-trip; go-sdk's shared.go itself documents this as a
-	// known upstream gap ("potential spec violation... when the feature list
-	// changes before the session ... is initialized"). Concretely: every
-	// session's registration-time per-session AddTool calls (setSessionToolsDirect)
-	// now cause a list_changed broadcast to every OTHER already-connected
-	// session too, not only the one just registered — this is inherent go-sdk
-	// behavior, not something introduced by the #5748 resync sink, and there is
-	// no supported hook to scope or suppress it short of patching the vendored
-	// SDK (out of scope here). It is accepted as a benign nuisance: MCP clients
-	// treat list_changed as "you may want to refetch," so an extra notification
-	// only costs an idempotent tools/list round-trip — it never changes what a
-	// given session's tools/list actually returns (each session's advertised
-	// set still comes solely from its own overlay). See
-	// docs/arch/10-virtual-mcp-architecture.md for the propagation writeup.
+	// AddTool/RemoveTools (and the resource/prompt equivalents) call a shared
+	// changeAndNotify that debounces (10ms) and then broadcasts the
+	// notification to EVERY session currently connected to this *gosdk.Server
+	// (mcpcompat/server/server.go's srv is one instance shared across all
+	// sessions) — not just the session whose overlay changed. go-sdk's own
+	// bind() adds a session to that broadcast list as soon as the transport
+	// connects (Connect), before initialize/notifications initialized even
+	// round-trip; go-sdk's shared.go itself documents this as a known upstream
+	// gap ("potential spec violation... when the feature list changes before
+	// the session ... is initialized"). Concretely: every session's
+	// registration-time per-session AddTool/resource/prompt calls
+	// (setSessionToolsDirect/setSessionResourcesDirect/
+	// setSessionResourceTemplatesDirect/setSessionPromptsDirect) now cause a
+	// list_changed broadcast to every OTHER already-connected session too, not
+	// only the one just registered — this is inherent go-sdk behavior, not
+	// something introduced by the #5748/#5969 resync sinks, and there is no
+	// supported hook to scope or suppress it short of patching the vendored SDK
+	// (out of scope here). It is accepted as a benign nuisance for all three
+	// capability kinds: MCP clients treat list_changed as "you may want to
+	// refetch," so an extra notification only costs an idempotent list
+	// round-trip — it never changes what a given session's own list actually
+	// returns (each session's advertised set still comes solely from its own
+	// overlay). See docs/arch/10-virtual-mcp-architecture.md for the
+	// propagation writeup.
 	mcpServer := server.NewMCPServer(
 		serveCfg.Name,
 		serveCfg.Version,
 		server.WithToolCapabilities(true),
-		server.WithResourceCapabilities(true, false),
+		server.WithResourceCapabilities(true, true),
+		server.WithPromptCapabilities(true),
 		server.WithLogging(),
 		server.WithHooks(hooks),
 		server.WithCompletionHandler(completionHandler),
@@ -325,11 +339,12 @@ func Serve(ctx context.Context, v core.VMCP, cfg *ServerConfig) (*Server, error)
 		statusReporter:   cfg.StatusReporter,
 	}
 
-	// Server-lifetime parent context for asynchronous tools/list_changed resync
-	// work (#5748). Cancelling it on Stop aborts any in-flight backend
-	// re-aggregation a late notification kicked off, so nothing outlives the
-	// server. context.Background() is the parent (not the Serve ctx, which may be
-	// request-scoped) so the resync lifetime is bounded solely by Stop.
+	// Server-lifetime parent context for asynchronous tools/resources/prompts
+	// list_changed resync work (#5748, #5969). Cancelling it on Stop aborts any
+	// in-flight backend re-aggregation a late notification kicked off, so
+	// nothing outlives the server. context.Background() is the parent (not the
+	// Serve ctx, which may be request-scoped) so the resync lifetime is bounded
+	// solely by Stop.
 	resyncCtx, resyncCancel := context.WithCancel(context.Background())
 	srv.resyncBaseCtx = resyncCtx
 	srv.shutdownFuncs = append(srv.shutdownFuncs, func(context.Context) error {

--- a/pkg/vmcp/server/serve_list_changed.go
+++ b/pkg/vmcp/server/serve_list_changed.go
@@ -15,30 +15,44 @@ import (
 	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
 )
 
-// This file holds the tools list_changed propagation added by #5748: a
-// persistent backend connection observing notifications/tools/list_changed
-// invalidates the shared capability cache and resyncs the affected session's
-// advertised tool set, so a client that already initialized eventually sees
-// the backend's change reflected in tools/list without reconnecting.
+// This file holds the tools/resources/prompts list_changed propagation added
+// by #5748 (tools) and extended by #5969 (resources/resource templates and
+// prompts): a persistent backend connection observing
+// notifications/tools/list_changed, notifications/resources/list_changed, or
+// notifications/prompts/list_changed invalidates the shared capability cache
+// and resyncs the affected session's advertised set for that capability kind,
+// so a client that already initialized eventually sees the backend's change
+// reflected in tools/list, resources/list, resources/templates/list, or
+// prompts/list without reconnecting.
 //
-// Scope: TOOLS only. Resources/prompts list_changed propagation is a tracked
-// follow-up (see docs/arch/10-virtual-mcp-architecture.md) — the backend
-// connector (pkg/vmcp/session/internal/backend) does not even dispatch those
-// notification methods to this sink yet.
+// Scope: additions AND removals propagate for tools; for resources/resource
+// templates/prompts, only ADDITIONS propagate today — see the add-only caveat
+// on resyncSessionResources/resyncSessionPrompts and
+// docs/arch/10-virtual-mcp-architecture.md. Cross-pod session restore
+// (RestoreSession) does not thread a sink at all (no live ClientSession to
+// resync there).
 
-// listChangedResyncWorker coalesces a session's tools/list_changed resyncs.
+// listChangedResyncWorker coalesces a session's list_changed resyncs for ONE
+// capability kind (tools, resources, or prompts). buildListChangedSink builds
+// one worker per (session, kind): a tools notification resyncing tools alone,
+// without touching resources/prompts, matters because each capability's
+// resync REPLACES that capability's session store, and re-deriving one kind
+// must not force a redundant re-apply (and possible spurious downstream
+// list_changed) of the others.
 //
 // The sink runs on the backend's receive-loop goroutine and must not block
 // (vmcpsession.ListChangedSink contract), so trigger() only flips a dirty flag
 // and, at most, starts ONE worker goroutine — it never does the resync inline
 // and never spawns a goroutine per notification. At most one resync is ever in
-// flight per session; notifications that arrive while one runs collapse into a
-// single follow-up run. This bounds a misbehaving backend to O(1) concurrent
-// resync work per session regardless of how fast it emits notifications.
+// flight per (session, kind); notifications that arrive while one runs
+// collapse into a single follow-up run. This bounds a misbehaving backend to
+// O(1) concurrent resync work per (session, kind) regardless of how fast it
+// emits notifications.
 type listChangedResyncWorker struct {
 	// run performs exactly one resync using the given (server-lifetime) context.
 	// It is self-contained: liveness check, context reconstruction, and the
-	// re-derive-and-replace of the session's tools.
+	// re-derive-and-replace of the session's advertised set for this worker's
+	// capability kind (tools, resources, or prompts).
 	run func(ctx context.Context)
 	// baseCtx bounds every run to the server lifetime (cancelled on Stop) so a
 	// late notification cannot start work that outlives the server.
@@ -84,52 +98,69 @@ func (w *listChangedResyncWorker) loop() {
 // buildListChangedSink returns the sink passed to
 // SessionManager.CreateSession for a newly-registered session. The returned
 // sink runs on the backend receive-loop goroutine and only hands work off to a
-// per-session coalescing worker (see listChangedResyncWorker) — it never does
-// the cache purge or backend re-aggregation inline.
+// per-(session, kind) coalescing worker (see listChangedResyncWorker) — it
+// never does the cache purge or backend re-aggregation inline.
 //
-// It closes over the SDK ClientSession, the session ID, and the caller's
-// identity AND per-request forwarded headers captured AT REGISTRATION TIME
-// (issue #5748, decision B1/Option 2). The async resync reconstructs a context
-// carrying that identity + those headers before calling into the core, because
-// the capability cache key and the outbound backend authentication are derived
-// from the CONTEXT (auth.IdentityFromContext / headerforward.ForwardedHeaders-
-// FromContext — see pkg/vmcp/aggregator/caching_aggregator.go and
-// pkg/vmcp/client), NOT from an explicit identity argument. Without this the
-// resync would enumerate backends unauthenticated and could advertise metadata
-// the principal's own credentials would not surface (or wrongly drop
-// credential-gated tools), while replacing the correctly-scoped registration
+// It builds one listChangedResyncWorker per ChangeKind (tools, resources,
+// prompts) rather than a single shared worker: each worker's run closure
+// resyncs only its own capability kind, so a tools notification cannot force a
+// spurious re-apply (and possible downstream list_changed) of the session's
+// resources/prompts overlay, and vice versa.
+//
+// Each worker closes over the SDK ClientSession, the session ID, and the
+// caller's identity AND per-request forwarded headers captured AT
+// REGISTRATION TIME (issue #5748, decision B1/Option 2). The async resync
+// reconstructs a context carrying that identity + those headers before calling
+// into the core, because the capability cache key and the outbound backend
+// authentication are derived from the CONTEXT (auth.IdentityFromContext /
+// headerforward.ForwardedHeadersFromContext — see
+// pkg/vmcp/aggregator/caching_aggregator.go and pkg/vmcp/client), NOT from an
+// explicit identity argument. Without this the resync would enumerate
+// backends unauthenticated and could advertise metadata the principal's own
+// credentials would not surface (or wrongly drop credential-gated
+// tools/resources/prompts), while replacing the correctly-scoped registration
 // set.
 //
 // Token-staleness risk: the captured identity is a snapshot. If its upstream
-// tokens are refreshed after registration (see #5323), this resync's
-// core.ListTools call authorizes/aggregates using the (possibly stale)
-// captured tokens, not the live per-request ones. This only affects the
-// accuracy of the asynchronous resync's own view — every live call still
-// authenticates via the fresh per-request identity through
+// tokens are refreshed after registration (see #5323), a resync's
+// core.ListTools/ListResources/ListPrompts call authorizes/aggregates using
+// the (possibly stale) captured tokens, not the live per-request ones. This
+// only affects the accuracy of the asynchronous resync's own view — every
+// live call still authenticates via the fresh per-request identity through
 // enforceSessionBinding, so staleness here cannot grant a call that would
 // otherwise be denied.
 func (s *Server) buildListChangedSink(
 	sessionID string, session server.ClientSession, identity *auth.Identity, forwardedHeaders map[string]string,
 ) vmcpsession.ListChangedSink {
-	worker := &listChangedResyncWorker{
-		baseCtx: s.resyncBaseCtx,
-		run: func(ctx context.Context) {
-			s.runListChangedResync(ctx, sessionID, session, identity, forwardedHeaders)
-		},
+	newWorker := func(kind vmcpsession.ChangeKind) *listChangedResyncWorker {
+		return &listChangedResyncWorker{
+			baseCtx: s.resyncBaseCtx,
+			run: func(ctx context.Context) {
+				s.runListChangedResync(ctx, sessionID, session, identity, forwardedHeaders, kind)
+			},
+		}
+	}
+	workers := map[vmcpsession.ChangeKind]*listChangedResyncWorker{
+		vmcpsession.KindTools:     newWorker(vmcpsession.KindTools),
+		vmcpsession.KindResources: newWorker(vmcpsession.KindResources),
+		vmcpsession.KindPrompts:   newWorker(vmcpsession.KindPrompts),
 	}
 	return func(_ context.Context, backendWorkloadID string, kind vmcpsession.ChangeKind) {
-		if kind != vmcpsession.KindTools {
-			// Resources/prompts list_changed: out of scope (see file doc).
+		worker, ok := workers[kind]
+		if !ok {
+			slog.Debug("ignoring list_changed notification of unknown kind",
+				"session_id", sessionID, "backend_id", backendWorkloadID, "kind", kind)
 			return
 		}
-		slog.Debug("backend reported tools/list_changed; scheduling session resync",
-			"session_id", sessionID, "backend_id", backendWorkloadID)
+		slog.Debug("backend reported list_changed; scheduling session resync",
+			"session_id", sessionID, "backend_id", backendWorkloadID, "kind", kind)
 		worker.trigger()
 	}
 }
 
-// runListChangedResync performs one coalesced resync for a session. It runs on
-// the worker goroutine (off the receive loop). Order matters:
+// runListChangedResync performs one coalesced resync for a session, for the
+// given capability kind. It runs on the worker goroutine (off the receive
+// loop). Order matters:
 //  1. Liveness guard — skip (and do no work) if the session was terminated, so
 //     a storm of notifications for a dead session cannot drive re-aggregation.
 //  2. Reconstruct the registration-time request context (identity + forwarded
@@ -137,18 +168,22 @@ func (s *Server) buildListChangedSink(
 //     backend auth match a real request from this principal.
 //  3. Invalidate the capability cache so the re-derivation below re-sweeps the
 //     backend rather than reading the entry it just purged.
-//  4. Re-derive and REPLACE the session's advertised tool set.
+//  4. Re-derive and REPLACE the session's advertised set for kind: KindTools
+//     resyncs tools, KindResources resyncs both resources and resource
+//     templates (MCP 2025-11-25 has no separate wire method for template
+//     changes), and KindPrompts resyncs prompts.
 func (s *Server) runListChangedResync(
 	baseCtx context.Context,
 	sessionID string,
 	session server.ClientSession,
 	identity *auth.Identity,
 	forwardedHeaders map[string]string,
+	kind vmcpsession.ChangeKind,
 ) {
 	// Liveness guard: if the session is gone (terminated/expired) there is
 	// nothing to resync, and doing the work would waste a full backend sweep.
 	if _, ok := s.vmcpSessionMgr.GetMultiSession(baseCtx, sessionID); !ok {
-		slog.Debug("skipping tools/list_changed resync for terminated session", "session_id", sessionID)
+		slog.Debug("skipping list_changed resync for terminated session", "session_id", sessionID, "kind", kind)
 		return
 	}
 
@@ -157,15 +192,27 @@ func (s *Server) runListChangedResync(
 		ctx = headerforward.WithForwardedHeaders(ctx, forwardedHeaders)
 	}
 
-	// Invalidate FIRST so resyncSessionTools' core.ListTools re-sweeps the
-	// backend instead of re-reading the stale cached aggregation. The purge is
-	// global (all identities) — see InvalidateCapabilityCache — but coalescing
-	// bounds it to at most once per resync burst.
+	// Invalidate FIRST so the re-derivation below re-sweeps the backend instead
+	// of re-reading the stale cached aggregation. The purge is global (all
+	// identities, all kinds) — see InvalidateCapabilityCache — but coalescing
+	// bounds it to at most once per resync burst per kind.
 	s.core.InvalidateCapabilityCache()
 
-	if err := s.resyncSessionTools(ctx, session, sessionID, identity); err != nil {
-		slog.Warn("failed to resync session tools after backend list_changed",
-			"session_id", sessionID, "error", err)
+	var err error
+	switch kind {
+	case vmcpsession.KindTools:
+		err = s.resyncSessionTools(ctx, session, sessionID, identity)
+	case vmcpsession.KindResources:
+		err = s.resyncSessionResources(ctx, session, sessionID, identity)
+	case vmcpsession.KindPrompts:
+		err = s.resyncSessionPrompts(ctx, session, sessionID, identity)
+	default:
+		slog.Debug("skipping resync for unknown list_changed kind", "session_id", sessionID, "kind", kind)
+		return
+	}
+	if err != nil {
+		slog.Warn("failed to resync session after backend list_changed",
+			"session_id", sessionID, "kind", kind, "error", err)
 	}
 }
 
@@ -202,5 +249,117 @@ func (s *Server) resyncSessionTools(
 
 	slog.Debug("resynced session tools after backend list_changed",
 		"session_id", sessionID, "tool_count", len(tools))
+	return nil
+}
+
+// resyncSessionResources re-derives sessionID's advertised resources AND
+// resource templates (via coreSessionResources/coreSessionResourceTemplates —
+// the core, cache now cold) and REPLACES the SDK session's resource and
+// resource-template stores with them, mirroring resyncSessionTools. Both are
+// re-derived together because MCP 2025-11-25 has no separate wire method for
+// resource-template changes: notifications/resources/list_changed covers both.
+//
+// ctx must already carry the resyncing principal's identity and forwarded
+// headers (runListChangedResync builds it) so the coreSession* helpers ->
+// core.ListResources/ListResourceTemplates enumerate backends with the
+// correct credentials and cache key.
+//
+// Add-only removal limitation: unlike resyncSessionTools, replacing the
+// overlay here propagates ADDITIONS but not REMOVALS. toolhive-core's
+// mcpcompat per-session sync for resources/resource templates
+// (syncSessionResources/syncSessionResourceTemplates) is add-only — unlike
+// syncSessionTools, which also calls RemoveTools — so a backend-removed
+// resource/template stays registered on the session's go-sdk server (listed
+// until re-initialize) even though this overlay no longer contains it. The
+// overlay itself IS replaced (not merged) here, so when toolhive-core gains
+// removal reconciliation (tracked follow-up: stacklok/toolhive-core#184),
+// removals start propagating with no change needed in this function.
+// Advertising listChanged:true stays honest — notifications ARE emitted on
+// change (except that a pure removal which EMPTIES the overlay issues no Add*
+// and therefore triggers no downstream list_changed, since go-sdk notifies
+// only via Add*/RemoveTools); listChanged promises notification, not list
+// minimization — but until that follow-up lands, a refetch after a pure
+// removal returns a stale superset.
+func (s *Server) resyncSessionResources(
+	ctx context.Context, session server.ClientSession, sessionID string, identity *auth.Identity,
+) error {
+	resources, err := s.coreSessionResources(ctx, sessionID, identity)
+	if err != nil {
+		return fmt.Errorf("resync session resources: core ListResources for session %s: %w", sessionID, err)
+	}
+	sessionWithResources, ok := session.(server.SessionWithResources)
+	if !ok {
+		return fmt.Errorf("resync session resources: session %s does not support per-session resources", sessionID)
+	}
+	resourceMap := make(map[string]server.ServerResource, len(resources))
+	for _, res := range resources {
+		resourceMap[res.Resource.URI] = res
+	}
+	sessionWithResources.SetSessionResources(resourceMap)
+
+	templates, err := s.coreSessionResourceTemplates(ctx, sessionID, identity)
+	if err != nil {
+		return fmt.Errorf("resync session resource templates: core ListResourceTemplates for session %s: %w", sessionID, err)
+	}
+	sessionWithTemplates, ok := session.(server.SessionWithResourceTemplates)
+	if !ok {
+		return fmt.Errorf(
+			"resync session resource templates: session %s does not support per-session resource templates", sessionID)
+	}
+	templateMap := make(map[string]server.ServerResourceTemplate, len(templates))
+	for _, tmpl := range templates {
+		templateMap[tmpl.Template.URITemplate] = tmpl
+	}
+	sessionWithTemplates.SetSessionResourceTemplates(templateMap)
+
+	slog.Debug("resynced session resources after backend list_changed",
+		"session_id", sessionID, "resource_count", len(resources), "resource_template_count", len(templates))
+	return nil
+}
+
+// resyncSessionPrompts re-derives sessionID's advertised prompt set (via
+// coreSessionPrompts — the core, cache now cold) and REPLACES the SDK
+// session's prompt store with it, mirroring resyncSessionTools.
+//
+// ctx must already carry the resyncing principal's identity and forwarded
+// headers (runListChangedResync builds it) so coreSessionPrompts ->
+// core.ListPrompts enumerates backends with the correct credentials and cache
+// key.
+//
+// Add-only removal limitation: as with resyncSessionResources, replacing the
+// overlay here propagates ADDITIONS but not REMOVALS. toolhive-core's
+// mcpcompat per-session sync for prompts (syncSessionPrompts) is add-only, so
+// a backend-removed prompt stays registered on the session's go-sdk server
+// (listed until re-initialize) even though this overlay no longer contains
+// it. The overlay itself IS replaced (not merged) here, so when toolhive-core
+// gains removal reconciliation (tracked follow-up: stacklok/toolhive-core#184),
+// removals start propagating with no change needed in this function.
+// Advertising listChanged:true stays honest — notifications ARE emitted on
+// change (except that a pure removal which EMPTIES the overlay issues no Add*
+// and therefore triggers no downstream list_changed, since go-sdk notifies
+// only via Add*/RemoveTools); listChanged promises notification, not list
+// minimization — but until that follow-up lands, a refetch after a pure
+// removal returns a stale superset.
+func (s *Server) resyncSessionPrompts(
+	ctx context.Context, session server.ClientSession, sessionID string, identity *auth.Identity,
+) error {
+	prompts, err := s.coreSessionPrompts(ctx, sessionID, identity)
+	if err != nil {
+		return fmt.Errorf("resync session prompts: core ListPrompts for session %s: %w", sessionID, err)
+	}
+
+	sessionWithPrompts, ok := session.(server.SessionWithPrompts)
+	if !ok {
+		return fmt.Errorf("resync session prompts: session %s does not support per-session prompts", sessionID)
+	}
+
+	promptMap := make(map[string]server.ServerPrompt, len(prompts))
+	for _, p := range prompts {
+		promptMap[p.Prompt.Name] = p
+	}
+	sessionWithPrompts.SetSessionPrompts(promptMap)
+
+	slog.Debug("resynced session prompts after backend list_changed",
+		"session_id", sessionID, "prompt_count", len(prompts))
 	return nil
 }

--- a/pkg/vmcp/server/serve_list_changed_test.go
+++ b/pkg/vmcp/server/serve_list_changed_test.go
@@ -58,6 +58,107 @@ func (f *fakeToolsSession) SetSessionTools(tools map[string]server.ServerTool) {
 var _ server.ClientSession = (*fakeToolsSession)(nil)
 var _ server.SessionWithTools = (*fakeToolsSession)(nil)
 
+// fakeCapsSession is a minimal server.ClientSession + SessionWithResources +
+// SessionWithResourceTemplates + SessionWithPrompts fake used to test
+// resyncSessionResources/resyncSessionPrompts/runListChangedResync without a
+// live SDK session. It records every SetSession* call so tests can assert
+// replacement semantics (#5969, mirroring fakeToolsSession for #5748).
+type fakeCapsSession struct {
+	id string
+
+	mu                               sync.Mutex
+	resources                        map[string]server.ServerResource
+	resourceTemplates                map[string]server.ServerResourceTemplate
+	prompts                          map[string]server.ServerPrompt
+	setSessionResourcesCalls         int
+	setSessionResourceTemplatesCalls int
+	setSessionPromptsCalls           int
+}
+
+func (*fakeCapsSession) Initialize()                                         {}
+func (*fakeCapsSession) Initialized() bool                                   { return true }
+func (*fakeCapsSession) NotificationChannel() chan<- mcp.JSONRPCNotification { return nil }
+func (f *fakeCapsSession) SessionID() string                                 { return f.id }
+
+func (f *fakeCapsSession) GetSessionResources() map[string]server.ServerResource {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]server.ServerResource, len(f.resources))
+	for k, v := range f.resources {
+		out[k] = v
+	}
+	return out
+}
+
+func (f *fakeCapsSession) SetSessionResources(resources map[string]server.ServerResource) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resources = resources
+	f.setSessionResourcesCalls++
+}
+
+func (f *fakeCapsSession) GetSessionResourceTemplates() map[string]server.ServerResourceTemplate {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]server.ServerResourceTemplate, len(f.resourceTemplates))
+	for k, v := range f.resourceTemplates {
+		out[k] = v
+	}
+	return out
+}
+
+func (f *fakeCapsSession) SetSessionResourceTemplates(templates map[string]server.ServerResourceTemplate) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resourceTemplates = templates
+	f.setSessionResourceTemplatesCalls++
+}
+
+func (f *fakeCapsSession) GetSessionPrompts() map[string]server.ServerPrompt {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]server.ServerPrompt, len(f.prompts))
+	for k, v := range f.prompts {
+		out[k] = v
+	}
+	return out
+}
+
+func (f *fakeCapsSession) SetSessionPrompts(prompts map[string]server.ServerPrompt) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.prompts = prompts
+	f.setSessionPromptsCalls++
+}
+
+var _ server.ClientSession = (*fakeCapsSession)(nil)
+var _ server.SessionWithResources = (*fakeCapsSession)(nil)
+var _ server.SessionWithResourceTemplates = (*fakeCapsSession)(nil)
+var _ server.SessionWithPrompts = (*fakeCapsSession)(nil)
+
+// resourcesOnlySession implements server.ClientSession + SessionWithResources
+// but NOT SessionWithResourceTemplates, so a resyncSessionResources test can
+// prove the templates-half type assertion fails loudly. It provides its own
+// resource methods (rather than embedding fakeCapsSession, which would also
+// promote the template/prompt methods and satisfy those interfaces).
+type resourcesOnlySession struct {
+	fake fakeCapsSession
+}
+
+func (*resourcesOnlySession) Initialize()                                         {}
+func (*resourcesOnlySession) Initialized() bool                                   { return true }
+func (*resourcesOnlySession) NotificationChannel() chan<- mcp.JSONRPCNotification { return nil }
+func (s *resourcesOnlySession) SessionID() string                                 { return s.fake.id }
+func (s *resourcesOnlySession) GetSessionResources() map[string]server.ServerResource {
+	return s.fake.GetSessionResources()
+}
+func (s *resourcesOnlySession) SetSessionResources(resources map[string]server.ServerResource) {
+	s.fake.SetSessionResources(resources)
+}
+
+var _ server.ClientSession = (*resourcesOnlySession)(nil)
+var _ server.SessionWithResources = (*resourcesOnlySession)(nil)
+
 // stubSessionManager is a minimal SessionManager for the #5748 resync tests.
 // Only GetMultiSession is meaningful (its returned liveness bool drives the
 // resync liveness guard); the rest satisfy the interface and fail loudly if a
@@ -131,6 +232,135 @@ func TestResyncSessionTools_SessionWithoutToolSupport(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not support per-session tools")
 }
 
+// TestResyncSessionResources_SessionWithoutResourceSupport verifies (#5969)
+// resyncSessionResources fails loudly (rather than silently no-opping) when
+// the session does not implement server.SessionWithResources.
+func TestResyncSessionResources_SessionWithoutResourceSupport(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{resources: []vmcp.Resource{{Name: "r", URI: "r"}}}
+	srv := &Server{core: fc}
+
+	// plainSession implements only server.ClientSession, not SessionWithResources.
+	type plainSession struct{ server.ClientSession }
+	sess := plainSession{&fakeCapsSession{id: "sess-1"}}
+
+	err := srv.resyncSessionResources(context.Background(), sess, "sess-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support per-session resources")
+}
+
+// TestResyncSessionResources_SessionWithoutTemplateSupport verifies (#5969)
+// resyncSessionResources fails loudly when the session supports per-session
+// resources but not resource templates (SessionWithResourceTemplates). The
+// resource store is set before the template assertion fails, so this pins the
+// exact error surfaced for the templates half.
+func TestResyncSessionResources_SessionWithoutTemplateSupport(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{resources: []vmcp.Resource{{Name: "r", URI: "r"}}}
+	srv := &Server{core: fc}
+
+	// resourcesOnlySession implements SessionWithResources but NOT
+	// SessionWithResourceTemplates.
+	sess := &resourcesOnlySession{fake: fakeCapsSession{id: "sess-1"}}
+
+	err := srv.resyncSessionResources(context.Background(), sess, "sess-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support per-session resource templates")
+}
+
+// TestResyncSessionPrompts_SessionWithoutPromptSupport verifies (#5969)
+// resyncSessionPrompts fails loudly (rather than silently no-opping) when the
+// session does not implement server.SessionWithPrompts.
+func TestResyncSessionPrompts_SessionWithoutPromptSupport(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{prompts: []vmcp.Prompt{{Name: "p"}}}
+	srv := &Server{core: fc}
+
+	// plainSession implements only server.ClientSession, not SessionWithPrompts.
+	type plainSession struct{ server.ClientSession }
+	sess := plainSession{&fakeCapsSession{id: "sess-1"}}
+
+	err := srv.resyncSessionPrompts(context.Background(), sess, "sess-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support per-session prompts")
+}
+
+// TestResyncSessionResources_ReplacesRatherThanMerges verifies (#5969) that
+// resyncSessionResources REPLACES both the session's resource store AND its
+// resource-template store with the freshly core-derived sets — unlike
+// setSessionResourcesDirect/setSessionResourceTemplatesDirect's
+// registration-time MERGE — so a resource/template the backend removed (and
+// the core therefore no longer advertises) disappears rather than lingering.
+func TestResyncSessionResources_ReplacesRatherThanMerges(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{
+		resources:         []vmcp.Resource{{Name: "kept", URI: "kept"}, {Name: "added", URI: "added"}},
+		resourceTemplates: []vmcp.ResourceTemplate{{Name: "kept-tmpl", URITemplate: "kept-tmpl"}},
+	}
+	srv := &Server{core: fc}
+
+	sess := &fakeCapsSession{
+		id: "sess-1",
+		resources: map[string]server.ServerResource{
+			"kept":    {Resource: mcp.Resource{Name: "kept", URI: "kept"}},
+			"removed": {Resource: mcp.Resource{Name: "removed", URI: "removed"}}, // must disappear
+		},
+		resourceTemplates: map[string]server.ServerResourceTemplate{
+			"kept-tmpl":    {Template: mcp.ResourceTemplate{Name: "kept-tmpl", URITemplate: "kept-tmpl"}},
+			"removed-tmpl": {Template: mcp.ResourceTemplate{Name: "removed-tmpl", URITemplate: "removed-tmpl"}}, // must disappear
+		},
+	}
+
+	err := srv.resyncSessionResources(context.Background(), sess, "sess-1", nil)
+	require.NoError(t, err)
+
+	gotResources := sess.GetSessionResources()
+	assert.Len(t, gotResources, 2)
+	assert.Contains(t, gotResources, "kept")
+	assert.Contains(t, gotResources, "added")
+	assert.NotContains(t, gotResources, "removed",
+		"resync must REPLACE the resource store, dropping a no-longer-advertised resource")
+	assert.Equal(t, 1, sess.setSessionResourcesCalls)
+
+	gotTemplates := sess.GetSessionResourceTemplates()
+	assert.Len(t, gotTemplates, 1)
+	assert.Contains(t, gotTemplates, "kept-tmpl")
+	assert.NotContains(t, gotTemplates, "removed-tmpl",
+		"resync must REPLACE the resource-template store, dropping a no-longer-advertised template")
+	assert.Equal(t, 1, sess.setSessionResourceTemplatesCalls)
+}
+
+// TestResyncSessionPrompts_ReplacesRatherThanMerges verifies (#5969) that
+// resyncSessionPrompts REPLACES the session's prompt store with the freshly
+// core-derived set — unlike setSessionPromptsDirect's registration-time
+// MERGE — so a prompt the backend removed (and the core therefore no longer
+// advertises) disappears rather than lingering.
+func TestResyncSessionPrompts_ReplacesRatherThanMerges(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{prompts: []vmcp.Prompt{{Name: "kept"}, {Name: "added"}}}
+	srv := &Server{core: fc}
+
+	sess := &fakeCapsSession{id: "sess-1", prompts: map[string]server.ServerPrompt{
+		"kept":    {Prompt: mcp.Prompt{Name: "kept"}},
+		"removed": {Prompt: mcp.Prompt{Name: "removed"}}, // must disappear after resync
+	}}
+
+	err := srv.resyncSessionPrompts(context.Background(), sess, "sess-1", nil)
+	require.NoError(t, err)
+
+	got := sess.GetSessionPrompts()
+	assert.Len(t, got, 2)
+	assert.Contains(t, got, "kept")
+	assert.Contains(t, got, "added")
+	assert.NotContains(t, got, "removed", "resync must REPLACE the prompt store, dropping a no-longer-advertised prompt")
+	assert.Equal(t, 1, sess.setSessionPromptsCalls)
+}
+
 // TestListChangedResyncWorker_CoalescesAndNonBlocking verifies the B-HIGH-2
 // hand-off: trigger() returns immediately, never spawns a goroutine per call,
 // runs at most one resync at a time, and coalesces concurrent triggers into a
@@ -191,11 +421,12 @@ func TestListChangedResyncWorker_CoalescesAndNonBlocking(t *testing.T) {
 		"50 triggers during one in-flight run must coalesce into exactly one follow-up run")
 }
 
-// TestRunListChangedResync verifies (#5748) the resync body run off the receive
-// loop: it skips terminated sessions (liveness guard), and for a live session
-// it invalidates the cache and reconstructs a context carrying the captured
-// identity + forwarded headers (B-HIGH-1) before re-deriving/replacing the
-// session's tools.
+// TestRunListChangedResync verifies (#5748, extended by #5969) the resync
+// body run off the receive loop, per capability kind: it skips terminated
+// sessions (liveness guard), and for a live session it invalidates the cache
+// and reconstructs a context carrying the captured identity + forwarded
+// headers (B-HIGH-1) before re-deriving/replacing ONLY the store belonging to
+// the notification's kind.
 func TestRunListChangedResync(t *testing.T) {
 	t.Parallel()
 
@@ -203,71 +434,208 @@ func TestRunListChangedResync(t *testing.T) {
 	identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: "alice"}}
 	fwd := map[string]string{fwdKey: "acme"}
 
-	t.Run("terminated session: skipped entirely", func(t *testing.T) {
-		t.Parallel()
-		fc := &fakeCore{tools: []vmcp.Tool{{Name: "fresh"}}}
-		srv := &Server{core: fc, vmcpSessionMgr: &stubSessionManager{alive: false}}
-		sess := &fakeToolsSession{id: "sess-1", tools: map[string]server.ServerTool{
-			"stale": {Tool: mcp.Tool{Name: "stale"}},
-		}}
+	tests := []struct {
+		name string
+		kind vmcpsession.ChangeKind
+	}{
+		{"KindTools", vmcpsession.KindTools},
+		{"KindResources", vmcpsession.KindResources},
+		{"KindPrompts", vmcpsession.KindPrompts},
+	}
 
-		srv.runListChangedResync(context.Background(), "sess-1", sess, identity, fwd)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		assert.Equal(t, int32(0), fc.invalidateCacheCalls.Load(), "terminated session must not invalidate the cache")
-		assert.Equal(t, int32(0), fc.listToolsCalls.Load(), "terminated session must not re-aggregate")
-		assert.Equal(t, 0, sess.setSessionToolsCalls)
-	})
+			t.Run("terminated session: skipped entirely", func(t *testing.T) {
+				t.Parallel()
+				fc := &fakeCore{
+					tools:             []vmcp.Tool{{Name: "fresh"}},
+					resources:         []vmcp.Resource{{Name: "fresh", URI: "fresh"}},
+					resourceTemplates: []vmcp.ResourceTemplate{{Name: "fresh", URITemplate: "fresh"}},
+					prompts:           []vmcp.Prompt{{Name: "fresh"}},
+				}
+				srv := &Server{core: fc, vmcpSessionMgr: &stubSessionManager{alive: false}}
+				toolsSess := &fakeToolsSession{id: "sess-1"}
+				capsSess := &fakeCapsSession{id: "sess-1"}
 
-	t.Run("live session: invalidates, reconstructs ctx, replaces tools", func(t *testing.T) {
-		t.Parallel()
-		fc := &fakeCore{tools: []vmcp.Tool{{Name: "fresh"}}}
-		srv := &Server{core: fc, vmcpSessionMgr: &stubSessionManager{alive: true}}
-		sess := &fakeToolsSession{id: "sess-1", tools: map[string]server.ServerTool{
-			"stale": {Tool: mcp.Tool{Name: "stale"}},
-		}}
+				var sess server.ClientSession = toolsSess
+				if tc.kind != vmcpsession.KindTools {
+					sess = capsSess
+				}
 
-		srv.runListChangedResync(context.Background(), "sess-1", sess, identity, fwd)
+				srv.runListChangedResync(context.Background(), "sess-1", sess, identity, fwd, tc.kind)
 
-		assert.Equal(t, int32(1), fc.invalidateCacheCalls.Load(), "live session must invalidate the cache once")
-		assert.Equal(t, 1, sess.setSessionToolsCalls)
-		got := sess.GetSessionTools()
-		require.Len(t, got, 1)
-		assert.Contains(t, got, "fresh")
-		assert.NotContains(t, got, "stale", "resync must replace the stale set")
+				assert.Equal(t, int32(0), fc.invalidateCacheCalls.Load(), "terminated session must not invalidate the cache")
+				assert.Equal(t, int32(0), fc.listToolsCalls.Load(), "terminated session must not re-aggregate")
+				assert.Equal(t, int32(0), fc.listResourcesCalls.Load(), "terminated session must not re-aggregate")
+				assert.Equal(t, int32(0), fc.listResourceTemplatesCalls.Load(), "terminated session must not re-aggregate")
+				assert.Equal(t, int32(0), fc.listPromptsCalls.Load(), "terminated session must not re-aggregate")
+			})
 
-		// B-HIGH-1: the resync must call the core with a context carrying the
-		// captured identity AND forwarded headers, so the cache key and outbound
-		// backend auth match a real request from this principal.
-		box := fc.lastListToolsCtx.Load()
-		require.NotNil(t, box, "ListTools must have been called")
-		resyncCtx := box.ctx
-		gotID, ok := auth.IdentityFromContext(resyncCtx)
-		require.True(t, ok, "resync context must carry the captured identity")
-		assert.Equal(t, "alice", gotID.Subject)
-		assert.Equal(t, "acme", headerforward.ForwardedHeadersFromContext(resyncCtx)[fwdKey],
-			"resync context must carry the captured forwarded headers")
-	})
+			t.Run("live session: invalidates, reconstructs ctx, replaces only this kind", func(t *testing.T) {
+				t.Parallel()
+				fc := &fakeCore{
+					tools:             []vmcp.Tool{{Name: "fresh"}},
+					resources:         []vmcp.Resource{{Name: "fresh", URI: "fresh"}},
+					resourceTemplates: []vmcp.ResourceTemplate{{Name: "fresh", URITemplate: "fresh"}},
+					prompts:           []vmcp.Prompt{{Name: "fresh"}},
+				}
+				srv := &Server{core: fc, vmcpSessionMgr: &stubSessionManager{alive: true}}
+				toolsSess := &fakeToolsSession{id: "sess-1", tools: map[string]server.ServerTool{
+					"stale": {Tool: mcp.Tool{Name: "stale"}},
+				}}
+				capsSess := &fakeCapsSession{
+					id: "sess-1",
+					resources: map[string]server.ServerResource{
+						"stale": {Resource: mcp.Resource{Name: "stale", URI: "stale"}},
+					},
+					resourceTemplates: map[string]server.ServerResourceTemplate{
+						"stale": {Template: mcp.ResourceTemplate{Name: "stale", URITemplate: "stale"}},
+					},
+					prompts: map[string]server.ServerPrompt{
+						"stale": {Prompt: mcp.Prompt{Name: "stale"}},
+					},
+				}
+
+				var sess server.ClientSession = toolsSess
+				if tc.kind != vmcpsession.KindTools {
+					sess = capsSess
+				}
+
+				srv.runListChangedResync(context.Background(), "sess-1", sess, identity, fwd, tc.kind)
+
+				assert.Equal(t, int32(1), fc.invalidateCacheCalls.Load(), "live session must invalidate the cache once")
+
+				var resyncCtx context.Context
+				switch tc.kind {
+				case vmcpsession.KindTools:
+					assert.Equal(t, int32(1), fc.listToolsCalls.Load())
+					assert.Equal(t, int32(0), fc.listResourcesCalls.Load())
+					assert.Equal(t, int32(0), fc.listResourceTemplatesCalls.Load())
+					assert.Equal(t, int32(0), fc.listPromptsCalls.Load())
+					assert.Equal(t, 1, toolsSess.setSessionToolsCalls)
+					got := toolsSess.GetSessionTools()
+					require.Len(t, got, 1)
+					assert.Contains(t, got, "fresh")
+					assert.NotContains(t, got, "stale", "resync must replace the stale set")
+					box := fc.lastListToolsCtx.Load()
+					require.NotNil(t, box, "ListTools must have been called")
+					resyncCtx = box.ctx
+				case vmcpsession.KindResources:
+					assert.Equal(t, int32(0), fc.listToolsCalls.Load())
+					assert.Equal(t, int32(1), fc.listResourcesCalls.Load())
+					assert.Equal(t, int32(1), fc.listResourceTemplatesCalls.Load())
+					assert.Equal(t, int32(0), fc.listPromptsCalls.Load())
+					assert.Equal(t, 1, capsSess.setSessionResourcesCalls)
+					assert.Equal(t, 1, capsSess.setSessionResourceTemplatesCalls)
+					gotResources := capsSess.GetSessionResources()
+					require.Len(t, gotResources, 1)
+					assert.Contains(t, gotResources, "fresh")
+					assert.NotContains(t, gotResources, "stale", "resync must replace the stale set")
+					gotTemplates := capsSess.GetSessionResourceTemplates()
+					require.Len(t, gotTemplates, 1)
+					assert.Contains(t, gotTemplates, "fresh")
+					assert.NotContains(t, gotTemplates, "stale", "resync must replace the stale set")
+					box := fc.lastListResourcesCtx.Load()
+					require.NotNil(t, box, "ListResources must have been called")
+					resyncCtx = box.ctx
+				case vmcpsession.KindPrompts:
+					assert.Equal(t, int32(0), fc.listToolsCalls.Load())
+					assert.Equal(t, int32(0), fc.listResourcesCalls.Load())
+					assert.Equal(t, int32(0), fc.listResourceTemplatesCalls.Load())
+					assert.Equal(t, int32(1), fc.listPromptsCalls.Load())
+					assert.Equal(t, 1, capsSess.setSessionPromptsCalls)
+					got := capsSess.GetSessionPrompts()
+					require.Len(t, got, 1)
+					assert.Contains(t, got, "fresh")
+					assert.NotContains(t, got, "stale", "resync must replace the stale set")
+					box := fc.lastListPromptsCtx.Load()
+					require.NotNil(t, box, "ListPrompts must have been called")
+					resyncCtx = box.ctx
+				}
+
+				// B-HIGH-1 (all kinds): the resync must call the core with a context
+				// carrying the captured identity AND forwarded headers, so the cache
+				// key and outbound backend auth match a real request from this
+				// principal. Asserting this for every kind guards a future refactor
+				// from silently dropping identity/header scoping on the
+				// resources/prompts paths.
+				require.NotNil(t, resyncCtx)
+				gotID, ok := auth.IdentityFromContext(resyncCtx)
+				require.True(t, ok, "resync context must carry the captured identity")
+				assert.Equal(t, "alice", gotID.Subject)
+				assert.Equal(t, "acme", headerforward.ForwardedHeadersFromContext(resyncCtx)[fwdKey],
+					"resync context must carry the captured forwarded headers")
+			})
+		})
+	}
 }
 
-// TestBuildListChangedSink_IgnoresNonToolsKind verifies the sink's kind gate:
-// a non-tools ChangeKind is dropped synchronously on the receive loop (no
-// worker goroutine, no cache invalidation, no resync). The gate returns before
-// worker.trigger, so the assertion is deterministic without waiting.
-func TestBuildListChangedSink_IgnoresNonToolsKind(t *testing.T) {
+// TestBuildListChangedSink_DispatchesByKind verifies (#5969) the sink's
+// per-kind worker dispatch: a KindResources or KindPrompts notification
+// triggers its own worker (invalidating the cache and resyncing only that
+// kind's store), and an unknown ChangeKind is dropped synchronously (no
+// worker goroutine, no cache invalidation, no resync).
+func TestBuildListChangedSink_DispatchesByKind(t *testing.T) {
 	t.Parallel()
 
-	fc := &fakeCore{tools: []vmcp.Tool{{Name: "fresh"}}}
-	srv := &Server{
-		core:           fc,
-		vmcpSessionMgr: &stubSessionManager{alive: true},
-		resyncBaseCtx:  context.Background(),
-	}
-	sess := &fakeToolsSession{id: "sess-1"}
+	t.Run("KindResources triggers a resources-only resync", func(t *testing.T) {
+		t.Parallel()
+		fc := &fakeCore{resources: []vmcp.Resource{{Name: "fresh", URI: "fresh"}}}
+		srv := &Server{
+			core:           fc,
+			vmcpSessionMgr: &stubSessionManager{alive: true},
+			resyncBaseCtx:  context.Background(),
+		}
+		sess := &fakeCapsSession{id: "sess-1"}
 
-	sink := srv.buildListChangedSink("sess-1", sess, nil, nil)
-	// A resources list_changed (out of scope) must be ignored synchronously.
-	sink(context.Background(), "backend-1", vmcpsession.ChangeKind("resources"))
+		sink := srv.buildListChangedSink("sess-1", sess, nil, nil)
+		sink(context.Background(), "backend-1", vmcpsession.KindResources)
 
-	assert.Equal(t, int32(0), fc.invalidateCacheCalls.Load(), "non-tools kind must not invalidate the cache")
-	assert.Equal(t, 0, sess.setSessionToolsCalls, "non-tools kind must not resync tools")
+		require.Eventually(t, func() bool { return fc.invalidateCacheCalls.Load() >= 1 },
+			2*time.Second, 10*time.Millisecond, "KindResources must invalidate the cache")
+		require.Eventually(t, func() bool { return len(sess.GetSessionResources()) == 1 },
+			2*time.Second, 10*time.Millisecond, "KindResources must resync the session's resources")
+		assert.Equal(t, int32(0), fc.listToolsCalls.Load(), "a resources notification must not resync tools")
+		assert.Equal(t, int32(0), fc.listPromptsCalls.Load(), "a resources notification must not resync prompts")
+	})
+
+	t.Run("KindPrompts triggers a prompts-only resync", func(t *testing.T) {
+		t.Parallel()
+		fc := &fakeCore{prompts: []vmcp.Prompt{{Name: "fresh"}}}
+		srv := &Server{
+			core:           fc,
+			vmcpSessionMgr: &stubSessionManager{alive: true},
+			resyncBaseCtx:  context.Background(),
+		}
+		sess := &fakeCapsSession{id: "sess-1"}
+
+		sink := srv.buildListChangedSink("sess-1", sess, nil, nil)
+		sink(context.Background(), "backend-1", vmcpsession.KindPrompts)
+
+		require.Eventually(t, func() bool { return fc.invalidateCacheCalls.Load() >= 1 },
+			2*time.Second, 10*time.Millisecond, "KindPrompts must invalidate the cache")
+		require.Eventually(t, func() bool { return len(sess.GetSessionPrompts()) == 1 },
+			2*time.Second, 10*time.Millisecond, "KindPrompts must resync the session's prompts")
+		assert.Equal(t, int32(0), fc.listToolsCalls.Load(), "a prompts notification must not resync tools")
+		assert.Equal(t, int32(0), fc.listResourcesCalls.Load(), "a prompts notification must not resync resources")
+	})
+
+	t.Run("unknown kind is dropped synchronously", func(t *testing.T) {
+		t.Parallel()
+		fc := &fakeCore{tools: []vmcp.Tool{{Name: "fresh"}}}
+		srv := &Server{
+			core:           fc,
+			vmcpSessionMgr: &stubSessionManager{alive: true},
+			resyncBaseCtx:  context.Background(),
+		}
+		sess := &fakeToolsSession{id: "sess-1"}
+
+		sink := srv.buildListChangedSink("sess-1", sess, nil, nil)
+		sink(context.Background(), "backend-1", vmcpsession.ChangeKind("unknown"))
+
+		assert.Equal(t, int32(0), fc.invalidateCacheCalls.Load(), "unknown kind must not invalidate the cache")
+		assert.Equal(t, 0, sess.setSessionToolsCalls, "unknown kind must not resync anything")
+	})
 }

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -168,6 +169,11 @@ type fakeCore struct {
 	// fixed struct type because atomic.Value panics when Store sees differing
 	// concrete context types across calls (HTTP request ctx vs Background).
 	lastListToolsCtx atomic.Pointer[ctxBox]
+	// lastListResourcesCtx and lastListPromptsCtx are the #5969 analogues, so
+	// the resources/prompts resyncs are guarded against silently dropping
+	// identity/header scoping too (auth-scoping regression guard).
+	lastListResourcesCtx atomic.Pointer[ctxBox]
+	lastListPromptsCtx   atomic.Pointer[ctxBox]
 }
 
 // ctxBox wraps a context.Context for atomic.Pointer storage on fakeCore.
@@ -195,8 +201,9 @@ func (f *fakeCore) CallTool(
 	return &vmcp.ToolCallResult{Content: []vmcp.Content{{Type: vmcp.ContentTypeText, Text: "ok"}}}, nil
 }
 
-func (f *fakeCore) ListResources(context.Context, *auth.Identity) ([]vmcp.Resource, error) {
+func (f *fakeCore) ListResources(ctx context.Context, _ *auth.Identity) ([]vmcp.Resource, error) {
 	f.listResourcesCalls.Add(1)
+	f.lastListResourcesCtx.Store(&ctxBox{ctx: ctx})
 	return f.resources, nil
 }
 
@@ -214,8 +221,9 @@ func (f *fakeCore) ReadResource(_ context.Context, _ *auth.Identity, uri string)
 	return &vmcp.ResourceReadResult{Contents: []vmcp.ResourceContent{{URI: uri, Text: "resource-body"}}}, nil
 }
 
-func (f *fakeCore) ListPrompts(context.Context, *auth.Identity) ([]vmcp.Prompt, error) {
+func (f *fakeCore) ListPrompts(ctx context.Context, _ *auth.Identity) ([]vmcp.Prompt, error) {
 	f.listPromptsCalls.Add(1)
+	f.lastListPromptsCtx.Store(&ctxBox{ctx: ctx})
 	return f.prompts, nil
 }
 
@@ -748,7 +756,9 @@ func registerServeSessionWithRegistry(
 // MakeSessionWithID received for the registered session and invoke it
 // directly, simulating an asynchronous backend notification firing after
 // registration completes.
-func registerServeSessionCapturingSink(t *testing.T, fc *fakeCore) (srv *Server, sessionID, baseURL string, state *toolSessionState) {
+func registerServeSessionCapturingSink(
+	t *testing.T, fc *fakeCore,
+) (sessionID, baseURL string, state *toolSessionState) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	factory, state := newToolSessionFactory(t, ctrl, fc.tools)
@@ -787,7 +797,7 @@ func registerServeSessionCapturingSink(t *testing.T, fc *fakeCore) (srv *Server,
 		2*time.Second, 10*time.Millisecond, "session should be registered")
 	require.Eventually(t, func() bool { return state.sink() != nil },
 		2*time.Second, 10*time.Millisecond, "MakeSessionWithID should have received a non-nil sink")
-	return srv, sessionID, ts.URL, state
+	return sessionID, ts.URL, state
 }
 
 // TestListChangedSink_EndToEnd_ResyncsRegisteredSession drives a real session
@@ -800,7 +810,7 @@ func TestListChangedSink_EndToEnd_ResyncsRegisteredSession(t *testing.T) {
 	t.Parallel()
 
 	fc := &fakeCore{tools: []vmcp.Tool{{Name: "kept"}, {Name: "removed"}}}
-	_, sessionID, baseURL, state := registerServeSessionCapturingSink(t, fc)
+	sessionID, baseURL, state := registerServeSessionCapturingSink(t, fc)
 
 	listResp := postServeMCP(t, baseURL, map[string]any{
 		"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{},
@@ -831,6 +841,133 @@ func TestListChangedSink_EndToEnd_ResyncsRegisteredSession(t *testing.T) {
 		got := toolNamesFromListResult(t, env)
 		return assert.ObjectsAreEqualValues([]string{"added", "kept"}, sortedCopy(got))
 	}, 2*time.Second, 10*time.Millisecond, "tools/list must reflect the resynced (replaced) tool set")
+}
+
+// TestListChangedSink_EndToEnd_ResyncsRegisteredSession_Resources mirrors
+// TestListChangedSink_EndToEnd_ResyncsRegisteredSession for resources (#5969):
+// a resources/list_changed sink invocation invalidates the cache and resyncs
+// the session's resource AND resource-template stores. Unlike tools, this
+// pins the documented ADD-ONLY limitation (resyncSessionResources doc
+// comment; toolhive-core mcpcompat per-session resource/template sync has no
+// removal reconciliation): an addition ("added"/"added-tmpl") becomes visible,
+// but a removed entry ("res-removed"/"tmpl-removed") STILL appears — it is
+// not expected to disappear here, unlike the tools contrast test above.
+func TestListChangedSink_EndToEnd_ResyncsRegisteredSession_Resources(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{
+		resources: []vmcp.Resource{
+			{Name: "res-kept", URI: "res-kept"},
+			{Name: "res-removed", URI: "res-removed"},
+		},
+		resourceTemplates: []vmcp.ResourceTemplate{
+			{Name: "tmpl-kept", URITemplate: "tmpl-kept"},
+			{Name: "tmpl-removed", URITemplate: "tmpl-removed"},
+		},
+	}
+	sessionID, baseURL, state := registerServeSessionCapturingSink(t, fc)
+
+	// Before snapshot: the added entries must be absent and the to-be-removed
+	// entries present, so the post-resync assertions cannot pass vacuously.
+	beforeResources := postServeMCPAndReadBody(t, baseURL, "resources/list", sessionID)
+	beforeTemplates := postServeMCPAndReadBody(t, baseURL, "resources/templates/list", sessionID)
+	assert.NotContains(t, beforeResources, "res-added")
+	assert.Contains(t, beforeResources, "res-removed")
+	assert.NotContains(t, beforeTemplates, "tmpl-added")
+	assert.Contains(t, beforeTemplates, "tmpl-removed")
+
+	// The core's advertised set changes: "res-removed"/"tmpl-removed" are gone
+	// (as if the backend removed them), "res-added"/"tmpl-added" are new.
+	fc.resources = []vmcp.Resource{
+		{Name: "res-kept", URI: "res-kept"},
+		{Name: "res-added", URI: "res-added"},
+	}
+	fc.resourceTemplates = []vmcp.ResourceTemplate{
+		{Name: "tmpl-kept", URITemplate: "tmpl-kept"},
+		{Name: "tmpl-added", URITemplate: "tmpl-added"},
+	}
+
+	sink := state.sink()
+	require.NotNil(t, sink)
+	sink(context.Background(), "some-backend", "resources")
+
+	require.Eventually(t, func() bool {
+		return fc.invalidateCacheCalls.Load() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "sink must invalidate the capability cache")
+
+	require.Eventually(t, func() bool {
+		resourcesBody := postServeMCPAndReadBody(t, baseURL, "resources/list", sessionID)
+		templatesBody := postServeMCPAndReadBody(t, baseURL, "resources/templates/list", sessionID)
+		return strings.Contains(resourcesBody, "res-kept") &&
+			strings.Contains(resourcesBody, "res-added") &&
+			strings.Contains(templatesBody, "tmpl-kept") &&
+			strings.Contains(templatesBody, "tmpl-added")
+	}, 2*time.Second, 10*time.Millisecond, "resources/list and resources/templates/list must reflect the resynced additions")
+
+	// ADD-ONLY GUARD (tracked toolhive-core follow-up, see resyncSessionResources
+	// doc comment): a removed resource/template is NOT expected to disappear —
+	// toolhive-core's mcpcompat per-session sync only adds, never removes, so
+	// the overlay being replaced here does not (yet) reach the live SDK server's
+	// removal path the way tools does.
+	resourcesBody := postServeMCPAndReadBody(t, baseURL, "resources/list", sessionID)
+	templatesBody := postServeMCPAndReadBody(t, baseURL, "resources/templates/list", sessionID)
+	assert.Contains(t, resourcesBody, "res-removed",
+		"add-only limitation: a removed resource still lingers until the toolhive-core follow-up lands")
+	assert.Contains(t, templatesBody, "tmpl-removed",
+		"add-only limitation: a removed resource template still lingers until the toolhive-core follow-up lands")
+}
+
+// TestListChangedSink_EndToEnd_ResyncsRegisteredSession_Prompts mirrors
+// TestListChangedSink_EndToEnd_ResyncsRegisteredSession for prompts (#5969),
+// including the same ADD-ONLY guard as the resources test above.
+func TestListChangedSink_EndToEnd_ResyncsRegisteredSession_Prompts(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeCore{prompts: []vmcp.Prompt{{Name: "prompt-kept"}, {Name: "prompt-removed"}}}
+	sessionID, baseURL, state := registerServeSessionCapturingSink(t, fc)
+
+	// Before snapshot: the added prompt must be absent and the to-be-removed
+	// prompt present, so the post-resync assertions cannot pass vacuously.
+	beforePrompts := postServeMCPAndReadBody(t, baseURL, "prompts/list", sessionID)
+	assert.NotContains(t, beforePrompts, "prompt-added")
+	assert.Contains(t, beforePrompts, "prompt-removed")
+
+	fc.prompts = []vmcp.Prompt{{Name: "prompt-kept"}, {Name: "prompt-added"}}
+
+	sink := state.sink()
+	require.NotNil(t, sink)
+	sink(context.Background(), "some-backend", "prompts")
+
+	require.Eventually(t, func() bool {
+		return fc.invalidateCacheCalls.Load() >= 1
+	}, 2*time.Second, 10*time.Millisecond, "sink must invalidate the capability cache")
+
+	require.Eventually(t, func() bool {
+		body := postServeMCPAndReadBody(t, baseURL, "prompts/list", sessionID)
+		return strings.Contains(body, "prompt-kept") && strings.Contains(body, "prompt-added")
+	}, 2*time.Second, 10*time.Millisecond, "prompts/list must reflect the resynced (added) prompt")
+
+	// ADD-ONLY GUARD (tracked toolhive-core follow-up, see resyncSessionPrompts
+	// doc comment): a removed prompt is NOT expected to disappear —
+	// toolhive-core's mcpcompat per-session prompt sync only adds, never
+	// removes.
+	body := postServeMCPAndReadBody(t, baseURL, "prompts/list", sessionID)
+	assert.Contains(t, body, "prompt-removed",
+		"add-only limitation: a removed prompt still lingers until the toolhive-core follow-up lands")
+}
+
+// postServeMCPAndReadBody sends a JSON-RPC list request over the Streamable
+// HTTP protocol and returns the raw response body as a string, for substring
+// assertions against the (un-parsed) list result.
+func postServeMCPAndReadBody(t *testing.T, baseURL, method, sessionID string) string {
+	t.Helper()
+	resp := postServeMCP(t, baseURL, map[string]any{
+		"jsonrpc": "2.0", "id": 99, "method": method, "params": map[string]any{},
+	}, sessionID)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(body)
 }
 
 // toolNamesFromListResult extracts the tool names from a tools/list JSON-RPC

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -338,10 +338,11 @@ type Server struct {
 	shutdownFuncs []func(context.Context) error
 
 	// resyncBaseCtx is the server-lifetime parent context for asynchronous
-	// tools/list_changed resync work (#5748). It is cancelled by a shutdownFunc
-	// on Stop, so an in-flight backend re-aggregation triggered by a late
-	// notification cannot outlive the server. Set by Serve; nil for direct-Serve
-	// callers that never register a list_changed sink.
+	// tools/resources/prompts list_changed resync work (#5748, #5969). It is
+	// cancelled by a shutdownFunc on Stop, so an in-flight backend
+	// re-aggregation triggered by a late notification cannot outlive the
+	// server. Set by Serve; nil for direct-Serve callers that never register a
+	// list_changed sink.
 	resyncBaseCtx context.Context
 }
 

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -42,18 +42,31 @@ const (
 // ChangeKind identifies which capability class a backend reported changed via
 // ListChangedSink. Using a typed constant (rather than a bare string) means a
 // typo is a compile error at the producer and consumer instead of a silent
-// no-op, and gives the resources/prompts follow-up (#5748) an obvious extension
-// point (KindResources/KindPrompts).
+// no-op.
 type ChangeKind string
 
-// KindTools is reported when a backend emits notifications/tools/list_changed.
-const KindTools ChangeKind = "tools"
+const (
+	// KindTools is reported when a backend emits notifications/tools/list_changed.
+	KindTools ChangeKind = "tools"
+
+	// KindResources is reported when a backend emits
+	// notifications/resources/list_changed. Per MCP 2025-11-25 there is no
+	// separate wire method for resource TEMPLATE changes, so this kind also
+	// covers a resync of the backend's resource templates (see
+	// resyncSessionResources in pkg/vmcp/server).
+	KindResources ChangeKind = "resources"
+
+	// KindPrompts is reported when a backend emits
+	// notifications/prompts/list_changed.
+	KindPrompts ChangeKind = "prompts"
+)
 
 // ListChangedSink is invoked when a persistent backend connection observes a
 // notification this package consumes asynchronously (outside any in-flight
-// call) — currently only notifications/tools/list_changed, reported with
-// kind=KindTools. Resources/prompts list_changed are out of scope for #5748 (a
-// tracked follow-up); this package does not dispatch them to sink.
+// call): notifications/tools/list_changed (kind=KindTools),
+// notifications/resources/list_changed (kind=KindResources, which also covers
+// resource templates — MCP 2025-11-25 has no separate wire method for those),
+// and notifications/prompts/list_changed (kind=KindPrompts).
 //
 // The sink is invoked on the mcpcompat client's receive-loop goroutine (see
 // Client.dispatch in toolhive-core), so implementations MUST be non-blocking:
@@ -67,24 +80,30 @@ type ListChangedSink func(ctx context.Context, backendWorkloadID string, kind Ch
 
 // newListChangedNotificationHandler builds the OnNotification handler
 // registered by createMCPClient when sink is non-nil. It dispatches
-// notifications/tools/list_changed to sink (kind=KindTools) and log-only handles
-// notifications/message; every other notification method is ignored — this
-// handler is not the mid-call server->client relay (that is
-// pkg/vmcp/client's per-call notification forwarder), it only feeds the
-// session-registration resync path.
+// notifications/tools/list_changed (kind=KindTools),
+// notifications/resources/list_changed (kind=KindResources, also covering
+// resource templates), and notifications/prompts/list_changed
+// (kind=KindPrompts) to sink, and log-only handles notifications/message;
+// every other notification method is ignored — this handler is not the
+// mid-call server->client relay (that is pkg/vmcp/client's per-call
+// notification forwarder), it only feeds the session-registration resync path.
 func newListChangedNotificationHandler(workloadID string, sink ListChangedSink) func(mcp.JSONRPCNotification) {
 	return func(n mcp.JSONRPCNotification) {
 		switch n.Method {
 		case vmcp.MethodToolsListChangedNotification:
 			sink(context.Background(), workloadID, KindTools)
+		case vmcp.MethodResourcesListChangedNotification:
+			sink(context.Background(), workloadID, KindResources)
+		case vmcp.MethodPromptsListChangedNotification:
+			sink(context.Background(), workloadID, KindPrompts)
 		case vmcp.MethodLogNotification:
 			// Out-of-call backend log messages are not relayed to the downstream
 			// client on this path; log so the signal is visible rather than
 			// silently dropped.
 			slog.Debug("backend log notification received outside call", "backendID", workloadID)
 		default:
-			// Other notification types (resources/prompts list_changed, resource
-			// subscription updates, ...) are out of scope here (#5748 follow-up).
+			// Other notification types (resource subscription updates, ...) are
+			// out of scope here.
 		}
 	}
 }
@@ -347,12 +366,13 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry) func(
 // registered, and the streamable-HTTP branch does not enable continuous
 // listening). When non-nil, an OnNotification handler is registered (before
 // c.Start, per the mcpcompat client's registration contract) that invokes sink
-// on notifications/tools/list_changed and log-only handles notifications/message.
-// For the streamable-HTTP transport, a non-nil sink also enables
-// mcptransport.WithContinuousListening() — required for the backend's
-// asynchronous (outside any in-flight call) notifications to reach this client
-// at all — since some backends hang when a standalone GET stream is opened
-// against them, this must stay opt-in (#5748 R3).
+// on notifications/tools/list_changed, notifications/resources/list_changed
+// (which also covers resource templates), and notifications/prompts/list_changed,
+// and log-only handles notifications/message. For the streamable-HTTP transport,
+// a non-nil sink also enables mcptransport.WithContinuousListening() — required
+// for the backend's asynchronous (outside any in-flight call) notifications to
+// reach this client at all — since some backends hang when a standalone GET
+// stream is opened against them, this must stay opt-in (#5748 R3).
 func createMCPClient(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
@@ -484,9 +504,11 @@ func createMCPClient(
 	// Register the notification handler before Start (mirrors the per-call
 	// client in pkg/vmcp/client, and matches the mcpcompat client's own
 	// registration contract): the handler dispatches
-	// notifications/tools/list_changed to sink and logs notifications/message.
-	// Strictly gated on sink != nil so a nil-sink caller registers no handler at
-	// all — this function's behavior for that caller is unchanged.
+	// notifications/tools/list_changed, notifications/resources/list_changed,
+	// and notifications/prompts/list_changed to sink and logs
+	// notifications/message. Strictly gated on sink != nil so a nil-sink caller
+	// registers no handler at all — this function's behavior for that caller is
+	// unchanged.
 	if sink != nil {
 		c.OnNotification(newListChangedNotificationHandler(target.WorkloadID, sink))
 	}

--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -38,6 +38,65 @@ func newTestRegistry(t *testing.T) vmcpauth.OutgoingAuthRegistry {
 // headerforward.MergeForwardedHeaders; full coverage lives in
 // pkg/vmcp/headerforward/transport_test.go (TestMergeForwardedHeaders).
 
+// TestNewListChangedNotificationHandler_DispatchesByMethod verifies (#5748,
+// #5969) newListChangedNotificationHandler's wire-method dispatch: each of
+// the three list_changed methods fires sink with the matching ChangeKind, and
+// neither notifications/message nor an unknown method fires sink at all.
+func TestNewListChangedNotificationHandler_DispatchesByMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		method    string
+		wantFired bool
+		wantKind  ChangeKind
+	}{
+		{"tools/list_changed dispatches KindTools", vmcp.MethodToolsListChangedNotification, true, KindTools},
+		{"resources/list_changed dispatches KindResources", vmcp.MethodResourcesListChangedNotification, true, KindResources},
+		{"prompts/list_changed dispatches KindPrompts", vmcp.MethodPromptsListChangedNotification, true, KindPrompts},
+		{"notifications/message does not dispatch", vmcp.MethodLogNotification, false, ""},
+		{"unknown method does not dispatch", "notifications/resources/updated", false, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			type firedCall struct {
+				workloadID string
+				kind       ChangeKind
+			}
+			fired := make(chan firedCall, 1)
+			sink := func(_ context.Context, workloadID string, kind ChangeKind) {
+				fired <- firedCall{workloadID: workloadID, kind: kind}
+			}
+
+			handler := newListChangedNotificationHandler("backend-1", sink)
+			handler(mcpmcp.JSONRPCNotification{
+				JSONRPC:      "2.0",
+				Notification: mcpmcp.Notification{Method: tc.method},
+			})
+
+			if !tc.wantFired {
+				select {
+				case got := <-fired:
+					t.Fatalf("sink must not fire for method %q, but fired with kind %q", tc.method, got.kind)
+				case <-time.After(50 * time.Millisecond):
+				}
+				return
+			}
+
+			select {
+			case got := <-fired:
+				assert.Equal(t, "backend-1", got.workloadID)
+				assert.Equal(t, tc.wantKind, got.kind)
+			case <-time.After(5 * time.Second):
+				t.Fatalf("sink never fired for method %q", tc.method)
+			}
+		})
+	}
+}
+
 func TestCreateMCPClient_UnsupportedTransport(t *testing.T) {
 	t.Parallel()
 
@@ -62,25 +121,31 @@ func TestCreateMCPClient_UnsupportedTransport(t *testing.T) {
 }
 
 // listChangedTestBackend is a real mcpcompat MCP server (streamable-HTTP) with
-// WithToolCapabilities(true). It captures its one connected session (via
-// OnRegisterSession) and exposes addTool, which appends a per-session tool via
-// SessionWithTools.SetSessionTools — the same mechanism ToolHive's own vMCP
-// Server uses (setSessionToolsDirect/resyncSessionTools) — which is what
-// actually drives the underlying go-sdk server's real
-// notifications/tools/list_changed broadcast. (The mcpcompat-wrapper-level
-// MCPServer.AddTool called AFTER the server starts serving does NOT do this:
-// it only mutates the wrapper's pre-serve tool set, registered once at
-// buildServer time, so it has no effect on an already-connected session.)
+// WithToolCapabilities(true), WithResourceCapabilities(true, true), and
+// WithPromptCapabilities(true). It captures its one connected session (via
+// OnRegisterSession) and exposes addTool/addResource/addPrompt, which append a
+// per-session tool/resource/prompt via SessionWithTools.SetSessionTools /
+// SessionWithResources.SetSessionResources / SessionWithPrompts.SetSessionPrompts
+// — the same mechanism ToolHive's own vMCP Server uses
+// (setSessionToolsDirect/resyncSessionTools and their resource/prompt
+// counterparts) — which is what actually drives the underlying go-sdk
+// server's real notifications/{tools,resources,prompts}/list_changed
+// broadcast. (The mcpcompat-wrapper-level MCPServer.AddTool/AddResource/
+// AddPrompt called AFTER the server starts serving does NOT do this: it only
+// mutates the wrapper's pre-serve set, registered once at buildServer time, so
+// it has no effect on an already-connected session.)
 type listChangedTestBackend struct {
 	url string
 
 	// ready closes once OnRegisterSession has captured session, decoupling
-	// addTool from the client-side race noted below.
+	// addTool/addResource/addPrompt from the client-side race noted below.
 	ready chan struct{}
 
-	mu      sync.Mutex
-	session mcpserver.ClientSession
-	tools   map[string]mcpserver.ServerTool
+	mu        sync.Mutex
+	session   mcpserver.ClientSession
+	tools     map[string]mcpserver.ServerTool
+	resources map[string]mcpserver.ServerResource
+	prompts   map[string]mcpserver.ServerPrompt
 }
 
 func newListChangedTool(name string) mcpserver.ServerTool {
@@ -88,6 +153,26 @@ func newListChangedTool(name string) mcpserver.ServerTool {
 		Tool: mcpmcp.NewTool(name, mcpmcp.WithDescription("a list_changed test tool")),
 		Handler: func(_ context.Context, _ mcpmcp.CallToolRequest) (*mcpmcp.CallToolResult, error) {
 			return mcpmcp.NewToolResultText("ok"), nil
+		},
+	}
+}
+
+func newListChangedResource(uri string) mcpserver.ServerResource {
+	return mcpserver.ServerResource{
+		Resource: mcpmcp.Resource{URI: uri, Name: uri},
+		Handler: func(context.Context, mcpmcp.ReadResourceRequest) ([]mcpmcp.ResourceContents, error) {
+			return []mcpmcp.ResourceContents{mcpmcp.TextResourceContents{URI: uri, Text: "ok"}}, nil
+		},
+	}
+}
+
+func newListChangedPrompt(name string) mcpserver.ServerPrompt {
+	return mcpserver.ServerPrompt{
+		Prompt: mcpmcp.NewPrompt(name),
+		Handler: func(context.Context, mcpmcp.GetPromptRequest) (*mcpmcp.GetPromptResult, error) {
+			return &mcpmcp.GetPromptResult{Messages: []mcpmcp.PromptMessage{
+				mcpmcp.NewPromptMessage(mcpmcp.RoleUser, mcpmcp.NewTextContent("ok")),
+			}}, nil
 		},
 	}
 }
@@ -101,6 +186,12 @@ func newListChangedTestBackend(t *testing.T) *listChangedTestBackend {
 		tools: map[string]mcpserver.ServerTool{
 			"initial_tool": newListChangedTool("initial_tool"),
 		},
+		resources: map[string]mcpserver.ServerResource{
+			"initial_resource": newListChangedResource("initial_resource"),
+		},
+		prompts: map[string]mcpserver.ServerPrompt{
+			"initial_prompt": newListChangedPrompt("initial_prompt"),
+		},
 	}
 
 	hooks := &mcpserver.Hooks{}
@@ -111,18 +202,44 @@ func newListChangedTestBackend(t *testing.T) *listChangedTestBackend {
 		for k, v := range b.tools {
 			tools[k] = v
 		}
+		resources := make(map[string]mcpserver.ServerResource, len(b.resources))
+		for k, v := range b.resources {
+			resources[k] = v
+		}
+		prompts := make(map[string]mcpserver.ServerPrompt, len(b.prompts))
+		for k, v := range b.prompts {
+			prompts[k] = v
+		}
 		b.mu.Unlock()
+
 		sessionWithTools, ok := session.(mcpserver.SessionWithTools)
 		if !ok {
 			t.Errorf("listChangedTestBackend: session does not support per-session tools")
 			return
 		}
 		sessionWithTools.SetSessionTools(tools)
+
+		sessionWithResources, ok := session.(mcpserver.SessionWithResources)
+		if !ok {
+			t.Errorf("listChangedTestBackend: session does not support per-session resources")
+			return
+		}
+		sessionWithResources.SetSessionResources(resources)
+
+		sessionWithPrompts, ok := session.(mcpserver.SessionWithPrompts)
+		if !ok {
+			t.Errorf("listChangedTestBackend: session does not support per-session prompts")
+			return
+		}
+		sessionWithPrompts.SetSessionPrompts(prompts)
+
 		close(b.ready)
 	})
 
 	srv := mcpserver.NewMCPServer("list-changed-backend", "1.0.0",
 		mcpserver.WithToolCapabilities(true),
+		mcpserver.WithResourceCapabilities(true, true),
+		mcpserver.WithPromptCapabilities(true),
 		mcpserver.WithHooks(hooks),
 	)
 	streamableSrv := mcpserver.NewStreamableHTTPServer(srv)
@@ -165,6 +282,56 @@ func (b *listChangedTestBackend) addTool(t *testing.T, name string) {
 	sessionWithTools, ok := session.(mcpserver.SessionWithTools)
 	require.True(t, ok, "listChangedTestBackend: session does not support per-session tools")
 	sessionWithTools.SetSessionTools(tools)
+}
+
+// addResource adds uri to the connected session's per-session resource set via
+// SetSessionResources, triggering a real, asynchronous
+// notifications/resources/list_changed broadcast. See addTool for the b.ready
+// synchronization rationale.
+func (b *listChangedTestBackend) addResource(t *testing.T, uri string) {
+	t.Helper()
+	select {
+	case <-b.ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listChangedTestBackend: timed out waiting for session registration")
+	}
+
+	b.mu.Lock()
+	session := b.session
+	b.resources[uri] = newListChangedResource(uri)
+	resources := make(map[string]mcpserver.ServerResource, len(b.resources))
+	for k, v := range b.resources {
+		resources[k] = v
+	}
+	b.mu.Unlock()
+	sessionWithResources, ok := session.(mcpserver.SessionWithResources)
+	require.True(t, ok, "listChangedTestBackend: session does not support per-session resources")
+	sessionWithResources.SetSessionResources(resources)
+}
+
+// addPrompt adds name to the connected session's per-session prompt set via
+// SetSessionPrompts, triggering a real, asynchronous
+// notifications/prompts/list_changed broadcast. See addTool for the b.ready
+// synchronization rationale.
+func (b *listChangedTestBackend) addPrompt(t *testing.T, name string) {
+	t.Helper()
+	select {
+	case <-b.ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listChangedTestBackend: timed out waiting for session registration")
+	}
+
+	b.mu.Lock()
+	session := b.session
+	b.prompts[name] = newListChangedPrompt(name)
+	prompts := make(map[string]mcpserver.ServerPrompt, len(b.prompts))
+	for k, v := range b.prompts {
+		prompts[k] = v
+	}
+	b.mu.Unlock()
+	sessionWithPrompts, ok := session.(mcpserver.SessionWithPrompts)
+	require.True(t, ok, "listChangedTestBackend: session does not support per-session prompts")
+	sessionWithPrompts.SetSessionPrompts(prompts)
 }
 
 // TestCreateMCPClient_ContinuousListeningGatedOnSink verifies createMCPClient
@@ -213,55 +380,93 @@ func TestCreateMCPClient_ContinuousListeningGatedOnSink(t *testing.T) {
 }
 
 // TestCreateMCPClient_ListChangedSink_FiresOnBackendNotification is the
-// end-to-end regression for #5748: a non-nil sink fires with the backend's
-// WorkloadID and kind="tools" when the real backend emits
-// notifications/tools/list_changed asynchronously (outside any in-flight
-// call), and the nil-sink path never panics or opens the standalone stream.
+// end-to-end regression for #5748 (tools) and #5969 (resources, prompts): a
+// non-nil sink fires with the backend's WorkloadID and the expected kind when
+// the real backend emits notifications/{tools,resources,prompts}/list_changed
+// asynchronously (outside any in-flight call), over the same
+// continuous-listening connection, and the nil-sink path never panics or
+// opens the standalone stream.
 func TestCreateMCPClient_ListChangedSink_FiresOnBackendNotification(t *testing.T) {
 	t.Parallel()
 
-	b := newListChangedTestBackend(t)
-	target := &vmcp.BackendTarget{
-		WorkloadID:    "list-changed-backend",
-		WorkloadName:  "list-changed-backend",
-		BaseURL:       b.url,
-		TransportType: "streamable-http",
+	tests := []struct {
+		name     string
+		trigger  func(t *testing.T, b *listChangedTestBackend)
+		wantKind ChangeKind
+	}{
+		{"tools", func(t *testing.T, b *listChangedTestBackend) {
+			t.Helper()
+			b.addTool(t, "added_tool")
+		}, KindTools},
+		{"resources", func(t *testing.T, b *listChangedTestBackend) {
+			t.Helper()
+			b.addResource(t, "added_resource")
+		}, KindResources},
+		{"prompts", func(t *testing.T, b *listChangedTestBackend) {
+			t.Helper()
+			b.addPrompt(t, "added_prompt")
+		}, KindPrompts},
 	}
 
-	type firedCall struct {
-		backendWorkloadID string
-		kind              ChangeKind
-	}
-	fired := make(chan firedCall, 4)
-	sink := func(_ context.Context, backendWorkloadID string, kind ChangeKind) {
-		fired <- firedCall{backendWorkloadID: backendWorkloadID, kind: kind}
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	c, err := createMCPClient(
-		context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), sink,
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = c.Close() })
+			b := newListChangedTestBackend(t)
+			target := &vmcp.BackendTarget{
+				WorkloadID:    "list-changed-backend",
+				WorkloadName:  "list-changed-backend",
+				BaseURL:       b.url,
+				TransportType: "streamable-http",
+			}
 
-	_, err = c.Initialize(context.Background(), mcpmcp.InitializeRequest{
-		Params: mcpmcp.InitializeParams{
-			ProtocolVersion: mcpmcp.LATEST_PROTOCOL_VERSION,
-			ClientInfo:      mcpmcp.Implementation{Name: "test-client", Version: "1.0"},
-		},
-	})
-	require.NoError(t, err)
+			type firedCall struct {
+				backendWorkloadID string
+				kind              ChangeKind
+			}
+			// Buffered generously: registration itself sets all three per-session
+			// stores (tools, resources, prompts), each of which fires its own
+			// registration-time list_changed broadcast (see serve.go's R1 note) in
+			// addition to the one this test explicitly triggers below.
+			fired := make(chan firedCall, 16)
+			sink := func(_ context.Context, backendWorkloadID string, kind ChangeKind) {
+				fired <- firedCall{backendWorkloadID: backendWorkloadID, kind: kind}
+			}
 
-	// Backend asynchronously changes its (per-session) tool set — a real
-	// tools/list_changed trigger, independent of any in-flight call from this
-	// client.
-	b.addTool(t, "added_tool")
+			c, err := createMCPClient(
+				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), sink,
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = c.Close() })
 
-	select {
-	case got := <-fired:
-		assert.Equal(t, "list-changed-backend", got.backendWorkloadID)
-		assert.Equal(t, KindTools, got.kind)
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for the list_changed sink to fire")
+			_, err = c.Initialize(context.Background(), mcpmcp.InitializeRequest{
+				Params: mcpmcp.InitializeParams{
+					ProtocolVersion: mcpmcp.LATEST_PROTOCOL_VERSION,
+					ClientInfo:      mcpmcp.Implementation{Name: "test-client", Version: "1.0"},
+				},
+			})
+			require.NoError(t, err)
+
+			// Backend asynchronously changes its per-session set — a real
+			// list_changed trigger, independent of any in-flight call from this
+			// client. Drain fired notifications (which may also include
+			// registration-time broadcasts of OTHER kinds, per the buffer comment
+			// above) until the expected kind is observed.
+			tc.trigger(t, b)
+
+			deadline := time.After(10 * time.Second)
+			for {
+				select {
+				case got := <-fired:
+					assert.Equal(t, "list-changed-backend", got.backendWorkloadID)
+					if got.kind == tc.wantKind {
+						return
+					}
+				case <-deadline:
+					t.Fatalf("timed out waiting for a %q list_changed notification", tc.wantKind)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/vmcp/session/session.go
+++ b/pkg/vmcp/session/session.go
@@ -24,9 +24,14 @@ type ListChangedSink = backend.ListChangedSink
 // reason as ListChangedSink.
 type ChangeKind = backend.ChangeKind
 
-// KindTools re-exports backend.KindTools so out-of-tree callers can match on it
-// without importing the internal package.
-const KindTools = backend.KindTools
+// KindTools, KindResources, and KindPrompts re-export the corresponding
+// backend.Kind* constants so out-of-tree callers can match on them without
+// importing the internal package.
+const (
+	KindTools     = backend.KindTools
+	KindResources = backend.KindResources
+	KindPrompts   = backend.KindPrompts
+)
 
 // ValidateCaller checks caller against a stored identity-binding string (the
 // value persisted under MetadataKeyIdentityBinding) and returns nil when the


### PR DESCRIPTION
## Summary

#5965 propagated backend `list_changed` to vMCP clients **for tools only**. Resources and prompts were explicitly deferred: the backend connector dropped their `list_changed` notifications, vMCP advertised `resources.listChanged=false`, and it **never advertised the `prompts` capability at all** — a spec-conformance defect, since MCP 2025-11-25 says *"Servers that support prompts MUST declare the `prompts` capability during initialization"* and vMCP already serves prompts per session.

This extends the **existing #5965 machinery** (no new coordinator) to resources and prompts:

- Dispatch backend `notifications/resources/list_changed` and `notifications/prompts/list_changed` (add `KindResources`/`KindPrompts`); resource-template changes ride the resources method (there is no separate templates notification in 2025-11-25).
- Run **one coalescing resync worker per `(session, kind)`** — reusing #5965's `listChangedResyncWorker` verbatim — so a tools change never triggers a resources/prompts re-apply (and vice-versa).
- On a change: invalidate the capability cache, re-derive the session's advertised resources, resource templates, and prompts under the session's own identity, and apply them with the **REPLACE** setters (`SetSessionResources`/`SetSessionResourceTemplates`/`SetSessionPrompts`). The per-session go-sdk server then auto-emits the downstream `list_changed`.
- Flip `WithResourceCapabilities(true, true)` and add `WithPromptCapabilities(true)`.

Closes #5969

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

`task lint-fix` 0 issues; `go build`/`go vet` clean; `go test -race` across `./pkg/vmcp/...` all green. Coverage added:
- **Unit**: connector method→kind dispatch (all three methods + negatives); per-kind resync isolation (a resources notification touches only `ListResources`+`ListResourceTemplates`, never tools/prompts); REPLACE-not-merge (a pre-seeded removed entry is dropped from the overlay); fail-loudly type-assert branches for resources/templates/prompts; auth-context reconstruction (identity + forwarded header) asserted for **all three** kinds.
- **Integration** (real go-sdk backend over continuous-listening): resources and prompts `list_changed` fire the sink with the right kind; end-to-end resync so a client `resources/list` / `resources/templates/list` / `prompts/list` reflects **added** items, with explicit before-snapshots.
- **Regression guards**: capability-regression asserts `resources.listChanged`/`prompts.listChanged`/`prompts` present + `resources.subscribe` retained; an **add-only guard** pins that a removed resource/prompt currently *still* appears (fails loudly when toolhive-core#184 lands).

## Does this introduce a user-facing change?

Yes: vMCP now propagates backend **resources and prompts** `list_changed` to clients (added items appear on the next `*/list` without reconnecting), advertises `resources.listChanged=true`, and — newly — advertises the `prompts` capability at initialize (fixing a spec MUST that previously hid vMCP's prompts from clients gating on `capabilities.prompts`).

## Special notes for reviewers

Reviewed by a 4-axis Opus panel (MCP-correctness, concurrency+quality, security, tests): security **APPROVE**, the rest **APPROVE-WITH-NITS** (all nits addressed).

**Known limitation (tracked): stacklok/toolhive-core#184.** mcpcompat's per-session sync for resources/resource templates/prompts is **add-only** (unlike tools, which reconciles removals via `RemoveTools`). So **additions propagate but removals do not** — a backend-removed resource/prompt lingers in the advertised list until the session re-initializes. Advertising `listChanged: true` remains honest (a notification *is* emitted on change; `listChanged` promises notification, not list minimization). **Read-time access is unaffected** — the read path re-derives admission per call, so a removed/deadmitted resource is denied at read time regardless of the stale list. Documented at the `resyncSessionResources`/`resyncSessionPrompts` apply paths; the add-only guard test will flip to assert removal once #184 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRh394VZgnqbYjJwjrcJWm