### PR TITLE
Make e2e workload readiness waits reliable

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -125,28 +125,52 @@ jobs:
 
       - name: Pre-pull container images
         run: |
-          # Pre-pull images used by E2E tests so that workload creation
-          # does not pay the image-pull cost inside the 60s API timeout.
-          docker pull ghcr.io/stackloklabs/osv-mcp/server:0.1.3 &
-          docker pull ghcr.io/stackloklabs/gofetch/server:1.0.2 &
-          docker pull ghcr.io/stacklok/toolhive/egress-proxy:latest &
+          # Pre-pull images used by E2E tests so that workload startup does not
+          # pay the image-pull cost inside a spec's readiness timeout.
+          #
+          # Images that tests reach through a registry server name (`thv run
+          # fetch`) are resolved from the binary under test instead of being
+          # hardcoded here. Renovate bumps github.com/stacklok/toolhive-catalog
+          # daily but has no manager for these docker pull lines, so hardcoded
+          # tags drift out of sync with the catalog silently and the pre-pull
+          # stops covering what the tests actually run.
+          servers="fetch osv"
+          images="ghcr.io/stacklok/toolhive/egress-proxy:latest"
           # yardstick is only needed for the vmcp test suite
           if [ "${{ matrix.label_filter }}" = "vmcp" ]; then
-            docker pull ghcr.io/stackloklabs/yardstick/yardstick-server:1.2.0 &
+            images="$images ghcr.io/stackloklabs/yardstick/yardstick-server:1.2.0"
           fi
           # the time server and yardstick (dual-era barrier mode) are only
           # used by the proxy (streamable-http) test suite
           if [ "${{ matrix.label_filter }}" = "proxy && !isolation" ]; then
-            docker pull ghcr.io/stacklok/dockyard/uvx/mcp-server-time:2026.1.26 &
-            docker pull ghcr.io/stackloklabs/yardstick/yardstick-server:1.2.0 &
+            servers="$servers time"
+            images="$images ghcr.io/stackloklabs/yardstick/yardstick-server:1.2.0"
           fi
           # Envoy is only used by the network-isolation test suite
           if [ "${{ matrix.title }}" = "network-isolation" ]; then
-            docker pull envoyproxy/envoy-distroless:v1.32.3 &
+            images="$images envoyproxy/envoy-distroless:v1.32.3"
           fi
+
+          for server in $servers; do
+            image="$(./bin/thv registry info "$server" --format json | jq -er '.image')"
+            echo "Resolved registry server '$server' -> $image"
+            images="$images $image"
+          done
+
+          for image in $images; do
+            docker pull -q "$image" &
+          done
           wait
+
+          # `wait` reports success even when a background pull failed, so check
+          # each image landed locally. Failing here is far cheaper to diagnose
+          # than a spec timing out later while it waits on a live pull.
           echo "Pre-pulled images:"
-          docker images --format '{{.Repository}}:{{.Tag}}' | grep -E 'osv-mcp|gofetch|egress-proxy|yardstick|mcp-server-time'
+          for image in $images; do
+            docker image inspect "$image" >/dev/null \
+              || { echo "::error::failed to pre-pull $image"; exit 1; }
+            echo "  $image"
+          done
 
       - name: Run E2E tests (${{ matrix.title }})
         env:

--- a/test/e2e/group_rm_test.go
+++ b/test/e2e/group_rm_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 			createWorkloadInGroup(workloadName, groupName)
 
 			// Verify the workload is running
-			err := e2e.WaitForMCPServer(config, workloadName, 60*time.Second)
+			err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
 			Expect(err).ToNot(HaveOccurred())
 
 			// Try to delete the group but provide 'n' for no
@@ -120,7 +120,7 @@ var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 
 			// Verify all workloads are running
 			for _, workloadName := range []string{groupWorkload1, groupWorkload2, nonGroupWorkload1, nonGroupWorkload2} {
-				err := e2e.WaitForMCPServer(config, workloadName, 60*time.Second)
+				err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -155,7 +155,7 @@ var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 
 			// Verify all workloads are running
 			for _, workloadName := range []string{workload1, workload2} {
-				err := e2e.WaitForMCPServer(config, workloadName, 60*time.Second)
+				err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
 				Expect(err).ToNot(HaveOccurred())
 			}
 

--- a/test/e2e/group_test.go
+++ b/test/e2e/group_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Group", Label("core", "groups", "e2e"), func() {
 	createWorkloadInGroup := func(workloadName, groupName string) {
 		e2e.NewTHVCommand(config, "run", "fetch", "--group", groupName, "--name", workloadName).ExpectSuccess()
 		createdWorkloads = append(createdWorkloads, workloadName)
-		err := e2e.WaitForMCPServer(config, workloadName, 60*time.Second)
+		err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
 		Expect(err).ToNot(HaveOccurred())
 	}
 
@@ -192,7 +192,7 @@ var _ = Describe("Group", Label("core", "groups", "e2e"), func() {
 				_, _ = e2e.NewTHVCommand(config, "restart", workloadName).ExpectSuccess()
 
 				By("Verifying the workload is still in the correct group")
-				err := e2e.WaitForMCPServer(config, workloadName, 60*time.Second)
+				err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
 				Expect(err).ToNot(HaveOccurred())
 
 				workloadGroupName, err := getWorkloadGroup(workloadName)

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -6,6 +6,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -16,6 +17,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck // Standard practice for Ginkgo
 	. "github.com/onsi/gomega"    //nolint:staticcheck // Standard practice for Gomega
+
+	rt "github.com/stacklok/toolhive/pkg/container/runtime"
+	"github.com/stacklok/toolhive/pkg/core"
 )
 
 // GenerateUniqueServerName creates a unique server name for tests
@@ -133,7 +137,45 @@ func (c *THVCommand) ExpectFailure() (string, string, error) {
 	return stdout, stderr, err
 }
 
-// WaitForMCPServer waits for an MCP server to be running
+// ServerReadyTimeoutEnv overrides how long specs wait for a freshly started
+// workload to reach the running state.
+const ServerReadyTimeoutEnv = "TOOLHIVE_E2E_SERVER_READY_TIMEOUT"
+
+// defaultServerReadyTimeout is the readiness budget used when
+// ServerReadyTimeoutEnv is unset.
+//
+// Reaching `running` covers more than starting a container: the detached worker
+// also polls the workload's own MCP endpoint until initialize succeeds before it
+// flips the status (pkg/runner.waitForInitializeSuccess, which the product is
+// willing to wait 5 minutes for). Specs that start several workloads at once
+// need a budget well above container-start time, otherwise they fail while the
+// workload is still legitimately starting on a loaded CI runner.
+const defaultServerReadyTimeout = 2 * time.Minute
+
+// ServerReadyTimeout returns the budget a spec should give a freshly started
+// workload to reach the running state. Set ServerReadyTimeoutEnv to any Go
+// duration (e.g. "3m") to raise it on a slow machine.
+func ServerReadyTimeout() time.Duration {
+	raw := os.Getenv(ServerReadyTimeoutEnv)
+	if raw == "" {
+		return defaultServerReadyTimeout
+	}
+
+	timeout, err := time.ParseDuration(raw)
+	if err != nil || timeout <= 0 {
+		Fail(fmt.Sprintf("%s must be a positive Go duration (e.g. \"3m\"), got %q", ServerReadyTimeoutEnv, raw))
+	}
+	return timeout
+}
+
+// WaitForMCPServer waits for an MCP server to be running.
+//
+// The status is read from the named workload's own record in `thv list --all
+// --format json`. Substring-matching the text table instead would accept "this
+// name appears somewhere and some workload is running", which can return while
+// the named workload is still starting. A timeout reports the last status
+// observed and dumps the server state, so a CI log shows whether the workload
+// was still starting, had errored, or never appeared at all.
 func WaitForMCPServer(config *TestConfig, serverName string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -141,28 +183,41 @@ func WaitForMCPServer(config *TestConfig, serverName string, timeout time.Durati
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
+	var lastObserved string
 	for {
+		workload, err := findWorkload(config, serverName)
+		switch {
+		case err != nil:
+			// `thv list` can fail transiently while other workloads are
+			// starting, so keep polling and surface the failure only if the
+			// timeout expires.
+			lastObserved = fmt.Sprintf("thv list failed: %v", err)
+		case workload == nil:
+			lastObserved = "not listed"
+		case workload.Status == rt.WorkloadStatusRunning:
+			return nil
+		default:
+			lastObserved = fmt.Sprintf("status %q", workload.Status)
+			if workload.StatusContext != "" {
+				lastObserved += fmt.Sprintf(" (%s)", workload.StatusContext)
+			}
+		}
+
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timeout waiting for MCP server %s to be running", serverName)
+			DebugServerState(config, serverName)
+			return fmt.Errorf("timeout waiting for MCP server %s to be running after %v; last observed: %s",
+				serverName, timeout, lastObserved)
 		case <-ticker.C:
-			stdout, _, err := NewTHVCommand(config, "list").Run()
-			if err != nil {
-				continue
-			}
-
-			// Check if the server is listed and running
-			if strings.Contains(stdout, serverName) && strings.Contains(stdout, "running") {
-				return nil
-			}
 		}
 	}
 }
 
 // IsServerRunning checks if an MCP server is running
 func IsServerRunning(config *TestConfig, serverName string) bool {
-	stdout, _ := NewTHVCommand(config, "list").ExpectSuccess()
-	return strings.Contains(stdout, serverName) && strings.Contains(stdout, "running")
+	workload, err := findWorkload(config, serverName)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should be able to list workloads")
+	return workload != nil && workload.Status == rt.WorkloadStatusRunning
 }
 
 // StopAndRemoveMCPServer stops and removes an MCP server
@@ -354,4 +409,26 @@ func CreateFakeBrowserDir(tempDir string) (string, error) {
 		}
 	}
 	return dir, nil
+}
+
+// findWorkload returns the named workload's record, or nil if it is not listed.
+// --all is required so that workloads which have not reached running yet
+// (starting, error) are visible rather than filtered out.
+func findWorkload(config *TestConfig, serverName string) (*core.Workload, error) {
+	stdout, stderr, err := NewTHVCommand(config, "list", "--all", "--format", "json").Run()
+	if err != nil {
+		return nil, fmt.Errorf("thv list: %w (stderr: %s)", err, strings.TrimSpace(stderr))
+	}
+
+	var workloads []core.Workload
+	if err := json.Unmarshal([]byte(stdout), &workloads); err != nil {
+		return nil, fmt.Errorf("failed to parse thv list output %q: %w", stdout, err)
+	}
+
+	for i := range workloads {
+		if workloads[i].Name == serverName {
+			return &workloads[i], nil
+		}
+	}
+	return nil, nil
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -220,6 +220,39 @@ func IsServerRunning(config *TestConfig, serverName string) bool {
 	return workload != nil && workload.Status == rt.WorkloadStatusRunning
 }
 
+// listTimeout bounds a single `thv list` call. It is well above how long a list
+// takes even on a loaded runner, and well below any readiness budget: callers
+// poll, so a list that overruns is retried rather than fatal. Run() would apply
+// TestConfig.TestTimeout instead, letting one hung list outlast the wait it is
+// being polled for.
+const listTimeout = 30 * time.Second
+
+// FindWorkload returns the named workload's record as reported by `thv list`, or
+// nil if it is not listed. newCmd builds each list invocation, so a spec that
+// runs thv under an isolated config/home/data env passes its own builder and
+// observes the workloads created in that state rather than the real config.
+//
+// --all is required so that workloads which have not reached running yet
+// (starting, error) are visible rather than filtered out.
+func FindWorkload(newCmd func(args ...string) *THVCommand, serverName string) (*core.Workload, error) {
+	stdout, stderr, err := newCmd("list", "--all", "--format", "json").RunWithTimeout(listTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("thv list: %w (stderr: %s)", err, strings.TrimSpace(stderr))
+	}
+
+	var workloads []core.Workload
+	if err := json.Unmarshal([]byte(stdout), &workloads); err != nil {
+		return nil, fmt.Errorf("failed to parse thv list output %q: %w", stdout, err)
+	}
+
+	for i := range workloads {
+		if workloads[i].Name == serverName {
+			return &workloads[i], nil
+		}
+	}
+	return nil, nil
+}
+
 // StopAndRemoveMCPServer stops and removes an MCP server
 // This function is designed for cleanup and tolerates servers that don't exist
 func StopAndRemoveMCPServer(config *TestConfig, serverName string) error {
@@ -411,31 +444,10 @@ func CreateFakeBrowserDir(tempDir string) (string, error) {
 	return dir, nil
 }
 
-// listTimeout bounds a single `thv list` call. It is well above how long a list
-// takes even on a loaded runner, and well below any readiness budget: callers
-// poll, so a list that overruns is retried rather than fatal. Run() would apply
-// TestConfig.TestTimeout instead, letting one hung list outlast the wait it is
-// being polled for.
-const listTimeout = 30 * time.Second
-
-// findWorkload returns the named workload's record, or nil if it is not listed.
-// --all is required so that workloads which have not reached running yet
-// (starting, error) are visible rather than filtered out.
+// findWorkload returns the named workload's record as reported by `thv list`,
+// or nil if it is not listed.
 func findWorkload(config *TestConfig, serverName string) (*core.Workload, error) {
-	stdout, stderr, err := NewTHVCommand(config, "list", "--all", "--format", "json").RunWithTimeout(listTimeout)
-	if err != nil {
-		return nil, fmt.Errorf("thv list: %w (stderr: %s)", err, strings.TrimSpace(stderr))
-	}
-
-	var workloads []core.Workload
-	if err := json.Unmarshal([]byte(stdout), &workloads); err != nil {
-		return nil, fmt.Errorf("failed to parse thv list output %q: %w", stdout, err)
-	}
-
-	for i := range workloads {
-		if workloads[i].Name == serverName {
-			return &workloads[i], nil
-		}
-	}
-	return nil, nil
+	return FindWorkload(func(args ...string) *THVCommand {
+		return NewTHVCommand(config, args...)
+	}, serverName)
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -411,11 +411,18 @@ func CreateFakeBrowserDir(tempDir string) (string, error) {
 	return dir, nil
 }
 
+// listTimeout bounds a single `thv list` call. It is well above how long a list
+// takes even on a loaded runner, and well below any readiness budget: callers
+// poll, so a list that overruns is retried rather than fatal. Run() would apply
+// TestConfig.TestTimeout instead, letting one hung list outlast the wait it is
+// being polled for.
+const listTimeout = 30 * time.Second
+
 // findWorkload returns the named workload's record, or nil if it is not listed.
 // --all is required so that workloads which have not reached running yet
 // (starting, error) are visible rather than filtered out.
 func findWorkload(config *TestConfig, serverName string) (*core.Workload, error) {
-	stdout, stderr, err := NewTHVCommand(config, "list", "--all", "--format", "json").Run()
+	stdout, stderr, err := NewTHVCommand(config, "list", "--all", "--format", "json").RunWithTimeout(listTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("thv list: %w (stderr: %s)", err, strings.TrimSpace(stderr))
 	}

--- a/test/e2e/list_group_e2e_test.go
+++ b/test/e2e/list_group_e2e_test.go
@@ -70,7 +70,7 @@ var _ = Describe("List Group", Label("core", "groups", "e2e"), func() {
 				_, _ = e2e.NewTHVCommand(config, "run", "fetch", "--group", groupName, "--name", workloadName).ExpectSuccess()
 
 				// Wait for workload to be fully registered
-				err := e2e.WaitForMCPServer(config, workloadName, 60*time.Second)
+				err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -131,7 +131,7 @@ var _ = Describe("List Group", Label("core", "groups", "e2e"), func() {
 			_, _ = e2e.NewTHVCommand(config, "run", "fetch", "--group", groupName, "--name", workloadName, "--label", "test=value").ExpectSuccess()
 
 			// Wait for workload to be fully registered
-			err := e2e.WaitForMCPServer(config, workloadName, 60*time.Second)
+			err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -194,9 +194,9 @@ var _ = Describe("List Group", Label("core", "groups", "e2e"), func() {
 			_, _ = e2e.NewTHVCommand(config, "run", "fetch", "--group", secondGroupName, "--name", workload2Name).ExpectSuccess()
 
 			// Wait for workloads to be fully registered
-			err := e2e.WaitForMCPServer(config, workload1Name, 60*time.Second)
+			err := e2e.WaitForMCPServer(config, workload1Name, e2e.ServerReadyTimeout())
 			Expect(err).ToNot(HaveOccurred())
-			err = e2e.WaitForMCPServer(config, workload2Name, 60*time.Second)
+			err = e2e.WaitForMCPServer(config, workload2Name, e2e.ServerReadyTimeout())
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/test/e2e/rm_group_test.go
+++ b/test/e2e/rm_group_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Group Remove E2E Tests", Label("core", "groups", "e2e"), func(
 
 			// Wait for the workloads to appear in thv list
 			for _, workloadName := range []string{groupWorkload1, groupWorkload2, nonGroupWorkload1, nonGroupWorkload2} {
-				err := e2e.WaitForMCPServer(config, workloadName, 60*time.Second)
+				err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
 				Expect(err).NotTo(HaveOccurred())
 			}
 

--- a/test/e2e/upgrade_e2e_test.go
+++ b/test/e2e/upgrade_e2e_test.go
@@ -7,12 +7,12 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/stacklok/toolhive/pkg/container/runtime"
 	"github.com/stacklok/toolhive/pkg/runner"
 	"github.com/stacklok/toolhive/pkg/workloads/upgrade"
 	"github.com/stacklok/toolhive/test/e2e"
@@ -107,7 +107,7 @@ var _ = Describe("Upgrade Command", Label("core", "upgrade", "e2e"), func() {
 				thvCmd("run", "--name", serverName, rawOSVImage).ExpectSuccess()
 
 				By("Waiting for the server to be running")
-				waitForIsolatedMCPServer(thvCmd, serverName, 60*time.Second)
+				waitForIsolatedMCPServer(thvCmd, serverName, e2e.ServerReadyTimeout())
 
 				By("Checking the workload for an available upgrade")
 				stdout, _ := thvCmd("upgrade", "check", serverName).ExpectSuccess()
@@ -123,7 +123,7 @@ var _ = Describe("Upgrade Command", Label("core", "upgrade", "e2e"), func() {
 				thvCmd("run", "--name", serverName, rawOSVImage).ExpectSuccess()
 
 				By("Waiting for the server to be running")
-				waitForIsolatedMCPServer(thvCmd, serverName, 60*time.Second)
+				waitForIsolatedMCPServer(thvCmd, serverName, e2e.ServerReadyTimeout())
 
 				By("Checking the workload for an available upgrade in JSON format")
 				stdout, _ := thvCmd("upgrade", "check", serverName, "--format", "json").ExpectSuccess()
@@ -240,19 +240,20 @@ var _ = Describe("Upgrade Command", Label("core", "upgrade", "e2e"), func() {
 	})
 })
 
-// waitForIsolatedMCPServer polls `thv list` (through the supplied isolated-env
-// command builder) until the named workload reports running, or fails the spec
-// on timeout. It mirrors e2e.WaitForMCPServer but runs every poll under the same
-// isolated config/home/data env as the rest of the spec, so it observes the
-// workload created in that isolated state rather than the real ToolHive config.
+// waitForIsolatedMCPServer polls until the named workload reports running, or
+// fails the spec on timeout. It exists alongside e2e.WaitForMCPServer because it
+// runs every poll through the supplied isolated-env command builder, so it
+// observes the workload created in that isolated config/home/data state rather
+// than the real ToolHive config. The lookup itself is shared, so the status is
+// read from the named workload's own record.
 func waitForIsolatedMCPServer(thvCmd func(args ...string) *e2e.THVCommand, serverName string, timeout time.Duration) {
 	GinkgoHelper()
 	Eventually(func() bool {
-		stdout, _, err := thvCmd("list").Run()
+		workload, err := e2e.FindWorkload(thvCmd, serverName)
 		if err != nil {
 			return false
 		}
-		return strings.Contains(stdout, serverName) && strings.Contains(stdout, "running")
+		return workload != nil && workload.Status == runtime.WorkloadStatusRunning
 	}, timeout, 1*time.Second).Should(BeTrue(),
 		"workload %q should be running within %s", serverName, timeout)
 }


### PR DESCRIPTION
## Summary

The `Group Remove` spec times out waiting for a freshly started workload to reach `running`. Three separate problems, all in test infrastructure:

- **The spec-side budget is far tighter than the product's own.** Reaching `running` is not just "container started": the detached worker starts the container, brings up the transparent proxy, then polls the workload's own MCP endpoint until `initialize` succeeds, and only then flips the status (`pkg/runner.waitForInitializeSuccess`, `pkg/runner/runner.go:572`) — a probe the product is willing to wait **5 minutes** for. The group specs gave it 60s while starting up to 4 workloads at once, so they fail while the workload is still legitimately starting on a loaded runner. Waits now take their budget from `e2e.ServerReadyTimeout()` (2m default, overridable via `TOOLHIVE_E2E_SERVER_READY_TIMEOUT`).

- **The readiness wait was not actually checking the named workload.** It matched `strings.Contains(stdout, serverName) && strings.Contains(stdout, "running")` against the whole `thv list` table, i.e. "this name appears somewhere **and** some workload is running" — so it could return while the named workload was still `starting`. It now reads that workload's own record from `thv list --all --format json`. The same defect was present in three places, all fixed: `WaitForMCPServer`, `IsServerRunning`, and `waitForIsolatedMCPServer` (a copy of the old body in the upgrade spec). The lookup is now shared via an exported `e2e.FindWorkload`, which takes the command builder so the isolated config/home/data spec can supply its own and observe its own state.

- **The failure was undiagnosable.** `timeout waiting for MCP server X to be running` said nothing about *why*. The error now carries the last status observed (including `status_context`) and dumps server state via the existing `DebugServerState` helper, so the next occurrence tells us whether the workload was still starting, had errored, or never appeared. The poll's own `thv list` is bounded at 30s, since `Run()` would apply `TestConfig.TestTimeout` (10m) and let one hung list outlast the wait it is being polled for.

- **CI's pre-pull had silently gone stale.** The step exists so workload startup does not pay the image-pull cost, but it hardcoded tags for images the tests reach *by registry name*. Renovate bumps `github.com/stacklok/toolhive-catalog` daily and has **no** manager for these `docker pull` lines, so they drifted:

  | server | catalog (what tests run) | what CI pre-pulled |
  |---|---|---|
  | `fetch` | `gofetch/server:1.0.5` | `gofetch/server:1.0.2` ❌ |
  | `time` | `mcp-server-time:2026.7.10` | `mcp-server-time:2026.1.26` ❌ |
  | `osv` | `osv-mcp/server:0.1.3` | `osv-mcp/server:0.1.3` ✅ |

  Those tags are now resolved from the binary under test (`thv registry info <server> --format json`), so they cannot drift again, and the step fails loudly if an image did not land locally (`wait` reports success even when a background pull failed).

Fixes #6011

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Docker is unavailable in my environment, so the e2e suite itself is verified by this PR's CI — that is the point of opening it as a draft. Verified locally:

- `task lint` → 0 issues; `go vet ./test/e2e/...` clean.
- The catalog drift, by resolving the images through the registry provider the tests actually use: `fetch` → `ghcr.io/stackloklabs/gofetch/server:1.0.5`, `time` → `ghcr.io/stacklok/dockyard/uvx/mcp-server-time:2026.7.10`.
- The new pre-pull shell logic, executed for the `core`, `proxy && !isolation` and `network-isolation` matrix entries against a stubbed `docker`, confirming the resolved tags and per-matrix image sets.
- That `thv registry info --format json` emits clean JSON on stdout (the update-notification banner goes to stderr, and is skipped in CI anyway), so both the `jq` call and the JSON parse in `FindWorkload` are safe.

## Changes

| File | Change |
|------|--------|
| `test/e2e/helpers.go` | `ServerReadyTimeout()`; exported `FindWorkload`; `WaitForMCPServer`/`IsServerRunning` read the workload's own record; timeout diagnostics; bounded list poll |
| `.github/workflows/e2e-tests.yml` | Resolve registry-server image tags from the binary under test; fail if a pre-pull did not land |
| `test/e2e/upgrade_e2e_test.go` | `waitForIsolatedMCPServer` uses the shared lookup instead of a copy of the old loose match |
| `test/e2e/rm_group_test.go`, `group_rm_test.go`, `group_test.go`, `list_group_e2e_test.go` | Use the shared readiness budget instead of a hardcoded 60s |

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **Watch the full e2e matrix on this PR, not just the `core` entry.** Tightening the wait to the named workload makes ~50 call sites wait for something they previously could skip. That is the correct contract, but any spec that was passing only because *another* workload happened to be running will now surface. If something unrelated goes red, that is the signal — I'd rather find it here than leave the helper accepting the wrong thing.
- **No fail-fast on `error` status, deliberately.** It is tempting to abort the wait as soon as the workload reports `error`, but the status is not monotonic across restarts (`thv restart` writes `stopped`/`starting` after a previous `error`), so a spec that restarts a workload could read a stale `error` and fail spuriously. The status is reported in the timeout message instead, which never fails earlier than the old code did.
- `upgrade_e2e_test.go` keeps its two explicit `120*time.Second` waits: that equals the new default anyway, and the author raised them above 60s deliberately for the slower upgrade flow, so leaving them hardcoded preserves that intent against an env override. Only its 60s waits moved to the shared budget. Remaining 60s call sites elsewhere are untouched to keep this reviewable; `ServerReadyTimeout()` is there to adopt if the same family shows up again (#5690, #5265, #2741).
- The stale pre-pull does not by itself explain the 60s timeout — the pull happens synchronously inside `thv run` (`cmd/thv/app/run_flags.go:417`), which the specs allow 10 minutes for. It burns suite wall-clock and pushes the workload-heavy matrix entries toward `TEST_TIMEOUT`, which is the #5265 family, so it is fixed here rather than filed separately.

Generated with [Claude Code](https://claude.com/claude-code)
