### PR TITLE
Let Cedar read user claims the upstream asserts only in its ID token

### DIFF
--- a/docs/operator/virtualmcpserver-kubernetes-guide.md
+++ b/docs/operator/virtualmcpserver-kubernetes-guide.md
@@ -651,48 +651,77 @@ spec:
 ```
 
 **Which token's claims a policy sees**: Cedar reads the primary upstream
-provider's *access token*. Claims that token asserts always win. Because many
-OIDC providers put profile claims in the `id_token` only and omit them from the
-access token, `name` and `email` fall back to **that same provider's `id_token`**
-(captured at login and stored alongside its access token) when the access token
-does not carry them. Provenance is preserved either way: `principal has
-claim_email` means "this upstream asserted an email". When a fallback happens the
-proxy logs, once per 30s:
+provider's *access token*. Claims that token asserts always win. Providers
+routinely split what they assert across their two tokens — `email` and group
+membership are both commonly in the `id_token` only — so any claim the access
+token does **not** carry falls back to **that same provider's `id_token`**
+(captured at login and stored alongside its access token). Provenance is preserved
+either way, since both tokens come from one login at one provider: `principal has
+claim_email` means "this upstream asserted an email", and `principal in
+THVGroup::"platform-eng"` means "this upstream put the user in that group". When a
+fallback happens the proxy logs, once per 30s:
 
 ```
-WARN upstream access token lacks profile claims; using the upstream ID token's
-     values for Cedar evaluation provider=okta claims="[email]"
+WARN upstream access token omits claims the upstream ID token asserts; using the
+     ID token's values for Cedar evaluation provider=okta claims="[email groups]"
 ```
 
-That fallback uses the stored `id_token` even after it has expired, by design. It
+Group and role claims are included, under whatever name the provider uses — the
+well-known names, `spec.incomingAuth.authzConfig.groupClaimName`/`roleClaimName`,
+and URI-style names such as `https://example.com/groups` alike. So are `hd`,
+`email_verified`, and any other claim the provider asserts about the user or their
+login (`acr`, `amr`, `auth_time`).
+
+Two categories are never taken from the `id_token`, no matter what the access
+token carries:
+
+* Claims that describe the `id_token` itself rather than the user — `iss`, `aud`,
+  `exp`, `nbf`, `iat`, `jti`, `nonce`, `at_hash`, `c_hash`, `s_hash`, `azp`,
+  `sid`, `client_id`. That `id_token`'s audience is ToolHive's own auth-server
+  client, so a policy gating on the resource-server `aud`, on token lifetime, or
+  on the requesting `client_id` would otherwise read a fact about a different
+  token.
+* `sub`, the principal. A rule keyed on `Client::"<upstream-subject>"` keeps
+  matching the upstream identity, and an access token with no `sub` is rejected
+  outright rather than having a principal chosen for it.
+
+**Precedence is fill-only, not union.** A claim the access token asserts is used
+verbatim and is never extended. If your provider filters group claims per
+application (Okta group filters, Entra group-claim configuration) so that the
+access token carries a *partial* group list and the `id_token` carries the full
+one, policies see the partial list. That is deliberate: the access token's list is
+the provider's answer to "which of this user's groups are relevant to this
+resource server", and unioning in a list minted for a different audience would
+restore groups the provider chose to withhold. If policies need the fuller list,
+configure the upstream to assert it in the access token.
+
+The fallback uses the stored `id_token` even after it has expired, by design. It
 is read as a record of what the upstream asserted when the user logged in, not
 presented to anyone as a credential. Since a session can outlive an `id_token` by
 days, expiring it out of policy evaluation would let the same user be permitted
-early in a session and denied later, with no configuration change.
+early in a session and denied later, with no configuration change. The
+consequence to plan for: where a claim comes from the `id_token`, it is a
+login-time fact. Access tokens are refreshed, so claims read from them track the
+provider; a stored `id_token` is replaced only when a refresh rotates one. A group
+revoked upstream can therefore keep granting until the session ends — shorten
+`spec.authServerConfig.tokenLifespans.refreshTokenLifespan` (7d by default) if
+that window is too wide for your policies.
 
 The token the client presented — the one ToolHive's auth server issued — is
-never a claim source here, even though it mirrors a `name` and `email`. In a
-multi-upstream chain those mirrored values come from the **first** configured
-upstream (the identity provider), which need not be the provider
-`primaryUpstreamProvider` names, so using them could attribute one IdP's email to
-another.
+never a claim source here, even though it mirrors a `name` and `email`. A group,
+role or scope claim on it grants nothing. In a multi-upstream chain those mirrored
+values come from the **first** configured upstream (the identity provider), which
+need not be the provider `primaryUpstreamProvider` names, so using them could
+attribute one IdP's claims to another.
 
 An OAuth 2.0 upstream that was never asked for the `openid` scope has no stored
 `id_token`, so nothing is available to fall back to and the claim stays absent.
 The proxy says so once per 30s:
 
 ```
-WARN no upstream ID token stored for provider; policies referencing profile
-     claims the access token omits will deny provider=okta
+WARN no upstream ID token stored for provider; policies referencing claims the
+     access token omits will deny provider=okta
 ```
-
-Every other claim is upstream-access-token-only. In particular, group, role and
-scope claims are not substituted from anywhere, so a policy such as `principal in
-THVGroup::"platform-eng"` only ever matches groups the upstream access token
-asserts. The same holds for the principal: `sub` is never substituted, so a rule
-keyed on `Client::"<upstream-subject>"` keeps matching the upstream identity, and
-an access token with no `sub` is rejected outright rather than having a principal
-chosen for it.
 
 If a policy references a claim that neither the access token nor the `id_token`
 carries, `principal has claim_x` is false and the policy denies — author domain

--- a/docs/operator/virtualmcpserver-kubernetes-guide.md
+++ b/docs/operator/virtualmcpserver-kubernetes-guide.md
@@ -670,9 +670,10 @@ Group and role claims are included, under whatever name the provider uses — th
 well-known names, `spec.incomingAuth.authzConfig.groupClaimName`/`roleClaimName`,
 and URI-style names such as `https://example.com/groups` alike. So are `hd`,
 `email_verified`, and any other claim the provider asserts about the user or their
-login (`acr`, `amr`, `auth_time`).
+login (`acr`, `amr`, `auth_time`). Read the group-revocation callout below before
+relying on this.
 
-Two categories are never taken from the `id_token`, no matter what the access
+Three categories are never taken from the `id_token`, no matter what the access
 token carries:
 
 * Claims that describe the `id_token` itself rather than the user — `iss`, `aud`,
@@ -681,6 +682,14 @@ token carries:
   client, so a policy gating on the resource-server `aud`, on token lifetime, or
   on the requesting `client_id` would otherwise read a fact about a different
   token.
+* **`scope` and `scp`**, the delegated grant. A group is a fact about the *user*,
+  which either token can report; a scope is the authority *a particular token*
+  carries, and the only authority at issue is the access token's. Where a provider
+  emits `scope` in an `id_token` at all (it is not a standard `id_token` claim) it
+  may echo what the client *requested* rather than what the user *granted* — and
+  granular or incremental consent makes those differ routinely. So a
+  `claimset_scp` or `claim_scope` gate only ever matches what the access token
+  asserts. Put scopes policies depend on in the access token.
 * `sub`, the principal. A rule keyed on `Client::"<upstream-subject>"` keeps
   matching the upstream identity, and an access token with no `sub` is rejected
   outright rather than having a principal chosen for it.
@@ -695,17 +704,35 @@ resource server", and unioning in a list minted for a different audience would
 restore groups the provider chose to withhold. If policies need the fuller list,
 configure the upstream to assert it in the access token.
 
-The fallback uses the stored `id_token` even after it has expired, by design. It
-is read as a record of what the upstream asserted when the user logged in, not
-presented to anyone as a credential. Since a session can outlive an `id_token` by
-days, expiring it out of policy evaluation would let the same user be permitted
-early in a session and denied later, with no configuration change. The
-consequence to plan for: where a claim comes from the `id_token`, it is a
-login-time fact. Access tokens are refreshed, so claims read from them track the
-provider; a stored `id_token` is replaced only when a refresh rotates one. A group
-revoked upstream can therefore keep granting until the session ends — shorten
-`spec.authServerConfig.tokenLifespans.refreshTokenLifespan` (7d by default) if
-that window is too wide for your policies.
+> ### ⚠️ Group revocation latency is session-scoped for `id_token`-sourced claims
+>
+> **Read this if your provider asserts groups in the `id_token` only.** Where a
+> claim comes from the `id_token`, policies evaluate it as a **login-time fact**,
+> not current state:
+>
+> * Upstream **access tokens are refreshed**, so a group revoked upstream stops
+>   granting within an access-token lifetime (minutes to an hour).
+> * A stored **`id_token` is replaced only when a refresh rotates one**, and it is
+>   used even after it expires. So a group revoked upstream can keep granting
+>   until the ToolHive **session** ends — up to
+>   `spec.authServerConfig.tokenLifespans.refreshTokenLifespan`, **7 days by
+>   default**.
+>
+> This is deliberate. Rejecting an expired `id_token` is not the remedy: it would
+> flip policies from permit to deny mid-session for *every* user at once, not just
+> a revoked one, with no configuration change. Sessions routinely outlive
+> `id_token`s by days.
+>
+> **What to do**: if your authorization model needs group revocation to propagate
+> faster than the session, either have the upstream assert groups in its **access
+> token** (which restores refresh-rate propagation), or shorten
+> `refreshTokenLifespan` to bound the window. Deployments whose groups already
+> come from the access token are unaffected.
+>
+> Note this is not a regression: before ToolHive read the `id_token`, these
+> deployments had an empty group set and denied *every* request, so the change is
+> broken → works-with-login-time-groups. But the revocation window is new
+> information, and it is wider than the access-token path's.
 
 The token the client presented — the one ToolHive's auth server issued — is
 never a claim source here, even though it mirrors a `name` and `email`. A group,

--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -142,13 +142,15 @@ type Identity struct {
 	//     exchange and surfaces the resulting `invalid_grant`. So such a caller must
 	//     either check `exp` first or be prepared to handle that failure.
 	//   - READING identity claims out of it — as the Cedar authorizer does for the
-	//     profile claims an upstream access token omits — is not subject to expiry at
-	//     all. The token is evidence that the upstream asserted something at login,
-	//     and expiry says nothing about whether that assertion happened. Rejecting it
-	//     once expired would flip an authorization decision mid-session, since
-	//     sessions outlive ID tokens by days; and the claims are no staler than the
-	//     alternative, since the profile claims mirrored into the ToolHive-issued
-	//     token are likewise captured once at login and never refreshed.
+	//     claims an upstream access token omits, profile and group alike — is not
+	//     subject to expiry at all. The token is evidence that the upstream asserted
+	//     something at login, and expiry says nothing about whether that assertion
+	//     happened. Rejecting it once expired would flip an authorization decision
+	//     mid-session, since sessions outlive ID tokens by days — and it would do so
+	//     for every user at once, which is worse than the staleness it would avoid.
+	//     Read the claims as login-time facts and size the session accordingly: a
+	//     group revoked upstream keeps evaluating as granted until the session ends,
+	//     because a stored ID token is replaced only when a refresh rotates one.
 	//
 	// Either way the token is NOT re-validated for signature or freshness here, so
 	// treat its claims as login-time facts rather than current state.

--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -171,8 +171,8 @@ type Authorizer struct {
 	// Mutex for thread safety
 	mu sync.RWMutex
 	// primaryUpstreamProvider names the upstream IDP provider whose access token
-	// is the source of JWT claims for Cedar evaluation, aside from the narrow
-	// user-profile supplement described in resolveClaims.
+	// is the primary source of JWT claims for Cedar evaluation, supplemented from
+	// the same provider's id_token as described in resolveClaims.
 	// When empty, claims from the token on the original client request are used,
 	// which may be a ToolHive-issued token or any other bearer token.
 	primaryUpstreamProvider string
@@ -191,13 +191,13 @@ type Authorizer struct {
 	// claimKeyLog rate-limits the diagnostic log of resolved JWT claim keys
 	// so it emits at most once per 30 seconds instead of once per authorization check.
 	claimKeyLog *syncutil.AtMost
-	// supplementLog rate-limits the warning that the upstream access token lacked
-	// profile claims. It is deliberately separate from claimKeyLog: a shared
+	// supplementLog rate-limits the warning that the upstream access token omitted
+	// claims its id_token asserts. It is deliberately separate from claimKeyLog: a shared
 	// timer would let whichever fires first suppress the other for the rest of
 	// the window, hiding the claim-key dump on exactly the deployments that need it.
 	supplementLog *syncutil.AtMost
 	// missingIDTokenLog rate-limits the warning that the primary provider has no
-	// usable stored id_token, so profile claims cannot be supplemented at all.
+	// usable stored id_token, so no claim can be supplemented at all.
 	// Separate from supplementLog because the two are mutually exclusive per
 	// request and describe opposite conditions.
 	missingIDTokenLog *syncutil.AtMost
@@ -220,13 +220,22 @@ type ConfigOptions struct {
 	// When empty, claims from the ToolHive-issued token are used.
 	// Must match an entry in identity.UpstreamTokens (e.g. "default", "github").
 	//
-	// The profile claims in profileClaimsFromIDToken fall back to the SAME
-	// provider's id_token when its access token omits them (many OIDC providers
-	// assert `email` only in the id_token), so `principal has claim_email` keeps
-	// meaning "this upstream asserted an email". Every other claim, including all
-	// group/role/scope claims, comes from the upstream access token or not at all,
-	// and the ToolHive-issued token the client presented is never a claim source on
-	// this path. See resolveClaims for the full contract.
+	// Any claim that access token omits falls back to the SAME provider's id_token,
+	// apart from the token-describing claims and `sub` named in
+	// idTokenClaimsNeverSupplemented. Providers routinely split what they assert
+	// across the two tokens — `email` in the id_token only, and group membership in
+	// the id_token only, are both common — so this is what makes `principal has
+	// claim_email` and `principal in THVGroup::"..."` mean "this upstream asserted
+	// it" rather than "this upstream asserted it in one particular token".
+	//
+	// Precedence is fill-only: a claim the access token asserts is used verbatim and
+	// is never overwritten or extended, so an access token carrying a PARTIAL
+	// `groups` list keeps exactly that list and the id_token's fuller list is not
+	// unioned in. See resolveClaims for why that is the safe direction.
+	//
+	// The ToolHive-issued token the client presented is never a claim source on this
+	// path, so a group, role or scope claim on it grants nothing. See resolveClaims
+	// for the full contract.
 	PrimaryUpstreamProvider string `json:"primary_upstream_provider,omitempty" yaml:"primary_upstream_provider,omitempty"`
 
 	// GroupClaimName is the JWT claim key that contains group membership for the
@@ -560,10 +569,13 @@ func (a *Authorizer) IsAuthorized(
 //
 // When primaryUpstreamProvider is set (the embedded auth server path), the claim
 // source is that provider's upstream credentials — and only that provider's. Its
-// access token is primary; the profile claims listed in profileClaimsFromIDToken
-// fall back to the same provider's id_token when the access token does not carry
-// them, because many OIDC providers assert `email` only in the id_token and the
-// access token alone was therefore a deny-all trap (#5916).
+// access token is primary; every claim the access token does not carry falls back
+// to the same provider's id_token, apart from the narrow set named in
+// idTokenClaimsNeverSupplemented. Providers routinely split what they assert
+// across the two tokens, and reading only the access token was a deny-all trap
+// twice over: for `email`, asserted in the id_token only by many OIDC providers
+// (#5916), and for group membership, likewise asserted in the id_token only where
+// groups are a profile-scope claim (#6049).
 //
 // Both tokens belong to the same upstream provider and session: the auth
 // middleware splits a single credential bundle into Identity.UpstreamTokens and
@@ -580,30 +592,66 @@ func (a *Authorizer) IsAuthorized(
 // those belong to the first configured upstream, which need not be the pinned
 // provider, so using them could attribute one IdP's email to another.
 //
-// The supplement is restricted to profileClaimsFromIDToken rather than merging
-// the two token bodies. Read this before widening it:
+// # Why the supplement is a deny-list, and why group and role claims are admitted
 //
-//   - An id_token's registered claims (`iss`, `aud`, `exp`, `nonce`, `at_hash`,
-//     `azp`) describe that token, not the user. Merging them would overwrite the
-//     access token's own `aud`/`exp` with values that mean something different.
-//   - Authorization-bearing claims (`groups`, `roles`, `scope`) are left alone for
-//     now. Taking them from this provider's id_token would be provenance-correct —
-//     unlike taking them from the ToolHive-issued token, which must never happen —
-//     but it would newly grant requests that deny today, so it belongs in its own
-//     change rather than riding along with a deny-all fix.
-//   - `sub` is excluded because it becomes the Cedar principal entity ID rather
-//     than an attribute, and Cedar has no `has`-style guard in the principal
-//     position. An access token without `sub` violates RFC 9068; failing closed
-//     with ErrMissingPrincipal beats silently choosing a principal.
+// This used to be an allow-list of {`name`, `email`}, on the stated reasoning that
+// authorization-bearing claims (`groups`, `roles`, `scope`) were "left alone for
+// now" because admitting them would newly GRANT requests that denied, and so
+// belonged in its own change rather than riding along with a deny-all fix. That
+// change is #6049, and this is it. Two things settle the shape:
 //
-// An access-token value always wins, so a claim the access token does assert can
-// never be shadowed. A claim absent from both tokens stays absent, so `has`-guarded
-// policies still fail closed.
+//   - Provenance does not distinguish the two tokens. They are projections of one
+//     credential bundle from one authentication event at one provider (see above),
+//     so `groups` read from the id_token is asserted by exactly the same IdP as
+//     `groups` read from the access token. The objection that ruled this out in
+//     #5916 was that claims must not come from the ToolHive-ISSUED token; that
+//     still holds and is still enforced — the issued token is not read here at all.
+//   - An allow-list cannot express the requirement, so it is not merely narrower,
+//     it is wrong. The claim carrying group membership is named by the deployment,
+//     not by ToolHive: GroupClaimName and RoleClaimName are user-configured, and
+//     Auth0/Okta put it under URI-style names such as
+//     "https://example.com/groups". No fixed list can enumerate names ToolHive
+//     does not choose, and every name missing from one denies silently — the
+//     defect shape of both #5916 and #6049, and the reason `hd` and per-tenant
+//     organization claims would have come back as a third round. Inverting the
+//     rule names instead the claims that must NEVER be read
+//     (idTokenClaimsNeverSupplemented, which is closed and spec-derived) and
+//     admits the rest.
+//
+// # Precedence is fill-only, deliberately not union
+//
+// A claim the access token asserts is used verbatim and is never overwritten or
+// extended, set-valued claims included. So a provider asserting a PARTIAL `groups`
+// list in its access token and the full list in its id_token keeps the partial
+// one. That is intentional and is the safe direction: per-application claim
+// filtering (Okta group filters, Entra group-claim configuration) is applied when
+// the token is minted for a given audience, so the access token's list is the
+// provider's answer to "which of this user's groups are relevant to this resource
+// server". Unioning in the id_token's list — minted for ToolHive's own auth-server
+// client — would restore groups the provider chose to withhold from this audience,
+// widening authority beyond what it asserted for it. Fill-only can only supply a
+// claim the provider left entirely absent here; it can never contradict or extend
+// one. A deployment wanting the fuller list should have the upstream assert it in
+// the access token.
+//
+// A claim absent from both tokens stays absent, so `has`-guarded policies still
+// fail closed.
+//
+// # Freshness
 //
 // The id_token is used without checking `exp`, deliberately: it is read as a record
 // of what the upstream asserted at login, not presented as a credential, and
 // rejecting it once expired would flip a policy from permit to deny mid-session.
 // See Identity.UpstreamIDTokens for that contract and its two consumers.
+//
+// One consequence of that is now load-bearing rather than incidental. For a
+// provider that asserts groups only in its id_token, group membership is a
+// login-time fact: upstream access tokens are refreshed, so groups read from them
+// track the provider, whereas a stored id_token is replaced only when a refresh
+// rotates one, so a group revoked upstream can keep granting until the ToolHive
+// session ends. Enforcing `exp` is not the remedy — it would flip permit to deny
+// mid-session for every user rather than only the revoked one. Shorten the session
+// (RefreshTokenLifespan) if login-time group membership is too stale to accept.
 func (a *Authorizer) resolveClaims(identity *auth.Identity) (jwt.MapClaims, error) {
 	requestClaims := jwt.MapClaims(identity.Claims)
 
@@ -652,9 +700,9 @@ func (a *Authorizer) resolveClaims(identity *auth.Identity) (jwt.MapClaims, erro
 	return merged, nil
 }
 
-// supplementFromIDToken returns upstreamClaims with the profileClaimsFromIDToken
-// it lacks filled in from the primary provider's stored id_token, logging what it
-// did. upstreamClaims is not mutated.
+// supplementFromIDToken returns upstreamClaims with the claims it lacks filled in
+// from the primary provider's stored id_token, logging what it did.
+// idTokenClaimsNeverSupplemented is withheld. upstreamClaims is not mutated.
 //
 // A provider with no stored id_token (an OAuth 2.0 upstream that was never asked
 // for `openid`, so nothing was captured at login) yields no supplement: the claims
@@ -666,10 +714,9 @@ func (a *Authorizer) supplementFromIDToken(identity *auth.Identity, upstreamClai
 	idToken := identity.UpstreamIDTokens[a.primaryUpstreamProvider] // nil map safe in Go
 	if idToken == "" {
 		a.missingIDTokenLog.Do(func() {
-			slog.Warn("no upstream ID token stored for provider; policies referencing profile claims "+
+			slog.Warn("no upstream ID token stored for provider; policies referencing claims "+
 				"the access token omits will deny",
-				"provider", a.primaryUpstreamProvider,
-				"profile_claims", profileClaimsFromIDToken)
+				"provider", a.primaryUpstreamProvider)
 		})
 		return upstreamClaims
 	}
@@ -680,23 +727,24 @@ func (a *Authorizer) supplementFromIDToken(identity *auth.Identity, upstreamClai
 		// reference its claims must keep working. An unparsable id_token means no
 		// supplement, which denies exactly the policies that needed it.
 		a.missingIDTokenLog.Do(func() {
-			slog.Warn("upstream ID token for provider is not a parsable JWT; not supplementing profile claims",
+			slog.Warn("upstream ID token for provider is not a parsable JWT; not supplementing claims from it",
 				"provider", a.primaryUpstreamProvider,
 				"error", err)
 		})
 		return upstreamClaims
 	}
 
-	merged, filled := supplementProfileClaims(upstreamClaims, idTokenClaims)
+	merged, filled := supplementFromIDTokenClaims(upstreamClaims, idTokenClaims)
 	if len(filled) > 0 {
 		// Rate-limited on its own timer, not claimKeyLog: sharing one would let
 		// this Warn consume the window and permanently starve the claim-key dump
 		// in resolveClaims, which is what you want when debugging a denying policy.
 		//
-		// Claim keys only — never claim values, which hold user PII.
+		// Claim keys only — never claim values, which hold user PII (and, for a
+		// group claim, the user's organizational placement).
 		a.supplementLog.Do(func() {
-			slog.Warn("upstream access token lacks profile claims; using the upstream ID token's values "+
-				"for Cedar evaluation",
+			slog.Warn("upstream access token omits claims the upstream ID token asserts; using the "+
+				"ID token's values for Cedar evaluation",
 				"provider", a.primaryUpstreamProvider,
 				"claims", filled)
 		})
@@ -704,60 +752,83 @@ func (a *Authorizer) supplementFromIDToken(identity *auth.Identity, upstreamClai
 	return merged
 }
 
-// OIDC Core 1.0 §5.1 standard claim names, declared here rather than borrowed
-// from another package. What this code reads is an upstream provider's id_token,
-// so these are wire names fixed by the OIDC spec — not names ToolHive chooses.
-// Anchoring them to a ToolHive constant would invert the dependency: renaming that
-// constant would silently change which claim Cedar reads out of a third party's
-// token. Two literals also do not justify pulling an authorization-server
-// dependency tree into the authorizer.
-const (
-	oidcNameClaim  = "name"
-	oidcEmailClaim = "email"
-)
-
-// profileClaimsFromIDToken are the OIDC Core §5.1 profile claims that may be read
-// from the primary provider's id_token when its access token omits them. They
-// coincide with the two claims the embedded auth server extracts from that same
-// id_token: pkg/authserver/upstream/oidc.go reads them by their OIDC names, and the
-// callback handler then passes them to session.New
-// (pkg/authserver/server/handlers/callback.go). Both sides key off the wire names
-// independently — a shared reliance on the spec, not a coupling. If the auth server
-// ever mirrors more, adding it here is a separate, deliberate decision.
+// idTokenClaimsNeverSupplemented names the claims that are never read out of the
+// primary provider's id_token, whatever the access token does or does not carry.
+// Everything else that id_token asserts is admitted — resolveClaims explains why
+// the rule is a deny-list rather than an allow-list, and why that admits
+// group/role claims. These are wire names fixed by RFC 7519 §4.1 and OIDC Core
+// 1.0, not names ToolHive chooses, so they are spelled literally here rather than
+// borrowed from an authorization-server constant: anchoring them to a ToolHive
+// constant would let renaming it silently change which claim Cedar reads out of a
+// third party's token.
 //
-// Widening this list widens what can satisfy a policy — see resolveClaims first.
-var profileClaimsFromIDToken = []string{oidcNameClaim, oidcEmailClaim}
+// Exactly two categories belong here, and the list is meant to stay closed:
+//
+//   - Claims describing the id_token itself, or the request that minted it, rather
+//     than the user or their login. Their subject is a token whose audience is
+//     ToolHive's own auth-server client, so filling one would answer a policy's
+//     question about the presented access token with a fact about a different
+//     token. `aud` and `exp` are the sharp cases — a gate on the resource-server
+//     audience, or on token lifetime, would silently read the id_token's — and
+//     `client_id`/`azp` the subtle ones, since they would report ToolHive's own
+//     client rather than the one that made the request.
+//   - `sub`, because it becomes the Cedar principal entity ID rather than an
+//     attribute, and Cedar has no `has`-style guard in the principal position. An
+//     access token without `sub` violates RFC 9068; failing closed with
+//     ErrMissingPrincipal beats silently choosing a principal. Pinned by
+//     TestAuthorizeWithJWTClaims_PrincipalStaysUpstreamSourced.
+//
+// Claims describing the LOGIN rather than the token — `auth_time`, `acr`, `amr` —
+// are deliberately absent: both tokens come out of one authentication event, so
+// the id_token's values describe the same login the access token's would.
+// `scope`/`scp` are absent for the same reason: an id_token that carries one
+// carries the scope of the very grant that produced the access token beside it, so
+// there is nothing to diverge, and excluding them by name would be a cosmetic
+// control anyway when the claim name is provider-chosen.
+var idTokenClaimsNeverSupplemented = map[string]struct{}{
+	// RFC 7519 §4.1 registered claims.
+	"iss": {}, "aud": {}, "exp": {}, "nbf": {}, "iat": {}, "jti": {},
+	// OIDC Core 1.0 §2 and §3.3.2.11 id_token claims, plus RFC 9068 §2.2's
+	// `client_id` and OIDC front/back-channel logout's `sid`.
+	"nonce": {}, "at_hash": {}, "c_hash": {}, "s_hash": {}, "azp": {},
+	"sid": {}, "client_id": {},
+	// The Cedar principal, not an attribute.
+	"sub": {},
+}
 
-// supplementProfileClaims returns a fresh claim set holding every access-token
-// claim plus, for each name in profileClaimsFromIDToken that the access token does
-// not carry, the id_token's value for that name. It also returns the sorted list of
-// names actually supplied by the id_token, for logging.
+// supplementFromIDTokenClaims returns a fresh claim set holding every access-token
+// claim plus, for each id_token claim that the access token does not carry and that
+// is not in idTokenClaimsNeverSupplemented, the id_token's value. It also returns
+// the sorted list of names actually supplied by the id_token, for logging.
+//
+// Precedence is fill-only: an access-token claim is never overwritten or extended,
+// so a claim the access token does assert can neither be shadowed nor unioned with
+// the id_token's value. Absent claims are never fabricated either: a name missing
+// from both tokens is missing from the result, which keeps `has`-guarded policies
+// failing closed. See resolveClaims for why both choices are the safe direction.
 //
 // Neither input is mutated and the result aliases neither, so the caller may hand
-// it to code that adds synthetic keys. Absent claims are never fabricated: a name
-// missing from both tokens is missing from the result, which keeps `has`-guarded
-// policies failing closed.
-func supplementProfileClaims(accessTokenClaims, idTokenClaims jwt.MapClaims) (merged jwt.MapClaims, filled []string) {
-	merged = make(jwt.MapClaims, len(accessTokenClaims)+len(profileClaimsFromIDToken))
+// it to code that adds synthetic keys.
+func supplementFromIDTokenClaims(accessTokenClaims, idTokenClaims jwt.MapClaims) (merged jwt.MapClaims, filled []string) {
+	merged = make(jwt.MapClaims, len(accessTokenClaims)+len(idTokenClaims))
 	for k, v := range accessTokenClaims {
 		merged[k] = v
 	}
 
-	for _, name := range profileClaimsFromIDToken {
-		if _, ok := merged[name]; ok {
-			// The access token asserted this claim; it always wins.
+	for name, v := range idTokenClaims {
+		if _, never := idTokenClaimsNeverSupplemented[name]; never {
 			continue
 		}
-		v, ok := idTokenClaims[name]
-		if !ok {
+		if _, ok := merged[name]; ok {
+			// The access token asserted this claim; it always wins.
 			continue
 		}
 		merged[name] = v
 		filled = append(filled, name)
 	}
 
-	// Sorted for a canonical, easily-greppable log line — profileClaimsFromIDToken
-	// is ordered for readability (name, email), not alphabetically.
+	// Sorted for a canonical, easily-greppable log line and a deterministic
+	// return value: the loop above walks a map, so iteration order is random.
 	slices.Sort(filled)
 	return merged, filled
 }

--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -233,9 +233,11 @@ type ConfigOptions struct {
 	// `groups` list keeps exactly that list and the id_token's fuller list is not
 	// unioned in. See resolveClaims for why that is the safe direction.
 	//
-	// The ToolHive-issued token the client presented is never a claim source on this
-	// path, so a group, role or scope claim on it grants nothing. See resolveClaims
-	// for the full contract.
+	// `scope`/`scp` are the exception: they assert the authority the presented access
+	// token carries, not a fact about the user, so they are read from that token or
+	// not at all. The ToolHive-issued token the client presented is never a claim
+	// source on this path either, so a group, role or scope claim on it grants
+	// nothing. See resolveClaims for the full contract.
 	PrimaryUpstreamProvider string `json:"primary_upstream_provider,omitempty" yaml:"primary_upstream_provider,omitempty"`
 
 	// GroupClaimName is the JWT claim key that contains group membership for the
@@ -598,7 +600,14 @@ func (a *Authorizer) IsAuthorized(
 // authorization-bearing claims (`groups`, `roles`, `scope`) were "left alone for
 // now" because admitting them would newly GRANT requests that denied, and so
 // belonged in its own change rather than riding along with a deny-all fix. That
-// change is #6049, and this is it. Two things settle the shape:
+// change is #6049, and this is it: `groups` and `roles` are now admitted, `scope`
+// deliberately still is not (see idTokenClaimsNeverSupplemented for that split).
+//
+// The shortest form of the argument is parity. The code above admits EVERY claim of
+// the upstream access token with no allow-list at all. An allow-list applied only
+// to the id_token was therefore an asymmetry between two tokens at the same trust
+// level from the same provider, not a trust boundary being held. Inverting to a
+// deny-list restores parity; it does not widen a boundary. Three further points:
 //
 //   - Provenance does not distinguish the two tokens. They are projections of one
 //     credential bundle from one authentication event at one provider (see above),
@@ -617,6 +626,11 @@ func (a *Authorizer) IsAuthorized(
 //     rule names instead the claims that must NEVER be read
 //     (idTokenClaimsNeverSupplemented, which is closed and spec-derived) and
 //     admits the rest.
+//   - Parity is between the two tokens' claims ABOUT THE USER, which is why the
+//     deny-list is not empty. A claim that asserts what a token may DO rather than
+//     who its bearer is — `scope`/`scp` — is not symmetric between them, because
+//     only the presented access token's authority is at issue. That is a different
+//     argument from "an allow-list can't work", and it survives it.
 //
 // # Precedence is fill-only, deliberately not union
 //
@@ -762,7 +776,7 @@ func (a *Authorizer) supplementFromIDToken(identity *auth.Identity, upstreamClai
 // constant would let renaming it silently change which claim Cedar reads out of a
 // third party's token.
 //
-// Exactly two categories belong here, and the list is meant to stay closed:
+// Exactly three categories belong here, and the list is meant to stay closed:
 //
 //   - Claims describing the id_token itself, or the request that minted it, rather
 //     than the user or their login. Their subject is a token whose audience is
@@ -772,6 +786,22 @@ func (a *Authorizer) supplementFromIDToken(identity *auth.Identity, upstreamClai
 //     audience, or on token lifetime, would silently read the id_token's — and
 //     `client_id`/`azp` the subtle ones, since they would report ToolHive's own
 //     client rather than the one that made the request.
+//   - The delegated grant: `scope` and `scp`. These are the one place where the
+//     deny-list is doing real work rather than avoiding confusion, so the
+//     distinction from a group claim matters. A group is a fact about the USER,
+//     which either token can report equally well. A scope is the AUTHORITY THIS
+//     TOKEN CARRIES, and the only token whose authority is at issue is the access
+//     token that was presented. Providers do not emit `scope` in an id_token per
+//     spec, but where one appears it can reflect what was REQUESTED rather than
+//     what was granted — and requested-minus-granted is routine, not theoretical,
+//     since granular/incremental consent lets a user approve a subset of the
+//     scopes the client asked for. Supplementing it would then match a
+//     `claimset_scp.containsAny(...)` gate on authority the access token does not
+//     actually carry. Never infer authority from a token that is not the one
+//     bearing it. Unlike a group claim name, these two are standardized names
+//     (RFC 8693/9068 `scope`, Entra `scp`), so excluding them by name is an
+//     effective control rather than a cosmetic one — the reason an allow-list had
+//     to go for groups does not transfer here.
 //   - `sub`, because it becomes the Cedar principal entity ID rather than an
 //     attribute, and Cedar has no `has`-style guard in the principal position. An
 //     access token without `sub` violates RFC 9068; failing closed with
@@ -780,11 +810,8 @@ func (a *Authorizer) supplementFromIDToken(identity *auth.Identity, upstreamClai
 //
 // Claims describing the LOGIN rather than the token — `auth_time`, `acr`, `amr` —
 // are deliberately absent: both tokens come out of one authentication event, so
-// the id_token's values describe the same login the access token's would.
-// `scope`/`scp` are absent for the same reason: an id_token that carries one
-// carries the scope of the very grant that produced the access token beside it, so
-// there is nothing to diverge, and excluding them by name would be a cosmetic
-// control anyway when the claim name is provider-chosen.
+// the id_token's values describe the same login the access token's would, and none
+// of them asserts an authority the way a scope does.
 var idTokenClaimsNeverSupplemented = map[string]struct{}{
 	// RFC 7519 §4.1 registered claims.
 	"iss": {}, "aud": {}, "exp": {}, "nbf": {}, "iat": {}, "jti": {},
@@ -792,6 +819,9 @@ var idTokenClaimsNeverSupplemented = map[string]struct{}{
 	// `client_id` and OIDC front/back-channel logout's `sid`.
 	"nonce": {}, "at_hash": {}, "c_hash": {}, "s_hash": {}, "azp": {},
 	"sid": {}, "client_id": {},
+	// The delegated grant, which belongs to the presented access token alone.
+	// RFC 8693/9068 spell it `scope`; Entra ID spells it `scp`.
+	"scope": {}, "scp": {},
 	// The Cedar principal, not an attribute.
 	"sub": {},
 }

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -1485,7 +1485,7 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 					}),
 				},
 			},
-			// `sub` is excluded from mirroredIdentityClaims, so the request
+			// `sub` is in idTokenClaimsNeverSupplemented, so the request
 			// token's subject must NOT stand in: the AS-issued subject is an
 			// internal user ID, and supplementing it would silently retarget the
 			// Cedar principal instead of failing closed. An upstream access token
@@ -1523,9 +1523,9 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 	}
 }
 
-// TestSupplementProfileClaims covers which id_token claims may stand in for a
+// TestSupplementFromIDTokenClaims covers which id_token claims may stand in for a
 // missing access-token claim, and which may never do so.
-func TestSupplementProfileClaims(t *testing.T) {
+func TestSupplementFromIDTokenClaims(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1557,10 +1557,18 @@ func TestSupplementProfileClaims(t *testing.T) {
 			wantFilled: []string{"email", "name"},
 		},
 		{
-			// Taking these from this provider's id_token would be provenance-correct,
-			// but it would newly grant requests that deny today, so it is out of scope
-			// here and pinned as unchanged behaviour.
-			name:              "authorization_bearing_claims_are_not_filled",
+			// #6049: these are asserted by the same IdP for the same login as the
+			// access token's claims, so they are admitted. Withholding them was the
+			// deny-all trap for every `principal in THVGroup::"..."` policy against a
+			// provider that puts group membership in the id_token only.
+			//
+			// This is the case that flipped in #6049; the invariant that a group claim
+			// on the TOOLHIVE-ISSUED token grants nothing is a different property and
+			// is pinned elsewhere (TestResolveClaimsUpstreamSupplement's
+			// leaked-from-as-token fixtures,
+			// TestAuthorizeWithJWTClaims_UpstreamProviderWithGroups/toolhive_groups_ignored_when_upstream_configured,
+			// and integration_test.go's direct_groups_ignored_when_upstream_configured).
+			name:              "authorization_bearing_claims_are_filled_from_the_id_token",
 			accessTokenClaims: jwt.MapClaims{"sub": "okta|alice"},
 			idTokenClaims: jwt.MapClaims{
 				"groups": []interface{}{"platform-eng"},
@@ -1568,22 +1576,85 @@ func TestSupplementProfileClaims(t *testing.T) {
 				"scope":  "tools:write",
 				"hd":     "example.com",
 			},
-			wantMerged: jwt.MapClaims{"sub": "okta|alice"},
-			wantFilled: nil,
+			wantMerged: jwt.MapClaims{
+				"sub":    "okta|alice",
+				"groups": []interface{}{"platform-eng"},
+				"roles":  []interface{}{"admin"},
+				"scope":  "tools:write",
+				"hd":     "example.com",
+			},
+			wantFilled: []string{"groups", "hd", "roles", "scope"},
+		},
+		{
+			// A custom namespaced group claim, the shape GroupClaimName exists for.
+			// A fixed allow-list of claim names could not admit this, since the name
+			// is chosen by the deployment's IdP rather than by ToolHive.
+			name:              "custom_namespaced_claims_are_filled_from_the_id_token",
+			accessTokenClaims: jwt.MapClaims{"sub": "okta|alice"},
+			idTokenClaims: jwt.MapClaims{
+				"https://example.com/groups": []interface{}{"platform-eng"},
+				"cognito:groups":             []interface{}{"admins"},
+			},
+			wantMerged: jwt.MapClaims{
+				"sub":                        "okta|alice",
+				"https://example.com/groups": []interface{}{"platform-eng"},
+				"cognito:groups":             []interface{}{"admins"},
+			},
+			wantFilled: []string{"cognito:groups", "https://example.com/groups"},
 		},
 		{
 			// An id_token's registered claims describe that token. Merging them would
-			// overwrite the access token's own aud/exp with different-meaning values.
+			// overwrite the access token's own aud/exp with different-meaning values,
+			// or report ToolHive's own auth-server client as the requesting client.
 			name: "id_token_registered_claims_are_never_filled_or_overwritten",
 			accessTokenClaims: jwt.MapClaims{
 				"sub": "okta|alice", "aud": "api://resource", "exp": 2000000000,
 			},
 			idTokenClaims: jwt.MapClaims{
-				"aud": "toolhive-as-client", "exp": 1000000000,
-				"nonce": "n-abc", "at_hash": "h-abc", "azp": "client-x",
+				"iss": "https://idp.example.com", "aud": "toolhive-as-client", "exp": 1000000000,
+				"nbf": 999999999, "iat": 999999999, "jti": "id-abc",
+				"nonce": "n-abc", "at_hash": "h-abc", "c_hash": "hc-abc", "s_hash": "hs-abc",
+				"azp": "client-x", "sid": "sess-abc", "client_id": "toolhive-as-client",
 			},
 			wantMerged: jwt.MapClaims{
 				"sub": "okta|alice", "aud": "api://resource", "exp": 2000000000,
+			},
+			wantFilled: nil,
+		},
+		{
+			// `auth_time`/`acr`/`amr` describe the authentication event both tokens
+			// came out of, not the id_token, so they are admitted alongside the user's
+			// own claims — a step-up-auth gate can be satisfied by what the provider
+			// actually asserted about the login.
+			name:              "login_describing_claims_are_filled_from_the_id_token",
+			accessTokenClaims: jwt.MapClaims{"sub": "okta|alice"},
+			idTokenClaims: jwt.MapClaims{
+				"auth_time": 1700000000,
+				"acr":       "urn:mace:incommon:iap:silver",
+				"amr":       []interface{}{"mfa", "pwd"},
+			},
+			wantMerged: jwt.MapClaims{
+				"sub":       "okta|alice",
+				"auth_time": 1700000000,
+				"acr":       "urn:mace:incommon:iap:silver",
+				"amr":       []interface{}{"mfa", "pwd"},
+			},
+			wantFilled: []string{"acr", "amr", "auth_time"},
+		},
+		{
+			// Precedence is fill-only, not union: an access token asserting a PARTIAL
+			// group list keeps exactly that list. Per-audience claim filtering means
+			// the access token's list is the provider's answer for THIS resource
+			// server; unioning the id_token's would widen beyond it.
+			name: "partial_access_token_group_list_is_not_unioned_with_the_id_token",
+			accessTokenClaims: jwt.MapClaims{
+				"sub": "okta|alice", "groups": []interface{}{"platform-eng"},
+			},
+			idTokenClaims: jwt.MapClaims{
+				"groups": []interface{}{"platform-eng", "sre", "finance-admins"},
+			},
+			wantMerged: jwt.MapClaims{
+				"sub": "okta|alice", "groups": []interface{}{"platform-eng"},
 			},
 			wantFilled: nil,
 		},
@@ -1634,7 +1705,7 @@ func TestSupplementProfileClaims(t *testing.T) {
 			accessBefore := maps.Clone(tt.accessTokenClaims)
 			idTokenBefore := maps.Clone(tt.idTokenClaims)
 
-			merged, filled := supplementProfileClaims(tt.accessTokenClaims, tt.idTokenClaims)
+			merged, filled := supplementFromIDTokenClaims(tt.accessTokenClaims, tt.idTokenClaims)
 
 			assert.Equal(t, tt.wantMerged, merged)
 			assert.Equal(t, tt.wantFilled, filled)
@@ -1652,8 +1723,8 @@ func TestSupplementProfileClaims(t *testing.T) {
 
 // TestResolveClaimsUpstreamSupplement pins the claim-source contract of
 // resolveClaims on the embedded-auth-server path: the pinned provider's access
-// token wins, its id_token supplies only the profile claims the access token
-// omits, and the ToolHive-issued token is not a claim source at all.
+// token wins, its id_token supplies the claims the access token omits (bar the
+// token-describing ones), and the ToolHive-issued token is not a claim source at all.
 //
 // The email-filling case is the #5916 reproducer — an upstream IdP whose access
 // token is a well-formed JWT carrying no `email` (the provider asserts it in the
@@ -1672,6 +1743,10 @@ func TestResolveClaimsUpstreamSupplement(t *testing.T) {
 		"email":     "leaked-from-as-token@example.com",
 		"name":      "Leaked From AS Token",
 		"client_id": "vscode",
+		// #6049 opened the id_token as a source of group claims. It did not open
+		// the issued token, so this group must never appear in any resolved claim
+		// set below — including the cases where the id_token does supply groups.
+		"groups": []interface{}{"leaked-from-as-token"},
 	}
 
 	tests := []struct {
@@ -1705,6 +1780,36 @@ func TestResolveClaimsUpstreamSupplement(t *testing.T) {
 				"name":  "Alice",
 				// The id_token's own aud/nonce are absent: they describe that
 				// token, not the user.
+			},
+		},
+		{
+			// The #6049 shape: the pinned upstream asserts group membership in its
+			// id_token only, so before that change the resolved claim set had no
+			// `groups` key and every THVGroup policy denied for everyone. `hd` and
+			// custom namespaced claims ride the same rule.
+			name:     "access_token_without_groups_falls_back_to_id_token_groups",
+			provider: providerName,
+			upstreamToken: makeUnsignedJWT(jwt.MapClaims{
+				"sub": "hub|alice",
+				"iss": "https://hub.example.com",
+			}),
+			idToken: makeUnsignedJWT(jwt.MapClaims{
+				"sub":                        "hub|alice",
+				"groups":                     []interface{}{"platform-eng"},
+				"hd":                         "example.com",
+				"https://hub.example.com/ou": "infra",
+				// Token-describing claims are withheld even now that the id_token is
+				// a general claim source.
+				"aud": "toolhive-as-client",
+				"sid": "sess-abc",
+			}),
+			requestClaims: asIssuedClaims,
+			wantClaims: jwt.MapClaims{
+				"sub":                        "hub|alice",
+				"iss":                        "https://hub.example.com",
+				"groups":                     []interface{}{"platform-eng"},
+				"hd":                         "example.com",
+				"https://hub.example.com/ou": "infra",
 			},
 		},
 		{
@@ -1750,20 +1855,24 @@ func TestResolveClaimsUpstreamSupplement(t *testing.T) {
 			// login, not presented as a credential, so `exp` is deliberately not
 			// enforced. Enforcing it would make a policy permit early in a session
 			// and silently deny later, since sessions outlive id_tokens by days.
+			// Since #6049 this covers group membership too, which is why
+			// resolveClaims documents it as a login-time fact.
 			name:     "expired_id_token_is_still_used",
 			provider: providerName,
 			upstreamToken: makeUnsignedJWT(jwt.MapClaims{
 				"sub": "hub|alice",
 			}),
 			idToken: makeUnsignedJWT(jwt.MapClaims{
-				"sub":   "hub|alice",
-				"email": "alice@example.com",
-				"exp":   1000000000, // long past
+				"sub":    "hub|alice",
+				"email":  "alice@example.com",
+				"groups": []interface{}{"platform-eng"},
+				"exp":    1000000000, // long past
 			}),
 			requestClaims: asIssuedClaims,
 			wantClaims: jwt.MapClaims{
-				"sub":   "hub|alice",
-				"email": "alice@example.com",
+				"sub":    "hub|alice",
+				"email":  "alice@example.com",
+				"groups": []interface{}{"platform-eng"},
 			},
 		},
 		{
@@ -1915,7 +2024,7 @@ func TestAuthorizeWithJWTClaims_UpstreamJWTMissingIdentityClaim(t *testing.T) {
 }
 
 // TestAuthorizeWithJWTClaims_PrincipalStaysUpstreamSourced pins the property that
-// keeps `sub` out of mirroredIdentityClaims: the Cedar principal entity ID is
+// keeps `sub` in idTokenClaimsNeverSupplemented: the Cedar principal entity ID is
 // derived from the upstream subject, never from the AS-issued token's internal
 // user ID. Unlike an attribute, the principal has no `has`-style guard available
 // in Cedar, so a supplemented subject would silently retarget every principal-keyed
@@ -1959,7 +2068,7 @@ func TestAuthorizeWithJWTClaims_PrincipalStaysUpstreamSourced(t *testing.T) {
 			wantAuthorize:  true,
 		},
 		{
-			// The sharp case. If `sub` were added to mirroredIdentityClaims, the
+			// The sharp case. If `sub` left idTokenClaimsNeverSupplemented, the
 			// AS subject would stand in, the principal would become
 			// Client::"7f3c1e64-..." and the broad permit would apply — the
 			// request would be ALLOWED instead of erroring. Fail closed instead.
@@ -2247,7 +2356,8 @@ func TestAuthorizeWithJWTClaims_CustomGroupClaimName(t *testing.T) {
 // TestAuthorizeWithJWTClaims_UpstreamProviderWithGroups verifies the end-to-end
 // path where PrimaryUpstreamProvider is set AND the Cedar policy uses group-based
 // authorization (principal in THVGroup::"..."). Groups must be extracted from the
-// upstream token's claims, not from the ToolHive-issued token.
+// pinned provider's own tokens — its access token, or its id_token for the claims
+// that access token omits (#6049) — and never from the ToolHive-issued token.
 func TestAuthorizeWithJWTClaims_UpstreamProviderWithGroups(t *testing.T) {
 	t.Parallel()
 
@@ -2339,6 +2449,83 @@ func TestAuthorizeWithJWTClaims_UpstreamProviderWithGroups(t *testing.T) {
 					// Upstream token has no groups.
 					providerName: makeUnsignedJWT(jwt.MapClaims{
 						"sub": "upstream-user",
+					}),
+				},
+			},
+			wantAuthorize: false,
+		},
+		{
+			// #6049: the upstream asserts group membership in its id_token only —
+			// common where groups are a profile-scope claim. This denied for every
+			// user before that change; it is the grant the change exists to make.
+			name: "id_token_groups_authorize_when_the_access_token_omits_them",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims:  map[string]any{"sub": "thv-user"},
+				},
+				UpstreamTokens: map[string]string{
+					providerName: makeUnsignedJWT(jwt.MapClaims{
+						"sub": "upstream-user",
+					}),
+				},
+				UpstreamIDTokens: map[string]string{
+					providerName: makeUnsignedJWT(jwt.MapClaims{
+						"sub":    "upstream-user",
+						"groups": []interface{}{"platform-eng", "devs"},
+					}),
+				},
+			},
+			wantAuthorize: true,
+		},
+		{
+			// Precedence: the access token's group list is used verbatim, so a
+			// provider whose access token withholds the permitted group still denies
+			// even though its id_token asserts it. Fill-only, never union.
+			name: "access_token_groups_win_over_different_id_token_groups",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims:  map[string]any{"sub": "thv-user"},
+				},
+				UpstreamTokens: map[string]string{
+					providerName: makeUnsignedJWT(jwt.MapClaims{
+						"sub":    "upstream-user",
+						"groups": []interface{}{"marketing"},
+					}),
+				},
+				UpstreamIDTokens: map[string]string{
+					providerName: makeUnsignedJWT(jwt.MapClaims{
+						"sub":    "upstream-user",
+						"groups": []interface{}{"platform-eng"},
+					}),
+				},
+			},
+			wantAuthorize: false,
+		},
+		{
+			// The security invariant #6049 must not weaken, retested with the
+			// id_token path live: opening the id_token as a group source did not open
+			// the ToolHive-issued token. The issued token names the permitted group,
+			// the pinned upstream names none in either of its tokens, so this denies.
+			name: "toolhive_groups_still_ignored_when_an_id_token_is_present",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims: map[string]any{
+						"sub":    "thv-user",
+						"groups": []interface{}{"platform-eng"},
+					},
+				},
+				UpstreamTokens: map[string]string{
+					providerName: makeUnsignedJWT(jwt.MapClaims{
+						"sub": "upstream-user",
+					}),
+				},
+				UpstreamIDTokens: map[string]string{
+					providerName: makeUnsignedJWT(jwt.MapClaims{
+						"sub":    "upstream-user",
+						"groups": []interface{}{"marketing"},
 					}),
 				},
 			},

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -1573,17 +1573,49 @@ func TestSupplementFromIDTokenClaims(t *testing.T) {
 			idTokenClaims: jwt.MapClaims{
 				"groups": []interface{}{"platform-eng"},
 				"roles":  []interface{}{"admin"},
-				"scope":  "tools:write",
 				"hd":     "example.com",
 			},
 			wantMerged: jwt.MapClaims{
 				"sub":    "okta|alice",
 				"groups": []interface{}{"platform-eng"},
 				"roles":  []interface{}{"admin"},
-				"scope":  "tools:write",
 				"hd":     "example.com",
 			},
-			wantFilled: []string{"groups", "hd", "roles", "scope"},
+			wantFilled: []string{"groups", "hd", "roles"},
+		},
+		{
+			// The deliberate split within "authorization-bearing": a group is a fact
+			// about the USER, which either token reports equally well, whereas a scope
+			// is the authority THIS TOKEN carries — and only the presented access
+			// token's authority is at issue. A provider emitting `scope` in an id_token
+			// (non-standard) may be echoing what was REQUESTED rather than granted, and
+			// granular consent makes requested-minus-granted routine, so supplementing
+			// it could satisfy a scope gate on authority the access token lacks.
+			// Unlike a group claim name, `scope`/`scp` are standardized names, so
+			// excluding them by name is effective rather than cosmetic.
+			name:              "delegated_scope_claims_are_never_filled_from_the_id_token",
+			accessTokenClaims: jwt.MapClaims{"sub": "okta|alice"},
+			idTokenClaims: jwt.MapClaims{
+				"scope": "tools:write tools:read",
+				"scp":   []interface{}{"Mail.ReadWrite"},
+			},
+			wantMerged: jwt.MapClaims{"sub": "okta|alice"},
+			wantFilled: nil,
+		},
+		{
+			// And an access token that does assert a scope keeps its own, so the
+			// id_token can neither supply nor broaden the delegated grant.
+			name: "access_token_scope_is_not_broadened_by_the_id_token",
+			accessTokenClaims: jwt.MapClaims{
+				"sub": "okta|alice", "scp": []interface{}{"Mail.Read"},
+			},
+			idTokenClaims: jwt.MapClaims{
+				"scp": []interface{}{"Mail.Read", "Mail.ReadWrite", "Files.ReadWrite.All"},
+			},
+			wantMerged: jwt.MapClaims{
+				"sub": "okta|alice", "scp": []interface{}{"Mail.Read"},
+			},
+			wantFilled: nil,
 		},
 		{
 			// A custom namespaced group claim, the shape GroupClaimName exists for.
@@ -1799,9 +1831,11 @@ func TestResolveClaimsUpstreamSupplement(t *testing.T) {
 				"hd":                         "example.com",
 				"https://hub.example.com/ou": "infra",
 				// Token-describing claims are withheld even now that the id_token is
-				// a general claim source.
-				"aud": "toolhive-as-client",
-				"sid": "sess-abc",
+				// a general claim source, and so is the delegated grant.
+				"aud":   "toolhive-as-client",
+				"sid":   "sess-abc",
+				"scope": "tools:write",
+				"scp":   []interface{}{"Mail.ReadWrite"},
 			}),
 			requestClaims: asIssuedClaims,
 			wantClaims: jwt.MapClaims{
@@ -2007,6 +2041,113 @@ func TestAuthorizeWithJWTClaims_UpstreamJWTMissingIdentityClaim(t *testing.T) {
 				},
 				UpstreamTokens:   map[string]string{providerName: upstreamToken},
 				UpstreamIDTokens: map[string]string{providerName: makeUnsignedJWT(tt.idTokenClaims)},
+			}
+			ctx := auth.WithIdentity(context.Background(), identity)
+
+			authorized, err := authorizer.AuthorizeWithJWTClaims(
+				ctx,
+				authorizers.MCPFeatureTool,
+				authorizers.MCPOperationCall,
+				"deploy",
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAuthorize, authorized)
+		})
+	}
+}
+
+// TestAuthorizeWithJWTClaims_ScopeStaysAccessTokenSourced pins the one claim
+// category #6049 deliberately did NOT open up. Group and role claims are facts
+// about the user, so either of the provider's tokens may report them; `scope`/`scp`
+// assert the authority a token carries, and only the presented access token's
+// authority is at issue. A provider that emits `scope` in an id_token (non-standard)
+// may be echoing what the client REQUESTED rather than what the user granted —
+// granular consent makes requested-minus-granted routine — so supplementing it
+// would let a scope gate match authority the access token does not carry.
+//
+// This is the sharpest available shape: an exact-element `claimset_scp` gate, which
+// is what the MultiValuedClaims documentation steers scope policies towards.
+func TestAuthorizeWithJWTClaims_ScopeStaysAccessTokenSourced(t *testing.T) {
+	t.Parallel()
+
+	const providerName = "hub"
+
+	authorizer, err := NewCedarAuthorizer(ConfigOptions{
+		Policies: []string{
+			`permit(principal, action == Action::"call_tool", resource)
+			 when { context has claimset_scp && context.claimset_scp.contains("Mail.ReadWrite") };`,
+		},
+		EntitiesJSON:            `[]`,
+		PrimaryUpstreamProvider: providerName,
+		MultiValuedClaims:       []string{"scp"},
+	}, "")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		accessTokenClaims jwt.MapClaims
+		idTokenClaims     jwt.MapClaims
+		wantAuthorize     bool
+	}{
+		{
+			// The access token carries the scope, so the gate matches. This is the
+			// only source that can ever satisfy it.
+			name: "access_token_scope_permits",
+			accessTokenClaims: jwt.MapClaims{
+				"sub": "hub|alice", "scp": []interface{}{"Mail.ReadWrite"},
+			},
+			idTokenClaims: jwt.MapClaims{"sub": "hub|alice"},
+			wantAuthorize: true,
+		},
+		{
+			// The guard. The access token asserts no scope at all and the id_token
+			// asserts the gated one; the request must still be denied rather than
+			// borrowing authority from the wrong token.
+			name:              "id_token_scope_does_not_permit",
+			accessTokenClaims: jwt.MapClaims{"sub": "hub|alice"},
+			idTokenClaims: jwt.MapClaims{
+				"sub": "hub|alice", "scp": []interface{}{"Mail.ReadWrite"},
+			},
+			wantAuthorize: false,
+		},
+		{
+			// The downscoped-consent shape: the client asked for Mail.ReadWrite and
+			// the user granted only Mail.Read, so the access token is narrower than
+			// whatever the id_token echoes. Fill-only precedence is not enough on its
+			// own here — `scp` is present, so nothing would be filled — but this pins
+			// that the narrower granted scope is what policy sees.
+			name: "access_token_scope_is_not_broadened_by_the_id_token",
+			accessTokenClaims: jwt.MapClaims{
+				"sub": "hub|alice", "scp": []interface{}{"Mail.Read"},
+			},
+			idTokenClaims: jwt.MapClaims{
+				"sub": "hub|alice", "scp": []interface{}{"Mail.Read", "Mail.ReadWrite"},
+			},
+			wantAuthorize: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			identity := &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					// The issued token names the gated scope too, and must likewise
+					// grant nothing.
+					Claims: map[string]any{
+						"sub": "thv-user",
+						"scp": []interface{}{"Mail.ReadWrite"},
+					},
+				},
+				UpstreamTokens: map[string]string{
+					providerName: makeUnsignedJWT(tt.accessTokenClaims),
+				},
+				UpstreamIDTokens: map[string]string{
+					providerName: makeUnsignedJWT(tt.idTokenClaims),
+				},
 			}
 			ctx := auth.WithIdentity(context.Background(), identity)
 

--- a/pkg/authz/integration_test.go
+++ b/pkg/authz/integration_test.go
@@ -970,8 +970,10 @@ func TestIntegrationTransitiveGroupHierarchy(t *testing.T) {
 }
 
 // TestIntegrationUpstreamProviderGroupAuth verifies that when
-// PrimaryUpstreamProvider is configured, group extraction uses the upstream
-// token's claims — not the direct request claims — through the full middleware.
+// PrimaryUpstreamProvider is configured, group extraction uses the pinned
+// provider's own tokens — its access token, or its id_token for the claims that
+// access token omits (#6049) — and never the direct request claims, through the
+// full middleware.
 func TestIntegrationUpstreamProviderGroupAuth(t *testing.T) {
 	t.Parallel()
 
@@ -991,7 +993,10 @@ func TestIntegrationUpstreamProviderGroupAuth(t *testing.T) {
 		name          string
 		directClaims  jwt.MapClaims
 		upstreamToken string
-		expectAllowed bool
+		// upstreamIDToken is the pinned provider's stored id_token. Empty means the
+		// provider has none stored (an OAuth 2.0 upstream never asked for `openid`).
+		upstreamIDToken string
+		expectAllowed   bool
 	}{
 		{
 			name:         "upstream_groups_authorize",
@@ -1012,12 +1017,47 @@ func TestIntegrationUpstreamProviderGroupAuth(t *testing.T) {
 			expectAllowed: false,
 		},
 		{
+			// #6049 through the full middleware: the pinned upstream asserts group
+			// membership in its id_token only, so the resolved claim set had no
+			// `groups` key and tools/call returned 403 for every user.
+			name:         "upstream_id_token_groups_authorize",
+			directClaims: jwt.MapClaims{"sub": "thv-user"},
+			upstreamToken: makeUnsignedJWT(t, jwt.MapClaims{
+				"sub": "upstream-user",
+			}),
+			upstreamIDToken: makeUnsignedJWT(t, jwt.MapClaims{
+				"sub":    "upstream-user",
+				"groups": []interface{}{"platform-eng"},
+			}),
+			expectAllowed: true,
+		},
+		{
 			name: "direct_groups_ignored_when_upstream_configured",
 			directClaims: jwt.MapClaims{
 				"sub":    "thv-user",
 				"groups": []interface{}{"platform-eng"},
 			},
 			upstreamToken: makeUnsignedJWT(t, jwt.MapClaims{
+				"sub":    "upstream-user",
+				"groups": []interface{}{"other"},
+			}),
+			expectAllowed: false,
+		},
+		{
+			// The same invariant with the #6049 id_token path live: opening the
+			// pinned provider's id_token as a group source did not open the
+			// ToolHive-issued token. Neither of the provider's own tokens names the
+			// permitted group, so the request stays 403 even though the token the
+			// client presented does.
+			name: "direct_groups_still_ignored_when_an_id_token_is_present",
+			directClaims: jwt.MapClaims{
+				"sub":    "thv-user",
+				"groups": []interface{}{"platform-eng"},
+			},
+			upstreamToken: makeUnsignedJWT(t, jwt.MapClaims{
+				"sub": "upstream-user",
+			}),
+			upstreamIDToken: makeUnsignedJWT(t, jwt.MapClaims{
 				"sub":    "upstream-user",
 				"groups": []interface{}{"other"},
 			}),
@@ -1046,6 +1086,9 @@ func TestIntegrationUpstreamProviderGroupAuth(t *testing.T) {
 					Claims:  tt.directClaims,
 				},
 				UpstreamTokens: map[string]string{providerName: tt.upstreamToken},
+			}
+			if tt.upstreamIDToken != "" {
+				identity.UpstreamIDTokens = map[string]string{providerName: tt.upstreamIDToken}
 			}
 			httpReq = httpReq.WithContext(auth.WithIdentity(httpReq.Context(), identity))
 


### PR DESCRIPTION
## Summary

Cedar read group and role claims from the pinned upstream's **access token** only, so a
provider that asserts group membership in its `id_token` produced an empty group set
and every `principal in THVGroup::"..."` policy denied for every user, with no
diagnostic beyond the `has` guard failing. Same shape as #5916 — a claim the upstream
does assert, in a token ToolHive already holds, that the authorizer never looked at.

`profileClaimsFromIDToken = {name, email}` is replaced by
`idTokenClaimsNeverSupplemented`, a closed spec-derived deny-list; every other claim
the pinned provider's `id_token` asserts is now admitted, still fill-only (the access
token always wins).

Fixes #6049

**Two things need a maintainer decision rather than my say-so — please read
"Special notes" before approving:** this is wider than the issue scoped (an allow-list
became a deny-list), and it makes group-revocation latency session-scoped for
id_token-sourced groups.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [ ] E2E tests (`task test-e2e`)

`task lint-fix` 0 issues; codespell clean over all 5 changed files;
`go test -race -count=1 ./pkg/authz/... ./pkg/auth/...` green; `task test` shows only
three failures that are pre-existing sandbox limitations (`pkg/api`
`TestNewServer_ReadTimeoutConfigured` and `TestSecurityHeaders` — no container runtime;
`pkg/secrets/keyring` `TestCompositeProvider_RealProviders` — no keyring).

Two negative controls, because tests for a change that *grants* access have to prove
the grant rather than describe it:

- Reverting the deny-list to the old `{name, email}` semantics fails **8** subtests,
  including both grant paths. Critically, the three security invariants pass
  **identically in both configurations** — so they bound the boundary rather than
  merely exercising the new code: `toolhive_groups_ignored_when_upstream_configured`,
  `direct_groups_ignored_when_upstream_configured`,
  `id_token_registered_claims_are_never_filled_or_overwritten`, and
  `TestAuthorizeWithJWTClaims_PrincipalStaysUpstreamSourced`.
- Deleting the single `"scope": {}, "scp": {}` deny-list line fails exactly three
  subtests, so that exclusion is load-bearing rather than decorative.

## Does this introduce a user-facing change?

Yes — it grants access that is currently denied. Only where `primaryUpstreamProvider`
is set, the pinned provider has a stored `id_token`, and the claim is one its **access
token omits entirely**:

1. Requests denied by a `THVGroup`/`GroupEntityType` policy because the provider
   asserts groups in the id_token only — `tools/list` goes from empty to populated,
   `tools/call` from 403 to 200. The widest case, and the reported one.
2. The same for `RoleClaimName`, `cognito:groups`, and URI-style group claims.
3. `has`-guarded gates on `hd`, `email_verified`, `acr`/`amr`/`auth_time` and custom
   user claims the provider puts in the id_token only.

Unchanged: `primaryUpstreamProvider` empty; the opaque-token branch; any claim the
access token already asserts (fill-only); providers with no stored id_token; group,
role **and scope** claims on the ToolHive-issued token (still grant nothing); the
principal; and the 15 token-describing claims. One direction can tighten rather than
loosen — a `forbid`/`unless` policy keyed on a claim being *absent* would now deny
where the id_token supplies it; no realistic example was constructible, since `unless`
gates in this codebase test presence, but it belongs in the release note.

## Special notes for reviewers

**1. The scope expansion — why an allow-list was replaced rather than extended.** An
allow-list provably cannot work here: the claim carrying group membership is named by
the deployment (`GroupClaimName`/`RoleClaimName`) or by the IdP (Auth0/Okta URI-style
names), so any fixed list denies silently for names ToolHive does not choose — the
defect shape of both #5916 and #6049. Config-derived would cover the two configured
names and still miss the well-known defaults' relatives, `hd`, and per-tenant
organization claims, guaranteeing a third round.

The shorter argument for why a deny-list is *safe*: `resolveClaims` already admits
**every** claim of the upstream access token with no allow-list at all. An allow-list
applied to the id_token alone was therefore an asymmetry between two tokens at the
same trust level from the same provider — not a boundary being held. Inverting restores
parity rather than widening a trust boundary.

**2. Precedence is fill-only, deliberately not union.** Union looked attractive for
set-valued claims and is unsafe in the direction that matters: per-application claim
filtering (Okta group filters, Entra group-claim config) is applied when a token is
minted for a given audience, so the access token's group list is the provider's answer
to "which of this user's groups are relevant to *this* resource server". Unioning the
id_token's list — minted for ToolHive's own auth-server client — would restore groups
the provider deliberately withheld from this audience. Fill-only can only ever supply
a claim the provider left entirely absent; it can never contradict or extend one.

**3. `scope`/`scp` are excluded, and this is the one place parity does not hold.**
Parity between the two tokens holds for claims about the **user**; a claim asserting
what a token may **do** is not symmetric between them. Concretely, granular and
incremental consent (Google granular permissions, Entra incremental consent) make
requested-minus-granted the normal case, and an id_token is minted from the
authorization *request*: client asks for `Mail.ReadWrite`, user grants only
`Mail.Read`, the access token carries the narrower grant, and supplementing would let
a `claimset_scp.containsAny("Mail.ReadWrite")` gate match authority the user
explicitly declined. Note this reverses an earlier position in this series — a prior
test named `scope` alongside `groups` as authorization-bearing — so it is a deliberate
change of stance, and `TestAuthorizeWithJWTClaims_ScopeStaysAccessTokenSourced`
includes the downscoped-consent case.

**4. Group revocation latency becomes session-scoped for id_token-sourced groups —
this is the trade-off to weigh.** Access tokens are refreshed, so a group revoked
upstream propagates within an access-token lifetime. A stored id_token is replaced only
when a refresh happens to rotate one, and is deliberately used past `exp` (see
`Identity.UpstreamIDTokens`), so a revoked group can keep granting until the session
ends — `refreshTokenLifespan`, 7 days by default. Enforcing `exp` is not the remedy: it
would flip permit→deny mid-session for every user, not only the revoked one. The
remedies are to assert groups in the access token, or shorten `refreshTokenLifespan`.
The affected deployments currently deny *everything*, so this is
broken→works-with-stale-groups rather than a regression — but it is a real change in
security posture and the call is yours. It is a ⚠️ callout in the operator guide rather
than prose.

This also corrects a claim I wrote in #6036: `Identity.UpstreamIDTokens` said the
id_token's claims are "no staler than the alternative, since the profile claims
mirrored into the ToolHive-issued token are likewise captured once at login". True for
`email`; false for groups, because there is no issued-token alternative for those.

**Interaction with #6052** (issue #6048): both touch `resolveClaims`, but the only edit
here is its doc comment — the `!looksLikeJWT` branch body is byte-identical to main —
so whichever lands second needs a comment-block rebase only. If #6052 lands first, its
opaque branch inherits this deny-list automatically, which is the intended coupling:
both branches widen together as one release decision.

Generated with [Claude Code](https://claude.com/claude-code)