### PR TITLE
Unblock main CI: fix vMCP nil-registry panic and CRD docs drift

### DIFF
--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -4813,6 +4813,7 @@ This type is shared with the Kubernetes operator CRD (VirtualMCPServer.Status.Di
 | `circuitBreakerState` _string_ | CircuitBreakerState is the current circuit breaker state (closed, open, half-open).<br />Empty when circuit breaker is disabled or not configured. |  | Enum: [closed open half-open] <br />Optional: \{\} <br /> |
 | `circuitLastChanged` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#time-v1-meta)_ | CircuitLastChanged is the timestamp when the circuit breaker state last changed.<br />Empty when circuit breaker is disabled or has never changed state. |  | Optional: \{\} <br /> |
 | `consecutiveFailures` _integer_ | ConsecutiveFailures is the current count of consecutive health check failures.<br />Resets to 0 when the backend becomes healthy again. |  | Optional: \{\} <br /> |
+| `mcpRevision` _string_ | MCPRevision is the backend's negotiated MCP protocol revision<br />("2026-07-28" or "2025-11-25"). Empty when the backend has not been probed. |  | Optional: \{\} <br /> |
 
 
 

--- a/pkg/vmcp/client/schema_ingestion_regression_test.go
+++ b/pkg/vmcp/client/schema_ingestion_regression_test.go
@@ -108,20 +108,19 @@ func TestRegression_ToolSchemaFidelity_PreservesCompositors(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	h := &httpBackendClient{
-		clientFactory: func(ctx context.Context, target *vmcp.BackendTarget, _ bool) (*client.Client, error) {
-			c, err := client.NewStreamableHttpClient(
-				target.BaseURL,
-				mcptransport.WithHTTPTimeout(30*time.Second),
-			)
-			if err != nil {
-				return nil, err
-			}
-			if err := c.Start(ctx); err != nil {
-				return nil, err
-			}
-			return c, nil
-		},
+	h := newProbeClient(t)
+	h.clientFactory = func(ctx context.Context, target *vmcp.BackendTarget, _ bool) (*client.Client, error) {
+		c, err := client.NewStreamableHttpClient(
+			target.BaseURL,
+			mcptransport.WithHTTPTimeout(30*time.Second),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.Start(ctx); err != nil {
+			return nil, err
+		}
+		return c, nil
 	}
 
 	target := &vmcp.BackendTarget{


### PR DESCRIPTION
Main is currently red on two independent checks, both fallout from the "Handle per-backend MCP revision in vMCP" merge. Since every PR branches off main, a fix for just one still inherits the other's red and never gets a green run — so this PR clears both.

## 1. `Tests / Test Go Code` — nil-registry panic

`TestRegression_ToolSchemaFidelity_PreservesCompositors` panics with a nil-pointer dereference, and because a panic tears down the whole `pkg/vmcp/client` test binary, every test in the package reports as failed.

**Why:** the test builds `httpBackendClient` as a raw struct literal that never sets `registry`. The per-backend revision handling made `ListCapabilities` run `probeRevision -> buildModernHTTPClient -> resolveAuthStrategy`, which calls `h.registry.GetStrategy(...)` on the nil registry (`client.go:454`). The real constructor `NewHTTPBackendClient` rejects a nil registry, so this is a test-setup gap, not a missing production guard.

**What:** build the probe client via the existing `newProbeClient(t)` helper (wires a real registry with `UnauthenticatedStrategy`). Test-only.

## 2. `Operator CI / Generate CRD Docs` — stale CRD reference

The same merge added an `MCPRevision` field to the backend status but did not regenerate `docs/operator/crd-api.md`, so `crd-ref-docs` + `git diff --exit-code` fails. Regenerated to add the missing `mcpRevision` entry. Generated-docs only.

Both are carved from the fixes bundled in #5993 (go-sdk v1.7 migration) so main and dependent PRs can go green now instead of waiting on that larger PR. cc @JAORMX — #5993 can rebase cleanly over this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Unit tests (`task test`): `go test ./pkg/vmcp/client/ -run TestRegression_ToolSchemaFidelity_PreservesCompositors -count=2` — panics before, passes after.
- [x] `task crdref-gen` produces no further diff after this change.

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)