### PR TITLE
Echo the request JSON-RPC id in session-not-found 404s

### DIFF
--- a/pkg/transport/proxy/transparent/backend_routing_test.go
+++ b/pkg/transport/proxy/transparent/backend_routing_test.go
@@ -5,6 +5,7 @@ package transparent
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -194,6 +195,89 @@ func TestRoundTripReturns404ForUnknownSession(t *testing.T) {
 	_ = resp.Body.Close()
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	assert.Contains(t, string(body), `"code":-32001`)
+}
+
+// TestRoundTrip404EchoesRequestID pins #5945: the unknown-session 404 must echo
+// the incoming JSON-RPC id so a client correlating responses by id can match the
+// error to the request that caused it. Before the fix the transparent proxy
+// hardcoded a null id here, while the sibling classification-error path on the
+// same RoundTrip already echoed it.
+//
+// Note TestRoundTripReturns404ForUnknownSession above cannot catch this: its body
+// carries no "id", so it renders a null id either way.
+func TestRoundTrip404EchoesRequestID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		body   string
+		wantID string
+	}{
+		{
+			name:   "numeric id is echoed verbatim",
+			body:   `{"jsonrpc":"2.0","id":7,"method":"tools/list"}`,
+			wantID: `"id":7`,
+		},
+		{
+			name:   "string id is echoed verbatim",
+			body:   `{"jsonrpc":"2.0","id":"abc-123","method":"tools/list"}`,
+			wantID: `"id":"abc-123"`,
+		},
+		{
+			// A notification has no id by definition, so JSON-RPC requires null.
+			name:   "notification renders a null id",
+			body:   `{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+			wantID: `"id":null`,
+		},
+		{
+			// An explicit null id is not a correlatable id either.
+			name:   "explicit null id stays null",
+			body:   `{"jsonrpc":"2.0","id":null,"method":"tools/list"}`,
+			wantID: `"id":null`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				// Reaching the backend would mean the guard did not fire; the
+				// assertions below would fail on the 200 that results.
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer backend.Close()
+
+			tt2 := newTracingTransport(http.DefaultTransport, NewTransparentProxyWithOptions(
+				"localhost", 0, backend.URL,
+				nil, nil, nil,
+				false, false, "sse",
+				nil, nil, "", false,
+				nil,
+			))
+
+			req, err := http.NewRequest(http.MethodPost, backend.URL+"/mcp", strings.NewReader(tt.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Mcp-Session-Id", uuid.New().String()) // unknown to the store
+
+			resp, err := tt2.RoundTrip(req)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusNotFound, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			_ = resp.Body.Close()
+
+			assert.Contains(t, string(body), `"code":-32001`)
+			assert.Contains(t, string(body), tt.wantID)
+
+			// The body must remain a single valid JSON-RPC error object -- echoing
+			// a raw id must not corrupt the envelope.
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(body, &decoded))
+			assert.Equal(t, "2.0", decoded["jsonrpc"])
+		})
+	}
 }
 
 // TestRoundTripAllowsInitializeWithUnknownSession verifies that an initialize

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -598,6 +598,12 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	isJSON := strings.Contains(req.Header.Get("Content-Type"), "application/json")
 	sawInitialize := false
 	revision := mcp.RevisionLegacy
+	// requestID carries the incoming JSON-RPC id so an error response built below
+	// can echo it, letting a client correlate the error with its request. It is set
+	// only when parseRPCRequest reports a single request, which by construction
+	// means the id is present and non-null; it stays nil for a notification, a
+	// batch, or a bodiless GET/DELETE, where JSON-RPC requires a null id.
+	var requestID any
 
 	if len(reqBody) > 0 &&
 		((isMCP && isJSON) ||
@@ -605,6 +611,7 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		method, params, id, singleRequest, isInit := t.parseRPCRequest(reqBody)
 		sawInitialize = isInit
 		if singleRequest {
+			requestID = id
 			meta := mcp.ExtractMeta(params)
 			rev, cerr := mcp.ClassifyRevision(method, meta, req.Header.Get("MCP-Protocol-Version"))
 			if cerr != nil {
@@ -628,7 +635,7 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 				slog.Error("session store lookup failed", "error", err)
 				return plainResponse(req, http.StatusServiceUnavailable, "session store unavailable"), nil
 			}
-			return session.NotFoundResponse(req), nil
+			return session.NotFoundResponse(req, requestID), nil
 		}
 	}
 

--- a/pkg/transport/session/jsonrpc_errors.go
+++ b/pkg/transport/session/jsonrpc_errors.go
@@ -24,8 +24,13 @@ const (
 
 // NotFoundBody returns the JSON-encoded body for a session-not-found
 // JSON-RPC error response. The requestID is the "id" from the incoming
-// JSON-RPC request; pass nil when the request ID is not available (e.g.,
-// DELETE requests, batch pre-parse, transparent proxy).
+// JSON-RPC request, echoed so a client correlating by id can match this error
+// to the request that caused it.
+//
+// Pass nil only when the request genuinely carries no id, in which case
+// JSON-RPC requires a null id: a bodiless GET (standalone SSE) or DELETE, a
+// notification, or a batch. Do NOT pass nil merely because threading the id to
+// the call site is inconvenient — that was the asymmetry fixed in #5945.
 func NotFoundBody(requestID any) []byte {
 	resp := map[string]any{
 		"jsonrpc": "2.0",
@@ -57,8 +62,12 @@ func WriteNotFound(w http.ResponseWriter, requestID any) {
 // NotFoundResponse constructs an *http.Response with HTTP 404 and a
 // JSON-RPC error body. Use this in httputil.ReverseProxy.ModifyResponse
 // (transparent proxy) where no http.ResponseWriter is available.
-func NotFoundResponse(req *http.Request) *http.Response {
-	body := NotFoundBody(nil)
+//
+// requestID follows NotFoundBody: pass the incoming request's JSON-RPC id so the
+// error echoes it, or nil when the request has none. Callers that reject a
+// request before parsing a body (GET/DELETE) pass nil.
+func NotFoundResponse(req *http.Request, requestID any) *http.Response {
+	body := NotFoundBody(requestID)
 	hdr := make(http.Header)
 	hdr.Set("Content-Type", "application/json")
 	return &http.Response{

--- a/pkg/transport/session/jsonrpc_errors_test.go
+++ b/pkg/transport/session/jsonrpc_errors_test.go
@@ -84,15 +84,56 @@ func TestWriteNotFound(t *testing.T) {
 func TestNotFoundResponse(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
-	resp := NotFoundResponse(req)
+	tests := []struct {
+		name      string
+		requestID any
+		wantID    string
+	}{
+		{
+			// A request with no id of its own: bodiless GET/DELETE, or a
+			// notification. JSON-RPC requires a null id here.
+			name:      "nil id renders null",
+			requestID: nil,
+			wantID:    `"id":null`,
+		},
+		{
+			name:      "string id is echoed",
+			requestID: "req-1",
+			wantID:    `"id":"req-1"`,
+		},
+		{
+			// The shape the transparent proxy passes: the raw bytes of the
+			// incoming "id", forwarded verbatim so a numeric id stays numeric
+			// rather than being coerced to a float or a string (#5945).
+			name:      "raw numeric id is echoed verbatim",
+			requestID: json.RawMessage(`42`),
+			wantID:    `"id":42`,
+		},
+		{
+			name:      "raw string id is echoed verbatim",
+			requestID: json.RawMessage(`"abc"`),
+			wantID:    `"id":"abc"`,
+		},
+	}
 
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	assert.Equal(t, req, resp.Request)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Contains(t, string(body), `"code":-32001`)
-	assert.Contains(t, string(body), `"id":null`)
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			resp := NotFoundResponse(req, tt.requestID)
+
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+			assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+			assert.Equal(t, req, resp.Request)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), `"code":-32001`)
+			assert.Contains(t, string(body), tt.wantID)
+			// ContentLength must match the body actually written, or a client
+			// reading exactly that many bytes truncates or blocks.
+			assert.Equal(t, int64(len(body)), resp.ContentLength)
+		})
+	}
 }

--- a/test/e2e/hostile_input_proxy_test.go
+++ b/test/e2e/hostile_input_proxy_test.go
@@ -101,11 +101,9 @@ var _ = Describe("Hostile Input Proxy", Label("proxy", "stateless", "hostile-inp
 			resp, err := client.Send(context.Background(), proxyURL, req)
 			Expect(err).ToNot(HaveOccurred(), tc.name)
 			Expect(resp.StatusCode).To(Equal(tc.wantStatus), tc.name)
-			if tc.idNotEchoed {
-				Expect(resp.ID).To(BeNil(), "%s: echoed id", tc.name)
-			} else {
-				Expect(resp.ID).To(Equal(json.Number(fmt.Sprintf("%d", tc.id))), "%s: echoed id", tc.name)
-			}
+			// Every rejection path here echoes the id, session-not-found
+			// included: #5945 removed the one asymmetry (see below).
+			Expect(resp.ID).To(Equal(json.Number(fmt.Sprintf("%d", tc.id))), "%s: echoed id", tc.name)
 			Expect(resp.Error).ToNot(BeNil(), tc.name)
 			Expect(resp.Error.Code).To(Equal(tc.wantCode), tc.name)
 			if tc.wantData != nil {
@@ -188,12 +186,6 @@ type hostileCase struct {
 	wantStatus int
 	wantCode   int64
 	wantData   map[string]any // nil means the error must carry no "data" field at all
-	// idNotEchoed marks a rejection path that -- unlike ClassificationErrorResponse
-	// -- doesn't echo the request id at all: session.NotFoundResponse hardcodes a
-	// nil id (see jsonrpc_errors.go's NotFoundBody(nil) call). A real minor
-	// asymmetry in the current code, left flagged rather than fixed (out of scope
-	// for a test-only step).
-	idNotEchoed bool
 }
 
 // hostileRejectionCases enumerates the classification-error and session-guard
@@ -273,10 +265,14 @@ func hostileRejectionCases() []hostileCase {
 				// in revision_guard_regression_test.go.
 				req.WithSessionID("foreign-" + uuid.NewString())
 			},
-			wantStatus:  http.StatusNotFound,
-			wantCode:    session.CodeSessionNotFound,
-			wantData:    nil,
-			idNotEchoed: true,
+			// Like the classification rejections above, this 404 echoes the
+			// request id: session.NotFoundResponse used to hardcode a nil id
+			// while ClassificationErrorResponse on the same RoundTrip echoed
+			// it, an asymmetry #5945 removed by threading the parsed id through
+			// to the guard.
+			wantStatus: http.StatusNotFound,
+			wantCode:   session.CodeSessionNotFound,
+			wantData:   nil,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Closes #5945. The transparent proxy's unknown-session guard returned a `-32001` 404 whose body hardcoded a **null** id, while the classification-error path on the *very same* `RoundTrip` already echoed the incoming id. A client correlating responses by id got `null` for this one error class.

The cause is scoping, not intent: the id *is* parsed a few lines above the guard, but inside the classification block, so the guard could not reach it. `sawInitialize` was already hoisted out of that block for the same reason; the id now is too.

It is set **only** when `parseRPCRequest` reports a single request — and that predicate is already `method != "" && len(id) > 0 && id != "null"`, so by construction a set id is present and non-null. Notifications, batches, and bodiless GET/DELETE keep the null id JSON-RPC requires.

## Audit of the sibling call sites — **corrected**

> ⚠️ **An earlier revision of this description contained an error.** It listed
> `httpsse/http_proxy.go:555` as a bodiless **GET** and concluded the transparent proxy was
> "the only site discarding an id it had". That is wrong: line 555 is inside `handlePostRequest`
> (line 537, which rejects non-POST at 539), and `io.ReadAll(r.Body)` runs at ~line 569 —
> *after* the session lookup. So it is a POST whose id is available but not yet read.
> The corrected table is below. Thanks to the follow-up audit for catching it.

| Site | Request shape | id available? | Verdict |
|---|---|---|---|
| `transparent_proxy.go` guard | POST with JSON-RPC body | **yes, discarded** | **fixed here** |
| `streamable_proxy.go:1096` | POST | yes | already echoes `req.ID.Raw()` |
| `streamable_proxy.go:433` | standalone SSE **GET** | no body | `nil` correct |
| `streamable_proxy.go:484` | **DELETE** | no body | `nil` correct |
| `httpsse/http_proxy.go:555` | **POST** (`handlePostRequest`) | **yes, but unread at that point** | **same asymmetry survives — see below** |

So the accurate claim is narrower than the original: this fixes the asymmetry in the transparent proxy, and the identical asymmetry **still exists in the legacy HTTP+SSE transport**. A client POSTing `{"jsonrpc":"2.0","id":7,…}` to `/messages?session_id=<unknown>` still receives `"id":null`.

**That is deliberately not fixed here.** Fixing it means reading and parsing the body *before* the session lookup, which changes error precedence — a malformed body under an unknown session would become 400 instead of 404. That is a design call about which error wins, not a scoping oversight, and it belongs in its own PR. Filed as a follow-up.

Consequently `NotFoundBody`'s doc comment — which listed "transparent proxy" as an id-unavailable case — became untrue, so it now states when `nil` is legitimate instead of implying it is a free choice.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — `pkg/transport/session` and `pkg/transport/proxy/transparent` green with `-race`
- [x] Linting — `golangci-lint run ./test/e2e/...` 0 issues; `go vet ./...` and `go vet ./test/e2e/...` clean
- [x] Manual testing (described below)
- [ ] E2E suite — **cannot be run in our environment** (no container runtime; `thv --help` itself exits 1, so `CheckTHVBinaryAvailable` fails in `BeforeEach`). CI is the verification.

**`TestRoundTrip404EchoesRequestID`** is the end-to-end pin, table-driven over numeric id, string id, notification, and explicit-null id. It also decodes the body to assert the envelope stays a valid JSON-RPC object.

**Mutation-verified.** Setting `requestID = nil` inside the `singleRequest` block (semantically pre-fix, build intact) fails exactly the two id-bearing subtests and correctly leaves the two null-id subtests passing.

**Why the existing test could not have caught the original bug:** `TestRoundTripReturns404ForUnknownSession` sends `{"method":"tools/list"}` with **no `id`**, so it renders a null id before and after the fix.

### Second commit: the e2e assertion that encoded the old behaviour

`3c6aa253` fixes `test/e2e/hostile_input_proxy_test.go`, which had a `hostileCase.idNotEchoed` field whose doc comment pinned the old asymmetry explicitly ("*a real minor asymmetry in the current code, left flagged rather than fixed*"). With the asymmetry gone that field has no true case, so it and its branch are deleted and all five hostile cases assert the echoed id. Verified by tracing that all five are single JSON-RPC POSTs with explicit ids, so none can now produce a nil id.

A repo-wide audit for other assertions encoding the old behaviour found **none** — every other null-id assertion is a genuinely id-less path (batch `-32600` rejections, bodiless DELETE, the raw client's own envelope parsing).

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

`session.NotFoundResponse` gains a `requestID` parameter. Internal Go helper, single production caller; no operator API surface touched.

## Does this introduce a user-facing change?

Yes, narrowly. A session-not-found 404 from the **transparent proxy** now echoes the request's JSON-RPC id instead of always sending `null`. The legacy HTTP+SSE transport is unchanged (see the follow-up above). Requests carrying no id are unaffected.

## Special notes for reviewers

The 404 **behaviour** is deliberately untouched. As #5945 notes, the guard keying on `Mcp-Session-Id` presence rather than the client-forgeable revision is a fail-safe by design — this changes only the id in the error body.

Two currently-red checks are not this PR's doing:

1. `Go Vulnerability Check` — `GO-2026-5841` in `klauspost/compress`, red repo-wide since ~17:52 (this same check passed here at 17:08). Fixed by #6041.
2. `E2E Tests Core (core)` — `group_rm_test.go:124`, a pre-existing flake tracked as #6040, reproduced on `main` and on unrelated branches.

Closes #5945

Generated with [Claude Code](https://claude.com/claude-code)