### PR TITLE
Add vMCP per-session security regression tests

### DIFF
--- a/pkg/vmcp/server/authz_integration_test.go
+++ b/pkg/vmcp/server/authz_integration_test.go
@@ -118,18 +118,27 @@ func buildCedarAuthzServer(
 	require.NoError(t, err)
 	agg := aggregator.NewDefaultAggregator(backendClient, resolver, nil, nil)
 
-	// Inject a fixed authenticated identity on every request so the session binds to it at
+	// Inject an authenticated identity on every request so the session binds to it at
 	// initialize and the Cedar authorizer can resolve the principal on subsequent calls.
-	// The MCP parser is composed inside it, mirroring the production incoming-auth factory
-	// (see pkg/vmcp/auth/factory): audit and authz read parsed MCP data from the request
-	// context, and the audit middleware sits between auth and the parser applied in Handler.
+	// The principal defaults to the fixed "user-123" (all existing authz tests rely on
+	// this), but a request carrying X-Test-Principal derives the identity from that header
+	// instead — letting a single running server authenticate different callers as distinct
+	// principals (see TestRegression_PerSessionToolProjection_DivergesByPrincipal), without
+	// changing behavior for any test that never sets the header. The MCP parser is composed
+	// inside it, mirroring the production incoming-auth factory (see pkg/vmcp/auth/factory):
+	// audit and authz read parsed MCP data from the request context, and the audit
+	// middleware sits between auth and the parser applied in Handler.
 	identityMiddleware := func(next http.Handler) http.Handler {
 		withParser := mcpparser.ParsingMiddleware(next)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			principal := r.Header.Get("X-Test-Principal")
+			if principal == "" {
+				principal = "user-123"
+			}
 			id := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{
-				Subject: "user-123",
+				Subject: principal,
 				Name:    "Test User",
-				Claims:  map[string]any{"sub": "user-123", "name": "Test User"},
+				Claims:  map[string]any{"sub": principal, "name": "Test User"},
 			}}
 			withParser.ServeHTTP(w, r.WithContext(auth.WithIdentity(r.Context(), id)))
 		})
@@ -517,6 +526,132 @@ func TestIntegration_CedarAuthzDenial_ModernPath_IsAudited(t *testing.T) {
 	event := findToolCallAuditEvent(t, auditLogPath)
 	assert.Equal(t, "denied", event["outcome"],
 		"a policy-denied Modern tools/call must be audited with outcome denied")
+}
+
+// waitForClientTool polls c.ListTools until toolName appears in the advertised
+// set, or the deadline elapses. The poll condition is best-effort: any
+// transport/read error returns false so the poll simply retries, and it never
+// calls require/FailNow inside the closure (testify runs the condition on its
+// own goroutine, where FailNow would Goexit off the test goroutine, hang the
+// poll to its ceiling, and misreport the failure).
+func waitForClientTool(t *testing.T, c *MCPTestClient, toolName string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		resp := c.ListTools()
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		return resp.StatusCode == http.StatusOK && strings.Contains(string(body), `"`+toolName+`"`)
+	}, 5*time.Second, 50*time.Millisecond,
+		"client's tools/list must advertise "+toolName)
+}
+
+// listToolsBody returns the client's current tools/list response body as a
+// string. Unlike waitForClientTool's poll closure, this runs on the test
+// goroutine, so requiring a clean read/200 here is safe.
+func listToolsBody(t *testing.T, c *MCPTestClient) string {
+	t.Helper()
+	resp := c.ListTools()
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "tools/list must succeed")
+	return string(body)
+}
+
+// TestRegression_PerSessionToolProjection_DivergesByPrincipal pins the fixed
+// per-principal Cedar admission behind the mcp-go -> go-sdk migration
+// (toolhive-core v0.0.32, #5742): two clients authenticated as DIFFERENT
+// principals, against the SAME running server instance, must get divergent
+// tools/list projections when a Cedar policy permits a tool for one principal
+// only. Before the fix, the server's identity middleware stamped every request
+// with a single fixed principal, so per-session admission could not diverge by
+// caller — this test would have failed (or passed vacuously) against that
+// regression.
+func TestRegression_PerSessionToolProjection_DivergesByPrincipal(t *testing.T) {
+	t.Parallel()
+
+	backendURL := startEchoPingBackend(t)
+	// The Cedar principal for a JWT-claims-derived caller is Client::"<sub>"
+	// (cedar authorizeToolCall). Give each principal a DISTINCT positively-
+	// permitted tool -- alice may call echo, bob may call ping -- so the two
+	// sessions' tools/list projections (gated by these call_tool permissions)
+	// must diverge in BOTH directions on the same running server.
+	ts := newCedarAuthzTestServer(t, backendURL,
+		`permit(principal == Client::"alice", action == Action::"call_tool", resource == Tool::"echo");`,
+		`permit(principal == Client::"bob", action == Action::"call_tool", resource == Tool::"ping");`)
+
+	alice := NewMCPTestClient(t, ts.URL).WithPrincipal("alice")
+	alice.InitializeSession()
+	bob := NewMCPTestClient(t, ts.URL).WithPrincipal("bob")
+	bob.InitializeSession()
+
+	// Wait until EACH session has registered its OWN permitted tool. This is
+	// the anti-vacuity guard: it proves both sessions finished their
+	// (asynchronous) registration and each principal resolved to its own
+	// identity. Without it, an empty tools/list (registration still pending)
+	// would be indistinguishable from a correctly-filtered one, so a real
+	// cross-principal projection leak could pass unnoticed.
+	waitForClientTool(t, alice, "echo")
+	waitForClientTool(t, bob, "ping")
+
+	// Divergence in both directions: alice sees echo but NOT bob's ping; bob
+	// sees ping but NOT alice's echo. A regression that collapsed all sessions
+	// onto one fixed principal, or shared a cached projection across principals,
+	// would leak the other principal's tool here.
+	aliceTools := listToolsBody(t, alice)
+	assert.Contains(t, aliceTools, `"echo"`, "alice must see her permitted tool echo")
+	assert.NotContains(t, aliceTools, `"ping"`,
+		"alice must NOT see bob's tool ping on the SAME server instance")
+
+	bobTools := listToolsBody(t, bob)
+	assert.Contains(t, bobTools, `"ping"`, "bob must see his permitted tool ping")
+	assert.NotContains(t, bobTools, `"echo"`,
+		"bob must NOT see alice's tool echo on the SAME server instance")
+}
+
+// TestRegression_PerSessionToolCall_DeniedForUnprivilegedPrincipal is the
+// call-path counterpart of TestRegression_PerSessionToolProjection_DivergesByPrincipal:
+// on the SAME running server, a tools/call for a tool permitted to one
+// principal (alice) must succeed, while the identical call from a different
+// principal (bob) on their own concurrently-registered session must be denied
+// by the pre-dispatch authorization gate (403), not silently allowed through a
+// shared/fixed identity.
+func TestRegression_PerSessionToolCall_DeniedForUnprivilegedPrincipal(t *testing.T) {
+	t.Parallel()
+
+	backendURL := startRealMCPBackend(t)
+	ts := newCedarAuthzTestServer(t, backendURL,
+		`permit(principal == Client::"alice", action == Action::"call_tool", resource == Tool::"echo");`)
+
+	alice := NewMCPTestClient(t, ts.URL).WithPrincipal("alice")
+	alice.InitializeSession()
+	bob := NewMCPTestClient(t, ts.URL).WithPrincipal("bob")
+	bob.InitializeSession()
+
+	// Wait for alice's session to register echo before calling it.
+	waitForClientTool(t, alice, "echo")
+
+	aliceResp := alice.CallTool("echo", map[string]any{"input": "hello"})
+	defer aliceResp.Body.Close()
+	aliceBody, err := io.ReadAll(aliceResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, aliceResp.StatusCode,
+		"alice is permitted to call echo; body: %s", string(aliceBody))
+	assert.Contains(t, string(aliceBody), "hello", "alice's permitted call must reach the real backend")
+
+	bobResp := bob.CallTool("echo", map[string]any{"input": "hello"})
+	defer bobResp.Body.Close()
+	bobBody, err := io.ReadAll(bobResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, bobResp.StatusCode,
+		"bob is not permitted to call echo on the SAME running server; body: %s", string(bobBody))
+	rpcErr := parseRPCError(t, bobBody)
+	require.True(t, rpcErr.present, "the 403 must carry a JSON-RPC error envelope, body: %s", string(bobBody))
+	assert.Equal(t, mcpparser.JSONRPCCodeDenied, rpcErr.code,
+		"bob's denied call must surface the genericized authorization JSON-RPC error code")
 }
 
 // findToolCallAuditEvent reads the newline-delimited JSON audit log at path and

--- a/pkg/vmcp/server/context_isolation_regression_test.go
+++ b/pkg/vmcp/server/context_isolation_regression_test.go
@@ -92,6 +92,157 @@ func newPerToolSessionFactory(
 	return factory
 }
 
+// principalIdentityMiddleware stamps a per-request auth.Identity onto the
+// request context, derived from the X-Test-Principal header, mirroring the
+// identity-stamping pattern in buildCedarAuthzServer's identityMiddleware
+// (authz_integration_test.go). It deliberately leaves Identity.Token empty:
+// the mock session factory below binds the session as "unauthenticated", and
+// validateCallerBinding's anonymous-session upgrade-attack guard only rejects
+// a caller that presents a non-empty Token -- so distinct Subjects with no
+// token pass the binding check while still giving each request its own
+// identity for coreToolHandler/core.CallTool to observe. A request with no
+// header is left unauthenticated, matching every other test in this file that
+// never sets this middleware.
+func principalIdentityMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		principal := r.Header.Get("X-Test-Principal")
+		if principal == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		id := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{
+			Subject: principal,
+			Claims:  map[string]any{"sub": principal},
+		}}
+		next.ServeHTTP(w, r.WithContext(auth.WithIdentity(r.Context(), id)))
+	})
+}
+
+// TestRegression_ConcurrentSameSession_NoIdentityBleed pins the fix for issue
+// #156 item U3 (toolhive-core v0.0.32): go-sdk handles messages for an
+// existing session on that session's own connection goroutine using the
+// initialize-time context, so a per-POST request context (identity included)
+// would be lost unless bridged per-request. The shim bridges it via a nonce
+// keyed to the individual POST -- NOT the session ID -- specifically so two
+// concurrent POSTs on the SAME session cannot clobber each other's identity.
+// TestRegression_ConcurrentToolCalls_NoAuditBleed (above) already covers
+// concurrent same-session calls, but both requests carry the SAME (anonymous)
+// principal, so a regression that collapsed the per-POST bridge back to the
+// old session-keyed (or session-wide) context would not be caught there. This
+// test fires two concurrent tools/call POSTs on ONE session with DISTINCT
+// principals and asserts core.CallTool observed each request's own identity,
+// correlated by principal (a stable key), not by arrival order.
+func TestRegression_ConcurrentSameSession_NoIdentityBleed(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	testTool := vmcp.Tool{Name: "t"}
+	fc := &fakeCore{tools: []vmcp.Tool{testTool}}
+	fc.enableCallIdentityRecording()
+	factory, _ := newToolSessionFactory(t, ctrl, []vmcp.Tool{testTool})
+
+	srv, err := Serve(context.Background(), fc, &ServerConfig{
+		SessionTTL:           time.Minute,
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	streamable := server.NewStreamableHTTPServer(
+		srv.mcpServer,
+		server.WithEndpointPath("/mcp"),
+		server.WithSessionIdManager(srv.vmcpSessionMgr),
+	)
+	ts := httptest.NewServer(principalIdentityMiddleware(streamable))
+	t.Cleanup(ts.Close)
+	baseURL := ts.URL
+
+	initResp := postServeMCP(t, baseURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, http.StatusOK, initResp.StatusCode)
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+	require.Eventually(t, func() bool {
+		_, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID)
+		return ok
+	}, 2*time.Second, 10*time.Millisecond, "session should be registered")
+
+	principals := []string{"p1", "p2"}
+	var wg sync.WaitGroup
+	wg.Add(len(principals))
+	callErrs := make([]error, len(principals))
+	for i, principal := range principals {
+		i, principal := i, principal
+		go func() {
+			defer wg.Done()
+			// No require/assert here: FailNow from a worker goroutine only runs
+			// Goexit off the test goroutine and misreports. Collect the error and
+			// assert on the test goroutine after wg.Wait() below.
+			resp, doErr := doServeMCPWithHeaders(baseURL, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      2 + i,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": "t",
+					// "caller" travels in the request BODY and is echoed to
+					// fakeCore.CallTool via args, giving a correlator that is
+					// independent of the context-bridged identity. The recorder
+					// keys on it so the assertion below can detect a swap, not
+					// just a collapse.
+					"arguments": map[string]any{"caller": principal},
+				},
+			}, sessionID, map[string]string{"X-Test-Principal": principal})
+			if doErr != nil {
+				callErrs[i] = doErr
+				return
+			}
+			defer resp.Body.Close()
+			_, callErrs[i] = io.ReadAll(resp.Body)
+		}()
+	}
+
+	// Fail-fast wait: never block indefinitely on a WaitGroup.
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for concurrent same-session calls to complete")
+	}
+	for i, callErr := range callErrs {
+		require.NoError(t, callErr, "call for principal %q must succeed", principals[i])
+	}
+
+	require.Equal(t, int32(len(principals)), fc.callToolCalls.Load(),
+		"core.CallTool must be called exactly once per concurrent request")
+
+	// For each request (identified by its body-supplied "caller"), the identity
+	// core.CallTool observed must be that request's OWN identity. The recorder
+	// keys on the caller argument (from the request body) and stores the
+	// observed identity (from the context bridge) as the value; asserting
+	// value.Subject == caller therefore correlates the two independent sources.
+	// This catches BOTH failure modes of the U3 regression: a collapse (one
+	// caller key never recorded -> NotNil fails) AND a symmetric swap (request
+	// caller=p1 handled with p2's identity -> callIdentityFor("p1").Subject is
+	// "p2" -> Equal fails), which a Subject-keyed recorder could not detect.
+	for _, principal := range principals {
+		got := fc.callIdentityFor(principal)
+		require.NotNil(t, got, "no identity was recorded for caller %q; did it bleed into another request?", principal)
+		assert.Equal(t, principal, got.Subject,
+			"the request with caller=%q must be handled with its OWN identity, not a concurrent request's", principal)
+	}
+}
+
 // TestRegression_ConcurrentToolCalls_NoAuditBleed fires two tools/call POSTs
 // concurrently against the same session and asserts each response carries its
 // OWN tool's result text — no cross-contamination. The Serve path sets the

--- a/pkg/vmcp/server/serve_session_termination_test.go
+++ b/pkg/vmcp/server/serve_session_termination_test.go
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	tcredis "github.com/stacklok/toolhive-core/redis"
+	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+	"github.com/stacklok/toolhive/pkg/vmcp/server/sessionmanager"
+	sessionfactorymocks "github.com/stacklok/toolhive/pkg/vmcp/session/mocks"
+)
+
+// sharedRedisSessionKeyPrefix is the Redis key prefix shared by the origin
+// server's session-data storage and the out-of-band terminating Manager in
+// TestRegression_OriginPod_RejectsRequestAfterCrossPodTermination, so both see
+// the same underlying keys in the shared miniredis instance.
+const sharedRedisSessionKeyPrefix = "test:vmcp:session:"
+
+// TestRegression_OriginPod_RejectsRequestAfterCrossPodTermination pins the
+// real U5 fix (toolhive-core v0.0.32, #5742): a session present in the origin
+// pod's LOCAL bookkeeping but terminated in the SHARED (Redis) session store
+// by a second pod must be rejected on the very next request to the origin
+// pod, not served as if still live.
+//
+// This is distinct from the existing DELETE-path termination tests
+// (TestRegression_TerminatedSessionRejected et al., session_lifecycle_regression_test.go):
+// those terminate through the SAME server instance, so the SDK's local
+// session bookkeeping (forgetSession) is dropped in lockstep with the storage
+// delete. Here, termination happens on a SECOND Manager that only touches the
+// shared store -- the origin pod's local go-sdk session and node-local cache
+// entry are never told directly. The origin pod must instead detect the
+// termination by re-validating the shared store on the next request (see
+// mcpcompat/server/transports.go's "Local-session validation, issue #156,
+// item U5" comment), and drop its local bookkeeping only then.
+func TestRegression_OriginPod_RejectsRequestAfterCrossPodTermination(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+
+	// Origin server ("pod A"): a Serve-built server backed by Redis-backed
+	// session-data storage, so its vMCP session manager's Validate() answers
+	// from the shared store rather than an in-process-only map.
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	testTool := vmcp.Tool{Name: "t"}
+	factory, _ := newToolSessionFactory(t, ctrl, []vmcp.Tool{testTool})
+	fc := &fakeCore{tools: []vmcp.Tool{testTool}}
+
+	srv, err := Serve(context.Background(), fc, &ServerConfig{
+		SessionTTL: time.Minute,
+		SessionStorage: &vmcpconfig.SessionStorageConfig{
+			Provider:  "redis",
+			Address:   mr.Addr(),
+			KeyPrefix: sharedRedisSessionKeyPrefix,
+		},
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	handler, err := srv.Handler(context.Background())
+	require.NoError(t, err)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	initResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, http.StatusOK, initResp.StatusCode)
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+	require.Eventually(t, func() bool {
+		_, ok := srv.vmcpSessionMgr.GetMultiSession(context.Background(), sessionID)
+		return ok
+	}, 2*time.Second, 10*time.Millisecond, "session should be registered locally on the origin pod")
+
+	// Sanity: the origin pod must currently regard the session as live, or the
+	// post-termination 404 assertion below would pass vacuously.
+	liveResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": map[string]any{},
+	}, sessionID)
+	require.Equal(t, http.StatusOK, liveResp.StatusCode, "session must be live before cross-pod termination")
+	liveResp.Body.Close()
+
+	// A second Manager ("pod B") over the SAME shared Redis store terminates
+	// the session out-of-band. This does NOT go through the origin pod's
+	// in-process forgetSession bookkeeping -- it only mutates the shared
+	// store, exactly like a DELETE served by a different replica.
+	terminatorFactory := sessionfactorymocks.NewMockMultiSessionFactory(ctrl)
+	terminatorStorage, err := transportsession.NewRedisSessionDataStorage(
+		context.Background(),
+		tcredis.Config{Addr: mr.Addr()},
+		sharedRedisSessionKeyPrefix,
+		time.Hour,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = terminatorStorage.Close() })
+
+	smB, cleanupB, err := sessionmanager.New(
+		terminatorStorage,
+		&sessionmanager.FactoryConfig{Base: terminatorFactory},
+		vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanupB(context.Background()) })
+
+	isNotAllowed, err := smB.Terminate(sessionID)
+	require.NoError(t, err)
+	require.False(t, isNotAllowed)
+
+	// The origin pod must reject the NEXT request for the cross-pod-terminated
+	// session with HTTP 404 -- the streamable transport's validate-on-every-
+	// request path must observe the termination via the shared store and
+	// refuse to serve it from local state.
+	rejectResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": map[string]any{},
+	}, sessionID)
+	defer rejectResp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, rejectResp.StatusCode,
+		"a session terminated on another pod's shared store must be rejected as 404 "+
+			"on the very next request to the origin pod")
+}

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -174,6 +174,20 @@ type fakeCore struct {
 	// identity/header scoping too (auth-scoping regression guard).
 	lastListResourcesCtx atomic.Pointer[ctxBox]
 	lastListPromptsCtx   atomic.Pointer[ctxBox]
+
+	// callIdentitiesMu guards callIdentities. Additive, nil-safe recording of
+	// the identity CallTool observed per invocation (issue #156 item U3 /
+	// #5742 regression guard): nil until a test opts in via
+	// enableCallIdentityRecording, so existing fakeCore users that never call
+	// it are unaffected. Keyed by the request-supplied "caller" argument (which
+	// travels in the request BODY, independent of the context-bridged identity),
+	// with the observed identity as the value. A test asserts value.Subject ==
+	// key: since key and value come from independent sources, a concurrency
+	// regression that SWAPPED identities between two racing requests (request
+	// caller=p1 handled with p2's identity) records a mismatched pair and fails,
+	// not just a collapse where one key goes missing.
+	callIdentitiesMu sync.Mutex
+	callIdentities   map[string]*auth.Identity
 }
 
 // ctxBox wraps a context.Context for atomic.Pointer storage on fakeCore.
@@ -188,17 +202,56 @@ func (f *fakeCore) ListTools(ctx context.Context, _ *auth.Identity) ([]vmcp.Tool
 }
 
 func (f *fakeCore) CallTool(
-	_ context.Context, _ *auth.Identity, name string, args map[string]any, _ map[string]any,
+	_ context.Context, identity *auth.Identity, name string, args map[string]any, _ map[string]any,
 ) (*vmcp.ToolCallResult, error) {
 	f.callToolCalls.Add(1)
 	f.lastCallToolName.Store(name)
 	if args != nil {
 		f.lastCallToolArgs.Store(args)
 	}
+	f.recordCallIdentity(args, identity)
 	if f.callErr != nil {
 		return nil, f.callErr
 	}
 	return &vmcp.ToolCallResult{Content: []vmcp.Content{{Type: vmcp.ContentTypeText, Text: "ok"}}}, nil
+}
+
+// enableCallIdentityRecording turns on per-call identity recording (see
+// callIdentities). Call before Serve; a fakeCore that never calls this keeps
+// the zero-value nil map, so recordCallIdentity/CallTool remain a no-op and
+// existing callers are unaffected.
+func (f *fakeCore) enableCallIdentityRecording() {
+	f.callIdentitiesMu.Lock()
+	defer f.callIdentitiesMu.Unlock()
+	f.callIdentities = make(map[string]*auth.Identity)
+}
+
+// recordCallIdentity stores the observed identity keyed by the request-supplied
+// "caller" argument (from args, which travels in the request body independent of
+// the context-bridged identity) when recording is enabled; nil-safe no-op
+// otherwise (callIdentities is nil for every fakeCore that never calls
+// enableCallIdentityRecording). Keying on the request-body caller rather than
+// the identity's own Subject is what makes callIdentityFor(caller).Subject ==
+// caller a non-tautological, swap-detecting assertion.
+func (f *fakeCore) recordCallIdentity(args map[string]any, identity *auth.Identity) {
+	f.callIdentitiesMu.Lock()
+	defer f.callIdentitiesMu.Unlock()
+	if f.callIdentities == nil {
+		return
+	}
+	key := ""
+	if caller, ok := args["caller"].(string); ok {
+		key = caller
+	}
+	f.callIdentities[key] = identity
+}
+
+// callIdentityFor returns the identity CallTool observed for the request whose
+// "caller" argument equals key, or nil if no such call was recorded.
+func (f *fakeCore) callIdentityFor(key string) *auth.Identity {
+	f.callIdentitiesMu.Lock()
+	defer f.callIdentitiesMu.Unlock()
+	return f.callIdentities[key]
 }
 
 func (f *fakeCore) ListResources(ctx context.Context, _ *auth.Identity) ([]vmcp.Resource, error) {
@@ -1815,6 +1868,16 @@ func postServeMCP(t *testing.T, baseURL string, body map[string]any, sessionID s
 // FailNow/Goexit would run off the test goroutine and misreport. postServeMCP
 // wraps it for the common test-goroutine case.
 func doServeMCP(baseURL string, body map[string]any, sessionID string) (*http.Response, error) {
+	return doServeMCPWithHeaders(baseURL, body, sessionID, nil)
+}
+
+// doServeMCPWithHeaders is doServeMCP plus caller-supplied extra headers (e.g.
+// X-Test-Principal), for tests that need per-request header control. doServeMCP
+// delegates here with a nil header map (the range is then a no-op), so both
+// share one request-building path.
+func doServeMCPWithHeaders(
+	baseURL string, body map[string]any, sessionID string, headers map[string]string,
+) (*http.Response, error) {
 	rawBody, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -1828,6 +1891,9 @@ func doServeMCP(baseURL string, body map[string]any, sessionID string) (*http.Re
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	if sessionID != "" {
 		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	return http.DefaultClient.Do(req)

--- a/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
+++ b/pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go
@@ -388,3 +388,55 @@ func TestHorizontalScaling_InMemoryOnlyMode(t *testing.T) {
 	require.NotNil(t, sess)
 	assert.NotEmpty(t, sess.Tools(), "session on pod A must have tools")
 }
+
+// ---------------------------------------------------------------------------
+// Regression: cross-pod Validate() must observe a shared-store termination
+// ---------------------------------------------------------------------------
+
+// TestRegression_Validate_TerminatedInStore_ReturnsTerminated pins the real
+// U5 fix (toolhive-core v0.0.32, #5742): a session that Manager A ("pod A")
+// still holds live in its node-local cache, but which was terminated in the
+// SHARED Redis store by a second Manager ("pod B"), must be reported as
+// terminated by Manager A's very next Validate() call -- not treated as an
+// error (which the streamable transport would map to a retryable 503) and not
+// silently reported as still-live. Manager.Validate's documented contract
+// collapses "explicitly terminated" and "absent from storage" into the same
+// (isTerminated=true, nil) signal; this test exercises the termination
+// specifically via a DIFFERENT Manager instance terminating the SAME shared
+// store, not via Manager A's own Terminate (which the existing
+// "TestSessionManager_Terminate" suite already covers and which additionally
+// touches Manager A's local bookkeeping directly).
+func TestRegression_Validate_TerminatedInStore_ReturnsTerminated(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	storage := newSharedRedisStorage(t, mr)
+	backend := startMCPBackend(t, "backend-alpha", "echo")
+
+	// Manager A ("pod A"): create a full (Phase 2) session.
+	smA := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
+	sessionID := createSession(t, smA, nil)
+
+	// Sanity: the session must currently validate as live, or the
+	// post-termination assertion below would pass vacuously.
+	isTerminated, err := smA.Validate(sessionID)
+	require.NoError(t, err)
+	require.False(t, isTerminated, "a freshly created session must validate as live")
+
+	// Manager B ("pod B"): a second Manager over the SAME shared Redis store
+	// terminates the session out-of-band. This mutates only the shared store --
+	// it does NOT go through Manager A's in-process bookkeeping -- exactly like
+	// a DELETE served by a different replica.
+	smB := newTestManagerWithSharedStorage(t, storage, []*vmcp.Backend{backend})
+	isNotAllowed, err := smB.Terminate(sessionID)
+	require.NoError(t, err)
+	require.False(t, isNotAllowed)
+
+	// Manager A must observe the cross-pod termination on the very next
+	// Validate() call against the shared store.
+	isTerminated, err = smA.Validate(sessionID)
+	require.NoError(t, err)
+	assert.True(t, isTerminated,
+		"Manager A must report the session as terminated after Manager B terminates it "+
+			"in the shared store, even though Manager A never terminated it locally")
+}

--- a/pkg/vmcp/server/testutil_test.go
+++ b/pkg/vmcp/server/testutil_test.go
@@ -51,6 +51,50 @@ func startRealMCPBackend(t *testing.T) string {
 	return ts.URL + "/mcp"
 }
 
+// startEchoPingBackend is startRealMCPBackend with a second "ping" tool
+// (returns "pong"). Two tools let a per-principal projection test give each
+// principal a DISTINCT positively-permitted tool, so it can wait for each
+// session to register its own permitted tool (proving registration completed
+// and the principal resolved) before asserting the ABSENCE of the other
+// principal's tool — closing the "empty list because filtered" vs "empty list
+// because registration still pending" ambiguity. Returns the /mcp URL.
+func startEchoPingBackend(t *testing.T) string {
+	t.Helper()
+
+	mcpSrv := mcpserver.NewMCPServer("real-backend", "1.0.0")
+	mcpSrv.AddTool(
+		mcpmcp.NewTool("echo",
+			mcpmcp.WithDescription("Echoes the input back"),
+			mcpmcp.WithString("input", mcpmcp.Required()),
+		),
+		func(_ context.Context, req mcpmcp.CallToolRequest) (*mcpmcp.CallToolResult, error) {
+			args, _ := req.Params.Arguments.(map[string]any)
+			input, _ := args["input"].(string)
+			return &mcpmcp.CallToolResult{
+				Content: []mcpmcp.Content{mcpmcp.NewTextContent(input)},
+			}, nil
+		},
+	)
+	mcpSrv.AddTool(
+		mcpmcp.NewTool("ping",
+			mcpmcp.WithDescription("Returns pong"),
+		),
+		func(_ context.Context, _ mcpmcp.CallToolRequest) (*mcpmcp.CallToolResult, error) {
+			return &mcpmcp.CallToolResult{
+				Content: []mcpmcp.Content{mcpmcp.NewTextContent("pong")},
+			}, nil
+		},
+	)
+
+	streamableSrv := mcpserver.NewStreamableHTTPServer(mcpSrv)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", streamableSrv)
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts.URL + "/mcp"
+}
+
 // MCPTestClient provides higher-level test utilities for MCP protocol interactions.
 // This reduces boilerplate and improves test readability by providing semantic methods
 // instead of manual JSON-RPC construction.
@@ -59,6 +103,11 @@ type MCPTestClient struct {
 	sessionID string
 	t         *testing.T
 	nextID    int
+	// principal, when non-empty, is sent as the X-Test-Principal header on every
+	// POST so a test server whose identity middleware honors that header (see
+	// buildCedarAuthzServer) authenticates this client as a distinct principal.
+	// Existing callers never set this and are unaffected.
+	principal string
 }
 
 // NewMCPTestClient creates a new test client for the given server URL.
@@ -159,6 +208,15 @@ func (c *MCPTestClient) SessionID() string {
 	return c.sessionID
 }
 
+// WithPrincipal sets the X-Test-Principal header this client sends with every
+// subsequent request, so a server whose identity middleware honors that header
+// authenticates this client as principal rather than the fixed fallback
+// principal. Returns the client for chaining.
+func (c *MCPTestClient) WithPrincipal(principal string) *MCPTestClient {
+	c.principal = principal
+	return c
+}
+
 // Terminate sends a DELETE request to terminate the session.
 func (c *MCPTestClient) Terminate() *http.Response {
 	c.t.Helper()
@@ -199,6 +257,9 @@ func (c *MCPTestClient) postMCP(body map[string]any, sessionID string) *http.Res
 	req.Header.Set("Content-Type", "application/json")
 	if sessionID != "" {
 		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	if c.principal != "" {
+		req.Header.Set("X-Test-Principal", c.principal)
 	}
 
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
## Summary

Part of #5743. Advances #5742 (the acceptance gate for the `mcp-go` → `go-sdk` migration).

The migration to the `go-sdk`-backed `mcpcompat` shim already merged (go.mod is at `toolhive-core v0.0.32`, past the buggy v0.0.27 and the toolhive-core#156 fixes). Several **security-relevant** behaviors that regressed under the shim and were then fixed in toolhive-core#156 are currently pinned **only in toolhive-core** — a bad `go.mod` bump or a shim behavior change could reintroduce them and pass ToolHive CI silently. This PR adds ToolHive-side regression tests that fail loudly if any of them regress here.

A deep audit of the #5742 test matrix found most areas already covered by dedicated `TestRegression_*` files; this PR closes the three highest-value, security-relevant gaps:

- **Per-session tool projection divergence by principal** (matrix §3) — two clients authenticated as different principals against the *same* running server get divergent `tools/list` projections and `tools/call` outcomes (Cedar permits `echo`→alice, `ping`→bob). Proves per-principal admission is not collapsed onto a shared/fixed identity. Assertions are bidirectional and gated on each principal *positively* seeing its own permitted tool first, so the test cannot pass while a session's asynchronous registration is merely pending.
- **Concurrent same-session identity isolation** (matrix §9, toolhive-core#156 item U3) — two concurrent `tools/call` POSTs on one session with distinct principals each reach `core.CallTool` with their *own* identity. A body-supplied `caller` argument is correlated to the context-bridged identity via independent sources, so a symmetric identity *swap* is detected, not just a collapse. Pins the shim's per-POST nonce keying.
- **Origin-pod validation against shared store** (matrix §2, toolhive-core#156 item U5) — a session terminated out-of-band in shared (Redis) storage by a second pod is rejected (404) on the origin pod's next request. Exercises the real *local-session-terminated-in-store* branch, distinct from the DELETE path the existing termination tests cover.

## Type of change

- [x] Other (describe): Test-only — adds regression coverage, no production code changes.

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

All new tests pass under `-race`. Full `task test` is green except three pre-existing, environment-only failures unrelated to this change (no container runtime / no keyring in the sandbox), none in the touched packages.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/server/authz_integration_test.go` | Per-principal projection + call-denial regression tests; header-derived test principal (fixed `user-123` fallback preserves existing tests); `waitForClientTool`/`listToolsBody` helpers |
| `pkg/vmcp/server/testutil_test.go` | `startEchoPingBackend` (two-tool backend); `WithPrincipal` on `MCPTestClient` |
| `pkg/vmcp/server/context_isolation_regression_test.go` | Concurrent same-session identity-isolation regression test (U3) |
| `pkg/vmcp/server/serve_session_test.go` | Additive, nil-safe per-call identity recorder on `fakeCore`; `doServeMCP` delegates to `doServeMCPWithHeaders` |
| `pkg/vmcp/server/serve_session_termination_test.go` | New: origin-pod cross-pod-termination 404 regression test (U5) |
| `pkg/vmcp/server/sessionmanager/horizontal_scaling_integration_test.go` | `Manager.Validate` terminated-in-shared-store regression test (U5) |

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- This is the first slice of a broader effort to complete the #5742 regression gate; further in-repo test slices, a toolhive-core upstream fix for tool-schema ingestion fidelity, and a design issue for cross-pod elicitation will follow as separate PRs.
- The `X-Test-Principal` header seam is strictly test-only — production identity comes from `pkg/vmcp/auth`; nothing in production reads the header. The `user-123` fallback is byte-identical to the prior fixed identity, so no existing authz test is weakened.
- The two projection tests take ~30s each; this is pre-existing shutdown/drain cost of the Cedar real-backend harness (an existing test in the same file has the same profile), not introduced here.
- Reviewed by an Opus panel across security, MCP-protocol correctness, code-duplication/library-reuse, and test-quality/concurrency axes; an initial vacuity in the projection test (empty list indistinguishable from pending registration) and a tautological identity-isolation assertion were both found and fixed before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)