### PR TITLE
Consolidate the negotiate-down rationale

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -1031,14 +1031,12 @@ func newBackendHTTPClient(rt http.RoundTripper, timeout time.Duration) *http.Cli
 // capability flags. Used both by probeRevision and, on a Modern cache hit, by
 // ListCapabilities to re-fetch the flags without re-running the fallback ladder.
 //
-// A clean discover response is not, by itself, proof the peer speaks the
-// Modern (2026-07-28) revision: a go-sdk v1.7 shim answers server/discover even
-// for a backend that negotiates down to Legacy. The authoritative signal is
-// supportedVersions (SEP-2575; mirroring go-sdk's own reference client at
-// mcp/client.go:428-444) — when it does not contain MCPVersionModern (including
-// when it is absent or empty), this returns errModernNegotiatedDown instead of
-// the capabilities, so callers do not mistake a negotiated-down Legacy backend
-// for Modern.
+// A clean discover response is not, by itself, proof the peer speaks Modern —
+// supportedVersions is the authoritative signal. See errModernNegotiatedDown
+// (modern.go) for why. Concretely: when supportedVersions does not contain
+// MCPVersionModern (including when it is absent or empty), this returns
+// errModernNegotiatedDown instead of the capabilities, so callers do not mistake
+// a negotiated-down Legacy backend for Modern.
 func (h *httpBackendClient) modernDiscover(
 	ctx context.Context, target *vmcp.BackendTarget,
 ) (*mcp.ServerCapabilities, error) {
@@ -1091,9 +1089,9 @@ func discoverModernCapabilities(ctx context.Context, hc *http.Client, endpoint s
 //     errWrongEra, a -32601 (discover is mandatory for Modern), a generic
 //     JSON-RPC error, a bare 404/400/405, an empty/non-JSON body, a
 //     200-with-Legacy-result, OR errModernNegotiatedDown (a clean discover
-//     envelope whose supportedVersions lacks 2026-07-28 — a go-sdk v1.7 shim
-//     answers server/discover even for a backend negotiating down to Legacy, so
-//     a clean response alone is not proof of Modern; see modernDiscover);
+//     envelope whose supportedVersions lacks 2026-07-28 — see
+//     errModernNegotiatedDown in modern.go for why a clean response alone is not
+//     proof of Modern);
 //   - returns the error UNCACHED (leaving the backend unprobed) on an
 //     INCONCLUSIVE outcome — an auth blip (errModernAuth, 401/403) or a transient
 //     failure (errModernTransient: 408/429/5xx, mid-read, or transport/timeout).

--- a/pkg/vmcp/client/modern.go
+++ b/pkg/vmcp/client/modern.go
@@ -96,12 +96,17 @@ var errModernTransient = errors.New("modern backend returned a transient error")
 //     JSON-RPC error whose `data.supported` list omits it (including an absent
 //     or undecodable data payload).
 //
-// Per SEP-2575 (and go-sdk's own reference client, mcp/client.go:360-369),
-// the advertised version list — not a clean discover response or a bare
-// -32022 alone — is the authoritative signal of whether a peer actually
-// speaks the Modern (2026-07-28) revision: a go-sdk v1.7 shim answers both
-// server/discover and protocol errors even for a backend negotiating down to
-// Legacy, so neither on its own is proof of Modern.
+// CANONICAL RATIONALE for the negotiate-down rule. Per SEP-2575 (and go-sdk's
+// own reference client, mcp/client.go:360-369), the advertised version list —
+// not a clean discover response or a bare -32022 alone — is the authoritative
+// signal of whether a peer actually speaks the Modern (2026-07-28) revision: a
+// go-sdk v1.7 shim answers both server/discover and protocol errors even for a
+// backend negotiating down to Legacy, so neither on its own is proof of Modern.
+//
+// modernDiscover and probeRevision (client.go) both depend on this rule and
+// back-reference it here rather than restating it. Keep the explanation in one
+// place: it is the surface that has to be edited whenever the exact-match
+// tripwire in modernDiscover fires for a newer Modern revision.
 //
 // This is a definitive Legacy signal carried in a valid Modern envelope —
 // distinct from errWrongEra (peer does not speak Modern's wire shape at all)


### PR DESCRIPTION
> **Stacked on #6013** — base is `validate-xmcp-header-annotations`, so review only the top commit
> (`Consolidate the negotiate-down rationale`). GitHub will retarget this to `main` automatically
> when #6013 merges. Stacked rather than branched off `main` because both PRs edit
> `pkg/vmcp/client/modern.go` and `client.go`.

## Summary

#6002 item 4. The rule that `supportedVersions` — not a clean `server/discover` response — is the authoritative Modern signal was explained **in full at three separate sites**: the `errModernNegotiatedDown` doc in `modern.go`, and both `modernDiscover` and `probeRevision` in `client.go`.

That matters more than ordinary comment duplication because it is precisely the surface someone must edit when the exact-match tripwire fires for a newer Modern revision. Three copies is three chances to update two of them and leave the third quietly contradicting the code.

The explanation now lives on `errModernNegotiatedDown` — the thing being explained — marked as the canonical site and naming its two dependents. The other two back-reference it. Both **retain the concrete local behaviour they describe** (what each function returns, and when); only the shared reasoning moved, so neither doc comment became less useful on its own.

Comment-only: no statement, expression, or signature changed.

## Type of change

- [x] Other (describe): comment-only de-duplication

## Test plan

- [x] Unit tests (`task test`) — unchanged; only `pkg/api` and `pkg/secrets/keyring` fail, both environmental and verified identical on `main`
- [x] Linting (`task lint`) — 0 issues (this is the gate CI runs: `golangci-lint` **plus** `go vet ./...`)
- [x] Manual testing (described below)

Verified the de-duplication actually happened rather than being asserted: `grep -rn "answers both server/discover\|answers server/discover even" pkg/vmcp/client/*.go` now returns **exactly one** hit, the canonical site in `modern.go`. Before the change it returned three.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

No API surface of any kind is touched.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

The issue itself rates this item low-value, and I agree — it is worth having only because that comment block is load-bearing for the tripwire. Reasonable to reject in favour of leaving the duplication in place; nothing depends on it.

Refs #6002

Generated with [Claude Code](https://claude.com/claude-code)