### PR TITLE
Bind the vMCP test server's port directly

### DIFF
--- a/test/integration/vmcp/helpers/vmcp_server.go
+++ b/test/integration/vmcp/helpers/vmcp_server.go
@@ -5,7 +5,6 @@ package helpers
 
 import (
 	"context"
-	"net"
 	"testing"
 	"time"
 
@@ -122,24 +121,17 @@ func WithSessionTTL(ttl time.Duration) VMCPServerOption {
 	}
 }
 
-// getFreePort returns an available TCP port on localhost.
-func getFreePort(tb testing.TB) int {
-	tb.Helper()
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(tb, err, "failed to get free port")
-	defer func() { _ = listener.Close() }()
-
-	addr, ok := listener.Addr().(*net.TCPAddr)
-	if !ok {
-		tb.Fatalf("failed to get TCP address from listener")
-	}
-	return addr.Port
-}
-
 // NewVMCPServer creates a vMCP server for testing using the Serve path (core.New +
 // Serve). The server is automatically started and ready when this function returns.
 // Use functional options to customize behavior.
+//
+// The server binds an OS-assigned port (ServerConfig.Port is 0) and holds that
+// listener for its lifetime, so callers MUST read the address back from the
+// returned server's Address() rather than assuming a port. Address() reports the
+// bound port only once the server is ready, which this function waits for before
+// returning. Do not pre-select a port here by binding and closing a probe
+// listener: that releases the port, and any of the parallel tests in this suite
+// can claim it before the server rebinds (#6034).
 //
 // The Serve path is used (rather than the legacy server.New path) so that
 // integration tests exercise the production code path that routes tool/resource
@@ -197,7 +189,7 @@ func NewVMCPServer(
 		Name:               "test-vmcp",
 		Version:            "1.0.0",
 		Host:               "127.0.0.1",
-		Port:               getFreePort(tb),
+		Port:               0, // OS-assigned; see the note on NewVMCPServer
 		EndpointPath:       "/mcp",
 		SessionTTL:         30 * time.Minute,
 		AuthMiddleware:     auth.AnonymousMiddleware,


### PR DESCRIPTION
## Summary

- **Why**: `test/integration/vmcp/helpers.getFreePort` picked a port by binding `127.0.0.1:0`, reading the port back, and **closing** the listener — then handed that port to the vMCP server to bind later, in `Start`. Closing the probe listener releases the port, so between that close and the server's own `net.Listen` the OS could hand the same port to any of the ten `t.Parallel()` tests in this package (each of which also starts `httptest` backends). The symptom was an intermittent `bind: address already in use` failing CI on PRs with unrelated diffs — most recently #6031.
- **What**: Set `ServerConfig.Port` to `0` so the vMCP server's own listener picks the port *and holds it*, and read the bound address back from `vmcpServer.Address()`, which the helper already waits for via `Ready()`. `getFreePort` is deleted along with the now-unused `net` import. This closes the window rather than narrowing it: the port is never unbound between being chosen and being served.

Closes #6034

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test` — 3 pre-existing environmental failures, see below)
- [x] Linting (`task lint` — 0 issues)
- [x] Manual testing (described below)
- [ ] E2E tests

**Verified by code trace, not inferred from the doc comment:**

1. `Port: 0` really does reach a port-0 bind. `buildServeConfig` (`pkg/vmcp/server/serve.go:413`) passes `cfg.Port` straight through; `Start` formats `addr` from `Host`/`Port` (`server.go:733`) and calls `net.Listen("tcp", addr)` (`:745`).
2. `Address()` returns the **OS-assigned** port after `Ready()`. It returns `s.listener.Addr().String()` when the listener is non-nil (`server.go:882-889`), and `Start` stores the listener under `listenerMu` (`:750-752`) *before* `readyOnce.Do(close(s.ready))` (`:771`). **That ordering is what makes the fix correct — it is not incidental.**
3. No test reads a port or builds a URL before `Ready()`. All 20 call sites in `test/integration/vmcp/*_test.go` build `"http://" + vmcpServer.Address() + …` *after* `NewVMCPServer` returns, and it only returns after `<-vmcpServer.Ready()`.
4. `net` becomes unused and is removed; `require` and `testing` are still used elsewhere and stay.

**The original failure was reproduced before fixing it.** On a clean tree with the old `getFreePort` intact, amplifying the existing race (64 goroutines churning ephemeral-port allocation, plus a 3s delay widening the already-present window between the probe `Close()` and the server's bind) failed on the first run:

```
--- FAIL: TestVMCPServer_StructuredContent (8.13s)
    vmcp_server.go:242: vMCP server error: failed to create listener:
        listen tcp 127.0.0.1:39743: bind: address already in use
```

A standalone harness modelling only the bind-close-rebind pattern under the same pressure gave **24 collisions / 31,773 rebind attempts (~0.08%)**, all `bind: address already in use`.

**The fix removes it** under the identical amplification that failed above: 3/3 runs green, 0 collisions.

**Stress runs on the committed diff** (no instrumentation):

| Command | Result |
|---|---|
| `go vet ./...` | 0 issues |
| `task lint` (golangci-lint + `go vet ./...`) | `0 issues.` |
| `go test ./test/integration/vmcp/... -count=1 -race` | `ok` 95.6s |
| `go test ./test/integration/vmcp/... -count=10 -race -timeout 60m` | `ok` 945.8s, exit 0, **0 bind collisions** |
| `task test` | 3 failures, all pre-existing (below) |

`go vet ./...` was run separately from `task test` deliberately: `task test`'s formatter can swallow build failures, so a package whose tests don't compile would otherwise read as green.

The three `task test` failures are unrelated to this diff — `TestNewServer_ReadTimeoutConfigured` and `TestSecurityHeaders` (`pkg/api`, "no available runtime found") and `TestCompositeProvider_RealProviders` (`pkg/secrets/keyring`, no keyring). Confirmed pre-existing by checking out `origin/main` and running the same three there: all three fail identically.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

Test-helper only; no production code touched.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- The fix depends on the listener-stored-before-ready ordering in `(*Server).Start` (point 2). If that ordering is ever inverted, `Address()` falls back to the *configured* port — `0` — and every test in this package fails loudly rather than flakily, so the regression could not go unnoticed.
- **Out of scope, worth a follow-up**: `pkg/transport/proxy/streamable` has its own `getFreePort` (`streamable_proxy_integration_test.go:25`) with the identical bind-close-rebind shape, used by 8 call sites. Separate package, separate flake surface, left untouched to keep this to one logical change. Filed separately.
- Nothing contradicted #6034's diagnosis. One nuance worth recording: **the race is narrower than it looks**, because Linux's ephemeral-port allocator actively avoids immediate reuse — with 8 competing binders and a 50ms window, 0 collisions in 300 attempts despite 74,630 competing binds; reproduction needed 64 victims and 16 churners. That is consistent with a rare CI flake, and it means **a handful of green runs of the old code would not have been evidence it was fine.**

Generated with [Claude Code](https://claude.com/claude-code)