### PR TITLE
Refuse an unserved MCP revision conformantly

### DIFF
--- a/pkg/vmcp/server/authz_integration_test.go
+++ b/pkg/vmcp/server/authz_integration_test.go
@@ -173,6 +173,15 @@ func buildCedarAuthzServer(
 			Authz:          authzCfg,
 			AuditConfig:    auditCfg,
 			CodeModeConfig: codeModeCfg,
+			// Required for TestIntegration_CedarAuthzDenial_ModernPath_IsAudited to
+			// exercise what it claims: dispatchModern's re-homed call gate. Without
+			// it the kill switch refuses the Modern request in classifyingHandler and
+			// dispatchModern never runs. (Before the classifier learned to refuse an
+			// unserved revision, the request instead fell through to the SDK path, so
+			// that test passed on a denial from a different gate entirely.) Safe for
+			// the Legacy-shaped tests sharing this helper: classifyingHandler passes
+			// Legacy traffic through regardless of this flag.
+			ModernDispatchEnabled: true,
 		},
 		router.NewSessionRouter(&vmcp.RoutingTable{}),
 		backendClient,

--- a/pkg/vmcp/server/classification.go
+++ b/pkg/vmcp/server/classification.go
@@ -9,13 +9,21 @@ import (
 	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 )
 
+// methodServerDiscover is the Modern (2026-07-28) capability-probe method. It is
+// special-cased in two places — the kill-switch branch below and dispatchModern's
+// method switch — because it is how a client learns which revisions a server
+// supports, so it must never be refused on version grounds.
+const methodServerDiscover = "server/discover"
+
 // classifyingHandler classifies a parsed MCP request as Legacy (2025-11-25) or
 // Modern (2026-07-28) at the decode seam, rejects a malformed Modern request
 // with the correct JSON-RPC error before it reaches dispatch, and — when
 // Config.ModernDispatchEnabled — routes a well-formed Modern request to
 // dispatchModern instead of the SDK. Legacy traffic always falls through to
-// next unchanged, as does a well-formed Modern request while the switch is
-// off (default), matching pre-Modern-dispatch wire behavior byte for byte.
+// next unchanged. While the switch is off (default), a well-formed Modern
+// request is refused with a conformant -32022 rather than falling through —
+// see the kill-switch branch for why, and for why server/discover is exempt
+// and does still fall through.
 //
 // ValidateHeaderConsistency (Mcp-Method/Mcp-Name) only applies to Modern
 // requests: a Legacy request carrying a stray Mcp-Method/Mcp-Name header
@@ -67,10 +75,34 @@ func (s *Server) classifyingHandler(next http.Handler) http.Handler {
 		}
 
 		// TEMPORARY kill-switch (default off): until Modern dispatch is
-		// conformance-validated, a well-formed Modern request falls through to
-		// the SDK path unless explicitly enabled. See issue #5959.
+		// conformance-validated, vMCP does not serve the Modern revision unless
+		// explicitly enabled. See issue #5959.
+		//
+		// Answer that conformantly here rather than letting the request reach the
+		// SDK. The draft's Streamable HTTP "Protocol Version Header" section
+		// requires a server that does not implement a requested version -- "whether
+		// the version is unknown to the server, or is a known version the server has
+		// chosen not to support" -- to reply 400 with an UnsupportedProtocolVersionError
+		// listing the versions it does support. A disabled kill switch is exactly the
+		// second case. Falling through instead yields go-sdk's stateful-server
+		// rejection, which is a 400 with a PLAIN-TEXT body whose text is Go-API advice
+		// for the server author ("set StreamableHTTPOptions.Stateless = true") -- not
+		// parseable as a protocol error and carrying no version list.
+		//
+		// server/discover is deliberately exempt: it is how a client learns which
+		// revisions a server supports, so rejecting it on version grounds would leave
+		// the client no way to negotiate down. go-sdk exempts it for the same reason,
+		// and its stateful path answers discover correctly, so the fall-through is
+		// still right for that one method.
 		if !s.config.ModernDispatchEnabled {
-			next.ServeHTTP(w, r)
+			if parsed.Method == methodServerDiscover {
+				next.ServeHTTP(w, r)
+				return
+			}
+			mcpparser.WriteClassificationError(w, parsed.ID, &mcpparser.UnsupportedVersionError{
+				Requested: mcpparser.MCPVersionModern,
+				Supported: []string{mcpparser.MCPVersionLegacy},
+			})
 			return
 		}
 

--- a/pkg/vmcp/server/classification_test.go
+++ b/pkg/vmcp/server/classification_test.go
@@ -102,11 +102,23 @@ func TestClassifyingHandler(t *testing.T) {
 		},
 		{
 			// Same well-formed Modern request, but with the kill-switch at its
-			// default (off): dispatch must not happen and the request falls
-			// through to the SDK path unchanged, byte-identical to pre-Modern-
-			// dispatch wire behavior.
-			name:            "well-formed modern request falls through to next when the kill-switch is off",
-			parsed:          wellFormedModernToolsList(),
+			// default (off): vMCP does not serve the Modern revision, which the
+			// draft says must be answered with 400 + UnsupportedProtocolVersion
+			// listing the supported versions. It must NOT reach next: falling
+			// through lands on go-sdk's stateful rejection, a plain-text 400 no
+			// client can parse as a protocol error.
+			name:           "well-formed modern request is refused with -32022 when the kill-switch is off",
+			parsed:         wellFormedModernToolsList(),
+			protocolHeader: mcpparser.MCPVersionModern,
+			wantCode:       mcpparser.CodeUnsupportedProtocolVersion,
+		},
+		{
+			// server/discover is the one exemption: it is how a client learns
+			// which revisions the server supports, so refusing it on version
+			// grounds would leave the client unable to negotiate down. go-sdk's
+			// stateful path answers discover, so the fall-through is correct.
+			name:            "server/discover still falls through when the kill-switch is off",
+			parsed:          wellFormedModernDiscover(),
 			protocolHeader:  mcpparser.MCPVersionModern,
 			wantPassthrough: true,
 		},
@@ -297,5 +309,20 @@ func wellFormedModernToolsList() *mcpparser.ParsedMCPRequest {
 			metaKeyClientCapabilities: map[string]any{},
 		},
 		MCPMethodHeader: "tools/list",
+	}
+}
+
+// wellFormedModernDiscover is wellFormedModernToolsList for the one method the
+// kill-switch branch exempts from the unsupported-version refusal.
+func wellFormedModernDiscover() *mcpparser.ParsedMCPRequest {
+	return &mcpparser.ParsedMCPRequest{
+		Method:    methodServerDiscover,
+		ID:        "1",
+		IsRequest: true,
+		Meta: map[string]any{
+			metaKeyProtocolVersion:    mcpparser.MCPVersionModern,
+			metaKeyClientCapabilities: map[string]any{},
+		},
+		MCPMethodHeader: methodServerDiscover,
 	}
 }

--- a/pkg/vmcp/server/modern_dispatch.go
+++ b/pkg/vmcp/server/modern_dispatch.go
@@ -86,7 +86,7 @@ func (s *Server) dispatchModern(w http.ResponseWriter, r *http.Request, parsed *
 		s.dispatchModernResourceTemplatesList(ctx, w, parsed, identity)
 	case "prompts/list":
 		s.dispatchModernPromptsList(ctx, w, parsed, identity)
-	case "server/discover":
+	case methodServerDiscover:
 		s.dispatchModernDiscover(ctx, w, parsed, identity)
 	case "tools/call":
 		s.dispatchModernToolCall(ctx, w, parsed, identity)


### PR DESCRIPTION
> **Stacked on #6006** — base is `vmcp-dual-era-bridge`, so review only the top commit
> (`Refuse an unserved MCP revision conformantly`). GitHub will retarget this to `main`
> automatically when #6006 merges.

## Summary

With the Modern-dispatch kill switch off — **the default** — vMCP does not serve the MCP 2026-07-28
revision. It answered that by letting the request fall through to the SDK-backed stateful server,
which rejects it with a **plain-text** HTTP 400 whose body is Go-API advice addressed to the server
author:

```
Bad Request: protocol version "2026-07-28" is only supported on stateless HTTP servers
(set StreamableHTTPOptions.Stateless = true)
```

A client cannot parse that as a protocol error, cannot act on it, and learns nothing about what the
server does support.

The draft's Streamable HTTP "Protocol Version Header" section requires a server that does not
implement a requested version — explicitly including *"a known version the server has chosen not to
support"*, which is precisely a disabled kill switch — to reply 400 with an
`UnsupportedProtocolVersionError` **listing its supported versions**.

- Answer it in the classifier, which is the only layer that knows the switch state and therefore
  owns the decision. The error type and its supported-versions `Data()` already existed
  (`pkg/mcp/revision.go`); nothing new was needed but the call.
- **`server/discover` stays exempt and still falls through.** It is how a client learns which
  revisions a server supports, so refusing it on version grounds would leave the client unable to
  negotiate down. go-sdk exempts it for the same reason and its stateful path answers discover
  correctly.

Related: #6002 (Modern conformance follow-ups) — this is the *emitting* counterpart to #5997's
*consuming* side, which classifies an incoming `-32022` as Legacy. Also relevant to #5959, which
removes this kill switch entirely before GA; sequence that after this.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`) — `LABEL_FILTER="vmcp && dual-era"`, 6/6 green
- [x] Linting (`task lint-fix`)
- [x] Manual testing (described below)

The live dual-era suite matters here specifically: its kill-switch-off spec asserts an exact 400 with
no `resultType`, which is precisely the behaviour this changes. A `-32022` error envelope satisfies
both (an `error`, not a `result`), so the spec still passes — and it passes for the right reason
rather than by coincidence, which is why it was re-run rather than assumed.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

No operator API surface is touched — no CRD, no `api/v1*` type.

## Does this introduce a user-facing change?

Yes, and it changes **default** behaviour, since the kill switch ships off.

A client sending a well-formed MCP 2026-07-28 request to a vMCP that has not enabled Modern dispatch
now receives HTTP 400 with a JSON-RPC error body — code `-32022`
(`UNSUPPORTED_PROTOCOL_VERSION`), `data.supported: ["2025-11-25"]`, `data.requested: "2026-07-28"` —
instead of a plain-text 400.

Both are 400s and the draft's backward-compatibility guidance tells a dual-era client seeing an
unrecognised 400 body to fall back to `initialize`, so a conforming client behaved correctly before
and behaves correctly now. What changes is that it can now *distinguish* "this server does not serve
2026-07-28" from "your request was malformed", and it is told which versions to fall back to instead
of having to guess.

## Special notes for reviewers

**This surfaced a latent test defect worth knowing about.**
`TestIntegration_CedarAuthzDenial_ModernPath_IsAudited` never set `ModernDispatchEnabled`, so despite
its name it never reached `dispatchModern`'s re-homed authz call gate — with the switch off its
Modern request fell through to the SDK and the 403 it asserted came from a different gate entirely.
It has been passing without exercising the path it exists to cover. Its helper now enables the
switch, so the test does what it claims. The other tests sharing that helper send Legacy traffic,
which the classifier passes through regardless of the flag.

**The underlying go-sdk behaviour is a separate upstream defect, and this does not depend on it.**
`mcp/streamable.go` (v1.7.0-pre.3) calls `writeJSONRPCError` correctly for the *adjacent*
header-mismatch case two lines below the offending `http.Error`, so the SDK has the right tool and
does not use it on this path. Reported upstream separately. Fixing it there would not make this
change redundant: vMCP's condition is "*ToolHive* has chosen not to serve this revision", which only
the classifier knows — the SDK cannot see the kill-switch state. Every other SDK consumer serving a
stateful server is still affected until upstream lands.

**Deliberately not done in `mcpcompat`.** The shim could pre-empt this using its own `WithStateless`
knowledge, which would also cover the transport proxies, and that remains a reasonable follow-up if
a second consumer needs it. What was rejected is intercepting and rewriting the SDK's 400, which
would mean string-matching an SDK error message and would break silently the moment the wording
changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
