### PR TITLE
Pin tools/list pagination completeness for >1000-tool vMCP sets

### DIFF
--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -452,25 +452,32 @@ func TestServeRegistersSessionHooks(t *testing.T) {
 }
 
 // TestServeToolsListPagination_CompleteSet pins #5742 §5: when vMCP's aggregated
-// tool set exceeds go-sdk's DefaultPageSize (1000), a downstream client that
-// follows the MCP pagination cursor receives the COMPLETE set — the server must
-// paginate (emit nextCursor) rather than truncate, and every advertised tool
-// must be reachable across the pages.
+// tool set exceeds a single page, a downstream client that follows the MCP
+// pagination cursor receives the COMPLETE set — every advertised tool reachable,
+// no duplicates, no omissions. That completeness is the real contract; how the
+// server chunks it is not.
 //
-// go-sdk paginates server-side list responses at DefaultPageSize=1000
-// (mcp/server.go), emitting nextCursor. mcp-go (pre-migration) returned the
-// whole set in one page, so a naive reader that issues a single tools/list and
-// ignores nextCursor would silently drop the tail — this is the regression the
-// migration risked. vMCP does NOT override the page size (no WithPageSize on
-// the Serve path), so the served set IS paginated; the contract this pins is
-// that cursor-following recovers all of it.
+// Background: go-sdk paginates server-side list responses at DefaultPageSize
+// (1000), emitting nextCursor; mcp-go (pre-migration) returned the whole set in
+// one page, so a naive reader issuing a single tools/list and ignoring
+// nextCursor silently drops the tail — the regression the migration risked.
+// §5 sanctions either branch ("either the server page size is raised OR the
+// test exercises cursor-following"), and mcpcompat's own WithPageSize doc tells
+// aggregators with >1000 tools to raise it. So this test deliberately does NOT
+// assert that pagination happened — asserting nextCursor would go red on
+// exactly that recommended fix even though downstream clients are strictly
+// better off and completeness still holds. It drives the cursor loop and
+// asserts only the recovered set, which is invariant under both branches.
 //
-// The set is generated deterministically (tool-0000 … tool-1499) so the test
-// asserts the exact membership, not just the count.
+// The set is generated deterministically (tool-0000 … tool-1499) so the
+// assertion checks exact membership, not just the count. totalTools is a local
+// constant rather than derived from go-sdk's DefaultPageSize: the mcpcompat
+// import doesn't re-export that constant and go-sdk is an indirect dependency,
+// so pinning 1500 > 1000 by hand is cheaper than promoting it for one test.
 func TestServeToolsListPagination_CompleteSet(t *testing.T) {
 	t.Parallel()
 
-	const totalTools = 1500 // > go-sdk DefaultPageSize (1000), so the server paginates
+	const totalTools = 1500 // > go-sdk DefaultPageSize (1000) today, so the server paginates
 
 	ctrl := gomock.NewController(t)
 	tools := make([]vmcp.Tool, totalTools)
@@ -512,92 +519,56 @@ func TestServeToolsListPagination_CompleteSet(t *testing.T) {
 	require.NotEmpty(t, sessionID)
 	require.Eventually(t, state.makeWithIDCalled.Load, 2*time.Second, 10*time.Millisecond)
 
-	// Follow the pagination cursor, accumulating tool names until nextCursor is
-	// empty. A response is a JSON-RPC envelope (possibly SSE-framed), so decode
-	// the result payload rather than string-matching.
+	// Drive the cursor loop exactly as a real client does: the first request
+	// carries NO cursor (an empty string is only accepted by go-sdk leniency —
+	// mcp/server.go short-circuits "" before decodeCursor — not by any protocol
+	// guarantee, and the spec shows the initial call cursorless), then each
+	// non-empty nextCursor is echoed back until the server stops issuing one.
+	const maxPages = 10 // generous bound; 1500 tools at page size 1000 needs 2
 	var (
-		gotNames  []string
-		cursor    string
-		pages     int
-		sawCursor bool
+		gotNames []string
+		cursor   string
 	)
-	for {
-		pages++
+	for pages := 1; ; pages++ {
+		require.LessOrEqual(t, pages, maxPages, "pagination must terminate (no infinite cursor)")
+
+		params := map[string]any{}
+		if cursor != "" {
+			params["cursor"] = cursor
+		}
 		listResp := postServeMCP(t, ts.URL, map[string]any{
 			"jsonrpc": "2.0",
-			"id":      pages + 1,
+			"id":      pages + 100, // stay clear of the initialize id
 			"method":  "tools/list",
-			"params":  map[string]any{"cursor": cursor},
+			"params":  params,
 		}, sessionID)
 		require.Equal(t, http.StatusOK, listResp.StatusCode, "tools/list page %d should succeed", pages)
 
-		body, err := io.ReadAll(listResp.Body)
+		env, _ := readServeJSONRPC(t, listResp)
 		listResp.Body.Close()
-		require.NoError(t, err)
+		require.Nil(t, env["error"], "tools/list must not return a JSON-RPC error: %v", env)
 
-		names, next := decodeListToolsPage(t, body)
-		gotNames = append(gotNames, names...)
+		gotNames = append(gotNames, toolNamesFromListResult(t, env)...)
+		result, ok := env["result"].(map[string]any)
+		require.True(t, ok)
+		next, _ := result["nextCursor"].(string)
 		if next == "" {
 			break
 		}
-		sawCursor = true
 		cursor = next
-		require.LessOrEqual(t, pages, 10, "pagination must terminate (no infinite cursor)")
 	}
 
-	assert.True(t, sawCursor,
-		"a >1000-tool set must paginate (emit nextCursor); a single-page response would mean the page size was raised or the set truncated")
-	assert.Greater(t, pages, 1, "a 1500-tool set at page size 1000 spans multiple pages")
-
-	// The complete set must be reachable across the pages, with no duplicates and
-	// no omissions.
-	require.Len(t, gotNames, totalTools,
-		"cursor-following must recover every tool, not just the first page")
+	// The complete set must be reachable across the pages, with no duplicates
+	// and no omissions. require.Equal on the sorted slices dumps a single diff
+	// on mismatch — far more readable in CI than 1500 per-index assert failures
+	// when a dropped-and-duplicated pair shifts every later index.
+	want := make([]string, totalTools)
+	for i := range want {
+		want[i] = fmt.Sprintf("tool-%04d", i)
+	}
 	sort.Strings(gotNames)
-	for i, name := range gotNames {
-		assert.Equal(t, fmt.Sprintf("tool-%04d", i), name)
-	}
-}
-
-// decodeListToolsPage extracts the tool names and the next pagination cursor
-// from a tools/list response body. The Serve path streams responses as
-// Server-Sent Events (the request Accepts text/event-stream), so the JSON-RPC
-// envelope is on the SSE `data:` line; a plain-JSON body is also accepted for
-// robustness. Returns (toolNames, nextCursor) — nextCursor is empty on the
-// last page.
-func decodeListToolsPage(t *testing.T, body []byte) ([]string, string) {
-	t.Helper()
-
-	// Unwrap the SSE frame if present: take the first `data:` line's payload.
-	payload := body
-	for _, line := range strings.Split(string(body), "\n") {
-		if data, ok := strings.CutPrefix(line, "data: "); ok {
-			payload = []byte(strings.TrimSpace(data))
-			break
-		}
-	}
-
-	var envelope struct {
-		Result struct {
-			Tools []struct {
-				Name string `json:"name"`
-			} `json:"tools"`
-			NextCursor string `json:"nextCursor"`
-		} `json:"result"`
-		Error *struct {
-			Code    int    `json:"code"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
-	require.NoError(t, json.Unmarshal(payload, &envelope),
-		"tools/list response must be a JSON-RPC envelope; body: %s", string(body))
-	require.Nil(t, envelope.Error, "tools/list must not return a JSON-RPC error: %s", string(body))
-
-	names := make([]string, 0, len(envelope.Result.Tools))
-	for _, tool := range envelope.Result.Tools {
-		names = append(names, tool.Name)
-	}
-	return names, envelope.Result.NextCursor
+	require.Equal(t, want, gotNames,
+		"cursor-following must recover exactly the advertised set — no duplicates, no omissions")
 }
 
 // fakeSDKSession is a minimal server.ClientSession + server.SessionWithTools used to

--- a/pkg/vmcp/server/serve_session_test.go
+++ b/pkg/vmcp/server/serve_session_test.go
@@ -451,6 +451,155 @@ func TestServeRegistersSessionHooks(t *testing.T) {
 		"tools/list must reuse the fixed-at-initialize set, not re-aggregate via the core")
 }
 
+// TestServeToolsListPagination_CompleteSet pins #5742 §5: when vMCP's aggregated
+// tool set exceeds go-sdk's DefaultPageSize (1000), a downstream client that
+// follows the MCP pagination cursor receives the COMPLETE set — the server must
+// paginate (emit nextCursor) rather than truncate, and every advertised tool
+// must be reachable across the pages.
+//
+// go-sdk paginates server-side list responses at DefaultPageSize=1000
+// (mcp/server.go), emitting nextCursor. mcp-go (pre-migration) returned the
+// whole set in one page, so a naive reader that issues a single tools/list and
+// ignores nextCursor would silently drop the tail — this is the regression the
+// migration risked. vMCP does NOT override the page size (no WithPageSize on
+// the Serve path), so the served set IS paginated; the contract this pins is
+// that cursor-following recovers all of it.
+//
+// The set is generated deterministically (tool-0000 … tool-1499) so the test
+// asserts the exact membership, not just the count.
+func TestServeToolsListPagination_CompleteSet(t *testing.T) {
+	t.Parallel()
+
+	const totalTools = 1500 // > go-sdk DefaultPageSize (1000), so the server paginates
+
+	ctrl := gomock.NewController(t)
+	tools := make([]vmcp.Tool, totalTools)
+	for i := range tools {
+		tools[i] = vmcp.Tool{Name: fmt.Sprintf("tool-%04d", i), Description: "pagination test tool"}
+	}
+	factory, state := newToolSessionFactory(t, ctrl, tools)
+	fc := &fakeCore{tools: tools}
+
+	srv, err := Serve(context.Background(), fc, &ServerConfig{
+		SessionTTL:           time.Minute,
+		SessionManagerConfig: &sessionmanager.FactoryConfig{Base: factory},
+		BackendRegistry:      vmcp.NewImmutableRegistry([]vmcp.Backend{}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+
+	streamable := server.NewStreamableHTTPServer(
+		srv.mcpServer,
+		server.WithEndpointPath("/mcp"),
+		server.WithSessionIdManager(srv.vmcpSessionMgr),
+	)
+	ts := httptest.NewServer(streamable)
+	t.Cleanup(ts.Close)
+
+	initResp := postServeMCP(t, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer initResp.Body.Close()
+	require.Equal(t, http.StatusOK, initResp.StatusCode)
+	sessionID := initResp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+	require.Eventually(t, state.makeWithIDCalled.Load, 2*time.Second, 10*time.Millisecond)
+
+	// Follow the pagination cursor, accumulating tool names until nextCursor is
+	// empty. A response is a JSON-RPC envelope (possibly SSE-framed), so decode
+	// the result payload rather than string-matching.
+	var (
+		gotNames  []string
+		cursor    string
+		pages     int
+		sawCursor bool
+	)
+	for {
+		pages++
+		listResp := postServeMCP(t, ts.URL, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      pages + 1,
+			"method":  "tools/list",
+			"params":  map[string]any{"cursor": cursor},
+		}, sessionID)
+		require.Equal(t, http.StatusOK, listResp.StatusCode, "tools/list page %d should succeed", pages)
+
+		body, err := io.ReadAll(listResp.Body)
+		listResp.Body.Close()
+		require.NoError(t, err)
+
+		names, next := decodeListToolsPage(t, body)
+		gotNames = append(gotNames, names...)
+		if next == "" {
+			break
+		}
+		sawCursor = true
+		cursor = next
+		require.LessOrEqual(t, pages, 10, "pagination must terminate (no infinite cursor)")
+	}
+
+	assert.True(t, sawCursor,
+		"a >1000-tool set must paginate (emit nextCursor); a single-page response would mean the page size was raised or the set truncated")
+	assert.Greater(t, pages, 1, "a 1500-tool set at page size 1000 spans multiple pages")
+
+	// The complete set must be reachable across the pages, with no duplicates and
+	// no omissions.
+	require.Len(t, gotNames, totalTools,
+		"cursor-following must recover every tool, not just the first page")
+	sort.Strings(gotNames)
+	for i, name := range gotNames {
+		assert.Equal(t, fmt.Sprintf("tool-%04d", i), name)
+	}
+}
+
+// decodeListToolsPage extracts the tool names and the next pagination cursor
+// from a tools/list response body. The Serve path streams responses as
+// Server-Sent Events (the request Accepts text/event-stream), so the JSON-RPC
+// envelope is on the SSE `data:` line; a plain-JSON body is also accepted for
+// robustness. Returns (toolNames, nextCursor) — nextCursor is empty on the
+// last page.
+func decodeListToolsPage(t *testing.T, body []byte) ([]string, string) {
+	t.Helper()
+
+	// Unwrap the SSE frame if present: take the first `data:` line's payload.
+	payload := body
+	for _, line := range strings.Split(string(body), "\n") {
+		if data, ok := strings.CutPrefix(line, "data: "); ok {
+			payload = []byte(strings.TrimSpace(data))
+			break
+		}
+	}
+
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+			NextCursor string `json:"nextCursor"`
+		} `json:"result"`
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &envelope),
+		"tools/list response must be a JSON-RPC envelope; body: %s", string(body))
+	require.Nil(t, envelope.Error, "tools/list must not return a JSON-RPC error: %s", string(body))
+
+	names := make([]string, 0, len(envelope.Result.Tools))
+	for _, tool := range envelope.Result.Tools {
+		names = append(names, tool.Name)
+	}
+	return names, envelope.Result.NextCursor
+}
+
 // fakeSDKSession is a minimal server.ClientSession + server.SessionWithTools used to
 // drive lazyInjectSessionTools directly (the SDK's session-context plumbing is otherwise
 // only reachable over HTTP, via MCPServer.WithContext). Its tool store is the observable


### PR DESCRIPTION
## Summary

Part of #5742 (the mcp-go → go-sdk regression gate), test-matrix **§5 — pagination behavior**:

> A vMCP server exposing >1000 tools: verify downstream clients receive the complete set (go-sdk paginates at 1000; mcp-go returned everything).

This was the only matrix item with **zero** existing coverage (§1, §2, §3, §4, §6 are all pinned by existing tests — verified by surveying `pkg/vmcp/server/*_test.go`, `pkg/transport/bridge_test.go`, and the proxy regression suites). Note the direction: everything that existed pins the *inbound* side (vMCP following a **backend's** cursor via `pagination.ListAll`); a downstream client following vMCP's **own** cursor was genuinely uncovered.

**The contract being pinned: completeness.** Pre-migration, mcp-go returned a vMCP's full aggregated tool set in one page; the go-sdk-backed server paginates server-side at `DefaultPageSize = 1000`, emitting `nextCursor`. A downstream client that issues a single `tools/list` and ignores `nextCursor` silently drops the tail.

§5 sanctions *either* branch — "either the server page size is raised **or** the test exercises cursor-following" — and mcpcompat's `WithPageSize` doc tells aggregators with >1000 tools to raise it. So this test deliberately pins **completeness, not the pagination mechanism**: it drives the cursor loop and asserts the recovered set, which is invariant whether the server paginates at 1000 or a future `WithPageSize` returns everything in one page. (An earlier draft asserted `nextCursor` fires; review correctly flagged that this would go red on exactly that recommended fix.)

**The test.** Stands up a Serve-path vMCP advertising 1500 deterministic tools (`tool-0000…tool-1499`) and drives `tools/list` over the Streamable HTTP handler exactly as a real client does — first request cursorless, then echoing each non-empty `nextCursor` — asserting the recovered set equals the advertised set with no duplicates or omissions. Uses the existing `readServeJSONRPC` / `toolNamesFromListResult` helpers (POST responses are `application/json`, not SSE, since mcpcompat hardcodes `JSONResponse: true`).

**Mutation-verified:** dropping the last 500 tools from the advertised set fails exactly on the completeness assertion — the test is not vacuously green.

## Type of change

- [x] Other (describe): test-only

## Test plan

- [x] Unit tests (`task test`) — full `pkg/vmcp/server` package green with `-race`
- [x] Linting (`task lint-fix`) — 0 issues

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

No production code changed.

## Does this introduce a user-facing change?

No.