### PR TITLE
Fix bridge_regression_test build after reserved-meta API rename

### DIFF
--- a/pkg/vmcp/server/bridge_regression_test.go
+++ b/pkg/vmcp/server/bridge_regression_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -468,7 +469,7 @@ func TestRegression_BridgeCellA_PerPrincipalSessionIsolation(t *testing.T) {
 // keys, but vMCP -- not the downstream caller -- is the Legacy backend's MCP
 // peer on this hop, and go-sdk v1.7 hard-rejects (HTTP 400) ANY
 // _meta.protocolVersion on a stateful server. legacyCallTool strips them via
-// mcpparser.StripReservedModernMeta before forwarding
+// mcpparser.StripReservedMeta before forwarding
 // (pkg/vmcp/client/client.go); this asserts the Legacy backend receives NO
 // io.modelcontextprotocol/* key in the tools/call request body it actually
 // gets. Request path only -- response _meta is issue #5986's scope.
@@ -503,10 +504,12 @@ func TestRegression_BridgeCellA_NoReservedMetaLeakToLegacyBackend(t *testing.T) 
 		sawToolCall = true
 		params, _ := r.body["params"].(map[string]any)
 		meta, _ := params["_meta"].(map[string]any)
-		for _, reserved := range mcpparser.ReservedModernMetaKeys {
-			_, present := meta[reserved]
-			assert.False(t, present,
-				"Legacy backend must never see reserved Modern _meta key %q on the request path; got %+v", reserved, meta)
+		// Assert on the namespace, not a fixed list: this catches any reserved
+		// key, including ones the spec adds later. No passthroughMetaKeys entry
+		// is in play on a tools/call, so a blanket prefix check is exact.
+		for k := range meta {
+			assert.False(t, strings.HasPrefix(k, mcpparser.ReservedMetaPrefix),
+				"Legacy backend must never see reserved _meta key %q on the request path; got %+v", k, meta)
 		}
 		assert.Equal(t, "n1", meta["vmcp.test/nonce"],
 			"the strip must be surgical, not a blanket _meta drop; got %+v", meta)


### PR DESCRIPTION
## Summary

Main was red. `Linting / Lint Go Code` and `Tests / Test Go Code` both failed on #6006's merge commit (`08cbffd`):

```
pkg/vmcp/server/bridge_regression_test.go:506:38: undefined: mcpparser.ReservedModernMetaKeys (typecheck)
```

#6024 renamed the reserved-`_meta` API — `ReservedModernMetaKeys` / `StripReservedModernMeta` → `ReservedMetaPrefix` / `StripReservedMeta` (with `passthroughMetaKeys`) — and #6006's `bridge_regression_test.go` still referenced the removed identifier. The two PRs crossed in flight.

**Fix:** assert on the reserved namespace (`mcpparser.ReservedMetaPrefix`) instead of the removed fixed list — the same pattern `revision_realbackend_test.go:163` already uses. This is strictly stronger than the old list: it catches any reserved key the spec adds later, and since no `passthroughMetaKeys` entry rides a `tools/call`, a blanket prefix check is exact. Also updated the stale `StripReservedModernMeta` reference in the doc comment.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — full `pkg/vmcp/server` package green with `-race`; the previously-broken `TestRegression_BridgeCellA_NoReservedMetaLeakToLegacyBackend` compiles and passes
- [x] Linting (`task lint-fix`) — 0 issues

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

Test-only change.

## Does this introduce a user-facing change?

No.