### PR TITLE
Fix digest-pinned image pulls failing at container create

### DIFF
--- a/docs/arch/15-envoy-network-proxy.md
+++ b/docs/arch/15-envoy-network-proxy.md
@@ -173,9 +173,9 @@ reachable from the local machine.
 The upstream STRICT_DNS cluster resolves the MCP container's hostname inside the
 internal Docker network and forwards HTTP traffic to the MCP server port.
 
-The admin interface binds to `127.0.0.1` inside the Envoy container (container
-loopback, not reachable via Docker port forwarding) as a precaution against the
-admin API being accessible from other containers.
+The admin interface is intentionally omitted from the bootstrap configuration.
+Envoy does not start an admin server when the field is absent, eliminating the
+attack surface entirely.
 
 ### Bootstrap lifecycle
 
@@ -223,17 +223,10 @@ backend is stable.
 | Access logs | Per-container, text format | Unified stdout, structured |
 | Config format | Text template | Typed Go structs → protobuf-JSON |
 | Runtime config update | Restart required | xDS-capable (not yet used) |
-| Upstream image | Stacklok-built | Upstream distroless (pinned tag) |
+| Upstream image | Stacklok-built | Upstream distroless (pinned tag+digest) |
 
 ## Known Limitations
 
-- **Tag-pinned image.** The Envoy image is pinned by tag (`v1.32.3`), not by
-  digest. A future PR should pin by digest and add a `TOOLHIVE_ENVOY_IMAGE`
-  override for supply-chain policy requirements (the env var already exists).
-  Tracked in #5903.
-- **Admin interface port.** The admin API on `:9901` (loopback-only inside the
-  container) is always enabled. A follow-up can disable it entirely or make it
-  conditional.
 - **CONNECT access log timing.** Envoy logs CONNECT tunnel entries when the
   tunnel closes, not when it opens. With keep-alive HTTP clients the log entry
   may be delayed by minutes. Egress access logs are visible in `docker logs` but

--- a/pkg/container/images/registry.go
+++ b/pkg/container/images/registry.go
@@ -6,6 +6,7 @@ package images
 import (
 	"archive/tar"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -71,71 +71,89 @@ func (r *RegistryImageManager) ImageExists(_ context.Context, imageName string) 
 	return true, nil
 }
 
-// PullImage pulls an image from a registry and saves it to the local daemon
+// PullImage pulls an image from a registry and saves it to the local daemon.
+//
+// For digest-pinned references (tag@digest or digest-only), the Docker daemon's
+// native ImagePull is used. The daemon registers the OCI manifest digest so that
+// subsequent container creates using a tag@digest reference can resolve the image.
+// go-containerregistry's daemon.Write stores images under a tag only, without
+// registering the manifest digest; Docker's tag@digest cross-check at
+// container-create time then fails with "No such image".
+//
+// For plain tag references, go-containerregistry is used for cross-platform
+// support and custom keychain auth.
 func (r *RegistryImageManager) PullImage(ctx context.Context, imageName string) error {
 	//nolint:gosec // G706: image name from user/config input
 	slog.Info("pulling image", "image", imageName)
 
-	// Parse the image reference
 	ref, err := name.ParseReference(imageName)
 	if err != nil {
 		return fmt.Errorf("failed to parse image reference %q: %w", imageName, err)
 	}
 
-	// Configure remote options
+	if _, ok := ref.(name.Digest); ok {
+		return r.pullDigestViaDockerDaemon(ctx, imageName, ref)
+	}
+
+	tag, ok := ref.(name.Tag)
+	if !ok {
+		return fmt.Errorf("unsupported image reference type %T", ref)
+	}
+
 	remoteOpts := []remote.Option{
 		remote.WithAuthFromKeychain(r.keychain),
 		remote.WithContext(ctx),
 	}
-
 	if r.platform != nil {
 		remoteOpts = append(remoteOpts, remote.WithPlatform(*r.platform))
 	}
 
-	// Pull the image from the registry
 	img, err := remote.Image(ref, remoteOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to pull image from registry: %w", err)
 	}
 
-	// Convert reference to a name.Tag for daemon.Write.
-	// name.ParseReference returns name.Digest (not name.Tag) for tag@digest
-	// references like "image:tag@sha256:...". In that case we extract the tag
-	// portion (everything before the '@') so daemon.Write can store the image
-	// under its human-readable tag, while the pull itself was verified against
-	// the digest by go-containerregistry.
-	var tag name.Tag
-	switch v := ref.(type) {
-	case name.Tag:
-		tag = v
-	case name.Digest:
-		refStr := ref.String()
-		if atIdx := strings.Index(refStr, "@"); atIdx >= 0 {
-			// tag@digest — use the portion before '@' as the tag reference.
-			tag, err = name.NewTag(refStr[:atIdx])
-		} else {
-			// digest-only (no tag) — fall back to repository:latest.
-			tag, err = name.NewTag(v.Repository.String())
-		}
-		if err != nil {
-			return fmt.Errorf("failed to derive tag from digest reference: %w", err)
-		}
-	default:
-		return fmt.Errorf("unsupported image reference type %T", ref)
-	}
-
-	// Save the image to the local daemon
 	response, err := daemon.Write(tag, img, daemon.WithClient(r.dockerClient))
 	if err != nil {
 		return fmt.Errorf("failed to write image to daemon: %w", err)
 	}
 
-	// Display success message
 	if _, err := fmt.Fprintf(os.Stdout, "Successfully pulled %s\n", imageName); err != nil {
 		slog.Debug("failed to write success message", "error", err)
 	}
 	//nolint:gosec // G706: image name and response from registry pull
 	slog.Debug("pull complete", "image", imageName, "response", response)
+
+	return nil
+}
+
+// pullDigestViaDockerDaemon pulls a digest-pinned image (tag@digest or
+// digest-only form) using the Docker daemon client so the OCI manifest digest
+// is stored and Docker can resolve the reference at container-create time.
+func (r *RegistryImageManager) pullDigestViaDockerDaemon(ctx context.Context, imageName string, ref name.Reference) error {
+	// Resolve auth from the keychain and encode for the daemon API.
+	var registryAuth string
+	if auth, err := r.keychain.Resolve(ref.Context().Registry); err == nil && auth != authn.Anonymous {
+		if authCfg, err := auth.Authorization(); err == nil {
+			if authJSON, err := json.Marshal(authCfg); err == nil {
+				registryAuth = base64.URLEncoding.EncodeToString(authJSON)
+			}
+		}
+	}
+
+	resp, err := r.dockerClient.ImagePull(ctx, imageName, mobyclient.ImagePullOptions{
+		RegistryAuth: registryAuth,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to pull image: %w", err)
+	}
+	if err := resp.Wait(ctx); err != nil {
+		return fmt.Errorf("failed waiting for image pull: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(os.Stdout, "Successfully pulled %s\n", imageName); err != nil {
+		slog.Debug("failed to write success message", "error", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- When `PullImage` is called with a `tag@digest` reference (e.g. the pinned Envoy image `envoyproxy/envoy-distroless:v1.32.3@sha256:…`), it stored the image via go-containerregistry's `daemon.Write` under the tag only. Docker's `tag@digest` cross-check at container-create time requires the OCI manifest digest to be registered against that tag — `daemon.Write` does not do this, so `docker create` fails with "No such image" whenever the host already has a different image cached under the same tag.
- The fix routes `name.Digest` refs (both `tag@digest` and digest-only) through the Docker daemon's native `ImagePull`, which correctly registers the manifest digest. Plain tag refs continue to use the existing go-containerregistry path for cross-platform support and custom keychain auth. Auth is threaded through from the keychain for private registries.

Discovered while testing the Envoy proxy backend (`TOOLHIVE_NETWORK_PROXY=envoy`) from issue #5900.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Reproduced the failure: `thv run` with `TOOLHIVE_NETWORK_PROXY=envoy` fails with `Error response from daemon: No such image: envoyproxy/envoy-distroless:v1.32.3@sha256:…` when the host already has `v1.32.3` cached at a different digest
- [x] Verified the fix: after the change, `thv run` starts the Envoy container successfully without any manual `docker pull` workaround
- [x] `task build` clean
- [x] `task lint-fix` clean on changed files (pre-existing issues in unrelated files)

Ref: https://github.com/stacklok/toolhive/issues/5903

Generated with [Claude Code](https://claude.com/claude-code)