### PR TITLE
Harden group e2e workload naming and waits

### DIFF
--- a/test/e2e/group_rm_test.go
+++ b/test/e2e/group_rm_test.go
@@ -4,10 +4,8 @@
 package e2e_test
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,9 +23,8 @@ var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 
 	BeforeEach(func() {
 		config = e2e.NewTestConfig()
-		// Use a shared timestamp for all workload names in this test
-		groupName = fmt.Sprintf("group-rm-cancel-group-%d", time.Now().UnixNano())
-		secondGroupName = fmt.Sprintf("group-rm-cancel-group-2-%d", time.Now().UnixNano())
+		groupName = e2e.GenerateUniqueServerName("group-rm-cancel-group")
+		secondGroupName = e2e.GenerateUniqueServerName("group-rm-cancel-group-2")
 		createdWorkloads = []string{}
 
 		// Check if thv binary is available
@@ -61,7 +58,7 @@ var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 
 	Describe("thv group rm command", func() {
 		It("should return error when group does not exist", func() {
-			groupName := fmt.Sprintf("group-rm-non-existent-group-%d", time.Now().UnixNano())
+			groupName := e2e.GenerateUniqueServerName("group-rm-non-existent-group")
 			_, stderr, err := e2e.NewTHVCommand(config, "group", "rm", groupName).ExpectFailure()
 			Expect(err).To(HaveOccurred())
 			Expect(stderr).To(ContainSubstring("does not exist"))
@@ -69,12 +66,11 @@ var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 
 		It("should cancel deletion when user does not confirm", func() {
 			// Add a workload to the group
-			workloadName := fmt.Sprintf("group-rm-test-workload-%d", time.Now().UnixNano())
+			workloadName := e2e.GenerateUniqueServerName("group-rm-test-workload")
 			createWorkloadInGroup(workloadName, groupName)
 
 			// Verify the workload is running
-			err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
-			Expect(err).ToNot(HaveOccurred())
+			e2e.ExpectMCPServersRunning(config, workloadName)
 
 			// Try to delete the group but provide 'n' for no
 			cmd := exec.Command(config.THVBinary, "group", "rm", groupName)
@@ -105,13 +101,18 @@ var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 		})
 
 		It("should delete group with workloads", func() {
-			// Create workloads in the group
-			groupWorkload1 := fmt.Sprintf("group-rm-group-workload-1-%d", GinkgoRandomSeed())
-			groupWorkload2 := fmt.Sprintf("group-rm-group-workload-2-%d", GinkgoRandomSeed())
+			// Two members and two non-members are what make "rm keeps every
+			// member and leaves every non-member running" an assertion rather
+			// than an anecdote, so the setup stays at four. The workload count
+			// is not what makes this spec flaky: the same readiness wait has
+			// timed out in the two-workload specs here and in
+			// list_group_e2e_test.go (#6040).
+			groupWorkload1 := e2e.GenerateUniqueServerName("group-rm-group-workload-1")
+			groupWorkload2 := e2e.GenerateUniqueServerName("group-rm-group-workload-2")
 
 			// Create workloads not in the group
-			nonGroupWorkload1 := fmt.Sprintf("group-rm-non-group-workload-1-%d", GinkgoRandomSeed())
-			nonGroupWorkload2 := fmt.Sprintf("group-rm-non-group-workload-2-%d", GinkgoRandomSeed())
+			nonGroupWorkload1 := e2e.GenerateUniqueServerName("group-rm-non-group-workload-1")
+			nonGroupWorkload2 := e2e.GenerateUniqueServerName("group-rm-non-group-workload-2")
 
 			createWorkloadInGroup(groupWorkload1, groupName)
 			createWorkloadInGroup(groupWorkload2, groupName)
@@ -119,10 +120,7 @@ var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 			createWorkloadInGroup(nonGroupWorkload2, secondGroupName)
 
 			// Verify all workloads are running
-			for _, workloadName := range []string{groupWorkload1, groupWorkload2, nonGroupWorkload1, nonGroupWorkload2} {
-				err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
-				Expect(err).ToNot(HaveOccurred())
-			}
+			e2e.ExpectMCPServersRunning(config, groupWorkload1, groupWorkload2, nonGroupWorkload1, nonGroupWorkload2)
 
 			// Delete the group (provide confirmation)
 			cmd := exec.Command(config.THVBinary, "group", "rm", groupName)
@@ -147,17 +145,14 @@ var _ = Describe("Group RM E2E Tests", Label("core", "groups", "e2e"), func() {
 
 		It("should delete group and workloads with --with-workloads flag", func() {
 			// Create multiple workloads in the group
-			workload1 := fmt.Sprintf("group-rm-with-workloads-1-%d", GinkgoRandomSeed())
-			workload2 := fmt.Sprintf("group-rm-with-workloads-2-%d", GinkgoRandomSeed())
+			workload1 := e2e.GenerateUniqueServerName("group-rm-with-workloads-1")
+			workload2 := e2e.GenerateUniqueServerName("group-rm-with-workloads-2")
 
 			createWorkloadInGroup(workload1, groupName)
 			createWorkloadInGroup(workload2, groupName)
 
 			// Verify all workloads are running
-			for _, workloadName := range []string{workload1, workload2} {
-				err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
-				Expect(err).ToNot(HaveOccurred())
-			}
+			e2e.ExpectMCPServersRunning(config, workload1, workload2)
 
 			// Delete the group with --with-workloads flag (provide confirmation)
 			cmd := exec.Command(config.THVBinary, "group", "rm", groupName, "--with-workloads")

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -213,6 +213,21 @@ func WaitForMCPServer(config *TestConfig, serverName string, timeout time.Durati
 	}
 }
 
+// ExpectMCPServersRunning waits for each named workload to reach the running
+// state within ServerReadyTimeout, and fails naming the workload that did not.
+//
+// Specs that start several workloads used to wait in a loop over a bare
+// Expect(err).ToNot(HaveOccurred()), so a timeout said only that some workload
+// in the set was not ready. The failure is reported at the caller's line so a
+// CI annotation still points at the spec rather than at this helper.
+func ExpectMCPServersRunning(config *TestConfig, serverNames ...string) {
+	for _, serverName := range serverNames {
+		err := WaitForMCPServer(config, serverName, ServerReadyTimeout())
+		ExpectWithOffset(1, err).ToNot(HaveOccurred(),
+			"workload %s (of %v) should reach the running state", serverName, serverNames)
+	}
+}
+
 // IsServerRunning checks if an MCP server is running
 func IsServerRunning(config *TestConfig, serverName string) bool {
 	workload, err := findWorkload(config, serverName)

--- a/test/e2e/list_group_e2e_test.go
+++ b/test/e2e/list_group_e2e_test.go
@@ -70,8 +70,7 @@ var _ = Describe("List Group", Label("core", "groups", "e2e"), func() {
 				_, _ = e2e.NewTHVCommand(config, "run", "fetch", "--group", groupName, "--name", workloadName).ExpectSuccess()
 
 				// Wait for workload to be fully registered
-				err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
-				Expect(err).ToNot(HaveOccurred())
+				e2e.ExpectMCPServersRunning(config, workloadName)
 			})
 
 			AfterEach(func() {
@@ -131,8 +130,7 @@ var _ = Describe("List Group", Label("core", "groups", "e2e"), func() {
 			_, _ = e2e.NewTHVCommand(config, "run", "fetch", "--group", groupName, "--name", workloadName, "--label", "test=value").ExpectSuccess()
 
 			// Wait for workload to be fully registered
-			err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
-			Expect(err).ToNot(HaveOccurred())
+			e2e.ExpectMCPServersRunning(config, workloadName)
 		})
 
 		AfterEach(func() {
@@ -194,10 +192,7 @@ var _ = Describe("List Group", Label("core", "groups", "e2e"), func() {
 			_, _ = e2e.NewTHVCommand(config, "run", "fetch", "--group", secondGroupName, "--name", workload2Name).ExpectSuccess()
 
 			// Wait for workloads to be fully registered
-			err := e2e.WaitForMCPServer(config, workload1Name, e2e.ServerReadyTimeout())
-			Expect(err).ToNot(HaveOccurred())
-			err = e2e.WaitForMCPServer(config, workload2Name, e2e.ServerReadyTimeout())
-			Expect(err).ToNot(HaveOccurred())
+			e2e.ExpectMCPServersRunning(config, workload1Name, workload2Name)
 		})
 
 		AfterEach(func() {

--- a/test/e2e/rm_group_test.go
+++ b/test/e2e/rm_group_test.go
@@ -4,9 +4,6 @@
 package e2e_test
 
 import (
-	"fmt"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -23,8 +20,8 @@ var _ = Describe("Group Remove E2E Tests", Label("core", "groups", "e2e"), func(
 
 	BeforeEach(func() {
 		config = e2e.NewTestConfig()
-		testGroupName = fmt.Sprintf("rm-test-group-%d-%d", GinkgoRandomSeed(), time.Now().UnixNano())
-		secondGroupName = fmt.Sprintf("rm-test-group-2-%d-%d", GinkgoRandomSeed(), time.Now().UnixNano())
+		testGroupName = e2e.GenerateUniqueServerName("rm-test-group")
+		secondGroupName = e2e.GenerateUniqueServerName("rm-test-group-2")
 		createdWorkloads = []string{}
 
 		// Check if thv binary is available
@@ -59,7 +56,7 @@ var _ = Describe("Group Remove E2E Tests", Label("core", "groups", "e2e"), func(
 
 	Describe("thv rm --group command", func() {
 		It("should return error when group does not exist", func() {
-			groupName := fmt.Sprintf("rm-non-existent-group-%d", GinkgoRandomSeed())
+			groupName := e2e.GenerateUniqueServerName("rm-non-existent-group")
 			_, stderr, err := e2e.NewTHVCommand(config, "rm", "--group", groupName).ExpectFailure()
 			Expect(err).To(HaveOccurred())
 			Expect(stderr).To(ContainSubstring("does not exist"))
@@ -72,20 +69,17 @@ var _ = Describe("Group Remove E2E Tests", Label("core", "groups", "e2e"), func(
 		})
 
 		It("should remove workloads from group", func() {
-			groupWorkload1 := fmt.Sprintf("rm-group-workload-1-%d", GinkgoRandomSeed())
-			groupWorkload2 := fmt.Sprintf("rm-group-workload-2-%d", GinkgoRandomSeed())
-			nonGroupWorkload1 := fmt.Sprintf("rm-non-group-workload-1-%d", GinkgoRandomSeed())
-			nonGroupWorkload2 := fmt.Sprintf("rm-non-group-workload-2-%d", GinkgoRandomSeed())
+			groupWorkload1 := e2e.GenerateUniqueServerName("rm-group-workload-1")
+			groupWorkload2 := e2e.GenerateUniqueServerName("rm-group-workload-2")
+			nonGroupWorkload1 := e2e.GenerateUniqueServerName("rm-non-group-workload-1")
+			nonGroupWorkload2 := e2e.GenerateUniqueServerName("rm-non-group-workload-2")
 			createWorkloadInGroup(groupWorkload1, testGroupName)
 			createWorkloadInGroup(groupWorkload2, testGroupName)
 			createWorkloadInGroup(nonGroupWorkload1, secondGroupName)
 			createWorkloadInGroup(nonGroupWorkload2, secondGroupName)
 
 			// Wait for the workloads to appear in thv list
-			for _, workloadName := range []string{groupWorkload1, groupWorkload2, nonGroupWorkload1, nonGroupWorkload2} {
-				err := e2e.WaitForMCPServer(config, workloadName, e2e.ServerReadyTimeout())
-				Expect(err).NotTo(HaveOccurred())
-			}
+			e2e.ExpectMCPServersRunning(config, groupWorkload1, groupWorkload2, nonGroupWorkload1, nonGroupWorkload2)
 
 			// Remove all workloads in the group
 			e2e.NewTHVCommand(config, "rm", "--group", testGroupName).ExpectSuccess()


### PR DESCRIPTION
## Summary

- `Group RM E2E Tests > [It] should delete group with workloads` fails intermittently in the `core` shard on commits unrelated to groups. The failure point is the workload-readiness wait, and the four readiness loops in the group specs all shared one bare `Expect(err).ToNot(HaveOccurred())`, so a red shard said only "some workload in some group spec did not become ready" — triage had to open the CI log to learn which spec and which workload. Wait through `e2e.ExpectMCPServersRunning`, which names the failing workload and reports at the caller's line so the CI annotation still points at the spec.
- Workload names in `group_rm_test.go` and `rm_group_test.go` came from `GinkgoRandomSeed()` alone. That is the *suite* seed — constant for a whole run and not unique across runs — so a leftover container from an earlier run that drew the same seed collides by name. Use `e2e.GenerateUniqueServerName` (pid + nanosecond timestamp + seed), as the rest of the suite does.
- The four-workload setup stays, with a comment saying why, so the next reader does not "fix" the flake by deleting coverage. See the analysis below.

Refs #6040

**This PR does not close #6040, deliberately.** Its own CI reproduced the flake — see "This PR did not stop the flake" below.

## Type of change

- [x] Other (describe): test reliability and diagnosability

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint`)
- [x] Manual testing (describe below)

`task lint` reports 0 issues. `go vet ./...` is clean, run separately because `task test`'s formatter can swallow build failures; `go vet ./test/e2e/...` compiles the changed specs. `task test` shows only the three failures that also fail on `main` in this environment (`TestNewServer_ReadTimeoutConfigured`, `TestSecurityHeaders` — no container runtime; `TestCompositeProvider_RealProviders` — no keyring).

**The e2e suite could not be run locally**: it needs a container runtime the sandbox does not have, so these specs were not executed before pushing. CI was relied on for that — and CI's answer is recorded below rather than glossed.

## This PR did not stop the flake

Stating this plainly, because the PR is being merged with a red `core` shard and a reader deserves to know that was a decision rather than an oversight.

On `014b5a82`, run [30293849786](https://github.com/stacklok/toolhive/actions/runs/30293849786/job/90072524926) failed **two** group specs, not one:

```
Summarizing 2 Failures:
  [FAIL] Group RM E2E Tests     [It] should delete group with workloads    group_rm_test.go:123
  [FAIL] Group Remove E2E Tests [It] should remove workloads from group    rm_group_test.go:82
Ran 60 of 507 Specs — 58 Passed | 2 Failed        (781s)
```

Two things follow:

- The line move from `:124` to `:123` confirms `ExpectMCPServersRunning` is in the failing path — the new helper is being exercised, and it is the readiness wait that is timing out, exactly as diagnosed.
- Suite runtime rose from ~506s to 781s (+54%) on a change that adds no work, which points at host-level contention on the runner rather than anything in this diff.

So this PR delivers diagnosability and name-uniqueness and **does not** fix the underlying stall. #6040 stays open, and the next occurrence will name the workload that hung — which is the input a real fix needs and which no run so far has produced.

## What this fixes, and what it does not

Being explicit, because #6040's framing — which I wrote — turned out to be wrong in one respect:

- **Diagnosability (real, verified by inspection):** the readiness assertion now names the workload it was waiting for.
- **Name uniqueness (real fix, for a hazard distinct from the reported flake):** seed-only names are not unique across runs. This matters for local reruns and any environment with leftover containers; CI runners are ephemeral, so it is almost certainly *not* the cause of the CI failures in #6040.
- **The reported timeout itself: not fixed, and this PR does not claim to fix it.** No change here makes a slow workload start faster.

## Why the setup was not reduced, and why the timeout was not raised

#6040 suggests the spec may be doing too much (four workloads) or that `ServerReadyTimeout()` may be too tight. **GitHub check-run annotations for the failing `core` runs on `main` refute the first outright** — those annotations are publicly readable and carry the failing file and line:

| Run | Commit | Failure location | Workloads that spec starts |
|---|---|---|---|
| 30264573849 | `96f25d05` | `group_rm_test.go:124` **and** `list_group_e2e_test.go:200` | 4, and 2 |
| 30264963508 | `d3907301` | `group_rm_test.go:159` | 2 |
| 30268388184 | `f1dae946` | `group_rm_test.go:159` | 2 |

Three of the four observed failures are in **two**-workload specs. So:

- **Reducing four workloads to two would not have prevented any of these failures**, and would weaken the one thing that spec exists to prove — that `group rm` leaves every group member *and* every non-member running. Rejected; a comment now records the reasoning at the site.
- **The timeout was already raised**, from 60s to 2 minutes, in #6012 (`f1dae946`), with the product's own 5-minute initialize budget as rationale. Raising it again would hide whatever is actually stalling, and the `core` shard runs under a 15-minute Ginkgo budget, so longer per-workload waits eat the shard's own headroom. Rejected.

The common factor across the failures is not workload count but **starting two or more `fetch` workloads back to back**: `thv run` is detached, so containers, proxies and initialize probes all come up concurrently. Every group spec that does this has now flaked; every group spec that starts one workload at a time has not. Identifying what stalls under concurrent starts needs the `last observed:` status `WaitForMCPServer` prints on timeout, which lives in the job logs and JUnit artifacts.

## Changes

| File | Change |
|------|--------|
| `test/e2e/helpers.go` | Add `ExpectMCPServersRunning`, which waits for each named workload and fails naming the one that timed out, at the caller's line |
| `test/e2e/group_rm_test.go` | `GenerateUniqueServerName` for group and workload names; wait via the new helper; comment recording why the four-workload setup stays |
| `test/e2e/rm_group_test.go` | Same naming and wait changes — its "should remove workloads from group" spec is a near-copy of the flaking one |
| `test/e2e/list_group_e2e_test.go` | Wait via the new helper (its names already combine the seed with a nanosecond timestamp, so they are left alone) |

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **Merging with a red `core` shard is intentional** — see "This PR did not stop the flake". The failing specs are the pre-existing flake this PR improves the diagnosis of, not a regression it introduces. If you would rather hold for a green run, say so and I will.
- Sibling group specs were checked, not just the reported one. `group_rm_test.go` and `rm_group_test.go` each contain the same four-workload spec and the same seed-only workload names; `list_group_e2e_test.go` has already flaked on the same wait but its names are unique. `group_test.go` and `group_list_e2e_test.go` start at most one workload at a time and already build unique names — left untouched.
- One follow-up deliberately left out because the suite could not be run to validate it: `WaitForMCPServer` polls until the deadline even when the workload has reached a terminal status such as `error`, so a workload that fails outright still burns the full 2 minutes before reporting. Failing fast on terminal statuses would cut that, but it changes a helper roughly 50 specs depend on, and misjudging which statuses are terminal (`unauthenticated` and `auth_retrying` are not) would break passing specs.

Generated with [Claude Code](https://claude.com/claude-code)