### PR TITLE
Make swagger docgen deterministic (dedupe swag's doubled enums)

### DIFF
--- a/.github/workflows/verify-docgen.yml
+++ b/.github/workflows/verify-docgen.yml
@@ -16,5 +16,8 @@ jobs:
         with:
           go-version: 'stable'
       - name: Install swag
-        run: go install github.com/swaggo/swag/v2/cmd/swag@latest
+        # Pinned to match go.mod and Taskfile.yml — see the comment on the
+        # swagger-install task for why this alone doesn't make the check
+        # fully deterministic.
+        run: go install github.com/swaggo/swag/v2/cmd/swag@v2.0.0-rc5
       - run: ./cmd/help/verify.sh

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,17 +13,16 @@ tasks:
       - rm -rf docs/cli/*
       - go run cmd/help/main.go --dir docs/cli
       - swag init -g pkg/api/server.go --v3.1 -o docs/server --parseDependencyLevel 1
+      # swag can non-deterministically double enum arrays for types from
+      # external modules (see cmd/help/dedupe-enums); normalize the output.
+      - go run ./cmd/help/dedupe-enums docs/server/docs.go docs/server/swagger.json docs/server/swagger.yaml
       - task: helm-docs
 
   swagger-install:
     desc: Install the swag tool for OpenAPI/Swagger generation
     cmds:
       # Pinned to the version go.mod already requires, so @latest can't
-      # silently drift onto a newer/older swag release. Note: swag v2.0.0-rc5
-      # itself still has a run-to-run nondeterminism bug that can double
-      # x-enum-varnames/enum entries for types from external modules
-      # (packages.go's loadExternalPackage doesn't memoize by import path) —
-      # pinning removes version drift as a variable but does not fix that bug.
+      # silently drift onto a newer/older swag release.
       # Keep in sync with .github/workflows/verify-docgen.yml.
       - go install github.com/swaggo/swag/v2/cmd/swag@v2.0.0-rc5
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,7 +18,14 @@ tasks:
   swagger-install:
     desc: Install the swag tool for OpenAPI/Swagger generation
     cmds:
-      - go install github.com/swaggo/swag/v2/cmd/swag@latest
+      # Pinned to the version go.mod already requires, so @latest can't
+      # silently drift onto a newer/older swag release. Note: swag v2.0.0-rc5
+      # itself still has a run-to-run nondeterminism bug that can double
+      # x-enum-varnames/enum entries for types from external modules
+      # (packages.go's loadExternalPackage doesn't memoize by import path) —
+      # pinning removes version drift as a variable but does not fix that bug.
+      # Keep in sync with .github/workflows/verify-docgen.yml.
+      - go install github.com/swaggo/swag/v2/cmd/swag@v2.0.0-rc5
 
   helm-docs:
     desc: Generate Helm chart documentation

--- a/cmd/help/dedupe-enums/main.go
+++ b/cmd/help/dedupe-enums/main.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Command dedupe-enums works around a swag v2.0.0-rc5 nondeterminism bug:
+// loadExternalPackage (in swag's packages.go) reparses an external module's
+// package without memoizing by import path, which can non-deterministically
+// double the "enum"/"x-enum-varnames" arrays it emits for types defined
+// outside this module (model.ArgumentType, model.Format, model.Icon from
+// github.com/modelcontextprotocol/registry). When an array is exactly two
+// identical halves back to back, this collapses it to one.
+//
+// Run after `swag init`, on each generated docs/server file:
+//
+//	go run ./cmd/help/dedupe-enums docs/server/docs.go docs/server/swagger.json docs/server/swagger.yaml
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// jsonArray only matches quoted-string enum values (swag emits every enum in
+// docs/server today as strings); a doubled numeric/integer external enum
+// would pass through undeduped. yamlArray matches any scalar, so it has no
+// such gap.
+var (
+	jsonArray = regexp.MustCompile(`(?m)^([ \t]*"(?:enum|x-enum-varnames)": \[\n)((?:[ \t]*".*?",?\n)+?)([ \t]*\])`)
+	yamlArray = regexp.MustCompile(`(?m)^([ \t]*(?:enum|x-enum-varnames):\n)((?:[ \t]*- .+\n)+)`)
+)
+
+func main() {
+	for _, path := range os.Args[1:] {
+		data, err := os.ReadFile(path) // #nosec G304 -- path is a CLI argument we control (Taskfile/verify.sh)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		fixed := jsonArray.ReplaceAllStringFunc(string(data), dedupeJSONBlock)
+		fixed = yamlArray.ReplaceAllStringFunc(fixed, dedupeYAMLBlock)
+
+		if fixed == string(data) {
+			continue
+		}
+		if err := os.WriteFile(path, []byte(fixed), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println("deduped", path)
+	}
+}
+
+func dedupeJSONBlock(match string) string {
+	g := jsonArray.FindStringSubmatch(match)
+	header, body, footer := g[1], g[2], g[3]
+
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	trimmed := make([]string, len(lines))
+	for i, l := range lines {
+		trimmed[i] = strings.TrimSuffix(l, ",")
+	}
+
+	half, ok := firstHalfIfDoubled(trimmed)
+	if !ok {
+		return match
+	}
+	return header + strings.Join(half, ",\n") + "\n" + footer
+}
+
+func dedupeYAMLBlock(match string) string {
+	g := yamlArray.FindStringSubmatch(match)
+	header, body := g[1], g[2]
+
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	half, ok := firstHalfIfDoubled(lines)
+	if !ok {
+		return match
+	}
+	return header + strings.Join(half, "\n") + "\n"
+}
+
+// firstHalfIfDoubled reports whether lines is exactly two identical halves
+// back to back, returning the first half if so. It only catches this
+// specific shape (contiguous, order-preserved duplication), not any 2x
+// multiset — if swag's bug ever reordered values within the second copy,
+// this wouldn't fire. That matches the upstream bug: it re-appends the same
+// const list a second time, never reorders it.
+func firstHalfIfDoubled(lines []string) ([]string, bool) {
+	n := len(lines)
+	if n == 0 || n%2 != 0 {
+		return nil, false
+	}
+	half := n / 2
+	for i := 0; i < half; i++ {
+		if lines[i] != lines[half+i] {
+			return nil, false
+		}
+	}
+	return lines[:half], true
+}

--- a/cmd/help/dedupe-enums/main_test.go
+++ b/cmd/help/dedupe-enums/main_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFirstHalfIfDoubled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		lines []string
+		want  []string
+		ok    bool
+	}{
+		{
+			name:  "doubled",
+			lines: []string{"a", "b", "a", "b"},
+			want:  []string{"a", "b"},
+			ok:    true,
+		},
+		{
+			name:  "tripled is not a doubled shape",
+			lines: []string{"a", "b", "a", "b", "a", "b"},
+			ok:    false,
+		},
+		{
+			name:  "odd length",
+			lines: []string{"a", "b", "a"},
+			ok:    false,
+		},
+		{
+			name:  "single element",
+			lines: []string{"a"},
+			ok:    false,
+		},
+		{
+			name:  "empty",
+			lines: []string{},
+			ok:    false,
+		},
+		{
+			name:  "already deduped, idempotent",
+			lines: []string{"a", "b"},
+			ok:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := firstHalfIfDoubled(tt.lines)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if ok && !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/help/verify.sh
+++ b/cmd/help/verify.sh
@@ -10,6 +10,9 @@ diff -Naur -I "^  date:" "$tmpdir" docs/cli/
 api_tmpdir=$(mktemp -d)
 mkdir -p "$api_tmpdir/server"
 swag init -g pkg/api/server.go --v3.1 -o "$api_tmpdir/server" --parseDependencyLevel 1
+# swag can non-deterministically double enum arrays for types from external
+# modules (see cmd/help/dedupe-enums); normalize before diffing.
+go run ./cmd/help/dedupe-enums "$api_tmpdir/server/docs.go" "$api_tmpdir/server/swagger.json" "$api_tmpdir/server/swagger.yaml"
 # Exclude README.md from diff as it's manually maintained
 diff -Naur --exclude="README.md" "$api_tmpdir/server" docs/server/
 


### PR DESCRIPTION
## Summary

**Why:** The `Verify Swagger Documentation` check is a **flaky required gate** — it fails nondeterministically on unrelated PRs. Root cause is an upstream bug in `swag v2.0.0-rc5` (already required in `go.mod`): its `loadExternalPackage()` has no memoization by import path, so under `--parseDependencyLevel 1` it sometimes re-parses an out-of-module dependency and **doubles that type's `enum` / `x-enum-varnames` arrays**. Because swag walks Go maps (randomized iteration order), whether the doubling happens varies run-to-run with the identical binary and inputs. It only affects the three external MCP-registry enums reached across the module boundary — `model.ArgumentType`, `model.Format`, `model.Icon`. #5970 regenerated the docs to drop these duplicates, but that only got a lucky clean run; the check keeps flaking.

`GOMAXPROCS=1` does not help (map iteration order is randomized independent of goroutine scheduling — verified).

**What:**
- **Pin `swag`** to `@v2.0.0-rc5` (matching `go.mod`) in `Taskfile.yml` and `.github/workflows/verify-docgen.yml`, replacing `@latest` (hygiene against future drift).
- **Normalize the doubled enums** deterministically with a tiny stdlib tool, `cmd/help/dedupe-enums`: it collapses an `enum`/`x-enum-varnames` array only when it is exactly two contiguous, order-identical halves, and is a no-op on everything else. Wired in after `swag init` in `task docs` and before the `diff` in `cmd/help/verify.sh`, so generation and CI verification always agree regardless of whether swag doubled that run.
- `docs/server/*` are unchanged (already in the canonical deduped form).

No API, code, or generated-doc content changes — this is a build/CI determinism fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `cmd/help/dedupe-enums/main_test.go` — table test for the collapse rule (doubled→half, tripled/odd/single/empty→unchanged, idempotency).
- [x] Determinism: repeated `swag init` → dedupe → `git diff` cycles all come out clean whether or not swag doubled that run; multiple full `cmd/help/verify.sh` runs pass; full `task docs` pipeline yields zero diff (no `docs/server`, `docs/cli`, or helm churn).
- [x] `task build`, `task lint` (0 issues), `go vet` clean.

## Special notes for reviewers

- The dedup tool is build-tooling only (`package main` under `cmd/help/`, never imported by shipped binaries). gosec G304/G306 addressed (scoped `#nosec` matching the existing `cmd/thv/app/export.go` convention; `0o600` writes).
- Assumptions are documented in-code: the collapse targets swag's specific contiguous-order-identical duplication (not any 2× multiset), and the JSON element pattern matches quoted-string enums (no numeric external enums exist today; the YAML path handles any scalar).
- Proper fix belongs upstream (memoize `loadExternalPackage`); this removes the flake for every PR in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
