### PR TITLE
Correct two references in the canonical rationale

### DIFF
--- a/pkg/vmcp/client/modern.go
+++ b/pkg/vmcp/client/modern.go
@@ -96,17 +96,22 @@ var errModernTransient = errors.New("modern backend returned a transient error")
 //     JSON-RPC error whose `data.supported` list omits it (including an absent
 //     or undecodable data payload).
 //
-// CANONICAL RATIONALE for the negotiate-down rule. Per SEP-2575 (and go-sdk's
-// own reference client, mcp/client.go:360-369), the advertised version list —
-// not a clean discover response or a bare -32022 alone — is the authoritative
-// signal of whether a peer actually speaks the Modern (2026-07-28) revision: a
-// go-sdk v1.7 shim answers both server/discover and protocol errors even for a
-// backend negotiating down to Legacy, so neither on its own is proof of Modern.
+// CANONICAL RATIONALE for the negotiate-down rule. Per SEP-2575, the advertised
+// version list — not a clean discover response or a bare -32022 alone — is the
+// authoritative signal of whether a peer actually speaks the Modern (2026-07-28)
+// revision: a go-sdk v1.7 shim answers both server/discover and protocol errors
+// even for a backend negotiating down to Legacy, so neither on its own is proof
+// of Modern. go-sdk's own reference client applies the same rule at both
+// sources above — mcp/client.go:428-444 for (1), the discover/supportedVersions
+// path, and mcp/client.go:360-369 for (2), the -32022/data.supported path.
 //
 // modernDiscover and probeRevision (client.go) both depend on this rule and
 // back-reference it here rather than restating it. Keep the explanation in one
 // place: it is the surface that has to be edited whenever the exact-match
-// tripwire in modernDiscover fires for a newer Modern revision.
+// tripwire in discoverModernCapabilities (client.go) fires for a newer Modern
+// revision. Note the tripwire is in discoverModernCapabilities, which does the
+// supportedVersions check; modernDiscover only builds the transport and
+// delegates to it.
 //
 // This is a definitive Legacy signal carried in a valid Modern envelope —
 // distinct from errWrongEra (peer does not speak Modern's wire shape at all)


### PR DESCRIPTION
## Summary

Follow-up to @jhrozek's review on #6017, which landed as-is ("happy either way — fold them in or land as-is"). Both nits were correct, and both are factual errors in the comment block that #6017 made *canonical* — which is what makes them worth a follow-up rather than leaving. The entire point of consolidating three copies into one was to have a single place that correctly names the surface a future editor must touch; a canonical block that misnames that surface is the failure mode the consolidation existed to prevent.

**1. Wrong function named as the tripwire.** The block pointed at "the exact-match tripwire in `modernDiscover`". The tripwire is the `supportedVersions` containment check in `discoverModernCapabilities` (`client.go:1068`); `modernDiscover` only builds the transport and delegates:

```go
func (h *httpBackendClient) modernDiscover(...) (*mcp.ServerCapabilities, error) {
	hc, err := h.buildModernHTTPClient(ctx, target)
	...
	return discoverModernCapabilities(ctx, hc, target.BaseURL)
}
```

Two other references in the same file already named `discoverModernCapabilities` correctly, so this one was the odd one out.

**2. A lost citation.** The block documents two sources for `errModernNegotiatedDown` but carried only the second one's go-sdk citation. Source (1)'s citation — `mcp/client.go:428-444`, the discover/`supportedVersions` path — lived in the duplicated text in `modernDiscover` and left the repo entirely when #6017 removed it. Verified both against go-sdk v1.7.0-pre.3:

- `mcp/client.go:428-444` — `slices.Contains(res.SupportedVersions, protocolVersion)` then `negotiateMutuallySupportedVersion`, i.e. source (1)
- `mcp/client.go:360-369` — the `CodeUnsupportedProtocolVersion` / `data.Supported` branch, i.e. source (2)

Both are now cited and labelled by which source they back.

Comment-only: no statement, expression, or signature changed.

## Type of change

- [x] Other (describe): comment-only correction

## Test plan

- [x] Linting (`task lint`) — 0 issues (the CI gate: `golangci-lint` **plus** `go vet ./...`)
- [x] Manual testing (described below)

Verified the three properties that matter rather than asserting them:

- Zero remaining references to a tripwire in `modernDiscover`
- Both go-sdk citations present
- Still exactly **one** full statement of the rationale — the consolidation #6017 landed is not undone

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

The third point in that review — `"id": pages + 1` being an opaque off-by-one — was about **#6021**, not this comment block, so it is not addressed here.

Generated with [Claude Code](https://claude.com/claude-code)