### PR TITLE
Bridge era-mismatched client×backend cells in vMCP

### DIFF
--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -317,6 +317,18 @@ non-nil `ListChangedSink` is supplied at connection time, the connector:
   than a bare string so a typo is a compile error — and logs
   `notifications/message` received out-of-call (log-only; no relay).
 
+This propagation mechanism only applies to a Legacy (2025-11-25) backend: the
+per-session factory (`pkg/vmcp/session/factory.go`) skips the persistent
+connection — and therefore the handshake, the sink registration, and the
+standalone GET stream above — for any backend whose cached revision is known
+Modern (2026-07-28); see [Backend MCP Revision Classification](#backend-mcp-revision-classification)
+above for how that revision is resolved and cached. This is correct, not a gap in the skip: Modern removed
+`initialize` and `Mcp-Session-Id`, so there is no Legacy-shaped persistent
+connection to hold and no standalone GET stream a Modern backend could push
+on. Modern's own server-push mechanism is `subscriptions/listen` (see
+[Transport Architecture](03-transport-architecture.md)), which vMCP does not
+implement yet — so `list_changed` propagation is currently Legacy-only.
+
 The sink is built once per session, at registration (`pkg/vmcp/server`'s
 `buildListChangedSink`), closing over the SDK `ClientSession`, the session ID,
 and the caller's identity **and per-request forwarded headers** captured **at

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -4872,3 +4872,5 @@ This type is shared with the Kubernetes operator CRD (VirtualMCPServer.Status.Di
 
 
 
+
+

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stacklok/toolhive/pkg/container"
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/groups"
-	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/migration"
 	"github.com/stacklok/toolhive/pkg/telemetry"
 	"github.com/stacklok/toolhive/pkg/versions"
@@ -58,15 +57,6 @@ import (
 // see server.Config.ModernDispatchEnabled). Env-only ahead of any CLI-flag or
 // CRD wiring.
 const modernDispatchEnvVar = "TOOLHIVE_VMCP_MODERN_STATELESS"
-
-// revisionReporter is the optional accessor for a backend's cached MCP
-// revision. httpBackendClient implements it; it is NOT part of
-// vmcp.BackendClient (see pkg/vmcp/health's identical pattern), so it is
-// reached via a type assertion below and simply omitted from the session
-// factory's options when absent.
-type revisionReporter interface {
-	CachedRevision(workloadID string) (mcpparser.Revision, bool)
-}
 
 // ServeConfig holds all parameters needed to start the vMCP server.
 // Populated by the caller from Cobra flag values or equivalent.
@@ -368,7 +358,7 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 	// The factory never aggregates — the core is the single source of capability
 	// aggregation (agg feeds it via Config.Aggregator below).
 	var sessionFactoryOpts []vmcpsession.MultiSessionFactoryOption
-	if revisions, ok := backendClient.(revisionReporter); ok {
+	if revisions, ok := backendClient.(vmcp.RevisionReporter); ok {
 		sessionFactoryOpts = append(sessionFactoryOpts, vmcpsession.WithRevisionLookup(revisions.CachedRevision))
 	}
 	sessionFactory := vmcpsession.NewSessionFactory(outgoingRegistry, sessionFactoryOpts...)

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/container"
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/groups"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/migration"
 	"github.com/stacklok/toolhive/pkg/telemetry"
 	"github.com/stacklok/toolhive/pkg/versions"
@@ -57,6 +58,15 @@ import (
 // see server.Config.ModernDispatchEnabled). Env-only ahead of any CLI-flag or
 // CRD wiring.
 const modernDispatchEnvVar = "TOOLHIVE_VMCP_MODERN_STATELESS"
+
+// revisionReporter is the optional accessor for a backend's cached MCP
+// revision. httpBackendClient implements it; it is NOT part of
+// vmcp.BackendClient (see pkg/vmcp/health's identical pattern), so it is
+// reached via a type assertion below and simply omitted from the session
+// factory's options when absent.
+type revisionReporter interface {
+	CachedRevision(workloadID string) (mcpparser.Revision, bool)
+}
 
 // ServeConfig holds all parameters needed to start the vMCP server.
 // Populated by the caller from Cobra flag values or equivalent.
@@ -357,7 +367,11 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 	}
 	// The factory never aggregates — the core is the single source of capability
 	// aggregation (agg feeds it via Config.Aggregator below).
-	sessionFactory := vmcpsession.NewSessionFactory(outgoingRegistry)
+	var sessionFactoryOpts []vmcpsession.MultiSessionFactoryOption
+	if revisions, ok := backendClient.(revisionReporter); ok {
+		sessionFactoryOpts = append(sessionFactoryOpts, vmcpsession.WithRevisionLookup(revisions.CachedRevision))
+	}
+	sessionFactory := vmcpsession.NewSessionFactory(outgoingRegistry, sessionFactoryOpts...)
 
 	// When the optimizer is enabled, its meta-tools are pass-through tools.
 	// Authz uses this for optimizer-aware authorization/filtering.

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -990,10 +990,18 @@ func (h *httpBackendClient) setRevision(workloadID string, rev mcpparser.Revisio
 	h.revisions.Store(workloadID, rev)
 }
 
+// Compile-time guard that this client still satisfies the optional read-model
+// every consumer type-asserts to. Without it, renaming or dropping
+// CachedRevision below would compile cleanly and silently disable the telemetry
+// revision label, the /status field, and the session layer's Modern-connect
+// skip — each of which degrades gracefully by design when the assertion fails.
+var _ vmcp.RevisionReporter = (*httpBackendClient)(nil)
+
 // CachedRevision reports a backend's resolved MCP revision for status/telemetry
 // read-models. The second return is false when the backend has never been probed.
-// Exported (not on vmcp.BackendClient) so the telemetry decorator and health
-// monitor can read it via an optional interface without an interface/mock change.
+// Exported (not on vmcp.BackendClient) so the telemetry decorator, health
+// monitor and session factory can read it via vmcp.RevisionReporter without an
+// interface/mock change.
 func (h *httpBackendClient) CachedRevision(workloadID string) (mcpparser.Revision, bool) {
 	return h.cachedRevision(workloadID)
 }

--- a/pkg/vmcp/health/monitor.go
+++ b/pkg/vmcp/health/monitor.go
@@ -13,18 +13,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	healthcontext "github.com/stacklok/toolhive/pkg/vmcp/health/context"
 )
-
-// revisionReporter is the optional accessor for a backend's cached MCP revision.
-// The backend client (directly or through the telemetry decorator) implements it;
-// it is NOT part of vmcp.BackendClient, so the monitor reaches it via a type
-// assertion and simply reports no revision when absent.
-type revisionReporter interface {
-	CachedRevision(workloadID string) (mcpparser.Revision, bool)
-}
 
 // WithHealthCheckMarker marks a context as a health check request.
 // Authentication layers can use IsHealthCheck to identify and skip authentication
@@ -129,8 +120,8 @@ type Monitor struct {
 	checker vmcp.HealthChecker
 
 	// revisions reads each backend's negotiated MCP revision for the status
-	// read-model. Nil when the client does not implement revisionReporter.
-	revisions revisionReporter
+	// read-model. Nil when the client does not implement vmcp.RevisionReporter.
+	revisions vmcp.RevisionReporter
 
 	// statusTracker tracks health status for all backends.
 	statusTracker *statusTracker
@@ -267,7 +258,7 @@ func NewMonitor(
 
 	// The client (directly or via the telemetry decorator) optionally reports the
 	// negotiated MCP revision for the status read-model; nil when unsupported.
-	revisions, _ := client.(revisionReporter)
+	revisions, _ := client.(vmcp.RevisionReporter)
 
 	return &Monitor{
 		checker:       checker,

--- a/pkg/vmcp/internal/backendtelemetry/backendtelemetry.go
+++ b/pkg/vmcp/internal/backendtelemetry/backendtelemetry.go
@@ -29,14 +29,6 @@ import (
 	"github.com/stacklok/toolhive/pkg/vmcp"
 )
 
-// revisionReporter is the optional accessor the concrete backend client exposes
-// for its cached MCP revision (see client.CachedRevision). It is NOT part of
-// vmcp.BackendClient, so it is reached via a type assertion — a client that does
-// not implement it simply reports no revision.
-type revisionReporter interface {
-	CachedRevision(workloadID string) (mcpparser.Revision, bool)
-}
-
 const (
 	instrumentationName = "github.com/stacklok/toolhive/pkg/vmcp"
 )
@@ -141,12 +133,12 @@ type telemetryBackendClient struct {
 
 var _ vmcp.BackendClient = telemetryBackendClient{}
 
-// CachedRevision forwards to the wrapped client's optional revisionReporter so
+// CachedRevision forwards to the wrapped client's optional vmcp.RevisionReporter so
 // callers reaching the client THROUGH this decorator (e.g. the health monitor)
 // can still read the negotiated revision. Returns (0, false) when the wrapped
 // client does not report revisions.
 func (t telemetryBackendClient) CachedRevision(workloadID string) (mcpparser.Revision, bool) {
-	if r, ok := t.backendClient.(revisionReporter); ok {
+	if r, ok := t.backendClient.(vmcp.RevisionReporter); ok {
 		return r.CachedRevision(workloadID)
 	}
 	return 0, false

--- a/pkg/vmcp/mocks/mock_backend_client.go
+++ b/pkg/vmcp/mocks/mock_backend_client.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	mcp "github.com/stacklok/toolhive/pkg/mcp"
 	vmcp "github.com/stacklok/toolhive/pkg/vmcp"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -153,4 +154,43 @@ func (m *MockBackendClient) ReadResource(ctx context.Context, target *vmcp.Backe
 func (mr *MockBackendClientMockRecorder) ReadResource(ctx, target, uri any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadResource", reflect.TypeOf((*MockBackendClient)(nil).ReadResource), ctx, target, uri)
+}
+
+// MockRevisionReporter is a mock of RevisionReporter interface.
+type MockRevisionReporter struct {
+	ctrl     *gomock.Controller
+	recorder *MockRevisionReporterMockRecorder
+	isgomock struct{}
+}
+
+// MockRevisionReporterMockRecorder is the mock recorder for MockRevisionReporter.
+type MockRevisionReporterMockRecorder struct {
+	mock *MockRevisionReporter
+}
+
+// NewMockRevisionReporter creates a new mock instance.
+func NewMockRevisionReporter(ctrl *gomock.Controller) *MockRevisionReporter {
+	mock := &MockRevisionReporter{ctrl: ctrl}
+	mock.recorder = &MockRevisionReporterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRevisionReporter) EXPECT() *MockRevisionReporterMockRecorder {
+	return m.recorder
+}
+
+// CachedRevision mocks base method.
+func (m *MockRevisionReporter) CachedRevision(workloadID string) (mcp.Revision, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CachedRevision", workloadID)
+	ret0, _ := ret[0].(mcp.Revision)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// CachedRevision indicates an expected call of CachedRevision.
+func (mr *MockRevisionReporterMockRecorder) CachedRevision(workloadID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CachedRevision", reflect.TypeOf((*MockRevisionReporter)(nil).CachedRevision), workloadID)
 }

--- a/pkg/vmcp/server/authz_integration_test.go
+++ b/pkg/vmcp/server/authz_integration_test.go
@@ -178,6 +178,15 @@ func buildCedarAuthzServer(
 			Authz:          authzCfg,
 			AuditConfig:    auditCfg,
 			CodeModeConfig: codeModeCfg,
+			// Required for TestIntegration_CedarAuthzDenial_ModernPath_IsAudited to
+			// exercise what it claims: dispatchModern's re-homed call gate. Without
+			// it the kill switch refuses the Modern request in classifyingHandler and
+			// dispatchModern never runs. (Before the classifier learned to refuse an
+			// unserved revision, the request instead fell through to the SDK path, so
+			// that test passed on a denial from a different gate entirely.) Safe for
+			// the Legacy-shaped tests sharing this helper: classifyingHandler passes
+			// Legacy traffic through regardless of this flag.
+			ModernDispatchEnabled: true,
 		},
 		router.NewSessionRouter(&vmcp.RoutingTable{}),
 		backendClient,

--- a/pkg/vmcp/server/bridge_regression_test.go
+++ b/pkg/vmcp/server/bridge_regression_test.go
@@ -1,0 +1,810 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
+	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp/auth/strategies"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+	vmcpclient "github.com/stacklok/toolhive/pkg/vmcp/client"
+	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
+	"github.com/stacklok/toolhive/pkg/vmcp/router"
+	"github.com/stacklok/toolhive/pkg/vmcp/server"
+	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
+)
+
+// ---------------------------------------------------------------------------
+// This file pins the two cross-era "bridge cells" of vMCP's dual-protocol
+// dispatch: Modern client -> Legacy backend (Cell A) and Legacy client ->
+// Modern backend (Cell B). Both already work; nothing here changes production
+// behavior. RFC THV-0083 D6 plans a shared backend connection pool, which
+// would silently break Cell A's per-principal isolation if it ever collapsed
+// distinct backend sessions -- these tests exist so that change cannot land
+// without noticing.
+//
+// Scope: these pins cover the TRANSPORT/SESSION dimension of isolation only
+// (distinct backend connections, no cross-request credential bleed on the
+// wire). Credential *derivation* caching (e.g. token-exchange result caching,
+// pkg/vmcp/auth/strategies/tokenexchange.go) is a different layer and is not
+// exercised here.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Cell A: Modern client -> Legacy backend
+// ---------------------------------------------------------------------------
+
+// testIdentityEchoStrategyName is the outgoing-auth strategy name registered
+// by identityEchoStrategy below.
+const testIdentityEchoStrategyName = "test-identity-echo"
+
+// identityEchoStrategy stamps the calling principal's identity onto every
+// outgoing backend request as an Authorization header, so a test can observe
+// -- on the wire, via newRecordingBackendProxy -- which principal's
+// credential reached the backend on each individual request. The default
+// UnauthenticatedStrategy (used by every other real-backend test in this
+// package) injects nothing, so there would be nothing to assert; this is the
+// minimal seam for exercising the real property under test (the *calling*
+// principal's identity reaches outgoing auth on every re-originated call)
+// without needing real IdP infrastructure.
+type identityEchoStrategy struct{}
+
+func (identityEchoStrategy) Name() string { return testIdentityEchoStrategyName }
+
+func (identityEchoStrategy) Authenticate(ctx context.Context, req *http.Request, _ *authtypes.BackendAuthStrategy) error {
+	if identity, ok := auth.IdentityFromContext(ctx); ok && identity != nil {
+		req.Header.Set("Authorization", "Bearer test-"+identity.Subject)
+	}
+	return nil
+}
+
+func (identityEchoStrategy) Validate(_ *authtypes.BackendAuthStrategy) error { return nil }
+
+// bridgePrincipalMiddleware stamps a per-request auth.Identity derived from
+// the X-Test-Principal header. It duplicates the small stamping technique in
+// principalIdentityMiddleware (context_isolation_regression_test.go) rather
+// than importing it: that helper is unexported in package server, and this
+// file is package server_test so it can reach the real-backend helpers in
+// testutil_test.go.
+func bridgePrincipalMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		principal := r.Header.Get("X-Test-Principal")
+		if principal == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		id := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{Subject: principal, Claims: map[string]any{"sub": principal}}}
+		next.ServeHTTP(w, r.WithContext(auth.WithIdentity(r.Context(), id)))
+	})
+}
+
+// recordedBackendRequest captures one HTTP request newRecordingBackendProxy
+// forwarded to the real backend, plus the backend's response session id (when
+// present), so a test can correlate an initialize call with the tools/call
+// that reused its backend session via Mcp-Session-Id.
+type recordedBackendRequest struct {
+	jsonRPCMethod string
+	authorization string
+	reqSessionID  string
+	respSessionID string
+	body          map[string]any
+}
+
+// newRecordingBackendProxy starts an httptest.Server that transparently
+// forwards every request to backendURL while recording it. This gives the
+// test real MCP semantics plus full request observability, without
+// hand-rolling a fake MCP server (per the task's design suggestion). Returns
+// the proxy's /mcp URL and an accessor for a snapshot of everything recorded
+// so far.
+// flushWriter flushes the underlying http.ResponseWriter after every Write,
+// so a streamed response (the standalone SSE GET below) reaches the client
+// as it arrives instead of sitting in net/http's default write buffer.
+type flushWriter struct{ w http.ResponseWriter }
+
+func (fw flushWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	if f, ok := fw.w.(http.Flusher); ok {
+		f.Flush()
+	}
+	return n, err
+}
+
+func newRecordingBackendProxy(t *testing.T, backendURL string) (string, func() []recordedBackendRequest) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var records []recordedBackendRequest
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_ = r.Body.Close()
+
+		var decoded map[string]any
+		_ = json.Unmarshal(bodyBytes, &decoded)
+
+		fwdReq, err := http.NewRequestWithContext(r.Context(), r.Method, backendURL, bytes.NewReader(bodyBytes))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		fwdReq.Header = r.Header.Clone()
+
+		resp, err := http.DefaultClient.Do(fwdReq)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		method, _ := decoded["method"].(string)
+		mu.Lock()
+		records = append(records, recordedBackendRequest{
+			jsonRPCMethod: method,
+			authorization: r.Header.Get("Authorization"),
+			reqSessionID:  r.Header.Get("Mcp-Session-Id"),
+			respSessionID: resp.Header.Get("Mcp-Session-Id"),
+			body:          decoded,
+		})
+		mu.Unlock()
+
+		for k, vs := range resp.Header {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		// Flush the status line/headers immediately: the standalone SSE GET below
+		// can sit with headers sent but no body for a while (streamable.go's
+		// hangResponse), and the mcpcompat client's connectSSE blocks until it
+		// receives the response headers -- net/http's default buffered writer
+		// would otherwise hold them back indefinitely.
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Stream and flush every chunk, don't buffer: after `initialize`, the
+		// mcpcompat client opens that persistent standalone SSE GET, which the
+		// real backend intentionally never closes. Buffering the full response
+		// body before writing anything back would block forever on it, and a
+		// plain io.Copy alone would still hold each event back in the same
+		// buffered writer. flushWriter flushes after every write.
+		_, _ = io.Copy(flushWriter{w}, resp.Body)
+	})
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	getRecords := func() []recordedBackendRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]recordedBackendRequest, len(records))
+		copy(out, records)
+		return out
+	}
+	return ts.URL + "/mcp", getRecords
+}
+
+// newBridgeCellAServer builds a vMCP server with Modern dispatch's kill
+// switch ON, routing a single Legacy backend (at proxyURL) through
+// identityEchoStrategy so the credential that reaches the backend on each
+// call is observable. Mirrors newRealModernTestHandler's construction
+// (session_management_realbackend_integration_test.go), diverging only in
+// the backend's AuthConfig -- that helper always uses "unauthenticated",
+// which would leave nothing for this file's tests to assert.
+func newBridgeCellAServer(t *testing.T, proxyURL string) *httptest.Server {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	backend := vmcp.Backend{
+		ID:            "real-backend",
+		Name:          "real-backend",
+		BaseURL:       proxyURL,
+		TransportType: "streamable-http",
+		AuthConfig:    &authtypes.BackendAuthStrategy{Type: testIdentityEchoStrategyName},
+	}
+	mockBackendRegistry := mocks.NewMockBackendRegistry(ctrl)
+	mockBackendRegistry.EXPECT().List(gomock.Any()).Return([]vmcp.Backend{backend}).AnyTimes()
+	mockBackendRegistry.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&backend).AnyTimes()
+
+	authReg := vmcpauth.NewDefaultOutgoingAuthRegistry()
+	require.NoError(t, authReg.RegisterStrategy(authtypes.StrategyTypeUnauthenticated, strategies.NewUnauthenticatedStrategy()))
+	require.NoError(t, authReg.RegisterStrategy(testIdentityEchoStrategyName, identityEchoStrategy{}))
+
+	backendClient, err := vmcpclient.NewHTTPBackendClient(authReg)
+	require.NoError(t, err)
+	resolver, err := aggregator.NewPriorityConflictResolver([]string{backend.Name})
+	require.NoError(t, err)
+	agg := aggregator.NewDefaultAggregator(backendClient, resolver, nil, nil)
+
+	rt := router.NewSessionRouter(&vmcp.RoutingTable{})
+	srv, err := server.New(
+		context.Background(),
+		&server.Config{
+			Host:                  "127.0.0.1",
+			Port:                  0,
+			SessionTTL:            5 * time.Minute,
+			ModernDispatchEnabled: true,
+			SessionFactory:        vmcpsession.NewSessionFactory(authReg),
+			Aggregator:            agg,
+		},
+		rt,
+		backendClient,
+		mockBackendRegistry,
+		nil,
+	)
+	require.NoError(t, err)
+
+	handler, err := srv.Handler(context.Background())
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(bridgePrincipalMiddleware(handler))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// postModernToolCallAsPrincipal sends a Modern (2026-07-28) tools/call for
+// echo, stamped with X-Test-Principal so bridgePrincipalMiddleware
+// authenticates the caller as principal, and carrying the reserved
+// io.modelcontextprotocol/* _meta keys a real Modern client sends. Mirrors
+// postModern (modern_realbackend_integration_test.go), which has no hook for
+// extra headers -- needed here for the principal header.
+func postModernToolCallAsPrincipal(t *testing.T, baseURL, principal, input string) *http.Response {
+	t.Helper()
+
+	payload, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "echo",
+			"arguments": map[string]any{"input": input},
+			"_meta": map[string]any{
+				"io.modelcontextprotocol/protocolVersion":    "2026-07-28",
+				"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/mcp", bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("MCP-Protocol-Version", "2026-07-28")
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", "echo")
+	req.Header.Set("X-Test-Principal", principal)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestRegression_BridgeCellA_PerPrincipalSessionIsolation pins A1: two
+// different principals issuing Modern tools/calls, bridged to a Legacy
+// backend via dispatchModern -> core.CallTool -> legacyCallTool, must each
+// get their OWN backend initialize/session on EVERY call, and each
+// synthesized initialize/tools/call must carry that principal's own
+// credential -- nothing shared, cached, or reused across principals OR
+// across repeat calls from the same principal. legacyCallTool creates a
+// fresh MCP client (and runs a fresh initialize) per request and
+// `defer c.Close()`s it, so this holds today by construction; RFC THV-0083
+// D6's planned shared backend connection pool is the future change that
+// could silently break it.
+//
+// TWO SEQUENTIAL rounds of the same two principals, not one call each: with
+// only one call per principal, per-request client creation is never actually
+// exercised -- a pool keyed by (backend, principal) looks identical to
+// per-request creation on a single call, since there's nothing yet for it to
+// reuse. Round 2 gives such a pool its one chance to show up. The nonce is
+// decoupled from the principal name ("a1"/"a2" vs "alice") specifically so
+// the same principal calling twice is independently verifiable.
+func TestRegression_BridgeCellA_PerPrincipalSessionIsolation(t *testing.T) {
+	t.Parallel()
+
+	backendURL := startRealMCPBackend(t)
+	proxyURL, getRecords := newRecordingBackendProxy(t, backendURL)
+	ts := newBridgeCellAServer(t, proxyURL)
+
+	type call struct{ principal, nonce string }
+	round1 := []call{{"alice", "a1"}, {"bob", "b1"}} // pool cold
+	round2 := []call{{"alice", "a2"}, {"bob", "b2"}} // pool warm, if there were one
+	calls := append(append([]call{}, round1...), round2...)
+	wantCred := map[string]string{
+		"a1": "Bearer test-alice", "b1": "Bearer test-bob",
+		"a2": "Bearer test-alice", "b2": "Bearer test-bob",
+	}
+
+	doRound := func(round []call) {
+		t.Helper()
+		var wg sync.WaitGroup
+		wg.Add(len(round))
+		errs := make([]error, len(round))
+		statusCodes := make([]int, len(round))
+		for i, c := range round {
+			i, c := i, c
+			go func() {
+				defer wg.Done()
+				// No require/assert here: FailNow from a worker goroutine only runs
+				// Goexit off the test goroutine and misreports (see testing.md).
+				resp, err := func() (*http.Response, error) {
+					resp := postModernToolCallAsPrincipal(t, ts.URL, c.principal, c.nonce)
+					defer resp.Body.Close()
+					_, readErr := io.ReadAll(resp.Body)
+					return resp, readErr
+				}()
+				errs[i] = err
+				if resp != nil {
+					statusCodes[i] = resp.StatusCode
+				}
+			}()
+		}
+
+		done := make(chan struct{})
+		go func() { wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timeout waiting for concurrent Modern tool calls")
+		}
+		for i, err := range errs {
+			require.NoError(t, err, "principal %q", round[i].principal)
+			require.Equal(t, http.StatusOK, statusCodes[i], "principal %q", round[i].principal)
+		}
+	}
+
+	doRound(round1)
+	doRound(round2)
+
+	records := getRecords()
+	var initRecords, callRecords []recordedBackendRequest
+	for _, r := range records {
+		switch r.jsonRPCMethod {
+		case "initialize":
+			initRecords = append(initRecords, r)
+		case "tools/call":
+			callRecords = append(callRecords, r)
+		}
+	}
+	// mcpcompat's client library deterministically performs TWO initialize
+	// round-trips per legacyCallTool call (a capability pre-flight with empty
+	// capabilities, then the real one with elicitation/sampling added) -- so
+	// each call produces one SURVIVING session (the one its tools/call
+	// reuses) plus one abandoned pre-flight session. Assert "at least one",
+	// not "exactly one": the pre-flight count is a library implementation
+	// detail this pin does not depend on.
+	require.GreaterOrEqual(t, len(initRecords), len(calls), "expected at least one backend initialize per call")
+	require.Len(t, callRecords, len(calls), "expected one backend tools/call per call")
+
+	// (a) + (c): every backend session id is distinct -- none reused, across
+	// principals OR across repeat calls from the same principal (covers
+	// surviving AND abandoned pre-flight sessions alike). A pool keyed by
+	// (backend, principal) would reuse alice's round-1 session in round 2 and
+	// get caught right here.
+	seen := make(map[string]bool, len(initRecords))
+	for _, r := range initRecords {
+		require.NotEmpty(t, r.respSessionID, "backend initialize response must carry Mcp-Session-Id")
+		require.False(t, seen[r.respSessionID], "backend session id %q was reused", r.respSessionID)
+		seen[r.respSessionID] = true
+	}
+
+	// callByNonce keys each SURVIVING tools/call by its own nonce (not by
+	// session id, which a pool could legitimately vary): every call must
+	// appear exactly once on the wire.
+	callByNonce := make(map[string]recordedBackendRequest, len(callRecords))
+	for _, r := range callRecords {
+		params, _ := r.body["params"].(map[string]any)
+		args, _ := params["arguments"].(map[string]any)
+		nonce, _ := args["input"].(string)
+		callByNonce[nonce] = r
+	}
+	require.Len(t, callByNonce, len(calls), "every call's nonce must appear exactly once on the wire")
+
+	// (b) + the primary data-plane check: assert the credential on the
+	// tools/call itself (not only the initialize step), keyed by the call's
+	// own nonce so the same principal's repeat call in round 2 is checked
+	// independently of round 1. This is what actually distinguishes
+	// per-request client creation from a (backend, principal)-keyed pool --
+	// with only one call per principal there would be nothing to compare a
+	// repeat call against.
+	for _, c := range calls {
+		r := callByNonce[c.nonce]
+		assert.Equal(t, wantCred[c.nonce], r.authorization,
+			"the tools/call for nonce %q must carry principal %q's own credential", c.nonce, c.principal)
+	}
+
+	// Correlate each SURVIVING initialize's Authorization credential with the
+	// principal named by the tools/call that reused its backend session id
+	// (via Mcp-Session-Id). This catches a SYMMETRIC SWAP at the initialize
+	// step too: if two calls' credentials were exchanged, the session-id
+	// cardinality check above still passes, but the credential recorded on
+	// session X's initialize would not match the principal named by session
+	// X's own tools/call. An abandoned pre-flight session (no matching
+	// tools/call) has nothing to correlate against and is skipped -- its
+	// uniqueness was already checked above.
+	nonceBySession := make(map[string]string, len(callByNonce))
+	for nonce, r := range callByNonce {
+		nonceBySession[r.reqSessionID] = nonce
+	}
+	checked := 0
+	for _, r := range initRecords {
+		nonce, ok := nonceBySession[r.respSessionID]
+		if !ok {
+			continue
+		}
+		checked++
+		assert.Equal(t, wantCred[nonce], r.authorization,
+			"backend session %q's initialize must carry the credential of the principal behind nonce %q, not a bled/swapped one",
+			r.respSessionID, nonce)
+	}
+	require.Equal(t, len(calls), checked, "every call's surviving session must have been credential-checked at the initialize step too")
+}
+
+// TestRegression_BridgeCellA_NoReservedMetaLeakToLegacyBackend pins A2: a
+// Modern client's request carries reserved io.modelcontextprotocol/* _meta
+// keys, but vMCP -- not the downstream caller -- is the Legacy backend's MCP
+// peer on this hop, and go-sdk v1.7 hard-rejects (HTTP 400) ANY
+// _meta.protocolVersion on a stateful server. legacyCallTool strips them via
+// mcpparser.StripReservedModernMeta before forwarding
+// (pkg/vmcp/client/client.go); this asserts the Legacy backend receives NO
+// io.modelcontextprotocol/* key in the tools/call request body it actually
+// gets. Request path only -- response _meta is issue #5986's scope.
+//
+// Also carries a non-reserved _meta key ("vmcp.test/nonce") and asserts it
+// SURVIVES: proving absence of the reserved keys alone can't distinguish a
+// surgical strip from a blanket _meta drop (or the dispatcher simply ceasing
+// to forward _meta at all) -- either would also pass the reserved-key-absence
+// checks below on a zero value, silently killing real per-request metadata
+// (progressToken, trace context) on the Legacy hop.
+func TestRegression_BridgeCellA_NoReservedMetaLeakToLegacyBackend(t *testing.T) {
+	t.Parallel()
+
+	backendURL := startRealMCPBackend(t)
+	proxyURL, getRecords := newRecordingBackendProxy(t, backendURL)
+	ts := newBridgeCellAServer(t, proxyURL)
+
+	resp, decoded := postModern(t, ts.URL, "tools/call", map[string]any{
+		"name":      "echo",
+		"arguments": map[string]any{"input": "hello modern"},
+		"_meta":     map[string]any{"vmcp.test/nonce": "n1"},
+	}, 1, "echo")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "decoded: %+v", decoded)
+
+	records := getRecords()
+	var sawToolCall bool
+	for _, r := range records {
+		if r.jsonRPCMethod != "tools/call" {
+			continue
+		}
+		sawToolCall = true
+		params, _ := r.body["params"].(map[string]any)
+		meta, _ := params["_meta"].(map[string]any)
+		for _, reserved := range mcpparser.ReservedModernMetaKeys {
+			_, present := meta[reserved]
+			assert.False(t, present,
+				"Legacy backend must never see reserved Modern _meta key %q on the request path; got %+v", reserved, meta)
+		}
+		assert.Equal(t, "n1", meta["vmcp.test/nonce"],
+			"the strip must be surgical, not a blanket _meta drop; got %+v", meta)
+	}
+	require.True(t, sawToolCall, "expected the recording proxy to observe a tools/call request")
+}
+
+// ---------------------------------------------------------------------------
+// Cell B: Legacy client -> Modern backend
+// ---------------------------------------------------------------------------
+
+// bridgeModernBackend is a minimal REAL Modern (2026-07-28) MCP backend used
+// to pin Cell B: it speaks the raw Modern wire protocol directly
+// (server/discover, tools/list, tools/call), giving real MCP semantics plus
+// full request observability -- mirroring
+// pkg/vmcp/client/reclassify_test.go's modernDiscoverServer technique (that
+// helper, and the writeModernResult/modernReq helpers it uses, are
+// unexported in package client and unusable from server_test).
+type bridgeModernBackend struct {
+	srv *httptest.Server
+
+	mu       sync.Mutex
+	requests []string // Mcp-Method header value of every request received, in order
+}
+
+func newBridgeModernBackend(t *testing.T) *bridgeModernBackend {
+	t.Helper()
+	b := &bridgeModernBackend{}
+	b.srv = httptest.NewServer(http.HandlerFunc(b.handle))
+	t.Cleanup(b.srv.Close)
+	return b
+}
+
+func (b *bridgeModernBackend) handle(w http.ResponseWriter, r *http.Request) {
+	method := r.Header.Get("Mcp-Method")
+
+	b.mu.Lock()
+	b.requests = append(b.requests, method)
+	b.mu.Unlock()
+
+	if method == "" {
+		// No Mcp-Method header: a Legacy `initialize` handshake attempt (or any
+		// other Legacy request) against this Modern-only backend. Reject with
+		// 404, same as reclassify_test.go's modernDiscoverServer, rather than
+		// silently answering it.
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	var body struct {
+		ID     any             `json:"id"`
+		Params json.RawMessage `json:"params"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	switch method {
+	case "server/discover":
+		b.writeResult(w, body.ID, map[string]any{
+			"capabilities":      map[string]any{"tools": map[string]any{}},
+			"supportedVersions": []string{mcpparser.MCPVersionModern},
+		})
+	case "tools/list":
+		b.writeResult(w, body.ID, map[string]any{
+			"tools": []any{map[string]any{"name": "ping", "inputSchema": map[string]any{"type": "object"}}},
+		})
+	case "tools/call":
+		b.writeResult(w, body.ID, map[string]any{
+			"content": []any{map[string]any{"type": "text", "text": "pong"}},
+		})
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+// writeResult writes a Modern JSON-RPC success envelope, wrapping result
+// under resultType "complete" -- modernCall (pkg/vmcp/client/modern.go)
+// treats any other resultType, or its absence, as NOT this backend's genuine
+// response.
+func (*bridgeModernBackend) writeResult(w http.ResponseWriter, id any, result map[string]any) {
+	if result["resultType"] == nil {
+		result["resultType"] = "complete"
+	}
+	out, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(out)
+}
+
+func (b *bridgeModernBackend) requestMethods() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.requests))
+	copy(out, b.requests)
+	return out
+}
+
+func (b *bridgeModernBackend) url() string { return b.srv.URL }
+
+// revisionReporter mirrors the unexported interface of the same name in
+// pkg/vmcp/cli (serve.go) that wires WithRevisionLookup in production;
+// redeclared here because it is unexported there and this test needs the
+// same type assertion against the *vmcpclient.NewHTTPBackendClient it built
+// directly, without going through cli.Serve.
+type revisionReporter interface {
+	CachedRevision(workloadID string) (mcpparser.Revision, bool)
+}
+
+// newBridgeCellBServer builds a vMCP server routing a single Modern backend
+// through backendClient/sessionFactory, shared by both Cell B tests below.
+func newBridgeCellBServer(
+	t *testing.T, backend vmcp.Backend, backendClient vmcp.BackendClient, sessionFactory vmcpsession.MultiSessionFactory,
+) *httptest.Server {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockBackendRegistry := mocks.NewMockBackendRegistry(ctrl)
+	mockBackendRegistry.EXPECT().List(gomock.Any()).Return([]vmcp.Backend{backend}).AnyTimes()
+	mockBackendRegistry.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&backend).AnyTimes()
+
+	resolver, err := aggregator.NewPriorityConflictResolver([]string{backend.Name})
+	require.NoError(t, err)
+	agg := aggregator.NewDefaultAggregator(backendClient, resolver, nil, nil)
+	rt := router.NewSessionRouter(&vmcp.RoutingTable{})
+
+	srv, err := server.New(
+		context.Background(),
+		&server.Config{
+			Host:           "127.0.0.1",
+			Port:           0,
+			SessionTTL:     5 * time.Minute,
+			SessionFactory: sessionFactory,
+			Aggregator:     agg,
+		},
+		rt,
+		backendClient,
+		mockBackendRegistry,
+		nil,
+	)
+	require.NoError(t, err)
+	handler, err := srv.Handler(context.Background())
+	require.NoError(t, err)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestRegression_BridgeCellB_SubscriptionsListenFingerprintIsValid is a
+// positive control for the fingerprint TestRegression_BridgeCellB_
+// ModernBackendSetSkipsHandshakeAndStillWorks relies on below: it builds the
+// SAME Modern backend and session factory but WITHOUT WithRevisionLookup, so
+// the connector is never skipped and always runs go-sdk's Client.Connect().
+// Self-validates that subscriptions/listen really is observed against the
+// currently-pinned go-sdk version -- if a future go-sdk bump changes that
+// (e.g. gating the subscribe on registered handlers, or failing Connect
+// before discover completes), this test starts failing and flags the other
+// test's fingerprint as stale, instead of both silently passing forever.
+func TestRegression_BridgeCellB_SubscriptionsListenFingerprintIsValid(t *testing.T) {
+	t.Parallel()
+
+	modernBackend := newBridgeModernBackend(t)
+	backend := vmcp.Backend{
+		ID:            "modern-backend",
+		Name:          "modern-backend",
+		BaseURL:       modernBackend.url(),
+		TransportType: "streamable-http",
+	}
+
+	authReg := vmcpauth.NewDefaultOutgoingAuthRegistry()
+	require.NoError(t, authReg.RegisterStrategy(authtypes.StrategyTypeUnauthenticated, strategies.NewUnauthenticatedStrategy()))
+	backendClient, err := vmcpclient.NewHTTPBackendClient(authReg)
+	require.NoError(t, err)
+
+	// No WithRevisionLookup: the connector always attempts to connect,
+	// skip or no skip.
+	sessionFactory := vmcpsession.NewSessionFactory(authReg)
+	ts := newBridgeCellBServer(t, backend, backendClient, sessionFactory)
+
+	client := NewMCPTestClient(t, ts.URL)
+	client.InitializeSession()
+
+	require.Eventually(t, func() bool {
+		return slices.Contains(modernBackend.requestMethods(), "subscriptions/listen")
+	}, 5*time.Second, 50*time.Millisecond,
+		"go-sdk's Connect() must still open subscriptions/listen against a Modern backend when the connector is not skipped")
+}
+
+// TestRegression_BridgeCellB_ModernBackendSetSkipsHandshakeAndStillWorks pins
+// both Cell B properties against ONE session, since B2 (capabilities/calls
+// working) is the direct observable consequence of B1 (the connector being
+// skipped) actually mattering -- asserting them separately would just
+// duplicate this setup:
+//
+//   - B1: initOneBackend (pkg/vmcp/session/factory.go) must not attempt to
+//     connect against a backend whose cached MCP revision is known Modern.
+//     Asserted on the fake backend's own recorded request log two ways: (1)
+//     no request ever carries an empty Mcp-Method header (safe even though
+//     it never fires -- probeRevision is Modern-first and never sends a raw
+//     Legacy initialize, see reclassify_test.go); (2) no subscriptions/listen
+//     request is ever observed -- go-sdk's Client.Connect() issues that
+//     UNCONDITIONALLY once server/discover negotiates Modern, and nothing
+//     else in this path (this test's own priming probe, or the core's
+//     per-call Modern client) ever uses a go-sdk Client, so its presence is
+//     the fingerprint that the connector ran a full Connect() at all --
+//     validated against the currently-pinned SDK by the sibling
+//     TestRegression_BridgeCellB_SubscriptionsListenFingerprintIsValid.
+//   - B2: despite the connector being skipped (so this session holds no
+//     connection for the backend at all), a Legacy client session must still
+//     see the backend's tools via tools/list and successfully invoke one via
+//     tools/call -- because capability advertisement and calls flow through
+//     core.* (the revision-aware per-call client), never through the
+//     session's per-backend connections (serve_handlers.go).
+func TestRegression_BridgeCellB_ModernBackendSetSkipsHandshakeAndStillWorks(t *testing.T) {
+	t.Parallel()
+
+	modernBackend := newBridgeModernBackend(t)
+	backend := vmcp.Backend{
+		ID:            "modern-backend",
+		Name:          "modern-backend",
+		BaseURL:       modernBackend.url(),
+		TransportType: "streamable-http",
+	}
+
+	authReg := vmcpauth.NewDefaultOutgoingAuthRegistry()
+	require.NoError(t, authReg.RegisterStrategy(authtypes.StrategyTypeUnauthenticated, strategies.NewUnauthenticatedStrategy()))
+
+	backendClient, err := vmcpclient.NewHTTPBackendClient(authReg)
+	require.NoError(t, err)
+
+	// Prime the revision cache to "known Modern", the way the health monitor's
+	// first probe (or any earlier call) would in production -- initOneBackend's
+	// Modern-skip only fires for an ALREADY-classified backend (see its #5992
+	// cold-start-race doc comment). ListCapabilities dispatches through
+	// probeRevision on an unprobed backend, which is exactly that probe.
+	target := vmcp.BackendToTarget(&backend)
+	_, err = backendClient.ListCapabilities(context.Background(), target)
+	require.NoError(t, err, "priming probe against the real Modern backend must succeed")
+
+	revisions, ok := backendClient.(revisionReporter)
+	require.True(t, ok, "httpBackendClient must expose CachedRevision")
+	rev, known := revisions.CachedRevision(target.WorkloadID)
+	require.True(t, known && rev == mcpparser.RevisionModern, "backend must be cached Modern before session creation")
+
+	sessionFactory := vmcpsession.NewSessionFactory(authReg, vmcpsession.WithRevisionLookup(revisions.CachedRevision))
+	ts := newBridgeCellBServer(t, backend, backendClient, sessionFactory)
+
+	// Legacy client session (real initialize handshake against vMCP).
+	client := NewMCPTestClient(t, ts.URL)
+	sessionID := client.InitializeSession()
+
+	// B2a: tools/list must expose the Modern backend's tool once session
+	// registration (injectCoreSessionCapabilities -> core.ListTools) settles.
+	require.Eventually(t, func() bool {
+		names := listToolNames(t, ts.URL, sessionID)
+		return len(names) == 1 && names[0] == "ping"
+	}, 5*time.Second, 50*time.Millisecond, "tools/list should expose the Modern backend's 'ping' tool")
+
+	// B2b: tools/call must reach the Modern backend and succeed.
+	toolResp := client.CallTool("ping", map[string]any{})
+	defer toolResp.Body.Close()
+	toolBody, err := io.ReadAll(toolResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, toolResp.StatusCode, "body: %s", string(toolBody))
+
+	var rpc struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(toolBody, &rpc), "body: %s", string(toolBody))
+	assert.False(t, rpc.Result.IsError)
+	require.Len(t, rpc.Result.Content, 1)
+	assert.Equal(t, "pong", rpc.Result.Content[0].Text)
+
+	// B1: the session-level connector (backend.NewHTTPConnector) must never
+	// have run its own go-sdk Client.Connect() against this backend. Checked
+	// two ways:
+	//  1. No request ever carries an empty Mcp-Method header (the wire
+	//     signature of a raw Legacy request) -- safe even though it should
+	//     never fire either way: go-sdk v1.7's client is itself Modern-first
+	//     (SEP-2575), so even a "Legacy handshake attempt" against a Modern
+	//     backend negotiates via server/discover, not a raw Legacy initialize
+	//     (see pkg/vmcp/client/reclassify_test.go's identical observation for
+	//     the call-path client).
+	//  2. No subscriptions/listen request is ever observed. go-sdk's
+	//     Client.Connect() issues that call UNCONDITIONALLY once
+	//     server/discover negotiates Modern, and nothing else in this path
+	//     (this test's own priming probe, or the core's per-call Modern
+	//     client -- both raw modernCall, no go-sdk Client) ever makes it, so
+	//     its presence is the fingerprint that the connector ran a full
+	//     Connect() at all, skip or no skip. Validated against the
+	//     currently-pinned SDK by the sibling
+	//     TestRegression_BridgeCellB_SubscriptionsListenFingerprintIsValid.
+	for _, m := range modernBackend.requestMethods() {
+		assert.NotEmpty(t, m, "backend must never receive a request with no Mcp-Method header")
+		assert.NotEqual(t, "subscriptions/listen", m,
+			"the session connector must never run go-sdk Client.Connect() against a backend classified Modern")
+	}
+}

--- a/pkg/vmcp/server/classification.go
+++ b/pkg/vmcp/server/classification.go
@@ -9,13 +9,21 @@ import (
 	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 )
 
+// methodServerDiscover is the Modern (2026-07-28) capability-probe method. It is
+// special-cased in two places — the kill-switch branch below and dispatchModern's
+// method switch — because it is how a client learns which revisions a server
+// supports, so it must never be refused on version grounds.
+const methodServerDiscover = "server/discover"
+
 // classifyingHandler classifies a parsed MCP request as Legacy (2025-11-25) or
 // Modern (2026-07-28) at the decode seam, rejects a malformed Modern request
 // with the correct JSON-RPC error before it reaches dispatch, and — when
 // Config.ModernDispatchEnabled — routes a well-formed Modern request to
 // dispatchModern instead of the SDK. Legacy traffic always falls through to
-// next unchanged, as does a well-formed Modern request while the switch is
-// off (default), matching pre-Modern-dispatch wire behavior byte for byte.
+// next unchanged. While the switch is off (default), a well-formed Modern
+// request is refused with a conformant -32022 rather than falling through —
+// see the kill-switch branch for why, and for why server/discover is exempt
+// and does still fall through.
 //
 // ValidateHeaderConsistency (Mcp-Method/Mcp-Name) only applies to Modern
 // requests: a Legacy request carrying a stray Mcp-Method/Mcp-Name header
@@ -67,10 +75,34 @@ func (s *Server) classifyingHandler(next http.Handler) http.Handler {
 		}
 
 		// TEMPORARY kill-switch (default off): until Modern dispatch is
-		// conformance-validated, a well-formed Modern request falls through to
-		// the SDK path unless explicitly enabled. See issue #5959.
+		// conformance-validated, vMCP does not serve the Modern revision unless
+		// explicitly enabled. See issue #5959.
+		//
+		// Answer that conformantly here rather than letting the request reach the
+		// SDK. The draft's Streamable HTTP "Protocol Version Header" section
+		// requires a server that does not implement a requested version -- "whether
+		// the version is unknown to the server, or is a known version the server has
+		// chosen not to support" -- to reply 400 with an UnsupportedProtocolVersionError
+		// listing the versions it does support. A disabled kill switch is exactly the
+		// second case. Falling through instead yields go-sdk's stateful-server
+		// rejection, which is a 400 with a PLAIN-TEXT body whose text is Go-API advice
+		// for the server author ("set StreamableHTTPOptions.Stateless = true") -- not
+		// parseable as a protocol error and carrying no version list.
+		//
+		// server/discover is deliberately exempt: it is how a client learns which
+		// revisions a server supports, so rejecting it on version grounds would leave
+		// the client no way to negotiate down. go-sdk exempts it for the same reason,
+		// and its stateful path answers discover correctly, so the fall-through is
+		// still right for that one method.
 		if !s.config.ModernDispatchEnabled {
-			next.ServeHTTP(w, r)
+			if parsed.Method == methodServerDiscover {
+				next.ServeHTTP(w, r)
+				return
+			}
+			mcpparser.WriteClassificationError(w, parsed.ID, &mcpparser.UnsupportedVersionError{
+				Requested: mcpparser.MCPVersionModern,
+				Supported: []string{mcpparser.MCPVersionLegacy},
+			})
 			return
 		}
 

--- a/pkg/vmcp/server/classification_test.go
+++ b/pkg/vmcp/server/classification_test.go
@@ -102,11 +102,23 @@ func TestClassifyingHandler(t *testing.T) {
 		},
 		{
 			// Same well-formed Modern request, but with the kill-switch at its
-			// default (off): dispatch must not happen and the request falls
-			// through to the SDK path unchanged, byte-identical to pre-Modern-
-			// dispatch wire behavior.
-			name:            "well-formed modern request falls through to next when the kill-switch is off",
-			parsed:          wellFormedModernToolsList(),
+			// default (off): vMCP does not serve the Modern revision, which the
+			// draft says must be answered with 400 + UnsupportedProtocolVersion
+			// listing the supported versions. It must NOT reach next: falling
+			// through lands on go-sdk's stateful rejection, a plain-text 400 no
+			// client can parse as a protocol error.
+			name:           "well-formed modern request is refused with -32022 when the kill-switch is off",
+			parsed:         wellFormedModernToolsList(),
+			protocolHeader: mcpparser.MCPVersionModern,
+			wantCode:       mcpparser.CodeUnsupportedProtocolVersion,
+		},
+		{
+			// server/discover is the one exemption: it is how a client learns
+			// which revisions the server supports, so refusing it on version
+			// grounds would leave the client unable to negotiate down. go-sdk's
+			// stateful path answers discover, so the fall-through is correct.
+			name:            "server/discover still falls through when the kill-switch is off",
+			parsed:          wellFormedModernDiscover(),
 			protocolHeader:  mcpparser.MCPVersionModern,
 			wantPassthrough: true,
 		},
@@ -297,5 +309,20 @@ func wellFormedModernToolsList() *mcpparser.ParsedMCPRequest {
 			metaKeyClientCapabilities: map[string]any{},
 		},
 		MCPMethodHeader: "tools/list",
+	}
+}
+
+// wellFormedModernDiscover is wellFormedModernToolsList for the one method the
+// kill-switch branch exempts from the unsupported-version refusal.
+func wellFormedModernDiscover() *mcpparser.ParsedMCPRequest {
+	return &mcpparser.ParsedMCPRequest{
+		Method:    methodServerDiscover,
+		ID:        "1",
+		IsRequest: true,
+		Meta: map[string]any{
+			metaKeyProtocolVersion:    mcpparser.MCPVersionModern,
+			metaKeyClientCapabilities: map[string]any{},
+		},
+		MCPMethodHeader: methodServerDiscover,
 	}
 }

--- a/pkg/vmcp/server/modern_dispatch.go
+++ b/pkg/vmcp/server/modern_dispatch.go
@@ -86,7 +86,7 @@ func (s *Server) dispatchModern(w http.ResponseWriter, r *http.Request, parsed *
 		s.dispatchModernResourceTemplatesList(ctx, w, parsed, identity)
 	case "prompts/list":
 		s.dispatchModernPromptsList(ctx, w, parsed, identity)
-	case "server/discover":
+	case methodServerDiscover:
 		s.dispatchModernDiscover(ctx, w, parsed, identity)
 	case "tools/call":
 		s.dispatchModernToolCall(ctx, w, parsed, identity)

--- a/pkg/vmcp/server/status.go
+++ b/pkg/vmcp/server/status.go
@@ -29,13 +29,20 @@ type BackendStatus struct {
 	Health    string `json:"health"`              // "healthy", "degraded", "unhealthy", "unauthenticated", "unknown"
 	Transport string `json:"transport"`           // MCP transport protocol
 	AuthType  string `json:"auth_type,omitempty"` // "unauthenticated", "header_injection", "token_exchange"
+	// MCPRevision is the backend's resolved MCP protocol revision ("2025-11-25"
+	// or "2026-07-28"), mirroring the value the operator surfaces on
+	// VirtualMCPServer.status.discoveredBackends[]. Empty when the backend has
+	// not been probed yet or when health monitoring is disabled, since the
+	// revision is only observable through the live health state.
+	MCPRevision string `json:"mcp_revision,omitempty"`
 }
 
 // handleStatus handles /status HTTP requests for operational visibility.
 //
 // Security Note: This endpoint is unauthenticated to support operator consumption
-// and debugging. It exposes operational metadata (backend names, auth types)
-// but NOT secrets, tokens, internal URLs, or request data. In sensitive multi-tenant
+// and debugging. It exposes operational metadata (backend names, auth types,
+// negotiated MCP protocol revision) but NOT secrets, tokens, internal URLs, or
+// request data. In sensitive multi-tenant
 // deployments, restrict access to this endpoint via network policies.
 //
 // For minimal health checking (load balancers), use /health instead.
@@ -87,16 +94,22 @@ func (s *Server) buildStatusResponse(ctx context.Context) StatusResponse {
 	hasHealthyBackend := false
 	for _, backend := range backends {
 		// Prefer the live health monitor state over the static registry value.
+		// The MCP revision has no static counterpart — it is only ever observable
+		// through the live state, so it stays empty when health monitoring is
+		// disabled or the backend has not been probed yet.
 		healthStatus := backend.HealthStatus
+		var mcpRevision string
 		if liveState, ok := liveHealthStates[backend.ID]; ok {
 			healthStatus = liveState.Status
+			mcpRevision = liveState.MCPRevision
 		}
 
 		status := BackendStatus{
-			Name:      backend.Name,
-			Health:    string(healthStatus),
-			Transport: backend.TransportType,
-			AuthType:  getAuthType(backend.AuthConfig),
+			Name:        backend.Name,
+			Health:      string(healthStatus),
+			Transport:   backend.TransportType,
+			AuthType:    getAuthType(backend.AuthConfig),
+			MCPRevision: mcpRevision,
 		}
 		backendStatuses = append(backendStatuses, status)
 

--- a/pkg/vmcp/server/status_test.go
+++ b/pkg/vmcp/server/status_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/networking"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
@@ -34,10 +35,11 @@ type StatusResponse struct {
 
 // BackendStatus mirrors the server's backend status structure for test deserialization.
 type BackendStatus struct {
-	Name      string `json:"name"`
-	Health    string `json:"health"`
-	Transport string `json:"transport"`
-	AuthType  string `json:"auth_type,omitempty"`
+	Name        string `json:"name"`
+	Health      string `json:"health"`
+	Transport   string `json:"transport"`
+	AuthType    string `json:"auth_type,omitempty"`
+	MCPRevision string `json:"mcp_revision,omitempty"`
 }
 
 // createTestServerWithBackends creates a test server instance with custom backends
@@ -210,11 +212,28 @@ func createTestServerWithHealthMonitor(
 	t.Cleanup(ctrl.Finish)
 
 	mockBackendClient := mocks.NewMockBackendClient(ctrl)
-	rt := router.NewSessionRouter(&vmcp.RoutingTable{})
-
 	if setupMock != nil {
 		setupMock(mockBackendClient)
 	}
+
+	return createTestServerWithClient(t, backends, monitorCfg, mockBackendClient, groupRef)
+}
+
+// createTestServerWithClient is createTestServerWithHealthMonitor but takes an
+// already-built vmcp.BackendClient instead of constructing a bare mock — used
+// when a test needs a client satisfying an optional interface (e.g. the
+// health monitor's CachedRevision accessor) that the plain mock doesn't
+// implement.
+func createTestServerWithClient(
+	t *testing.T,
+	backends []vmcp.Backend,
+	monitorCfg health.MonitorConfig,
+	client vmcp.BackendClient,
+	groupRef string,
+) *server.Server {
+	t.Helper()
+
+	rt := router.NewSessionRouter(&vmcp.RoutingTable{})
 
 	port := networking.FindAvailable()
 	require.NotZero(t, port, "Failed to find available port")
@@ -233,7 +252,7 @@ func createTestServerWithHealthMonitor(
 		GroupRef:            groupRef,
 		HealthMonitorConfig: healthMonCfg,
 		SessionFactory:      newNoopMockFactory(t), Aggregator: newStubAggregator(nil),
-	}, rt, mockBackendClient, vmcp.NewImmutableRegistry(backends), nil)
+	}, rt, client, vmcp.NewImmutableRegistry(backends), nil)
 	require.NoError(t, err)
 
 	type startResult struct {
@@ -367,6 +386,13 @@ func TestStatusEndpoint_ReflectsLiveHealthMonitor_Healthy(t *testing.T) {
 	assert.True(t, status.Healthy)
 	require.Len(t, status.Backends, 1)
 	assert.Equal(t, string(vmcp.BackendHealthy), status.Backends[0].Health)
+	// The monitor is running here, but this test's client is a plain mock with
+	// no CachedRevision method — the shape of any BackendClient other than
+	// httpBackendClient. The revision must stay empty rather than being
+	// invented, so this is the third distinct state of mcp_revision alongside
+	// the two dedicated tests below.
+	assert.Empty(t, status.Backends[0].MCPRevision,
+		"revision must stay empty for a client that cannot report one")
 }
 
 // TestStatusEndpoint_FallsBackToRegistry_WhenMonitorDisabled confirms the
@@ -391,4 +417,68 @@ func TestStatusEndpoint_FallsBackToRegistry_WhenMonitorDisabled(t *testing.T) {
 	}
 	assert.Equal(t, string(vmcp.BackendHealthy), healthByName["healthy-backend"])
 	assert.Equal(t, string(vmcp.BackendUnhealthy), healthByName["unhealthy-backend"])
+}
+
+// revClientStub wraps a MockBackendClient and adds the optional CachedRevision
+// accessor the health monitor reads (mirrors pkg/vmcp/health/monitor_test.go's
+// revClientStub, unexported there and so not reusable across packages).
+type revClientStub struct {
+	*mocks.MockBackendClient
+	rev mcpparser.Revision
+}
+
+func (s revClientStub) CachedRevision(string) (mcpparser.Revision, bool) { return s.rev, true }
+
+// TestStatusEndpoint_MCPRevision_Populated verifies /status surfaces the
+// backend's negotiated MCP revision once the health monitor has probed it —
+// the field has no static registry counterpart, so this requires a client
+// that implements CachedRevision (the bare mock does not).
+func TestStatusEndpoint_MCPRevision_Populated(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockClient := mocks.NewMockBackendClient(ctrl)
+	mockClient.EXPECT().
+		ListCapabilities(gomock.Any(), gomock.Any()).
+		Return(&vmcp.CapabilityList{}, nil).
+		AnyTimes()
+	client := revClientStub{MockBackendClient: mockClient, rev: mcpparser.RevisionModern}
+
+	backends := []vmcp.Backend{{ID: "b1", Name: "modern-backend", TransportType: "streamable-http"}}
+	monitorCfg := health.MonitorConfig{
+		CheckInterval:      5 * time.Millisecond,
+		UnhealthyThreshold: 3,
+		Timeout:            time.Second,
+	}
+	srv := createTestServerWithClient(t, backends, monitorCfg, client, "")
+
+	require.Eventually(t, func() bool {
+		status := queryStatus(t, srv)
+		return len(status.Backends) == 1 && status.Backends[0].MCPRevision == mcpparser.MCPVersionModern
+	}, 5*time.Second, 20*time.Millisecond, "expected /status to report the negotiated MCP revision")
+}
+
+// TestStatusEndpoint_MCPRevision_AbsentWhenMonitorDisabled mirrors
+// TestStatusEndpoint_FallsBackToRegistry_WhenMonitorDisabled: with no health
+// monitor (and so no client capable of CachedRevision ever consulted), the
+// field must be empty and — because of omitempty — the "mcp_revision" key
+// must be absent from the JSON entirely, not merely an empty string.
+func TestStatusEndpoint_MCPRevision_AbsentWhenMonitorDisabled(t *testing.T) {
+	t.Parallel()
+
+	backends := []vmcp.Backend{{ID: "b1", Name: "test-backend", HealthStatus: vmcp.BackendHealthy}}
+	srv := createTestServerWithBackends(t, backends, "")
+
+	resp, err := http.Get("http://" + srv.Address() + "/status")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var raw struct {
+		Backends []map[string]any `json:"backends"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&raw))
+	require.Len(t, raw.Backends, 1)
+	_, present := raw.Backends[0]["mcp_revision"]
+	assert.False(t, present, "mcp_revision must be omitted, not present-empty, when unobservable")
 }

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -9,12 +9,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/stacklok/toolhive/pkg/auth"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
@@ -91,7 +93,8 @@ type MultiSessionFactory interface {
 }
 
 // backendConnector creates a connected, initialised backend Session for use
-// within a single MultiSession. It is called once per backend during MakeSession.
+// within a single MultiSession. It is called once per backend that is not
+// skipped as Modern (see initOneBackend) during MakeSession.
 //
 // The connector is responsible for:
 //  1. Creating and starting the MCP client transport.
@@ -114,7 +117,10 @@ type MultiSessionFactory interface {
 // to populate the session's routing table and capability lists.
 //
 // On error the factory treats the failure as a partial failure: a warning is
-// logged and the backend is excluded from the session.
+// logged and the backend is excluded from the session — except when the
+// backend's revision has meanwhile resolved to Modern, in which case
+// initOneBackend logs at DEBUG instead (see initOneBackend's doc comment for
+// why a Modern backend's session-establishment sequence fails there).
 type backendConnector func(
 	ctx context.Context,
 	target *vmcp.BackendTarget,
@@ -128,6 +134,7 @@ type defaultMultiSessionFactory struct {
 	connector          backendConnector
 	maxConcurrency     int
 	backendInitTimeout time.Duration
+	revisionLookup     func(workloadID string) (mcpparser.Revision, bool)
 }
 
 // MultiSessionFactoryOption configures a defaultMultiSessionFactory.
@@ -150,6 +157,32 @@ func WithBackendInitTimeout(d time.Duration) MultiSessionFactoryOption {
 		if d > 0 {
 			f.backendInitTimeout = d
 		}
+	}
+}
+
+// WithRevisionLookup supplies a function that reports a backend's cached MCP
+// revision (Legacy vs. Modern) by workload ID, so initOneBackend can skip
+// connecting to a backend known to speak the stateless Modern (2026-07-28)
+// revision. The connect attempt fails there anyway, and skipping it avoids
+// both the resulting WARN and the wasted work — see initOneBackend's doc
+// comment for the exact failure mechanism.
+//
+// The lookup's second return distinguishes "known Modern" from "unprobed"
+// (including RevisionLegacy's zero value): only a confirmed Modern result
+// skips the connect. A nil lookup (the default) or a cache miss reproduces
+// today's behaviour exactly — every backend gets an unconditional connect
+// attempt.
+//
+// A func value, not an interface, per the option-pattern rule in
+// .claude/rules/go-style.md: it stays compile-time safe without exposing
+// CachedRevision on vmcp.BackendClient for every implementation to satisfy.
+//
+// Concurrency: lookup is called from the per-backend init goroutines started
+// by makeBaseSession, up to maxConcurrency at once, so it must be safe for
+// concurrent use.
+func WithRevisionLookup(lookup func(workloadID string) (mcpparser.Revision, bool)) MultiSessionFactoryOption {
+	return func(f *defaultMultiSessionFactory) {
+		f.revisionLookup = lookup
 	}
 }
 
@@ -185,29 +218,96 @@ type initResult struct {
 // It is called from a goroutine inside MakeSession and handles all partial-
 // initialisation cases: connector errors, and nil conn/caps without an error.
 // Returns a non-nil *initResult on success, nil when the backend should be
-// skipped (failure already logged as a warning).
+// skipped. The second return is true when the skip is a deliberate Modern
+// (2026-07-28 revision) skip rather than a failure.
+//
+// Why the connect is worth skipping — the sequence fails, but NOT at a Legacy
+// handshake. Measured against a real stateless backend: go-sdk v1.7's Connect
+// is Modern-first, so server/discover SUCCEEDS and Modern is negotiated; no
+// raw Legacy initialize is ever sent. Connect then opens a
+// subscriptions/listen stream, because mcpcompat's Initialize unconditionally
+// installs the three list-changed notification handlers
+// (mcpcompat/client.installNotificationHandlers) and go-sdk opens that stream
+// whenever any of them is set. A stateless backend cannot serve it — it has no
+// Mcp-Session-Id, so it answers "session not found" — which fails Connect,
+// tears the connection down, and in turn fails the follow-up tools/list in
+// initAndQueryCapabilities. The connector therefore returns (nil, nil, err).
+//
+// So the wasted work is a whole sequence (discover, a failed subscribe, a
+// failed tools/list, teardown), not one round-trip, and it ends in a WARN that
+// looks exactly like a genuinely dead backend. Skipping is also correct on its
+// own terms: all three purposes of a persistent per-backend connection are
+// inapplicable to a Modern backend — list_changed propagation (Modern removed
+// server-initiated notifications; its push channel is subscriptions/listen,
+// which vMCP does not implement), backend-session-id resume hints (no
+// Mcp-Session-Id), and identity-binding metadata. The first of those is
+// precisely what makes the connect fail: vMCP asks for a notification stream
+// the backend cannot give it.
+//
+// Known caveat (#5992): the direction that matters here — a backend redeployed
+// stateless→stateful, so a cached Modern label is now wrong — self-corrects only
+// on error. The Modern call fails, dispatch's isRevisionMismatch fires and
+// reclassify flips the cache (pkg/vmcp/client/client.go). (The opposite
+// direction, Legacy→Modern, does self-heal on success: legacyInit flips the
+// cache when initialize negotiates Modern, added in #5997.) So calls are never
+// wrong for long, but until some call has re-probed, this method keeps skipping
+// a backend that now wants a connection, and that session holds none for it —
+// list_changed propagation is lost until a NEW session is created after the
+// reclassification. Closing that window needs a periodic re-probe, which is
+// #5992's remaining scope, not this method's.
+//
+// Cold start: the revision cache is populated by the first backend call
+// through dispatch (probeRevision) or, when configured, the health monitor's
+// periodic check — neither is ordered before the first client session. So EVERY
+// session created before the first backend call still pays the failing sequence
+// above for each Modern backend, and its WARN is not suppressed, because the
+// cache is still cold when the post-error re-check below runs. N clients that
+// connect without calling anything each pay it; there is no per-process bound.
+// Sessions created after the cache is warm skip the connect entirely.
 func (f *defaultMultiSessionFactory) initOneBackend(
 	ctx context.Context,
 	b *vmcp.Backend,
 	identity *auth.Identity,
 	sessionHint string,
 	sink backend.ListChangedSink,
-) *initResult {
+) (*initResult, bool) {
+	target := vmcp.BackendToTarget(b)
+
+	if f.isKnownModern(target.WorkloadID) {
+		slog.Debug("Skipping backend connection for Modern backend; no session to hold",
+			"backendID", b.ID,
+			"backendName", b.Name,
+		)
+		return nil, true
+	}
+
 	bCtx, cancel := context.WithTimeout(ctx, f.backendInitTimeout)
 	defer cancel()
 
-	target := vmcp.BackendToTarget(b)
 	conn, caps, err := f.connector(bCtx, target, identity, sessionHint, sink)
 	if err != nil {
 		if conn != nil {
 			_ = conn.Close()
+		}
+		// Narrows the WARN to DEBUG when the backend has resolved to Modern
+		// since the pre-connect check — either an era mismatch that lost the
+		// cold-start race (the expected case, see this method's doc comment) or
+		// an unrelated genuine failure (transport, auth) on a backend that
+		// happens to be Modern. Both are cases where a WARN would misinform.
+		if f.isKnownModern(target.WorkloadID) {
+			slog.Debug("Backend failed to initialise and is now known Modern; skipping",
+				"backendID", b.ID,
+				"backendName", b.Name,
+				"error", err,
+			)
+			return nil, true
 		}
 		slog.Warn("Failed to initialise backend for session; continuing without it",
 			"backendID", b.ID,
 			"backendName", b.Name,
 			"error", err,
 		)
-		return nil
+		return nil, false
 	}
 	if conn == nil || caps == nil {
 		if conn != nil {
@@ -217,9 +317,20 @@ func (f *defaultMultiSessionFactory) initOneBackend(
 			"backendID", b.ID,
 			"backendName", b.Name,
 		)
-		return nil
+		return nil, false
 	}
-	return &initResult{target: target, conn: conn, caps: caps}
+	return &initResult{target: target, conn: conn, caps: caps}, false
+}
+
+// isKnownModern reports whether workloadID's cached revision is confirmed
+// Modern. Returns false for an unprobed backend or when no lookup is
+// configured — indistinguishable from "attempt the connect" in either case.
+func (f *defaultMultiSessionFactory) isKnownModern(workloadID string) bool {
+	if f.revisionLookup == nil {
+		return false
+	}
+	rev, known := f.revisionLookup(workloadID)
+	return known && rev == mcpparser.RevisionModern
 }
 
 // buildRoutingTable populates a RoutingTable and capability lists from a sorted
@@ -331,6 +442,7 @@ func (f *defaultMultiSessionFactory) makeBaseSession(
 	backends = filtered
 
 	rawResults := make([]*initResult, len(backends))
+	modernSkipped := make([]bool, len(backends))
 	sem := make(chan struct{}, f.maxConcurrency)
 	var wg sync.WaitGroup
 	wg.Add(len(backends))
@@ -339,7 +451,7 @@ func (f *defaultMultiSessionFactory) makeBaseSession(
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			rawResults[i] = f.initOneBackend(ctx, b, identity, sessionHints[b.ID], sink)
+			rawResults[i], modernSkipped[i] = f.initOneBackend(ctx, b, identity, sessionHints[b.ID], sink)
 		}(i, b)
 	}
 	wg.Wait()
@@ -359,7 +471,10 @@ func (f *defaultMultiSessionFactory) makeBaseSession(
 		return results[i].target.WorkloadID < results[j].target.WorkloadID
 	})
 
-	if len(results) == 0 && len(backends) > 0 {
+	// Only warn when at least one backend was actually expected to hold a
+	// session — a set that skipped every backend as Modern is working as
+	// designed, not a failure.
+	if len(results) == 0 && len(backends) > 0 && slices.Contains(modernSkipped, false) {
 		slog.Warn("All backends failed to initialise; session will have no capabilities",
 			"backendCount", len(backends))
 	}

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -228,10 +228,15 @@ type initResult struct {
 // subscriptions/listen stream, because mcpcompat's Initialize unconditionally
 // installs the three list-changed notification handlers
 // (mcpcompat/client.installNotificationHandlers) and go-sdk opens that stream
-// whenever any of them is set. A stateless backend cannot serve it — it has no
-// Mcp-Session-Id, so it answers "session not found" — which fails Connect,
-// tears the connection down, and in turn fails the follow-up tools/list in
-// initAndQueryCapabilities. The connector therefore returns (nil, nil, err).
+// whenever any of them is set. The stateless server rejects it with
+// "session not found", which fails Connect, tears the connection down, and in
+// turn fails the follow-up tools/list in initAndQueryCapabilities. The connector
+// therefore returns (nil, nil, err).
+//
+// That rejection is a go-sdk v1.7.0-pre.3 artifact, NOT a spec requirement: the
+// Modern revision has no sessions, so nothing in it says subscriptions/listen
+// needs one. Do not read this as "Modern requires a session" — it is the SDK's
+// stateless server refusing a subscribe it has no session to hang the stream on.
 //
 // So the wasted work is a whole sequence (discover, a failed subscribe, a
 // failed tools/list, teardown), not one round-trip, and it ends in a WARN that
@@ -473,9 +478,12 @@ func (f *defaultMultiSessionFactory) makeBaseSession(
 
 	// Only warn when at least one backend was actually expected to hold a
 	// session — a set that skipped every backend as Modern is working as
-	// designed, not a failure.
+	// designed, not a failure. The message deliberately does NOT say the session
+	// has no capabilities: on the Serve path those come from the core, not from
+	// these connections, so a session with zero held connections still lists and
+	// calls tools normally. What is actually lost is list_changed propagation.
 	if len(results) == 0 && len(backends) > 0 && slices.Contains(modernSkipped, false) {
-		slog.Warn("All backends failed to initialise; session will have no capabilities",
+		slog.Warn("No backend held a session for this session; every non-Modern backend failed to initialise",
 			"backendCount", len(backends))
 	}
 

--- a/pkg/vmcp/session/factory_revision_test.go
+++ b/pkg/vmcp/session/factory_revision_test.go
@@ -156,7 +156,12 @@ func setupLogRecorder(t *testing.T) *bytes.Buffer {
 	return &buf
 }
 
-const allBackendsFailedMsg = "All backends failed to initialise"
+// allBackendsFailedMsg pins the substring of makeBaseSession's no-session-held
+// warning. Kept as the stable prefix rather than the whole line so a wording
+// tweak does not silently turn the NotContains assertion below into a vacuous
+// pass — the assertion that no warning fired is only meaningful while this
+// substring still matches the message the code emits.
+const allBackendsFailedMsg = "No backend held a session for this session"
 
 // TestMakeSession_AllBackendsFailedWarning verifies that the "all backends
 // failed" warning fires only when a real failure is present — an all-Modern

--- a/pkg/vmcp/session/factory_revision_test.go
+++ b/pkg/vmcp/session/factory_revision_test.go
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	internalbk "github.com/stacklok/toolhive/pkg/vmcp/session/internal/backend"
+)
+
+// TestInitOneBackend_RevisionAwareSkip verifies that WithRevisionLookup only
+// skips the connector for a backend the lookup confirms as Modern; an
+// unprobed backend, a known-Legacy backend, or the absence of a lookup at all
+// must reproduce today's unconditional connect.
+func TestInitOneBackend_RevisionAwareSkip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		lookup           func(string) (mcpparser.Revision, bool)
+		wantConnectorHit bool
+	}{
+		{
+			name:             "no lookup configured: connector invoked",
+			wantConnectorHit: true,
+		},
+		{
+			name:             "unprobed backend (cache miss): connector invoked",
+			lookup:           func(string) (mcpparser.Revision, bool) { return mcpparser.RevisionLegacy, false },
+			wantConnectorHit: true,
+		},
+		{
+			name:             "known Legacy: connector invoked",
+			lookup:           func(string) (mcpparser.Revision, bool) { return mcpparser.RevisionLegacy, true },
+			wantConnectorHit: true,
+		},
+		{
+			name:             "known Modern: connector not invoked",
+			lookup:           func(string) (mcpparser.Revision, bool) { return mcpparser.RevisionModern, true },
+			wantConnectorHit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var hit bool
+			connector := func(
+				_ context.Context, target *vmcp.BackendTarget, _ *auth.Identity, _ string, _ internalbk.ListChangedSink,
+			) (internalbk.Session, *vmcp.CapabilityList, error) {
+				hit = true
+				return &mockConnectedBackend{sessID: "sess-" + target.WorkloadID}, &vmcp.CapabilityList{}, nil
+			}
+
+			var opts []MultiSessionFactoryOption
+			if tt.lookup != nil {
+				opts = append(opts, WithRevisionLookup(tt.lookup))
+			}
+			factory := newSessionFactoryWithConnector(connector, opts...)
+
+			sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, []*vmcp.Backend{{ID: "backend-a"}}, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = sess.Close() })
+
+			assert.Equal(t, tt.wantConnectorHit, hit)
+		})
+	}
+}
+
+// TestInitOneBackend_ColdStartRecheckAvoidsWarning pins the post-error
+// re-check on initOneBackend: the backend is unprobed at the pre-connect
+// check, the connect is attempted and fails, and only the POST-failure
+// re-check resolves Modern. That must log at DEBUG rather than the
+// real-failure WARN, and must not attempt a second connect on this call.
+//
+// This models the cold-start race a real Modern backend loses: its connect
+// genuinely does fail (server/discover succeeds, then subscriptions/listen
+// cannot be served by a session-less backend — see initOneBackend's doc
+// comment), so the error branch here is the ordinary Modern path, not an
+// exotic one. The fake connector returns a generic error because this test is
+// about the re-check's log-level decision, not about reproducing go-sdk's
+// exact failure chain.
+//
+// The lookup's call-counter is a plain int, not atomic: this session has a
+// single backend, so a single per-backend goroutine makes both lookup calls,
+// in program order, with no other goroutine reading the counter. The test
+// goroutine only reads it after MakeSessionWithID returns, which happens
+// after that goroutine completes (via sync.WaitGroup in makeBaseSession) —
+// safe under the race detector without extra synchronization.
+//
+//nolint:paralleltest // setupLogRecorder swaps the global slog default logger; see its doc comment.
+func TestInitOneBackend_ColdStartRecheckAvoidsWarning(t *testing.T) {
+	buf := setupLogRecorder(t)
+
+	var lookupCalls int
+	lookup := func(string) (mcpparser.Revision, bool) {
+		lookupCalls++
+		if lookupCalls == 1 {
+			return mcpparser.RevisionLegacy, false // pre-connect check: unprobed
+		}
+		return mcpparser.RevisionModern, true // post-failure re-check: resolved Modern
+	}
+
+	var connectorCalls int
+	connector := func(
+		context.Context, *vmcp.BackendTarget, *auth.Identity, string, internalbk.ListChangedSink,
+	) (internalbk.Session, *vmcp.CapabilityList, error) {
+		connectorCalls++
+		return nil, nil, errors.New("dial tcp: connection refused")
+	}
+
+	factory := newSessionFactoryWithConnector(connector, WithRevisionLookup(lookup))
+	sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, []*vmcp.Backend{{ID: "backend-a"}}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	assert.Equal(t, 1, connectorCalls, "the connect must still be attempted when the backend is unprobed at the pre-check")
+	assert.NotContains(t, buf.String(), "Failed to initialise backend",
+		"a backend that resolves Modern on the post-failure re-check must not log the real-failure WARN")
+	// Positive control: without this, downgrading the real-failure WARN to DEBUG
+	// would leave the buffer empty and the assertion above would pass silently.
+	assert.Contains(t, buf.String(), "is now known Modern",
+		"the re-check must log the expected-skip DEBUG line, proving the buffer captures at all")
+}
+
+// setupLogRecorder swaps the global slog default logger for a text handler
+// writing to the returned buffer, for the duration of the calling test, and
+// restores it on cleanup. Matches the established repo pattern (see
+// pkg/vmcp/core/core_vmcp_test.go, pkg/vmcp/client/reclassify_test.go).
+//
+// Not compatible with t.Parallel(): slog's default logger is process-global,
+// so a parallel subtest logging concurrently would race this one. Callers
+// must not mark themselves (or their subtests) parallel.
+func setupLogRecorder(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	// LevelDebug so tests can assert on the DEBUG lines too, not just WARN.
+	// Without it a test asserting only the ABSENCE of a WARN would still pass
+	// if that WARN were downgraded to DEBUG — it needs a positive control.
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+const allBackendsFailedMsg = "All backends failed to initialise"
+
+// TestMakeSession_AllBackendsFailedWarning verifies that the "all backends
+// failed" warning fires only when a real failure is present — an all-Modern
+// backend set is a deliberate, expected zero-connection outcome, not a
+// failure, while mixing a Modern-skip with one genuine failure still warns.
+//
+//nolint:paralleltest // setupLogRecorder swaps the global slog default logger; see its doc comment.
+func TestMakeSession_AllBackendsFailedWarning(t *testing.T) {
+	tests := []struct {
+		name     string
+		lookup   func(workloadID string) (mcpparser.Revision, bool)
+		backends []*vmcp.Backend
+		wantWarn bool
+	}{
+		{
+			name:     "all backends skipped as Modern: no warning",
+			lookup:   func(string) (mcpparser.Revision, bool) { return mcpparser.RevisionModern, true },
+			backends: []*vmcp.Backend{{ID: "backend-a"}, {ID: "backend-b"}},
+			wantWarn: false,
+		},
+		{
+			name: "Modern skip mixed with a genuine failure: still warns",
+			lookup: func(workloadID string) (mcpparser.Revision, bool) {
+				if workloadID == "backend-modern" {
+					return mcpparser.RevisionModern, true
+				}
+				return mcpparser.RevisionLegacy, false
+			},
+			backends: []*vmcp.Backend{{ID: "backend-modern"}, {ID: "backend-fail"}},
+			wantWarn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := setupLogRecorder(t)
+			factory := newSessionFactoryWithConnector(nilBackendConnector(), WithRevisionLookup(tt.lookup))
+
+			sess, err := factory.MakeSessionWithID(t.Context(), uuid.New().String(), nil, tt.backends, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = sess.Close() })
+
+			if tt.wantWarn {
+				assert.Contains(t, buf.String(), allBackendsFailedMsg)
+			} else {
+				assert.NotContains(t, buf.String(), allBackendsFailedMsg)
+			}
+		})
+	}
+}

--- a/pkg/vmcp/types.go
+++ b/pkg/vmcp/types.go
@@ -9,6 +9,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/stacklok/toolhive/pkg/mcp"
 	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 )
 
@@ -770,6 +771,25 @@ type BackendClient interface {
 	// ListCapabilities queries a backend for its capabilities.
 	// Returns tools, resources, and prompts exposed by the backend.
 	ListCapabilities(ctx context.Context, target *BackendTarget) (*CapabilityList, error)
+}
+
+// RevisionReporter reports a backend's resolved MCP protocol revision, keyed by
+// workload ID. The second return distinguishes "known" from "not probed yet" —
+// callers must not read the Revision when it is false, since RevisionLegacy is
+// the zero value.
+//
+// Deliberately NOT part of [BackendClient]: it is a read-model for
+// status/telemetry and for deciding whether a Legacy session connect is worth
+// attempting, not a protocol operation, and every BackendClient implementation
+// (including the generated mocks) would otherwise have to satisfy it. Consumers
+// type-assert to it and degrade gracefully when the assertion fails.
+//
+// Because that assertion is the failure mode — a wrapper that forgets to forward
+// CachedRevision silently disables the behaviour with no compile error —
+// implementations should pin themselves with a compile-time assertion, e.g.
+// `var _ vmcp.RevisionReporter = (*httpBackendClient)(nil)`.
+type RevisionReporter interface {
+	CachedRevision(workloadID string) (mcp.Revision, bool)
 }
 
 // CapabilityList contains the capabilities from a backend's MCP server.

--- a/test/e2e/thv-operator/virtualmcp/helpers.go
+++ b/test/e2e/thv-operator/virtualmcp/helpers.go
@@ -1278,10 +1278,11 @@ type VMCPStatusResponse struct {
 // VMCPBackendStatus mirrors server.BackendStatus
 // (pkg/vmcp/server/status.go) for test deserialization.
 type VMCPBackendStatus struct {
-	Name      string `json:"name"`
-	Health    string `json:"health"` // "healthy", "degraded", "unhealthy", "unknown"
-	Transport string `json:"transport"`
-	AuthType  string `json:"auth_type,omitempty"`
+	Name        string `json:"name"`
+	Health      string `json:"health"` // "healthy", "degraded", "unhealthy", "unknown"
+	Transport   string `json:"transport"`
+	AuthType    string `json:"auth_type,omitempty"`
+	MCPRevision string `json:"mcp_revision,omitempty"`
 }
 
 // VMCPBackendsHealthResponse mirrors BackendHealthResponse

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_dual_era_backends_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_dual_era_backends_test.go
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package virtualmcp
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
+	coremcp "github.com/stacklok/toolhive/pkg/mcp"
+	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
+	"github.com/stacklok/toolhive/test/e2e/images"
+)
+
+// This spec closes #5979: unlike virtualmcp_discovered_mode_test.go (Legacy
+// backends only, gofetch/osv), it mixes a Legacy backend (gofetch) with a
+// Modern (2026-07-28, stateless) backend -- yardstick-server run with
+// TRANSPORT=streamable-http, STATELESS=true, BACKEND_MODE=echo, the env
+// combination confirmed at acceptance_tests/dual_era_k8s_test.go:151-155 --
+// in the same discovered-mode aggregation. That's what actually exercises
+// probeRevision/modernEnumerate/dispatch resolving BOTH eras behind one vMCP;
+// the existing spec never resolves a Modern revision at all.
+//
+// OUT OF SCOPE (deliberate): reclassify / mid-run revision-flip coverage.
+// #5979 lists it as a stretch goal; it's hard to trigger deterministically
+// against a live backend, and pkg/vmcp/client/reclassify_test.go already
+// covers it deterministically as a unit test.
+//
+// mcpRevision is only observable through the LIVE health monitor state
+// (pkg/vmcp/health/status.go), on both surfaces this spec checks
+// (VirtualMCPServer.status.discoveredBackends[] and the /status endpoint).
+// Health monitoring is NOT the operator's default -- it's gated on
+// Operational.FailureHandling.HealthCheckInterval > 0 (pkg/vmcp/cli/serve.go)
+// -- so the VirtualMCPServer config below sets FailureHandling explicitly;
+// without it both mcpRevision assertions would time out empty.
+var _ = Describe("VirtualMCPServer Dual-Era Backends", Ordered, func() {
+	var (
+		testNamespace   = "default"
+		mcpGroupName    = "test-dual-era-group"
+		vmcpServerName  = "test-vmcp-dual-era"
+		legacyBackend   = "backend-dual-era-legacy"
+		modernBackend   = "backend-dual-era-modern"
+		echoToolName    = "echo"
+		timeout         = 3 * time.Minute
+		pollingInterval = 2 * time.Second
+		vmcpNodePort    int32
+	)
+
+	// assertRevisions checks that got[modernBackend] and got[legacyBackend] hold
+	// the expected MCP revision, returning a descriptive error otherwise. Shared
+	// by the CRD-status and /status assertions below, which differ only in how
+	// they build the map.
+	assertRevisions := func(got map[string]string) error {
+		if rev := got[modernBackend]; rev != coremcp.MCPVersionModern {
+			return fmt.Errorf("modern backend %s: want revision %q, got %q (all: %v)",
+				modernBackend, coremcp.MCPVersionModern, rev, got)
+		}
+		if rev := got[legacyBackend]; rev != coremcp.MCPVersionLegacy {
+			return fmt.Errorf("legacy backend %s: want revision %q, got %q (all: %v)",
+				legacyBackend, coremcp.MCPVersionLegacy, rev, got)
+		}
+		return nil
+	}
+
+	BeforeAll(func() {
+		By("Creating MCPGroup")
+		CreateMCPGroupAndWait(ctx, k8sClient, mcpGroupName, testNamespace,
+			"Test MCP Group for VirtualMCP dual-era backend E2E tests", timeout, pollingInterval)
+
+		By("Creating Legacy (gofetch) and Modern (yardstick, stateless echo) backends in parallel")
+		CreateMultipleMCPServersInParallel(ctx, k8sClient, []BackendConfig{
+			{
+				Name:      legacyBackend,
+				Namespace: testNamespace,
+				GroupRef:  mcpGroupName,
+				Image:     images.GofetchServerImage,
+			},
+			{
+				Name:      modernBackend,
+				Namespace: testNamespace,
+				GroupRef:  mcpGroupName,
+				// Same image as the Legacy backends above: since #6004 it is a single
+				// go-sdk v1.7 build serving both eras, and STATELESS is what decides
+				// which. In session mode it negotiates down and vMCP classifies it
+				// Legacy from server/discover's supportedVersions, so a forgotten
+				// STATELESS here would silently produce an all-Legacy backend set --
+				// which is why the mcpRevision assertions below check both eras.
+				Image: images.YardstickServerImage,
+				Env: []mcpv1beta1.EnvVar{
+					{Name: "STATELESS", Value: "true"}, // Modern (2026-07-28) capable backend
+					{Name: "BACKEND_MODE", Value: "echo"},
+				},
+			},
+		}, timeout, pollingInterval)
+
+		By("Creating VirtualMCPServer in discovered mode over the mixed backend set")
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace,
+			v1beta1test.WithVMCPGroupRef(mcpGroupName),
+			v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+				Group: mcpGroupName,
+				Aggregation: &vmcpconfig.AggregationConfig{
+					ConflictResolution: "prefix", // avoid tool-name collisions across backends
+				},
+				// Health monitoring is what resolves and caches MCPRevision; it is
+				// opt-in (see the header comment), so it must be turned on explicitly
+				// for the mcpRevision assertions below to ever see a non-empty value.
+				Operational: &vmcpconfig.OperationalConfig{
+					FailureHandling: &vmcpconfig.FailureHandlingConfig{
+						HealthCheckInterval: vmcpconfig.Duration(10 * time.Second),
+						// Must be set explicitly and be strictly LESS than the interval.
+						// Supplying the failureHandling object at all makes kubebuilder
+						// apply its siblings' CRD defaults, and healthCheckTimeout
+						// defaults to 10s -- equal to the interval above, which
+						// pkg/vmcp/config/validator.go rejects ("must be less than
+						// healthCheckInterval to prevent checks from queuing up"). The
+						// vmcp pod then crash-loops on config validation and the
+						// VirtualMCPServer never leaves Pending, so every assertion here
+						// fails on a readiness timeout with no hint of the real cause.
+						HealthCheckTimeout:      vmcpconfig.Duration(2 * time.Second),
+						UnhealthyThreshold:      3,
+						StatusReportingInterval: vmcpconfig.Duration(5 * time.Second),
+					},
+				},
+			}),
+			v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+				Type: "anonymous",
+			}),
+			v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+				v.Spec.ServiceType = "NodePort"
+			}),
+		)
+		Expect(k8sClient.Create(ctx, vmcpServer)).To(Succeed())
+
+		By("Waiting for VirtualMCPServer to be ready")
+		WaitForVirtualMCPServerReady(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+
+		By("Waiting for VirtualMCPServer to discover both backends")
+		WaitForCondition(ctx, k8sClient, vmcpServerName, testNamespace, "BackendsDiscovered", "True", timeout, pollingInterval)
+
+		By("Getting NodePort for VirtualMCPServer")
+		vmcpNodePort = GetVMCPNodePort(ctx, k8sClient, vmcpServerName, testNamespace, timeout, pollingInterval)
+	})
+
+	AfterAll(func() {
+		By("Cleaning up VirtualMCPServer")
+		vmcpServer := v1beta1test.NewVirtualMCPServer(vmcpServerName, testNamespace)
+		if err := k8sClient.Delete(ctx, vmcpServer); err != nil {
+			GinkgoWriter.Printf("Warning: failed to delete VirtualMCPServer: %v\n", err)
+		}
+
+		By("Cleaning up backend MCPServers")
+		for _, name := range []string{legacyBackend, modernBackend} {
+			backend := &mcpv1beta1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+			}
+			if err := k8sClient.Delete(ctx, backend); err != nil {
+				GinkgoWriter.Printf("Warning: failed to delete backend %s: %v\n", name, err)
+			}
+		}
+
+		By("Cleaning up MCPGroup")
+		mcpGroup := &mcpv1beta1.MCPGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: mcpGroupName, Namespace: testNamespace},
+		}
+		if err := k8sClient.Delete(ctx, mcpGroup); err != nil {
+			GinkgoWriter.Printf("Warning: failed to delete MCPGroup: %v\n", err)
+		}
+	})
+
+	Context("when aggregating a mixed Legacy+Modern backend set", func() {
+		It("aggregates tools from both the Legacy and Modern backends", func() {
+			// This is the real coverage gap the discovered-mode test leaves open:
+			// it only exercises Legacy backends, so it never resolves a Modern
+			// revision or calls modernEnumerate. Retrying with fresh sessions
+			// (WaitForExpectedTools) avoids flaking on first-probe races.
+			WaitForExpectedTools(vmcpNodePort, "toolhive-e2e-dual-era-list", func(tools []mcp.Tool) error {
+				var hasFetch, hasEcho bool
+				for _, t := range tools {
+					if strings.Contains(t.Name, fetchToolName) {
+						hasFetch = true
+					}
+					if strings.Contains(t.Name, echoToolName) {
+						hasEcho = true
+					}
+				}
+				if !hasFetch {
+					return fmt.Errorf("missing Legacy backend's %q tool in aggregated list: %v", fetchToolName, toolNames(tools))
+				}
+				if !hasEcho {
+					return fmt.Errorf("missing Modern backend's %q tool in aggregated list: %v", echoToolName, toolNames(tools))
+				}
+				return nil
+			}, timeout)
+		})
+
+		It("routes a tool call to the Modern backend and it succeeds", func() {
+			// Covers dispatch's Modern call path with real traffic, not just a
+			// readiness/count check (per .claude/rules/testing.md's E2E Test
+			// Coverage rule).
+			TestToolListingAndCall(vmcpNodePort, "toolhive-e2e-dual-era-call", echoToolName, "dual-era-modern-check")
+		})
+	})
+
+	Context("when surfacing per-backend MCP revision", func() {
+		It("surfaces the correct mcpRevision in VirtualMCPServer.status.discoveredBackends for each backend", func() {
+			Eventually(func() error {
+				status, err := GetVirtualMCPServerStatus(ctx, k8sClient, vmcpServerName, testNamespace)
+				if err != nil {
+					return fmt.Errorf("failed to get VirtualMCPServer status: %w", err)
+				}
+
+				got := make(map[string]string, len(status.DiscoveredBackends))
+				for _, b := range status.DiscoveredBackends {
+					got[b.Name] = b.MCPRevision
+				}
+				return assertRevisions(got)
+			}, timeout, pollingInterval).Should(Succeed())
+		})
+
+		It("surfaces the correct mcp_revision in the /status endpoint's backends[] for each backend", func() {
+			Eventually(func() error {
+				status, err := GetVMCPStatus(vmcpNodePort)
+				if err != nil {
+					return fmt.Errorf("failed to get /status: %w", err)
+				}
+
+				got := make(map[string]string, len(status.Backends))
+				for _, b := range status.Backends {
+					got[b.Name] = b.MCPRevision
+				}
+				return assertRevisions(got)
+			}, timeout, pollingInterval).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/vmcp_dual_era_helpers_test.go
+++ b/test/e2e/vmcp_dual_era_helpers_test.go
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/stacklok/toolhive/test/e2e"
+	"github.com/stacklok/toolhive/test/e2e/images"
+)
+
+// modernDispatchEnvVar mirrors pkg/vmcp/cli/serve.go's modernDispatchEnvVar
+// constant (unexported there, so duplicated here rather than imported --
+// this suite only needs the string value, not the package).
+const modernDispatchEnvVar = "TOOLHIVE_VMCP_MODERN_STATELESS"
+
+// launchYardstickLegacyOnPort starts a non-stateless (Legacy-only) yardstick
+// backend on the given port in the given group. Deliberately structured as a
+// near-duplicate of launchYardstickModernOnPort below rather than reusing the
+// shared launchYardstickOnPort (vmcp_cli_helpers_test.go), so that everything
+// differing between the two backends this suite stands up is visible side by
+// side. Both explicitly set BACKEND_MODE=echo rather than one relying on
+// yardstick-server's default, leaving STATELESS as the only difference.
+func launchYardstickLegacyOnPort(config *e2e.TestConfig, groupName, backendName string, port int) {
+	portStr := strconv.Itoa(port)
+	e2e.NewTHVCommand(config,
+		"run", images.YardstickServerImage,
+		"--name", backendName,
+		"--group", groupName,
+		"--transport", "streamable-http",
+		"--isolate-network=false",
+		"--target-port", portStr,
+		"--env", "TRANSPORT=streamable-http",
+		"--env", "BACKEND_MODE=echo",
+		"--", "-port", portStr, "-transport", "streamable-http",
+	).ExpectSuccess()
+}
+
+// startYardstickLegacyOnPort runs launchYardstickLegacyOnPort and waits for
+// the backend to become ready.
+func startYardstickLegacyOnPort(config *e2e.TestConfig, groupName, backendName string, port int) {
+	launchYardstickLegacyOnPort(config, groupName, backendName, port)
+	err := e2e.WaitForMCPServer(config, backendName, 120*time.Second)
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("legacy yardstick backend %q should become running", backendName))
+}
+
+// launchYardstickModernOnPort starts a stateless (Modern-capable) yardstick
+// backend on the given port in the given group. It differs from
+// launchYardstickLegacyOnPort above only in STATELESS=true, which is what makes
+// yardstick's own discover response advertise 2026-07-28 support (confirmed at
+// test/e2e/thv-operator/acceptance_tests/dual_era_k8s_test.go:151-155).
+//
+// Both backends run the same image, which since #6004 is a single go-sdk v1.7
+// build serving both eras: in session mode it negotiates down and vMCP
+// classifies it Legacy from server/discover's supportedVersions. That is why
+// the suite's BeforeEach asserts each backend's negotiated revision via
+// /status rather than trusting the env. One forgotten STATELESS would
+// otherwise leave both backends Legacy, and every cell here would still pass
+// while testing the Legacy backend edge twice.
+func launchYardstickModernOnPort(config *e2e.TestConfig, groupName, backendName string, port int) {
+	portStr := strconv.Itoa(port)
+	e2e.NewTHVCommand(config,
+		"run", images.YardstickServerImage,
+		"--name", backendName,
+		"--group", groupName,
+		"--transport", "streamable-http",
+		"--isolate-network=false",
+		"--target-port", portStr,
+		"--env", "TRANSPORT=streamable-http",
+		"--env", "STATELESS=true",
+		"--env", "BACKEND_MODE=echo",
+		"--", "-port", portStr, "-transport", "streamable-http",
+	).ExpectSuccess()
+}
+
+// startYardstickModernOnPort runs launchYardstickModernOnPort and waits for
+// the backend to become ready.
+func startYardstickModernOnPort(config *e2e.TestConfig, groupName, backendName string, port int) {
+	launchYardstickModernOnPort(config, groupName, backendName, port)
+	err := e2e.WaitForMCPServer(config, backendName, 120*time.Second)
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("modern yardstick backend %q should become running", backendName))
+}
+
+// healthCheckConfigYAML is appended to a `thv vmcp init`-generated config file
+// to turn on health monitoring. This is required for /status to ever report
+// mcp_revision: pkg/vmcp/server/status.go's BackendStatus.MCPRevision doc
+// notes it "is only observable through the live health state", and
+// pkg/vmcp/cli/serve.go only builds a health.MonitorConfig when
+// Operational.FailureHandling.HealthCheckInterval > 0. Quick mode (--group)
+// generates a config with no Operational section at all and has no CLI flag
+// to add one (see generateQuickModeConfig), so this suite uses config-file
+// mode instead, purely to make mcp_revision observable.
+const healthCheckConfigYAML = `
+operational:
+  failureHandling:
+    healthCheckInterval: 1s
+    unhealthyThreshold: 1
+`
+
+// appendHealthCheckConfig appends healthCheckConfigYAML to the config file at
+// path (a fresh top-level YAML key; thv vmcp init never emits an
+// "operational:" section, so there is nothing to overwrite).
+func appendHealthCheckConfig(path string) {
+	GinkgoHelper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	Expect(err).ToNot(HaveOccurred())
+	defer f.Close()
+	_, err = f.WriteString(healthCheckConfigYAML)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// startDualEraVMCP starts `thv vmcp serve`, with the Modern dispatcher
+// enabled or disabled per modernEnabled. Uses --config configPath when
+// configPath is non-empty, else falls back to quick mode (--group groupName).
+// This exists instead of reusing e2e.StartLongRunningTHVCommand solely to
+// control that one env var: StartLongRunningTHVCommand always inherits a plain
+// os.Environ() with no override hook.
+//
+// The variable is stripped from the inherited environment and then set
+// explicitly for BOTH cases, rather than only appended when enabling. Leaving
+// it inherited would make the kill-switch-off specs depend on the ambient
+// environment: a CI runner or developer shell exporting
+// TOOLHIVE_VMCP_MODERN_STATELESS=true would start those with Modern dispatch
+// ON, and the spec would fail for a reason that has nothing to do with the
+// code. Appending an override would also work (serve.go parses the value with
+// strconv.ParseBool, and exec dedups Env keeping the last entry), but relying
+// on that dedup order is too subtle to leave to a reader.
+func startDualEraVMCP(config *e2e.TestConfig, groupName, configPath string, port int, modernEnabled bool) *exec.Cmd {
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, modernDispatchEnvVar+"=") {
+			env = append(env, kv)
+		}
+	}
+	env = append(env, fmt.Sprintf("%s=%t", modernDispatchEnvVar, modernEnabled))
+
+	args := []string{"vmcp", "serve", "--port", strconv.Itoa(port)}
+	if configPath != "" {
+		args = append(args, "--config", configPath)
+	} else {
+		args = append(args, "--group", groupName)
+	}
+
+	//nolint:gosec // fixed subcommand, test-controlled args
+	cmd := exec.Command(config.THVBinary, args...)
+	cmd.Env = env
+	cmd.Stdout = GinkgoWriter
+	cmd.Stderr = GinkgoWriter
+
+	err := cmd.Start()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to start thv vmcp serve")
+	return cmd
+}
+
+// vmcpStatusResponse decodes the subset of pkg/vmcp/server.StatusResponse
+// this suite needs. Decoded independently rather than by importing
+// pkg/vmcp/server: that package is a server implementation detail a
+// black-box e2e client should not depend on.
+type vmcpStatusResponse struct {
+	Backends []struct {
+		Name        string `json:"name"`
+		MCPRevision string `json:"mcp_revision"`
+	} `json:"backends"`
+}
+
+// vmcpStatusURL returns the /status endpoint URL for a vMCP serve process
+// listening on the given port.
+func vmcpStatusURL(port int) string {
+	return fmt.Sprintf("http://127.0.0.1:%d/status", port)
+}
+
+// fetchVMCPStatus GETs statusURL and decodes it as a vmcpStatusResponse.
+func fetchVMCPStatus(statusURL string) (vmcpStatusResponse, error) {
+	httpClient := http.Client{Timeout: 5 * time.Second}
+	resp, err := httpClient.Get(statusURL) //nolint:gosec // test-controlled URL
+	if err != nil {
+		return vmcpStatusResponse{}, err
+	}
+	defer resp.Body.Close()
+
+	var out vmcpStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return vmcpStatusResponse{}, err
+	}
+	return out, nil
+}
+
+// waitForBackendRevision polls statusURL until it reports backendName's
+// mcp_revision as wantRevision, or fails the spec after timeout.
+//
+// This is the only positive proof in this suite that vMCP classified a
+// backend's MCP edge correctly. Every other assertion here (tool call
+// succeeds, echoes the right value) is satisfied identically whether vMCP
+// classified the "Modern" backend as Modern or silently fell back to Legacy
+// -- both backends run the same yardstick echo tool, so a misclassification
+// would not change any response body. Without this check the 2x2 matrix this
+// suite claims to cover could silently collapse to 1x2.
+func waitForBackendRevision(statusURL, backendName, wantRevision string) {
+	GinkgoHelper()
+	Eventually(func() (string, error) {
+		status, err := fetchVMCPStatus(statusURL)
+		if err != nil {
+			return "", err
+		}
+		for _, b := range status.Backends {
+			if b.Name == backendName {
+				return b.MCPRevision, nil
+			}
+		}
+		return "", nil
+	}, 30*time.Second, 500*time.Millisecond).Should(Equal(wantRevision),
+		"vMCP never classified backend %q as %q via /status", backendName, wantRevision)
+}

--- a/test/e2e/vmcp_dual_era_test.go
+++ b/test/e2e/vmcp_dual_era_test.go
@@ -1,0 +1,450 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/test/e2e"
+)
+
+// This suite is the live e2e tier proving vMCP bridges all four client x
+// backend MCP-revision combinations (issue #5912). vMCP is an aggregating
+// gateway: it terminates the client connection and re-originates calls to
+// each backend, classifying the two edges independently -- the client edge
+// per request (Legacy 2025-11-25 vs. Modern 2026-07-28, cached per
+// server/discover probe on the backend edge). Existing coverage
+// (pkg/vmcp/server/bridge_regression_test.go) pins this at the unit/
+// integration level with mocked backends; this file proves it with two real
+// yardstick-server backends and a real thv vmcp serve process.
+//
+// De-risked live before writing this: a Modern server/discover probe sent
+// BY vMCP through the thv proxy fronting a stateless yardstick backend is
+// correctly classified Modern (its tool appears in vMCP's aggregated
+// tools/list under the "{backend}_" prefix, and a tools/call routed to it
+// succeeds) -- confirming the one assumption this whole suite rests on.
+//
+// Also confirmed live: an ordinary (non-initialize) tools/call response --
+// through vMCP, on either client edge -- never carries Mcp-Session-Id; only
+// the Legacy initialize response does. So "session id present for Legacy"
+// is asserted on the initialize handshake, not on every subsequent call
+// (mirrors the same finding already documented in dual_era_mixing_test.go
+// for the single-server transparent proxy).
+//
+// Known harness limitation: no request in this file sets
+// "Accept: application/json, text/event-stream" (a MUST on both revisions),
+// since e2e.RawMCPClient has no SSE response parser and the proxy switches to
+// an SSE body whenever that header is present (see mcp_raw_client.go). So the
+// bridge is proven here only under a non-conformant Accept header.
+var _ = Describe("vMCP Dual-Era Bridge", Label("vmcp", "dual-era", "e2e"), Serial, func() {
+	Context("Modern dispatcher enabled", func() {
+		var (
+			config            *e2e.TestConfig
+			groupName         string
+			legacyBackendName string
+			modernBackendName string
+			legacyToolName    string
+			modernToolName    string
+			vMCPCmd           *exec.Cmd
+			vMCPPort          int
+			vMCPURL           string
+			rawClient         *e2e.RawMCPClient
+		)
+
+		BeforeEach(func() {
+			config = e2e.NewTestConfig()
+			groupName = e2e.GenerateUniqueServerName("vmcp-dual-era-group")
+			legacyBackendName = e2e.GenerateUniqueServerName("vmcp-dual-era-legacy")
+			modernBackendName = e2e.GenerateUniqueServerName("vmcp-dual-era-modern")
+			legacyToolName = legacyBackendName + "_echo"
+			modernToolName = modernBackendName + "_echo"
+			vMCPCmd = nil
+			vMCPPort = allocateVMCPPort()
+			vMCPURL = vmcpEndpointURL(vMCPPort)
+
+			err := e2e.CheckTHVBinaryAvailable(config)
+			Expect(err).ToNot(HaveOccurred(), "thv binary should be available")
+
+			rawClient, err = e2e.NewRawMCPClient(20 * time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("creating a group with one Legacy and one Modern-capable backend")
+			e2e.NewTHVCommand(config, "group", "create", groupName).ExpectSuccess()
+			// allocateVMCPPort just allocates any free 127.0.0.1 port; reused here
+			// for the backends too.
+			startYardstickLegacyOnPort(config, groupName, legacyBackendName, allocateVMCPPort())
+			startYardstickModernOnPort(config, groupName, modernBackendName, allocateVMCPPort())
+
+			By("generating a vMCP config with health monitoring enabled")
+			// Config-file mode (not quick mode) solely so health monitoring can be
+			// turned on -- see appendHealthCheckConfig's doc comment -- which is what
+			// makes /status's mcp_revision observable below.
+			tmpDir, err := os.MkdirTemp("", "vmcp-dual-era-config-*")
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = os.RemoveAll(tmpDir) })
+			configFilePath := filepath.Join(tmpDir, "vmcp.yaml")
+			initVMCPConfig(config, groupName, configFilePath)
+			appendHealthCheckConfig(configFilePath)
+
+			By("starting thv vmcp serve with the Modern dispatcher enabled")
+			vMCPCmd = startDualEraVMCP(config, groupName, configFilePath, vMCPPort, true)
+			err = e2e.WaitForMCPServerReady(config, vMCPURL, "streamable-http", 60*time.Second)
+			Expect(err).ToNot(HaveOccurred(), "vMCP server should become ready")
+
+			By("confirming vMCP classified each backend's MCP revision correctly")
+			// The positive, direct proof that this suite's 2x2 matrix has not
+			// silently collapsed to 1x2 -- see waitForBackendRevision's doc comment.
+			statusURL := vmcpStatusURL(vMCPPort)
+			waitForBackendRevision(statusURL, legacyBackendName, mcpparser.MCPVersionLegacy)
+			waitForBackendRevision(statusURL, modernBackendName, mcpparser.MCPVersionModern)
+		})
+
+		AfterEach(func() {
+			stopVMCPProcess(vMCPCmd)
+			vMCPCmd = nil
+
+			if config.CleanupAfter {
+				_ = e2e.StopAndRemoveMCPServer(config, legacyBackendName)
+				_ = e2e.StopAndRemoveMCPServer(config, modernBackendName)
+				_ = e2e.RemoveGroup(config, groupName)
+			}
+		})
+
+		It("bridges Legacy client to Legacy backend (baseline)", func() {
+			ctx := context.Background()
+			sessionID := legacyInitialize(ctx, rawClient, vMCPURL)
+
+			resp := legacyToolCall(ctx, rawClient, vMCPURL, sessionID, legacyToolName, "legacytolegacy")
+			assertBridgedCall(resp, "legacytolegacy", "")
+		})
+
+		It("bridges Modern client to Modern backend (both edges stateless)", func() {
+			ctx := context.Background()
+			resp := modernToolCall(ctx, rawClient, vMCPURL, modernToolName, "moderntomodern")
+			assertBridgedCall(resp, "moderntomodern", "complete")
+			Expect(resp.Headers.Get(e2e.HeaderMCPSessionID)).To(BeEmpty(), "Modern responses must never carry Mcp-Session-Id")
+		})
+
+		It("bridges Modern client to Legacy backend (vMCP synthesizes a per-request backend session)", func() {
+			ctx := context.Background()
+			resp := modernToolCall(ctx, rawClient, vMCPURL, legacyToolName, "moderntolegacy")
+			assertBridgedCall(resp, "moderntolegacy", "complete")
+			Expect(resp.Headers.Get(e2e.HeaderMCPSessionID)).To(BeEmpty(), "Modern responses must never carry Mcp-Session-Id")
+		})
+
+		It("bridges Legacy client to Modern backend (vMCP terminates the client session, re-originates stateless)", func() {
+			ctx := context.Background()
+			sessionID := legacyInitialize(ctx, rawClient, vMCPURL)
+
+			resp := legacyToolCall(ctx, rawClient, vMCPURL, sessionID, modernToolName, "legacytomodern")
+			assertBridgedCall(resp, "legacytomodern", "")
+		})
+
+		It("never cross-delivers between two concurrent principals across mismatched backends", func() {
+			// Principal A: a Legacy session calling the Legacy backend, perEra
+			// times per round. Principal B: a stateless Modern client calling the
+			// Modern backend, also perEra times per round. All 2*perEra requests
+			// fire concurrently, each carrying a unique nonce -- a wrong echoed
+			// nonce means vMCP delivered one request's response to another. Firing
+			// several requests per era (not just one) also covers same-era
+			// same-backend interleaving, not only a cross-era swap.
+			const rounds = 5
+			const perEra = 4
+			sessionID := legacyInitialize(context.Background(), rawClient, vMCPURL)
+
+			for round := 0; round < rounds; round++ {
+				label := fmt.Sprintf("round-%d", round)
+				results := fireConcurrentBridgedBatch(rawClient, vMCPURL, sessionID, legacyToolName, modernToolName, perEra, round)
+				assertCorrelated(results, 2*perEra, label)
+			}
+		})
+
+		It("never cross-delivers when both BRIDGE cells are in flight together", func() {
+			// The spec above races the two SAME-era cells (Legacy client→Legacy
+			// backend, Modern client→Modern backend). That leaves the cells this
+			// suite exists for untested under concurrency: here the tool names are
+			// crossed, so the Legacy session calls the MODERN backend and the
+			// stateless Modern client calls the LEGACY backend -- both bridge cells,
+			// concurrently, with distinct principals.
+			//
+			// This is the configuration where a cross-delivery would matter most.
+			// Each bridge cell re-originates through a different egress (the Legacy
+			// session's calls reach a Modern backend via the stateless modernCall
+			// path; the Modern client's calls reach a Legacy backend via a
+			// per-request initialize+call+close), and both are in flight at once. A
+			// wrong echoed nonce means vMCP crossed a response between two
+			// principals whose requests took *different* egress paths -- the failure
+			// the per-request client construction is what prevents, and which
+			// RFC-0083 D6's shared connection pool is the change most likely to
+			// break. The pkg/vmcp/server bridge pins cover that at the unit level
+			// for the Modern→Legacy direction; this is the live counterpart for
+			// both directions at once.
+			const rounds = 5
+			const perEra = 4
+			sessionID := legacyInitialize(context.Background(), rawClient, vMCPURL)
+
+			for round := 0; round < rounds; round++ {
+				label := fmt.Sprintf("bridge-round-%d", round)
+				// Crossed on purpose: legacy CLIENT calls the modern tool, modern
+				// CLIENT calls the legacy tool.
+				results := fireConcurrentBridgedBatch(rawClient, vMCPURL, sessionID, modernToolName, legacyToolName, perEra, round)
+				assertCorrelated(results, 2*perEra, label)
+			}
+		})
+	})
+
+	Context("Modern dispatcher disabled (kill switch off)", func() {
+		var (
+			config      *e2e.TestConfig
+			groupName   string
+			backendName string
+			toolName    string
+			vMCPCmd     *exec.Cmd
+			vMCPPort    int
+			vMCPURL     string
+			rawClient   *e2e.RawMCPClient
+		)
+
+		BeforeEach(func() {
+			config = e2e.NewTestConfig()
+			groupName = e2e.GenerateUniqueServerName("vmcp-dual-era-off-group")
+			backendName = e2e.GenerateUniqueServerName("vmcp-dual-era-off-backend")
+			toolName = backendName + "_echo"
+			vMCPCmd = nil
+			vMCPPort = allocateVMCPPort()
+			vMCPURL = vmcpEndpointURL(vMCPPort)
+
+			err := e2e.CheckTHVBinaryAvailable(config)
+			Expect(err).ToNot(HaveOccurred(), "thv binary should be available")
+
+			rawClient, err = e2e.NewRawMCPClient(20 * time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("creating a group with one Modern-capable backend")
+			e2e.NewTHVCommand(config, "group", "create", groupName).ExpectSuccess()
+			startYardstickModernOnPort(config, groupName, backendName, allocateVMCPPort())
+
+			By("starting thv vmcp serve with the Modern dispatcher left at its default (off)")
+			vMCPCmd = startDualEraVMCP(config, groupName, "", vMCPPort, false)
+			err = e2e.WaitForMCPServerReady(config, vMCPURL, "streamable-http", 60*time.Second)
+			Expect(err).ToNot(HaveOccurred(), "vMCP server should become ready")
+		})
+
+		AfterEach(func() {
+			stopVMCPProcess(vMCPCmd)
+			vMCPCmd = nil
+
+			if config.CleanupAfter {
+				_ = e2e.StopAndRemoveMCPServer(config, backendName)
+				_ = e2e.RemoveGroup(config, groupName)
+			}
+		})
+
+		It("does not serve a well-formed Modern request via the Modern dispatcher", func() {
+			// Mirrors TestIntegration_Modern_RealBackend_KillSwitchOff
+			// (pkg/vmcp/server/modern_realbackend_integration_test.go): with the
+			// kill-switch at its default (off), a well-formed Modern tools/call
+			// falls through to the SDK path instead of dispatchModern, which
+			// (confirmed live) rejects the Modern protocol version outright on a
+			// non-stateless server -- a plain-text HTTP 400 carrying no
+			// "resultType" at all.
+			resp := modernToolCall(context.Background(), rawClient, vMCPURL, toolName, "killswitchoff")
+			Expect(resp.StatusCode).To(Equal(400), "body: %s", resp.Body)
+
+			var decoded map[string]any
+			_ = json.Unmarshal(resp.Body, &decoded)
+			Expect(decoded).ToNot(HaveKey("resultType"), "must not be served by dispatchModern: %s", resp.Body)
+		})
+	})
+})
+
+// legacyInitialize sends a Legacy initialize request, followed by the
+// notifications/initialized notification the 2025-11-25 spec requires a
+// client to send immediately after (before any other request on the
+// session) -- a real client always sends it, so this suite should too rather
+// than only ever exercising the (also-valid, but unrepresentative) omitted
+// case. Returns the assigned Mcp-Session-Id, failing the spec if the
+// handshake does not succeed, omits the session id, or the notification is
+// not accepted.
+func legacyInitialize(ctx context.Context, client *e2e.RawMCPClient, url string) string {
+	GinkgoHelper()
+	req := e2e.NewLegacyInitializeRequest("dual-era-legacy-client", "1.0")
+	resp, err := client.Send(ctx, url, req)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(200), "body: %s", resp.Body)
+	sessionID := resp.Headers.Get(e2e.HeaderMCPSessionID)
+	Expect(sessionID).ToNot(BeEmpty(), "Legacy initialize must assign a session id")
+
+	notifyReq, err := e2e.NewLegacyRequest("notifications/initialized", nil)
+	Expect(err).ToNot(HaveOccurred())
+	// WithID(nil) omits "id" entirely, making this a true JSON-RPC notification.
+	notifyReq.WithID(nil).WithSessionID(sessionID).SetHeader(e2e.HeaderMCPProtocolVersion, mcpparser.MCPVersionLegacy)
+	notifyResp, err := client.Send(ctx, url, notifyReq)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(notifyResp.StatusCode).To(Equal(202), "body: %s", notifyResp.Body)
+
+	return sessionID
+}
+
+// legacyToolCall sends a Legacy tools/call for toolName with sessionID,
+// carrying the MCP-Protocol-Version header the 2025-11-25 spec requires on
+// every post-initialize request.
+func legacyToolCall(
+	ctx context.Context, client *e2e.RawMCPClient, url, sessionID, toolName, input string,
+) *e2e.RawResponse {
+	GinkgoHelper()
+	req, err := e2e.NewLegacyRequest("tools/call", map[string]any{
+		"name":      toolName,
+		"arguments": map[string]any{"input": input},
+	})
+	Expect(err).ToNot(HaveOccurred())
+	req.WithSessionID(sessionID).SetHeader(e2e.HeaderMCPProtocolVersion, mcpparser.MCPVersionLegacy)
+	resp, err := client.Send(ctx, url, req)
+	Expect(err).ToNot(HaveOccurred())
+	return resp
+}
+
+// modernToolCall sends a stateless Modern tools/call for toolName.
+func modernToolCall(ctx context.Context, client *e2e.RawMCPClient, url, toolName, input string) *e2e.RawResponse {
+	GinkgoHelper()
+	req, err := e2e.NewModernRequest("tools/call", map[string]any{
+		"name":      toolName,
+		"arguments": map[string]any{"input": input},
+	})
+	Expect(err).ToNot(HaveOccurred())
+	resp, err := client.Send(ctx, url, req)
+	Expect(err).ToNot(HaveOccurred())
+	return resp
+}
+
+// fireConcurrentBridgedBatch fires perEra concurrent Legacy tools/call
+// requests (principal A, sessionID, legacyClientTool) and perEra concurrent
+// Modern tools/call requests (principal B, stateless, modernClientTool) --
+// 2*perEra requests total, all released together via a start channel so they
+// are genuinely in flight at once (not sequential per era) -- each carrying a
+// round-unique nonce in _meta. Reuses crossDeliveryResult/extractNonce from
+// dual_era_proxy_test.go (same package); the caller asserts on the returned
+// results with assertCorrelated.
+//
+// The two tool names decide which CELLS run concurrently, and the caller picks:
+// passing (legacyTool, modernTool) races the two SAME-era cells, while passing
+// them crossed (modernTool, legacyTool) races the two BRIDGE cells. Both matter
+// -- see the callers.
+func fireConcurrentBridgedBatch(
+	client *e2e.RawMCPClient, url, sessionID, legacyClientTool, modernClientTool string, perEra, round int,
+) []crossDeliveryResult {
+	const joinTimeout = 20 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), joinTimeout)
+	defer cancel()
+
+	total := 2 * perEra
+	results := make([]crossDeliveryResult, total)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	fire := func(i int, build func() (*e2e.RawRequest, error)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			nonce := fmt.Sprintf("round-%d-req-%d", round, i)
+			<-start
+
+			req, err := build()
+			if err != nil {
+				results[i] = crossDeliveryResult{nonce: nonce, err: err}
+				return
+			}
+			req.SetMeta("nonce", nonce)
+
+			reqStart := time.Now()
+			resp, sendErr := client.Send(ctx, url, req)
+			elapsed := time.Since(reqStart)
+			if sendErr != nil {
+				results[i] = crossDeliveryResult{nonce: nonce, err: sendErr, elapsed: elapsed}
+				return
+			}
+			results[i] = crossDeliveryResult{
+				nonce:      nonce,
+				statusCode: resp.StatusCode,
+				elapsed:    elapsed,
+				rpcErr:     resp.Error,
+				gotNonce:   extractNonce(resp),
+			}
+		}()
+	}
+
+	for i := 0; i < perEra; i++ {
+		fire(i, func() (*e2e.RawRequest, error) {
+			req, err := e2e.NewLegacyRequest("tools/call", map[string]any{
+				"name":      legacyClientTool,
+				"arguments": map[string]any{"input": "concurrencycheck"},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return req.WithSessionID(sessionID).SetHeader(e2e.HeaderMCPProtocolVersion, mcpparser.MCPVersionLegacy), nil
+		})
+	}
+	for i := 0; i < perEra; i++ {
+		fire(perEra+i, func() (*e2e.RawRequest, error) {
+			return e2e.NewModernRequest("tools/call", map[string]any{
+				"name":      modernClientTool,
+				"arguments": map[string]any{"input": "concurrencycheck"},
+			})
+		})
+	}
+
+	close(start) // release every goroutine together
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(joinTimeout):
+		Fail(fmt.Sprintf("round %d: timed out waiting for %d concurrent requests", round, total))
+	}
+
+	return results
+}
+
+// echoResult is the decoded shape of yardstick's echo tool result.
+// ResultType is only present in a Modern client's response envelope
+// (empty for Legacy) -- see this file's doc comment.
+type echoResult struct {
+	ResultType        string `json:"resultType"`
+	StructuredContent struct {
+		Output string `json:"output"`
+	} `json:"structuredContent"`
+}
+
+// assertBridgedCall asserts a tools/call response succeeded, round-tripped
+// wantOutput, and carries the era-correct resultType (only a Modern client's
+// own response is wrapped with resultType, regardless of which era backend
+// served it). This proves a round-trip to *a* backend with the era-correct
+// envelope; it does NOT by itself prove WHICH backend answered -- both
+// backends run the same yardstick echo tool, so a misrouted call would echo
+// the same value back. Backend attribution is proven separately, by the
+// waitForBackendRevision /status check in this context's BeforeEach.
+func assertBridgedCall(resp *e2e.RawResponse, wantOutput, wantResultType string) {
+	GinkgoHelper()
+	Expect(resp.Error).To(BeNil(), "unexpected JSON-RPC error: %+v", resp.Error)
+	Expect(resp.StatusCode).To(Equal(200), "body: %s", resp.Body)
+
+	var result echoResult
+	Expect(json.Unmarshal(resp.Result, &result)).To(Succeed(), "result: %s", resp.Result)
+	Expect(result.StructuredContent.Output).To(Equal(wantOutput),
+		"tools/call round-trip did not echo the expected output")
+	Expect(result.ResultType).To(Equal(wantResultType))
+}


### PR DESCRIPTION
## Summary

vMCP classifies the client edge per request and each backend edge independently, so a client on
either MCP revision can reach backends on either revision. RFC-0081 marked the two era-mismatched
combinations "Fails" for a pass-through proxy and deferred them here, because vMCP is the component
that terminates the client connection and re-originates backend calls.

**Investigating those two cells first changed what this PR needed to be.** Both were already
largely functional after #5910/#5911, and their difficulty is inverted from how #5912 describes it:

- **Modern client → Legacy backend** (the issue's "hard cell", expected to need a synthesized
  session held per request and partitioned by `(principal, backend)`) already holds by
  construction. `legacyCallTool` opens a client, initializes, calls and closes per request, so
  nothing is pooled and no credential can bleed. There was nothing to build — only an undefended
  invariant to pin.
- **Legacy client → Modern backend** (the "easy cell") had the one real defect: the session factory
  attempted a connect that cannot succeed.

So the work is one small behaviour fix, one additive status field, and the coverage that makes all
four cells falsifiable.

- **Skip a connect that cannot succeed.** Measured, not assumed: go-sdk v1.7's `Connect` is
  Modern-first, so `server/discover` succeeds and no Legacy `initialize` is ever sent — but
  `mcpcompat`'s `Initialize` unconditionally installs the list-changed handlers, so go-sdk opens a
  `subscriptions/listen` stream, which a session-less backend answers `session not found`. That
  fails `Connect`, tears the connection down, and fails the follow-up `tools/list`. Every session
  paid a discover + failed subscribe + failed list + teardown per Modern backend, ending in a WARN
  indistinguishable from a dead backend. Note the causality: `list_changed` is one of the three
  reasons those connections exist, and it is precisely what breaks the connect — vMCP was asking
  for a notification stream the backend cannot give it.
- **Surface each backend's negotiated revision on `/status`.** The operator already published it via
  `VirtualMCPServer.status.discoveredBackends[].mcpRevision`; the HTTP endpoint did not, so no e2e
  tier could assert which era a backend negotiated.
- **Pin the bridge's confidentiality invariants** so RFC-0083 D6's planned shared connection pool
  cannot break them silently.
- **Live e2e for all four cells**, at both the CLI and operator tiers.

Closes #5912
Closes #5979

## Type of change

- [x] Other (describe): completes a feature — one behaviour fix, one additive `/status` field, and the live dual-era e2e matrix

## Test plan

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`) — `LABEL_FILTER="vmcp && dual-era"`, 6/6 green
- [x] Linting (`task lint-fix`)
- [x] Manual testing (described below)

Manual verification beyond the suites:

- **Every new assertion was mutation-verified** — deliberately broken, observed to fail, restored
  byte-identically. Including two that revealed the assertion itself was wrong:
  - Cell B's first fingerprint ("no request with an empty `Mcp-Method`") passed *with the production
    skip removed*, because go-sdk v1.7's client is Modern-first and never sends a raw Legacy
    `initialize`. Re-based on the presence of `subscriptions/listen`, which only a full SDK client
    handshake emits.
  - Cell A's `_meta` pin asserted only that reserved keys were **absent**, which a blanket `_meta`
    drop would also satisfy — silently killing `progressToken` and trace context. Now also asserts a
    non-reserved key survives the same hop.
- **The environment-independence of the kill-switch specs was proven both ways**: with
  `TOOLHIVE_VMCP_MODERN_STATELESS=true` exported, the pre-fix helper leaked it and exactly the
  kill-switch spec failed; with the fix, 6/6.
- **The Modern probe was verified by hand through the thv proxy** before any spec was written
  (`server/discover` → `resultType:"complete"`, `supportedVersions:["2026-07-28","2025-11-25"]`),
  because the whole suite rests on that hop working.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

No operator API surface is touched — no CRD, no `api/v1*` type. The `/status` change is additive on
the vMCP HTTP endpoint (`mcp_revision`, `omitempty`), so existing consumers see byte-identical JSON
whenever health monitoring is disabled.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/session/factory.go` | Skip the backend connect for a backend already classified Modern; suppress the all-failed warning when every backend was skipped that way |
| `pkg/vmcp/cli/serve.go` | Wire the revision lookup into the session factory at the composition root |
| `pkg/vmcp/server/status.go` | Add `BackendStatus.MCPRevision`, populated from the live health state |
| `pkg/vmcp/server/bridge_regression_test.go` | New — pins both bridge cells' confidentiality invariants |
| `pkg/vmcp/session/factory_revision_test.go` | New — the skip decision and the post-error re-check |
| `pkg/vmcp/server/status_test.go` | Coverage for all three `mcp_revision` states |
| `test/e2e/vmcp_dual_era_test.go`, `..._helpers_test.go` | New — live four-cell matrix, CLI tier |
| `test/e2e/thv-operator/virtualmcp/virtualmcp_dual_era_backends_test.go` | New — mixed-era operator tier (#5979) |
| `test/e2e/thv-operator/virtualmcp/helpers.go` | One additive field on the `VMCPBackendStatus` test mirror, so it stops drifting from `server.BackendStatus` |
| `docs/arch/10-virtual-mcp-architecture.md` | Record that Modern backends hold no per-session connection, and why that is correct rather than a gap |

## Does this introduce a user-facing change?

Yes. The vMCP `/status` endpoint's `backends[]` entries now carry `mcp_revision` — the backend's
negotiated MCP protocol revision (`2025-11-25` or `2026-07-28`). It is `omitempty` and is populated
only from live health state, so it is absent when health monitoring is disabled or a backend has not
been probed yet. The endpoint is unauthenticated by design, so this is a real (if small) widening of what an
unauthenticated caller learns: which MCP revision each backend negotiated. It is a protocol version,
not a secret, and the same value is also published on `VirtualMCPServer.status.discoveredBackends[]`
— but that is behind cluster RBAC, a different trust boundary, so treat the two as separate
disclosures rather than one. Deployments that care should restrict `/status` by network policy, as
its own doc comment already advises.

## Special notes for reviewers

**Two assertions carry most of the value, and both exist because a naive version passed vacuously.**

1. `BeforeEach` gates every CLI-tier spec on `/status` reporting `2026-07-28` for the stateless
   backend and `2025-11-25` for the other. Without it the 2×2 matrix can silently collapse to 1×2:
   a regressed `server/discover` probe would classify the stateless backend Legacy and **all six
   specs would still pass** while testing the Legacy backend edge twice. This is not hypothetical —
   it caught exactly that during a rebase, when #6004 changed which yardstick image is Modern-capable.
2. Cell A correlates a per-request nonce (carried in tool arguments) against the credential the
   backend observed. Counting distinct backend sessions is insufficient: under a *symmetric swap* of
   two principals' credentials the count stays correct. The two channels are independent, so a swap
   makes them diverge.

**Health monitoring is opt-in, and that is the sharpest edge in this feature.** `mcp_revision` is
observable only through live health state, and vMCP only starts the monitor when
`operational.failureHandling.healthCheckInterval > 0`. Both e2e tiers must enable it explicitly;
with the section absent the status payload carries no backends at all and the revision assertions
time out. `unhealthyThreshold` is mandatory once the interval is set, or the vmcp pod fails at
startup. This bit the work four separate times and is the strongest argument for the TTL re-probe
tracked in #5992.

**Known limitations, deliberate:**

- The operator-tier spec has **not** been run against a cluster. It is authored for
  `test-e2e-lifecycle.yml` and verified by compile + `go vet` + lint, following the precedent set by
  #5981's own k8s tier. The one assumption no existing test covers is a yardstick backend inside a
  *discovered-mode* vMCP group alongside a Legacy backend; if it fails, the "aggregates tools from
  both backends" `It` times out first.
- The raw e2e client cannot parse SSE, so the CLI-tier bridge is proven only under a non-conformant
  `Accept` header (recorded in the file). The k8s tier opts into the full header.
- The stale-revision-cache window (#5992) is documented in `initOneBackend` rather than fixed: a
  backend redeployed stateless→stateful keeps a stale `Modern` label until a call re-probes.

**Follow-ups this unblocks:**

- #5986 (strip reserved keys from backend **response** `_meta`) is deliberately untouched — this PR
  asserts nothing about response `_meta` so the two cannot conflict. One trap for whoever takes it:
  `conversion.ToMCPMeta` is bidirectional, called on both the response path and outbound requests,
  so the strip belongs at the response call sites rather than inside it.
- The two specs #5981 removed pending this bridge (mixed-era over a shared Redis session store, and
  Redis-outage → 503) are now unblocked. Neither tier here configures Redis, so that coverage is
  still outstanding — the operator-tier file is the natural place to grow it.
- Separately, with the Modern kill switch off, a well-formed Modern request currently receives
  go-sdk's plain-text 400 rather than the `-32022` + supported-versions body the draft mandates. A
  fix is ready on a follow-up branch, and the underlying go-sdk defect has been written up for
  upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
