### PR TITLE
Fall back to Legacy on an inconclusive vMCP revision probe

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -1053,7 +1053,9 @@ func (h *httpBackendClient) modernDiscover(
 //     leaving it unprobed lets the next call re-probe once the outage clears.
 //
 // A hard error is also returned when the backend transport cannot be built at all
-// (e.g. invalid auth/CA config); that is a genuine misconfiguration.
+// (e.g. invalid auth/CA config); that is a genuine misconfiguration. Note that
+// dispatch, the sole caller, does not distinguish these error classes — it falls
+// back to Legacy uncached on any error this function returns.
 // The resolved capabilities are intentionally not returned: callers that need
 // them (ListCapabilities) re-fetch via modernDiscover, so probeRevision only
 // classifies and caches the revision.
@@ -1382,6 +1384,11 @@ func (*httpBackendClient) legacyInit(
 // and runs fn with it. Every call verb AND ListCapabilities route through this
 // seam so revision selection — and self-correction — lives in one place.
 //
+// A probeRevision error of any kind (inconclusive probe or transport-build
+// failure) falls back to Legacy — the pre-dual-era default — WITHOUT caching,
+// so a genuinely Modern backend re-probes on the next call instead of being
+// pinned to Legacy by one bad probe.
+//
 // On a revision mismatch (isRevisionMismatch), dispatch always re-probes
 // authoritatively and flips the cache so future calls use the corrected
 // revision. It RETRIES fn only when the failure proves the backend did NOT
@@ -1391,8 +1398,10 @@ func (*httpBackendClient) legacyInit(
 // cache is flipped but fn is NOT re-run. The retry is unconditionally single
 // (no re-check), so it can never loop.
 //
-// When the revision was just probed in THIS call (uncached), a re-probe would
-// return the same answer, so a mismatch is surfaced directly without re-probing.
+// When the revision was resolved in THIS call (uncached), a mismatch is surfaced
+// directly without re-probing: on a successful probe a re-probe would just repeat
+// the same answer, and on the Legacy fallback above there is no cached revision to
+// correct — the next call re-probes anyway once the outage clears.
 func (h *httpBackendClient) dispatch(
 	ctx context.Context, target *vmcp.BackendTarget,
 	fn func(ctx context.Context, rev mcpparser.Revision) error,
@@ -1401,9 +1410,19 @@ func (h *httpBackendClient) dispatch(
 	if !cached {
 		probed, err := h.probeRevision(ctx, target)
 		if err != nil {
-			return wrapBackendError(err, target.WorkloadID, "probe revision")
+			// A failed probe (auth blip / transient 5xx / timeout / connection
+			// refused, or a transport that could not be built) says nothing about
+			// the revision and must NOT fail a backend that is reachable on the
+			// Legacy path — which re-validates the transport itself. Fall back to Legacy —
+			// the pre-dual-era default — WITHOUT caching, so a transient outage
+			// never pins a revision and a genuinely Modern backend is corrected on
+			// the next call's re-probe.
+			slog.DebugContext(ctx, "revision probe inconclusive; attempting Legacy uncached",
+				"backend", target.WorkloadID, "probe_error", err)
+			rev = mcpparser.RevisionLegacy
+		} else {
+			rev = probed
 		}
-		rev = probed
 	}
 
 	err := fn(ctx, rev)

--- a/pkg/vmcp/client/dispatch_legacy_fallback_test.go
+++ b/pkg/vmcp/client/dispatch_legacy_fallback_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// TestDispatch_LegacyFallbackOnInconclusiveProbe pins the fix for the
+// dispatch abort regressed by merge 885e8b14f: a Modern server/discover probe
+// that comes back transient (HTTP 503, -> errModernTransient) must fall back
+// to the Legacy initialize/tools-list path uncached, not fail the whole call.
+// Caching the fallback would pin a genuinely Modern backend to Legacy past a
+// transient outage, so the revision cache must remain unset afterward.
+func TestDispatch_LegacyFallbackOnInconclusiveProbe(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Mcp-Method") != "" {
+			// Modern probe: transient failure, discovered before the body is read.
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+
+		body, err := readAll(t, r)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var req jsonRPCRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Method {
+		case "initialize":
+			resp := jsonRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result: json.RawMessage(`{
+					"protocolVersion": "2024-11-05",
+					"capabilities": {"tools": {}},
+					"serverInfo": {"name": "flaky-probe", "version": "1.0.0"}
+				}`),
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case "tools/list":
+			resp := jsonRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result: json.RawMessage(`{
+					"tools": [{"name": "echo", "description": "echoes input"}]
+				}`),
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			_ = json.NewEncoder(w).Encode(jsonRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  json.RawMessage(`{}`),
+			})
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// newProbeClient, not setRevision: the probe must actually run so the
+	// Modern 503 is hit and the fallback path exercised.
+	h := newProbeClient(t)
+	target := &vmcp.BackendTarget{
+		WorkloadID:    "flaky-probe",
+		BaseURL:       srv.URL,
+		TransportType: "streamable-http",
+	}
+
+	caps, err := h.ListCapabilities(context.Background(), target)
+	require.NoError(t, err)
+	require.Len(t, caps.Tools, 1)
+	assert.Equal(t, "echo", caps.Tools[0].Name)
+
+	_, ok := h.cachedRevision("flaky-probe")
+	assert.False(t, ok, "an inconclusive probe must not pin a revision")
+}


### PR DESCRIPTION
## Summary

`ListCapabilities` is both the vMCP health-check probe (`pkg/vmcp/health/checker.go:99`) and the startup aggregation call (`pkg/vmcp/aggregator/default_aggregator.go:95`). Since 885e8b14f it routes through `dispatch`, which resolves the backend's MCP revision by probing `server/discover` first and **treated any probe error as fatal**.

`probeRevision` deliberately returns its error *uncached* for the two inconclusive classes — `errModernAuth` (401/403/407) and `errModernTransient` (408/429/5xx, mid-stream read failure, or any transport error) — precisely because those outcomes say nothing about the backend's revision. Aborting on them meant a backend that was up and serving **Legacy** got reported unhealthy, which the existing readiness machinery amplified into delayed vMCP `Ready` and an empty aggregated tool list.

This restores the pre-885e8b14f outcome: fall back to Legacy, the pre-dual-era default, **without caching** the revision.

- A transient outage can no longer pin a backend to Legacy.
- A genuinely Modern backend is corrected by the next call's re-probe.
- A truly-down backend still fails fast — the Legacy `initialize` hits the same dead socket.

The fallback lives in `dispatch`, **not** `probeRevision`, on purpose: `probeRevision` must keep returning inconclusive errors uncached so the revision cache is never poisoned. Everything after `err := fn(ctx, rev)` — the reclassify-on-mismatch block — is unchanged.

Closes #6000

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

| File | Change |
|---|---|
| `pkg/vmcp/client/client.go` | `dispatch` falls back to `RevisionLegacy` uncached on a probe error instead of returning `wrapBackendError(..., "probe revision")`; doc comments on `dispatch` and `probeRevision` updated to match |
| `pkg/vmcp/client/dispatch_legacy_fallback_test.go` | New regression test |

## Test plan

- [x] Unit tests pass (`task test`)
- [x] New regression test added

`TestDispatch_LegacyFallbackOnInconclusiveProbe` drives one `httptest.Server` that discriminates on the `Mcp-Method` header: the Modern probe gets HTTP 503 (→ `errModernTransient`), while the Legacy `initialize` + `tools/list` path succeeds. It asserts `ListCapabilities` returns the tool, and that the revision cache is **not** pinned afterwards.

Verified as a negative control — with the production hunk reverted, the new test fails with exactly the bug's fingerprint:

```
backend unavailable: failed to probe revision for backend flaky-probe:
modern backend returned a transient error: HTTP 503
```

Also confirmed still green: `TestProbeRevision_TransientLeavesUnprobed`, `TestDispatch_TransientDoesNotReclassify`, `TestProbeRevision_TruthTable`, `TestRegression_401_*`, `TestRegression_403OnInitialize_*`, `TestRegression_ToolSchemaFidelity_PreservesCompositors`, `TestListCapabilities_*`.

## Special notes for reviewers

**Scope — please read.** This does *not* fix the `dial tcp …: connect: connection refused` signature seen in some failing e2e runs. There the socket is genuinely dead and the Legacy `initialize` fails identically; the health monitor's retry interval absorbs it. What this removes is the **5xx/408/429/auth window** that 885e8b14f made fatal — concretely, a ToolHive proxy that is listening while its MCP container is still starting answers the probe with 502/503, and the probe consumes that window and aborts before the Legacy path is ever attempted. I'd rather state that precisely than claim it eliminates every vMCP e2e flake.

**Why the fallback is unconditional.** It triggers on *any* `probeRevision` error, including the "failed to build transport" misconfiguration class. `defaultClientFactory` (`client.go:659`) calls the same `buildBackendRoundTripper`, so that class fails identically on the Legacy path — only the operation label in the error changes ("create client" vs "probe revision"). Narrowing it to the two sentinels would add a branch that distinguishes nothing observable.

**Safety checks done:**

- *No double execution.* `dispatch` is shared with `CallTool`, but in the uncached branch `if !cached { return err }` short-circuits before the retry machinery, so `fn` runs at most once. `legacyCallTool` also runs `legacyInit` first (`client.go:1572`) and returns early on failure, so a genuinely Modern backend rejects the Legacy `initialize` before `c.CallTool` (`client.go:1590`) is reachable.
- *No protocol downgrade.* Both eras build their transport through the same `buildBackendRoundTripper` (`client.go:560`) and the same `newBackendHTTPClient` choke point (`client.go:1010`), so auth injection, TLS/CA, `SameHostRedirectPolicy` and the SSRF dial hook are identical. There is no weaker Legacy path to downgrade to.
- *Health classification unchanged.* The 401/403-with-outgoing-auth → `BackendHealthy` mapping in `categorizeError`/`authErrorStatus` is untouched.

**Known cost:** against a permanently-misconfigured or down backend, the fallback adds one extra attempt per call (transport construction is CPU-only and repeated, since the failure is deliberately never cached). The fallback shares the probe's context, so it inherits the remaining health-check budget rather than a fresh one — harmless for the case being fixed, where the probe returns immediately.

Out of scope and deliberately untouched: the readiness/health-filtering amplifiers in `pkg/vmcp/server/status_reporting.go`, `pkg/vmcp/health/monitor.go` and `pkg/vmcp/core/core_vmcp.go` (`ListTools`) — pre-existing, tracked in #3100.

This is the third and last fix for 885e8b14f fallout, after #5999.

cc @JAORMX (owner of the related migration PR #5993)

Generated with [Claude Code](https://claude.com/claude-code)
