### PR TITLE
Bump klauspost/compress to v1.18.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/compress v1.18.7 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
-github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
+github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/knadh/koanf/maps v0.1.1 h1:G5TjmUh2D7G2YWf5SQQqSiHRJEjaicvU0KpypqB3NIs=


### PR DESCRIPTION
## Summary

**`Go Vulnerability Check` is currently red on `main` and on every open PR.** This unblocks it.

`GO-2026-5841` (`GHSA-259r-337f-4rfw`) is an out-of-bounds read in `github.com/klauspost/compress/s2`, fixed in **v1.18.7**. We were pinned at v1.18.6.

**The advisory is newly published, not newly introduced.** The same check **passed on #6031 at 17:08 and failed at 17:52** on a test-only delta. `govulncheck` queries the advisory database at run time, so nothing in the tree changed — the database did. That is worth stating because a red security check on an unrelated PR reads as that PR's fault until someone opens the log.

## Why bump rather than exclude

The workflow's `IGNORED_VULNS` list exists and would have been faster, but it is reserved for advisories that cannot be fixed, each with a written justification:

- `GO-2026-5932` — `x/crypto/openpgp`, deprecated-by-design, **no fixed version exists or is planned**
- `GO-2026-5037/38/39` — Go stdlib, fixed in go1.26.4 but `setup-go: stable` still resolves to go1.26.3 because the `actions/go-versions` manifest lags

`GO-2026-5841` has a fixed version available today, so adding it there would misuse that mechanism and leave a real advisory silently suppressed.

## Scope

The dependency remains **indirect** — it reaches us via `prometheus/client_golang` → `klauspost/compress/zstd`. Only `zstd` is used, not the affected `s2` package, so actual exposure was low. I am not leaning on that: the fix is one line, so reachability does not need arguing.

## Type of change

- [x] Dependency update

## Test plan

- [x] `go build ./...` — pass
- [x] `go mod tidy` — clean, and **the bump survived it**, which is the non-obvious risk here: `tidy` recomputes MVS minimums and can silently revert an indirect-dependency bump. Verified `go.mod` still reads `v1.18.7` afterwards.
- [x] Diff scope confirmed: `go.mod` (1 line) + `go.sum` (2 lines), nothing else
- [ ] `govulncheck` — **could not run locally** (not installed in my environment). CI's `Go Vulnerability Check` is the verification, and it is the check this PR exists to fix.

I have deliberately not claimed to have confirmed the advisory is cleared. The fixed version comes from the Go vulnerability database entry for `GO-2026-5841` (`affected[].ranges[].events[].fixed = 1.18.7`), and CI will confirm.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

No first-party code changes.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

Renovate would normally own this, but `renovate.json` extends `config:recommended` and this is an **indirect** dependency, so a bump is not guaranteed to be proposed promptly — and `main` is red until it lands.

Unrelated observation while verifying, flagged rather than fixed here to keep this PR single-purpose: `main` now reports 4 `paralleltest`/`tparallel` findings in `pkg/authz/authorizers/cedar/core_test.go` under golangci-lint 2.12.2 locally, which CI does not flag. That looks like a linter-version difference between local installs and the action's default, and it means local `task lint` is no longer clean on `main` for anyone. Worth a separate look.

Generated with [Claude Code](https://claude.com/claude-code)