### PR TITLE
Document vMCP backend revision classification

### DIFF
--- a/docs/arch/03-transport-architecture.md
+++ b/docs/arch/03-transport-architecture.md
@@ -682,7 +682,7 @@ path for server->client messages.
 `subscriptions/listen`, a POST method whose response stream stays open for
 server-pushed subscription events. `serverStreamRegistry` is a reasonable
 decoupled fan-out seam to build a future Modern handler for this method on top
-of, but it is **not** a drop-in reuse. Per the draft spec, real adaptation is
+of, but it is **not** a drop-in reuse. Per the 2026-07-28 spec, real adaptation is
 required: `subscriptions/listen` is a long-lived POST, not a GET; Modern has no
 sessions, so streams must be keyed per-subscription-id rather than per session
 ID; delivery requires per-notification-type AND per-URI opt-in filtering, not

--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -171,6 +171,112 @@ Steps can be of three types:
 
 **Implementation**: `pkg/vmcp/composer/`
 
+## Backend MCP Revision Classification
+
+vMCP speaks both MCP revisions at once. The **client edge** is classified per
+request (see [Transport Architecture](03-transport-architecture.md)); each
+**backend edge** is classified independently, so a client on either revision can
+reach backends on either revision. This section covers the backend edge, in
+`pkg/vmcp/client`.
+
+Two names are used throughout the code: **Legacy** is 2025-11-25 (session-based,
+`initialize` handshake, `Mcp-Session-Id`) and **Modern** is 2026-07-28
+(stateless, no handshake, per-request `_meta`).
+
+### The probe: Modern-first `server/discover`
+
+`probeRevision` decides a backend's revision once, then caches it. It is
+Modern-first — it asks, rather than assuming Legacy:
+
+1. **SSE backends short-circuit to Legacy.** A `TransportType` of `sse` is the
+   2024-11-05 two-endpoint transport (`GET /sse` + `POST /messages`), which has
+   no Modern endpoint at `BaseURL` to discover. This gate is *ToolHive routing*,
+   not a protocol rule — HTTP+SSE is Deprecated in the spec, not removed.
+2. Otherwise vMCP POSTs `server/discover` (`discoverModernCapabilities`) and
+   reads `supportedVersions`.
+
+**`supportedVersions` is the authoritative signal — a clean `server/discover`
+response is not, by itself, proof of Modern.** A go-sdk v1.7 shim answers
+`server/discover` even when it is negotiating *down* to Legacy, so vMCP requires
+`supportedVersions` to actually contain `2026-07-28`; if it does not, the probe
+fails with `errModernNegotiatedDown` and the backend is classified Legacy. The
+containment check is an **exact match**, deliberately stricter than go-sdk's
+reference client (which accepts negotiated `>= 2026-07-28`), because vMCP's shim
+speaks exactly one Modern wire shape. That exactness is a tripwire: adding a
+newer Modern revision must widen this to a set/range check, or a newer-only
+backend is misclassified Legacy.
+
+Probe outcomes:
+
+| Discover result | Classification | Why |
+|---|---|---|
+| Success, `supportedVersions` contains `2026-07-28` | **Modern** | Backend affirmatively serves the revision |
+| A Modern-specific `-3202x` protocol error | **Modern** | The peer validated our Modern `_meta`, so it speaks the revision |
+| A valid Modern envelope with `resultType != "complete"` | **Modern** | Only a Modern peer produces that envelope (`errModernInputRequired`) |
+| Auth rejection (401/403/407) or transient (408/429/5xx, timeout) | **Inconclusive** | Says nothing about the revision; left unprobed so the next call re-probes |
+| Anything else, including negotiated-down | **Legacy** | `errModernNegotiatedDown`, `errWrongEra`, and every other genuine not-Modern signal |
+
+A probe that fails inconclusively falls back to Legacy for that one call
+**without caching it**, so a transient outage can never pin a backend to the
+wrong revision.
+
+### The cache, and its asymmetric self-healing
+
+`dispatch` wraps every backend verb: it resolves the revision (probing on a
+miss), runs the call, and on a revision-shaped failure (`isRevisionMismatch`)
+re-probes and retries. The two directions self-heal by different mechanisms,
+which is worth knowing when reading the code:
+
+- **Modern cached, backend is really Legacy** — `server/discover` no longer
+  advertises `2026-07-28`, producing `errModernNegotiatedDown`, which
+  `isRevisionMismatch` recognises on the Modern arm; the cache is reclassified.
+- **Legacy cached, backend is really Modern** — corrected **in band** rather
+  than by a mismatch: `legacyInit` reads the genuinely-negotiated protocol
+  version off every `InitializeResult` and flips the cache when it comes back
+  `2026-07-28`. The SDK's Modern-first client negotiates Modern unaided even on
+  vMCP's Legacy code path, so the call still succeeds while the label corrects
+  itself.
+
+Reclassification never re-runs a request that may already have executed. An
+`errLegacyResponseBody` (a lenient Legacy backend that answered a Modern-shaped
+request) corrects the cache for *future* calls but returns the error, because the
+backend may have performed the side effect.
+
+### Reserved `_meta` must not cross a Legacy hop
+
+Before any Legacy backend call, vMCP strips the reserved
+`io.modelcontextprotocol/*` keys from a caller-supplied `_meta`
+(`mcp.StripReservedModernMeta`, applied in `pkg/vmcp/client` and
+`pkg/vmcp/session/internal/backend`). This is not cosmetic: go-sdk v1.7 rejects
+**any** `_meta.protocolVersion` on a stateful streamable-HTTP server outright
+(HTTP 400), regardless of its value. vMCP — not the downstream caller — is the
+backend's MCP peer on that hop, so those keys are vMCP's to own. Non-reserved
+caller keys (progress tokens, W3C trace context) are preserved.
+
+### Observability
+
+Each backend's resolved revision is exposed as `mcpRevision` on the backend
+status read-model (`vmcp.BackendStatus.MCPRevision`, fed from the health
+monitor's `RecordRevision`), and surfaces on
+`VirtualMCPServer.status.discoveredBackends[]`. It is empty until the backend has
+been probed.
+
+### Limitation: elicitation and sampling are unavailable on Modern backends
+
+vMCP declares **empty** `clientCapabilities` on every Modern backend call
+(`mcp.ModernRequestMeta`). That is honest — the Modern shim performs single-shot
+dispatch and cannot drive multi-round retrieval — but it has a consequence worth
+naming explicitly rather than leaving to be inferred:
+
+**Mid-call elicitation and sampling forwarding, which vMCP *does* implement for
+Legacy backends (`forwardingClientOptions`), is structurally unavailable for
+Modern backends.** A spec-compliant Modern backend that needs caller input
+returns `-32021`, which surfaces as an opaque `errModernProtocolError`. The
+2026-07-28 revision replaces server-initiated requests with client-polled
+multi-round tool retrieval (MRTR), so the fix is shaped MRTR-first rather than by
+extending the SSE standalone-stream model — see the epic (#5743) and the
+mid-call forwarding section below for the Legacy behaviour this contrasts with.
+
 ## Served MCP Capabilities
 
 Beyond tools, vMCP aggregates and serves the full complement of MCP capabilities. Every served capability flows through the domain **core** (`pkg/vmcp/core`), so the same admission decision that filters `tools/list` also gates reads, gets, and completions.


### PR DESCRIPTION
## Summary

The entire vMCP dual-revision subsystem was undocumented. `server/discover` had **zero hits anywhere under `docs/`**, and `docs/arch/10-virtual-mcp-architecture.md` had no Legacy/Modern content at all — despite CLAUDE.md requiring `docs/arch/` updates for architectural changes. Both the PR that introduced revision classification and #5993 (go-sdk v1.7 adoption) landed without touching it. This is #6002 item 3.

A new **Backend MCP Revision Classification** section documents what a reader cannot infer without tracing the code:

- **`supportedVersions` is the authoritative signal — a clean `server/discover` response is not.** A go-sdk v1.7 shim answers `discover` even while negotiating *down*, which is the single most surprising thing about this subsystem and the reason `errModernNegotiatedDown` exists.
- **The containment check is an exact match**, deliberately stricter than go-sdk's reference client (`>= 2026-07-28`), and therefore a **tripwire**: adding a newer Modern revision must widen it or a newer-only backend is silently misclassified Legacy.
- **An inconclusive probe deliberately does not cache**, so a transient outage or auth blip can never pin a backend to the wrong revision.
- **The cache self-heals asymmetrically** — Modern→Legacy via a mismatch/re-probe, but Legacy→Modern *in band*, off the negotiated version on `InitializeResult`. Reclassification never re-runs a request that may already have executed.
- A probe-outcome table covering all five discover results.

It also records two things that read as gaps but are deliberate:

- The **SSE short-circuit to Legacy** is ToolHive routing, not a protocol rule (HTTP+SSE is Deprecated in the spec, not removed).
- **Elicitation/sampling forwarding is structurally unavailable on Modern backends**, because vMCP declares empty `clientCapabilities` there; a compliant Modern backend needing input returns `-32021`, surfacing as an opaque `errModernProtocolError`. This is #6002 item 5, which asked for exactly this to be a named limitation rather than inferable from three scattered code comments.

Plus one stale correction: 2026-07-28 is no longer "the draft spec" (`03-transport-architecture.md`).

## Type of change

- [x] Documentation

## Test plan

- [x] Linting (`task lint-fix`) — 0 issues (no Go changed; run to confirm nothing else regressed)
- [x] Manual testing (described below)

Every claim was verified against the code on `main` before writing, not from memory:

| Claim | Verified at |
|---|---|
| SSE ⇒ Legacy short-circuit | `probeRevision`, `pkg/vmcp/client/client.go` |
| `supportedVersions` exact-match + tripwire | `discoverModernCapabilities` |
| `-3202x` / `input_required` ⇒ Modern; auth/transient ⇒ inconclusive | `probeRevision` switch |
| Inconclusive probe does not cache | `dispatch` |
| Legacy→Modern in-band self-heal | `legacyInit` reading `InitializeResult` |
| No re-run on `errLegacyResponseBody` | `dispatch` |
| Reserved `_meta` strip before Legacy hops | `StripReservedModernMeta` call sites |
| `mcpRevision` status field | `vmcp.BackendStatus.MCPRevision`, `health.RecordRevision` |
| Empty `clientCapabilities` on Modern egress | `mcp.ModernRequestMeta` |
| Legacy-only forwarding | `forwardingClientOptions` |

## Does this introduce a user-facing change?

No. Documentation only.

## Special notes for reviewers

- **Deliberately written to dovetail with #6006, which is still open and also edits this file.** I read its pending diff first: it inserts into the `list_changed` section (~line 211) explaining that propagation is Legacy-only because the session factory skips the persistent connection for Modern backends. My section is placed elsewhere (before *Served MCP Capabilities*) so it should not conflict textually, and it cross-references rather than restates that point. If #6006 lands first this may still want a read-through for tonal overlap.
- **Scoped to the vMCP backend edge.** The client-edge classifier (`hasModernSignal`, `ValidateHeaderConsistency`, the transport proxies) is only cross-referenced, not documented here — that belongs with the transport-proxy docs.
- I did **not** document the vMCP HTTP `/status` exposure of `mcpRevision`, because that is added by #6006 and is not on `main` yet. What I document is the CRD/health read-model path, which is.

Refs #6002

Generated with [Claude Code](https://claude.com/claude-code)