### PR TITLE
Echo the request id in session-not-found 404s

### DIFF
--- a/pkg/transport/proxy/transparent/revision_guard_regression_test.go
+++ b/pkg/transport/proxy/transparent/revision_guard_regression_test.go
@@ -104,6 +104,9 @@ func TestGuardUnknownSessionFiresDespiteForgedModernRevision(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"code":-32001`)
+	// The 404 echoes the request's JSON-RPC id so a client can correlate it,
+	// matching the classification-error path (#5945).
+	assert.Contains(t, string(body), `"id":1`)
 	assert.False(t, backendCalled.Load(),
 		"backend must not be contacted: the unknown-session guard must fire regardless of the classified revision")
 }

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -598,12 +598,17 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	isJSON := strings.Contains(req.Header.Get("Content-Type"), "application/json")
 	sawInitialize := false
 	revision := mcp.RevisionLegacy
+	// Echoed by the unknown-session guard below so its 404 correlates with the
+	// request, like every sibling error path (#5945). Stays nil for bodies that
+	// carry no JSON-RPC id, which NotFoundBody renders as "id":null.
+	var rpcID json.RawMessage
 
 	if len(reqBody) > 0 &&
 		((isMCP && isJSON) ||
 			t.p.transportType == types.TransportTypeStreamableHTTP.String()) {
 		method, params, id, singleRequest, isInit := t.parseRPCRequest(reqBody)
 		sawInitialize = isInit
+		rpcID = id
 		if singleRequest {
 			meta := mcp.ExtractMeta(params)
 			rev, cerr := mcp.ClassifyRevision(method, meta, req.Header.Get("MCP-Protocol-Version"))
@@ -628,7 +633,7 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 				slog.Error("session store lookup failed", "error", err)
 				return plainResponse(req, http.StatusServiceUnavailable, "session store unavailable"), nil
 			}
-			return session.NotFoundResponse(req), nil
+			return session.NotFoundResponse(req, rpcID), nil
 		}
 	}
 

--- a/pkg/transport/session/jsonrpc_errors.go
+++ b/pkg/transport/session/jsonrpc_errors.go
@@ -54,11 +54,14 @@ func WriteNotFound(w http.ResponseWriter, requestID any) {
 	_, _ = w.Write(NotFoundBody(requestID))
 }
 
-// NotFoundResponse constructs an *http.Response with HTTP 404 and a
-// JSON-RPC error body. Use this in httputil.ReverseProxy.ModifyResponse
+// NotFoundResponse constructs an *http.Response with HTTP 404 and a JSON-RPC
+// error body echoing requestID. Use this in httputil.ReverseProxy.ModifyResponse
 // (transparent proxy) where no http.ResponseWriter is available.
-func NotFoundResponse(req *http.Request) *http.Response {
-	body := NotFoundBody(nil)
+//
+// Pass nil when the incoming request carries no JSON-RPC id: a GET or DELETE
+// (no body), or a body that did not parse as a single JSON-RPC request.
+func NotFoundResponse(req *http.Request, requestID any) *http.Response {
+	body := NotFoundBody(requestID)
 	hdr := make(http.Header)
 	hdr.Set("Content-Type", "application/json")
 	return &http.Response{

--- a/pkg/transport/session/jsonrpc_errors_test.go
+++ b/pkg/transport/session/jsonrpc_errors_test.go
@@ -84,15 +84,52 @@ func TestWriteNotFound(t *testing.T) {
 func TestNotFoundResponse(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
-	resp := NotFoundResponse(req)
+	tests := []struct {
+		name      string
+		requestID any
+		wantID    string
+	}{
+		{
+			name:      "no request id echoes null",
+			requestID: nil,
+			wantID:    `"id":null`,
+		},
+		{
+			name:      "string request id is echoed",
+			requestID: "req-1",
+			wantID:    `"id":"req-1"`,
+		},
+		{
+			// The transparent proxy passes the id straight through as a
+			// json.RawMessage; a nil one must still render as null rather
+			// than producing an invalid body.
+			name:      "raw json id is echoed verbatim",
+			requestID: json.RawMessage(`42`),
+			wantID:    `"id":42`,
+		},
+		{
+			name:      "nil raw json id echoes null",
+			requestID: json.RawMessage(nil),
+			wantID:    `"id":null`,
+		},
+	}
 
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	assert.Equal(t, req, resp.Request)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Contains(t, string(body), `"code":-32001`)
-	assert.Contains(t, string(body), `"id":null`)
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			resp := NotFoundResponse(req, tt.requestID)
+
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+			assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+			assert.Equal(t, req, resp.Request)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), `"code":-32001`)
+			assert.Contains(t, string(body), tt.wantID)
+			assert.Equal(t, int64(len(body)), resp.ContentLength)
+		})
+	}
 }

--- a/test/e2e/hostile_input_proxy_test.go
+++ b/test/e2e/hostile_input_proxy_test.go
@@ -101,11 +101,7 @@ var _ = Describe("Hostile Input Proxy", Label("proxy", "stateless", "hostile-inp
 			resp, err := client.Send(context.Background(), proxyURL, req)
 			Expect(err).ToNot(HaveOccurred(), tc.name)
 			Expect(resp.StatusCode).To(Equal(tc.wantStatus), tc.name)
-			if tc.idNotEchoed {
-				Expect(resp.ID).To(BeNil(), "%s: echoed id", tc.name)
-			} else {
-				Expect(resp.ID).To(Equal(json.Number(fmt.Sprintf("%d", tc.id))), "%s: echoed id", tc.name)
-			}
+			Expect(resp.ID).To(Equal(json.Number(fmt.Sprintf("%d", tc.id))), "%s: echoed id", tc.name)
 			Expect(resp.Error).ToNot(BeNil(), tc.name)
 			Expect(resp.Error.Code).To(Equal(tc.wantCode), tc.name)
 			if tc.wantData != nil {
@@ -188,12 +184,6 @@ type hostileCase struct {
 	wantStatus int
 	wantCode   int64
 	wantData   map[string]any // nil means the error must carry no "data" field at all
-	// idNotEchoed marks a rejection path that -- unlike ClassificationErrorResponse
-	// -- doesn't echo the request id at all: session.NotFoundResponse hardcodes a
-	// nil id (see jsonrpc_errors.go's NotFoundBody(nil) call). A real minor
-	// asymmetry in the current code, left flagged rather than fixed (out of scope
-	// for a test-only step).
-	idNotEchoed bool
 }
 
 // hostileRejectionCases enumerates the classification-error and session-guard
@@ -273,10 +263,9 @@ func hostileRejectionCases() []hostileCase {
 				// in revision_guard_regression_test.go.
 				req.WithSessionID("foreign-" + uuid.NewString())
 			},
-			wantStatus:  http.StatusNotFound,
-			wantCode:    session.CodeSessionNotFound,
-			wantData:    nil,
-			idNotEchoed: true,
+			wantStatus: http.StatusNotFound,
+			wantCode:   session.CodeSessionNotFound,
+			wantData:   nil,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- The transparent proxy's unknown-session guard returned a `-32001` (session not found) 404 whose body hardcoded `"id":null`. Every sibling rejection path — `mcp.ClassificationErrorResponse`, and the streamable proxy's `resolveSessionForRequest` — echoes the incoming JSON-RPC id, so a client correlating responses by id got `null` for this one error class and nothing else.
- `session.NotFoundResponse` now takes a `requestID` and forwards it to `NotFoundBody`, which already accepted one. The transparent proxy passes the id it has already parsed.
- The parsed id was block-scoped inside the classification block in `RoundTrip` and not visible at the guard 20 lines below. Hoisting it to `rpcID` is the whole production change.

Closes #5945

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests — **scoped**, see note
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing

Note on scope, so the boxes aren't read as more than they are. What I actually ran:

```
go test -ldflags=-extldflags=-Wl,-w -race \
  ./pkg/transport/session/... ./pkg/transport/proxy/transparent/...   # both ok
go vet ./test/e2e/...                                                 # clean
```

The flags mirror `test-unixlike` in the Taskfile. The `go vet` is there because `task test` filters out `/test/e2e`, so the e2e file this PR edits would otherwise never be compiled locally.

Not run locally: full `task test`, `task lint-fix`, `task test-e2e`. Leaving those to CI.

## Changes

| File | Change |
|------|--------|
| `pkg/transport/session/jsonrpc_errors.go` | `NotFoundResponse` takes `requestID any` instead of hardcoding `NotFoundBody(nil)` |
| `pkg/transport/proxy/transparent/transparent_proxy.go` | Hoist the parsed JSON-RPC id out of the classification block; pass it to the guard's `NotFoundResponse` |
| `pkg/transport/session/jsonrpc_errors_test.go` | `TestNotFoundResponse` becomes table-driven: nil, string, raw-JSON, and nil-`json.RawMessage` ids |
| `pkg/transport/proxy/transparent/revision_guard_regression_test.go` | `TestGuardUnknownSessionFiresDespiteForgedModernRevision` already sent `"id":1`; now asserts it comes back |
| `test/e2e/hostile_input_proxy_test.go` | Delete the `idNotEchoed` case field, its branch, and the comment documenting this bug as known-and-deferred — the session-guard case was its only user and now echoes like every sibling |

## Does this introduce a user-facing change?

Yes, though a small one. A client that sends a request with an unknown or expired `Mcp-Session-Id` through the transparent proxy now gets its JSON-RPC id echoed in the `-32001` error response instead of `null`, so the error can be matched to the request that caused it. Requests that genuinely carry no id — GET on the SSE stream, DELETE, or a body that isn't a single JSON-RPC request — still return `"id":null`.

## Special notes for reviewers

A few things worth knowing:

**`json.RawMessage` nil handling.** `rpcID` is passed through as a `json.RawMessage` boxed into `any`. A nil one marshals to `null` (`RawMessage.MarshalJSON` special-cases the nil slice), so the no-id case is byte-identical to before. This is the same value and the same code path `ClassificationErrorResponse(req, id, cerr)` already takes two lines earlier, so it isn't introducing a new edge case. `parseRPCRequest` never returns a non-nil-but-empty id, which is the one input that would produce an invalid body. There are unit cases pinning both nil forms.

**#5883 was investigated in the same pass and closed without code.** It reported that a batch containing `initialize` skips this same guard. That turned out to be already fixed by #5931 (`a18f17e2d`), which added an unconditional `mcp.IsBatchRequest` rejection at `transparent_proxy.go:591` — a 400 that lands 33 lines before the guard — and replaced the old test with `TestRoundTripRejectsBatch`, whose first case is verbatim the payload from that report. Closed with the details in a comment.

**One thing I deliberately left alone.** The batch-scanning branch in `parseRPCRequest` is now unreachable from `RoundTrip`, but it's still what would set `sawInitialize = true` for a batch. It's the mechanism that would resurrect #5883 if the batch rejection at `:591` is ever moved or relaxed. Deleting it would make the function fail-closed, but that's a separate change from this one and I didn't want to mix it in. Flagging it for whoever edits that guard next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
