### PR TITLE
Audit stream opens on flush and pre-write panics

### DIFF
--- a/pkg/audit/auditor.go
+++ b/pkg/audit/auditor.go
@@ -231,10 +231,13 @@ func (a *Auditor) Middleware(next http.Handler) http.Handler {
 		// carries the authenticated identity (or records the 401/403 denial).
 		if a.isMCPStreamOpenRequest(r) {
 			sw := &streamOpenWriter{ResponseWriter: w, auditor: a, req: r}
+			// Deferred BEFORE ServeHTTP so a panic in an inner handler still
+			// produces the connection event during unwinding — some chains run
+			// the recovery middleware OUTSIDE audit (e.g. the vMCP Serve path),
+			// which would otherwise swallow the event entirely. If the stream
+			// already logged on first write this is a no-op.
+			defer sw.logOnce(http.StatusOK)
 			next.ServeHTTP(sw, r)
-			// Streams that end without a single write still get an event
-			// (net/http sends an implicit 200 in that case).
-			sw.logOnce(http.StatusOK)
 			return
 		}
 
@@ -703,7 +706,12 @@ func (sw *streamOpenWriter) Write(data []byte) (int, error) {
 }
 
 // Flush implements http.Flusher if the underlying ResponseWriter supports it.
+// A flush commits the response headers with an implicit 200, so it counts as
+// the stream being established — log the connection event here too, otherwise
+// a handler that flushes before its first write would delay (or, on a stream
+// that only ever flushes, lose) the event.
 func (sw *streamOpenWriter) Flush() {
+	sw.logOnce(http.StatusOK)
 	if flusher, ok := sw.ResponseWriter.(http.Flusher); ok {
 		flusher.Flush()
 	}

--- a/pkg/audit/auditor_test.go
+++ b/pkg/audit/auditor_test.go
@@ -1224,4 +1224,43 @@ func TestStreamOpenAuditEvents(t *testing.T) {
 		assert.Equal(t, OutcomeSuccess, events[0]["outcome"],
 			"net/http sends an implicit 200 when the handler writes nothing")
 	})
+
+	t.Run("flush before first write logs the connection event", func(t *testing.T) {
+		t.Parallel()
+		auditor, logBuf := newBufferAuditor(t)
+
+		// A handler that establishes the stream by flushing headers and then
+		// blocks (waiting for events to send) never hits WriteHeader/Write.
+		flusher := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		})
+		auditor.Middleware(flusher).ServeHTTP(httptest.NewRecorder(), newStreamRequest())
+
+		events := decodeAuditEvents(t, logBuf)
+		require.Len(t, events, 1, "the flush must not bypass the connection event")
+		assert.Equal(t, EventTypeSSEConnection, events[0]["type"])
+		assert.Equal(t, OutcomeSuccess, events[0]["outcome"])
+	})
+
+	t.Run("panic before first write still logs the connection event", func(t *testing.T) {
+		t.Parallel()
+		auditor, logBuf := newBufferAuditor(t)
+
+		panicker := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			panic("boom before first write")
+		})
+		handler := auditor.Middleware(panicker)
+		require.Panics(t, func() {
+			handler.ServeHTTP(httptest.NewRecorder(), newStreamRequest())
+		}, "no recovery middleware on this chain: the panic must propagate")
+
+		events := decodeAuditEvents(t, logBuf)
+		require.Len(t, events, 1,
+			"chains whose recovery middleware runs OUTSIDE audit (e.g. the vMCP Serve path) "+
+				"must not lose the connection event to a panic")
+		assert.Equal(t, EventTypeSSEConnection, events[0]["type"])
+	})
 }


### PR DESCRIPTION
## Summary

Stacked on #5874 — addresses the two minor, non-blocking follow-ups from @rdimitrov's [review](https://github.com/stacklok/toolhive/pull/5874#pullrequestreview-4733136620), both in the deferred stream-open logging in `pkg/audit/auditor.go`:

1. **`streamOpenWriter.Flush()` bypassed `logOnce`** — a handler that establishes the stream by flushing headers and then blocks waiting for events sends the implicit 200 through `Flush()` without ever hitting `WriteHeader`/`Write`, so the connection event was delayed until a later data write or connection close. `Flush()` now calls `logOnce(http.StatusOK)`; a flush commits the response headers with an implicit 200, so it counts as the stream being established.

2. **Stream-open event lost on a panic before the first write** — on the vMCP Serve path, recovery is the outermost wrapper (outside audit), so a panic in an inner layer before any byte is written unwound straight past audit: recovery returns 500 and no stream-open event was recorded. The `sw.logOnce(http.StatusOK)` call moved into a `defer` registered *before* `next.ServeHTTP`, so the event is produced during unwinding. If the stream already logged on first write, the deferred call is a no-op. This restores parity with the pre-#5874 arrival-time logging for that case (the connection-open is recorded; the 500 written by the outer recovery is not visible to audit, same as before).

The runner/proxy path was already unaffected by (2) — recovery is innermost there, so the 500 flows back out through `streamOpenWriter` and `logOnce(500)` fires.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)

Two new subtests in `TestStreamOpenAuditEvents`: `flush before first write logs the connection event` and `panic before first write still logs the connection event`.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

No CRD or exported-API changes.

## Does this introduce a user-facing change?

Yes. Audit logs now always contain the stream-connection event for SSE / streamable GET opens: previously it could be delayed or lost for handlers that flush before writing, and lost entirely on a pre-write panic on the vMCP Serve path.