### PR TITLE
Fix main: bridge test references removed meta key set

### DIFF
--- a/pkg/vmcp/server/bridge_regression_test.go
+++ b/pkg/vmcp/server/bridge_regression_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -467,8 +468,19 @@ func TestRegression_BridgeCellA_PerPrincipalSessionIsolation(t *testing.T) {
 // Modern client's request carries reserved io.modelcontextprotocol/* _meta
 // keys, but vMCP -- not the downstream caller -- is the Legacy backend's MCP
 // peer on this hop, and go-sdk v1.7 hard-rejects (HTTP 400) ANY
+// legacyRequestPassthroughMetaKeys mirrors pkg/mcp's unexported
+// passthroughMetaKeys: the reserved keys StripReservedMeta deliberately does NOT
+// remove, because they are end-to-end payload for the original endpoints rather
+// than per-hop control. Duplicated here only because the production set is
+// unexported; keep the two in sync, and prefer widening the production set over
+// adding exemptions here.
+var legacyRequestPassthroughMetaKeys = map[string]struct{}{
+	mcpparser.ReservedMetaPrefix + "related-task":             {},
+	mcpparser.ReservedMetaPrefix + "model-immediate-response": {},
+}
+
 // _meta.protocolVersion on a stateful server. legacyCallTool strips them via
-// mcpparser.StripReservedModernMeta before forwarding
+// mcpparser.StripReservedMeta before forwarding
 // (pkg/vmcp/client/client.go); this asserts the Legacy backend receives NO
 // io.modelcontextprotocol/* key in the tools/call request body it actually
 // gets. Request path only -- response _meta is issue #5986's scope.
@@ -503,10 +515,16 @@ func TestRegression_BridgeCellA_NoReservedMetaLeakToLegacyBackend(t *testing.T) 
 		sawToolCall = true
 		params, _ := r.body["params"].(map[string]any)
 		meta, _ := params["_meta"].(map[string]any)
-		for _, reserved := range mcpparser.ReservedModernMetaKeys {
-			_, present := meta[reserved]
-			assert.False(t, present,
-				"Legacy backend must never see reserved Modern _meta key %q on the request path; got %+v", reserved, meta)
+		// Scan by prefix rather than against a fixed key list: #6024 replaced the
+		// enumerated strip set with ReservedMetaPrefix + a passthrough exemption,
+		// so a prefix scan also catches reserved keys added later. Matches the
+		// assertion style in modern_envelope_test.go and revision_realbackend_test.go.
+		for k := range meta {
+			if _, passthrough := legacyRequestPassthroughMetaKeys[k]; passthrough {
+				continue
+			}
+			assert.False(t, strings.HasPrefix(k, mcpparser.ReservedMetaPrefix),
+				"Legacy backend must never see reserved Modern _meta key %q on the request path; got %+v", k, meta)
 		}
 		assert.Equal(t, "n1", meta["vmcp.test/nonce"],
 			"the strip must be surgical, not a blanket _meta drop; got %+v", meta)


### PR DESCRIPTION
## Summary

**`main` does not currently build its tests.** `pkg/vmcp/server/bridge_regression_test.go:506` references `mcpparser.ReservedModernMetaKeys`, which no longer exists:

```
vet: pkg/vmcp/server/bridge_regression_test.go:506:38: undefined: mcpparser.ReservedModernMetaKeys
```

Both `go vet ./...` and `task lint` fail for everyone on `main`, and this is **already failing other people's PRs** — #6022 is red on `Linting / Lint Go Code` and `Tests / Test Go Code` with exactly this error, having been green on its previous head before these landed.

**Neither PR was wrong on its own.** #6024 replaced the enumerated reserved-key slice with `ReservedMetaPrefix` + a passthrough exemption, and converted the three call sites that existed on its branch (`modern_envelope_test.go`, `revision_realbackend_test.go`, `mcp_session_meta_propagation_test.go`). #6006 added this file, which uses the old symbol. Each was green; the merge of the two is not. Same semantic-conflict class as an interface change landing beside a new call site — which bit #6013 earlier today for the same underlying reason.

The fix converts the assertion to the prefix scan #6024 established, and is **strictly stronger than the original**: it catches any reserved `io.modelcontextprotocol/*` key, including ones added after this test was written, rather than only the four the removed slice happened to list.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — `pkg/vmcp/server` green, full package, 94s
- [x] Linting (`task lint`) — 0 issues; `go vet ./...` clean (this is the gate that was failing)
- [x] Manual testing (described below)

Confirmed the break is pre-existing and not introduced by me: `git stash && go vet ./pkg/vmcp/server/` on unmodified `main` reproduces the identical error. Also confirmed #6022's lint annotation is byte-for-byte the same failure, so this unblocks that PR too.

**One thing I did *not* manage to verify**, stated plainly: I could not mutation-verify that the converted assertion still fires on a real leak. Neutering it leaves the test passing, because the strip works and no reserved key is present either way — it is a regression guard, not a currently-firing check. What I can attest to is that the build is restored, the property asserted is unchanged in intent, and the key set it covers is now a superset of before.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

Test-only change.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- `legacyRequestPassthroughMetaKeys` duplicates `pkg/mcp`'s unexported `passthroughMetaKeys`. That duplication is deliberate but unfortunate — if the production set gains an entry and this one doesn't, the test starts failing on a legitimate passthrough. The comment says to prefer widening the production set. If you'd rather export the production set and drop the local copy, that's a cleaner end state and I'm happy to do it instead.
- Worth considering whether `go vet ./...` belongs in a fast-failing CI job. `task lint` does run it, so CI *did* catch this — but only on the PRs that came after, not on the merge that caused it. A branch-protection check on `main` post-merge would have flagged it at the source.

Generated with [Claude Code](https://claude.com/claude-code)