### PR TITLE
Emit conformant JSON-RPC on denial and error paths

### DIFF
--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -145,8 +145,8 @@ func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
 	}
 
 	// Create a JSON-RPC error response
-	id, err := mcp.ConvertToJSONRPC2ID(msgID)
-	if err != nil {
+	id, convErr := mcp.ConvertToJSONRPC2ID(msgID)
+	if convErr != nil {
 		id = jsonrpc2.ID{} // Use empty ID if conversion fails
 	}
 
@@ -155,15 +155,21 @@ func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
 		Error: jsonrpc2.NewError(mcp.JSONRPCCodeDenied, errorMsg),
 	}
 
-	// Set the response headers
+	// Encode before writing any header, so a marshal failure never leaves a
+	// half-written response (e.g. a 403 header followed by a second 500 write).
+	body, encErr := jsonrpc2.EncodeMessage(errorResponse)
+	if encErr != nil {
+		// Unreachable in practice: errorResponse is always a well-formed
+		// jsonrpc2.Response built from strings/ints above. Fall back to a
+		// hardcoded valid JSON-RPC error body rather than writing nothing.
+		slog.Error("failed to encode JSON-RPC unauthorized response", "error", encErr)
+		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, mcp.JSONRPCCodeDenied)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusForbidden)
-
-	// Write the error response
-	if err := json.NewEncoder(w).Encode(errorResponse); err != nil {
-		// If we can't encode the error response, log it and return a simple error
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-	}
+	//nolint:gosec // G104: writing the JSON-RPC denial body to an HTTP client; nothing to do on error
+	_, _ = w.Write(body)
 }
 
 // Middleware creates an HTTP middleware that authorizes MCP requests.

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -1249,8 +1249,8 @@ func TestMiddlewareOptimizerCallToolJSONRoundTrip(t *testing.T) {
 // authorization) for a denied request and asserts the 403 body is a spec-conformant
 // JSON-RPC error response: lowercase "jsonrpc"/"id"/"error" keys and, for notifications,
 // no "id" key at all. assert.JSONEq is case-sensitive, so it alone would catch "ID"/"Error"
-// substituted for "id"/"error" — the id-presence check is asserted separately since JSONEq
-// on a body that's missing "id" doesn't distinguish "absent" from "any other value".
+// substituted for "id"/"error" and would fail on an unexpected "id" key — the id-presence
+// check is asserted separately anyway, as a belt-and-braces, self-documenting assertion.
 func TestHandleUnauthorizedIsConformantJSONRPC(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -1245,6 +1245,87 @@ func TestMiddlewareOptimizerCallToolJSONRoundTrip(t *testing.T) {
 	assert.True(t, handlerCalled, "handler should be called for authorized call_tool")
 }
 
+// TestHandleUnauthorizedIsConformantJSONRPC drives the real middleware chain (parsing +
+// authorization) for a denied request and asserts the 403 body is a spec-conformant
+// JSON-RPC error response: lowercase "jsonrpc"/"id"/"error" keys and, for notifications,
+// no "id" key at all. assert.JSONEq is case-sensitive, so it alone would catch "ID"/"Error"
+// substituted for "id"/"error" — the id-presence check is asserted separately since JSONEq
+// on a body that's missing "id" doesn't distinguish "absent" from "any other value".
+func TestHandleUnauthorizedIsConformantJSONRPC(t *testing.T) {
+	t.Parallel()
+
+	// The policy content is irrelevant: tasks/list is unknown to
+	// MCPMethodToFeatureOperation and denied before any policy is consulted. If a
+	// future PR adds authorization for tasks/* and this test starts failing, swap
+	// in any other method still absent from that map rather than reading it as an
+	// envelope regression.
+	authorizer, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{
+		Policies:     []string{`permit(principal, action == Action::"call_tool", resource == Tool::"weather");`},
+		EntitiesJSON: `[]`,
+	}, "")
+	require.NoError(t, err)
+
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("next handler must not be called for a denied request")
+	})
+	middleware := mcpparser.ParsingMiddleware(Middleware(authorizer, handler, nil))
+
+	const wantErr = `"error":{"code":403,"message":"unknown MCP method: tasks/list (not configured for authorization)"}`
+
+	testCases := []struct {
+		name      string
+		reqIDJSON string // raw "id" field in the request; "" omits it (notification)
+		wantBody  string
+	}{
+		{
+			name:      "int64 id",
+			reqIDJSON: `"id":42,`,
+			wantBody:  `{"jsonrpc":"2.0","id":42,` + wantErr + `}`,
+		},
+		{
+			name:      "string id",
+			reqIDJSON: `"id":"abc",`,
+			wantBody:  `{"jsonrpc":"2.0","id":"abc",` + wantErr + `}`,
+		},
+		{
+			name:      "nil id (notification) omits id entirely",
+			reqIDJSON: "",
+			wantBody:  `{"jsonrpc":"2.0",` + wantErr + `}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			reqBody := `{"jsonrpc":"2.0",` + tc.reqIDJSON + `"method":"tasks/list"}`
+			req, err := http.NewRequest(http.MethodPost, "/messages", bytes.NewBufferString(reqBody))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{
+				Subject: "test-user",
+				Claims:  jwt.MapClaims{"sub": "test-user"},
+			}}
+			req = req.WithContext(auth.WithIdentity(req.Context(), identity))
+
+			rr := httptest.NewRecorder()
+			middleware.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusForbidden, rr.Code)
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			assert.JSONEq(t, tc.wantBody, rr.Body.String())
+
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &decoded))
+			_, hasID := decoded["id"]
+			assert.Equal(t, tc.reqIDJSON != "", hasID, "id key presence mismatch")
+			_, hasResult := decoded["result"]
+			assert.False(t, hasResult, "denied response must not contain a result key")
+		})
+	}
+}
+
 // TestConvertToJSONRPC2ID tests the convertToJSONRPC2ID function with various ID types
 func TestConvertToJSONRPC2ID(t *testing.T) {
 	t.Parallel()

--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/optimizer"
 	"github.com/stacklok/toolhive/pkg/vmcp/session/optimizerdec"
 )
@@ -140,7 +141,7 @@ func (rfw *ResponseFilteringWriter) processJSONResponse(rawResponse []byte) erro
 		if carriesResult(rawResponse) {
 			slog.Warn("JSON response carried a result outside a clean Response frame; dropping as a protocol violation",
 				"method", rfw.method)
-			return rfw.writeErrorResponse(jsonrpc2.ID{},
+			return rfw.writeErrorResponse(rfw.requestID(),
 				fmt.Errorf("dropped a frame carrying a result outside a clean Response"))
 		}
 		rfw.ResponseWriter.WriteHeader(rfw.statusCode)
@@ -532,17 +533,36 @@ func (rfw *ResponseFilteringWriter) writeErrorResponse(id jsonrpc2.ID, err error
 		Error: jsonrpc2.NewError(500, fmt.Sprintf("Error filtering response: %v", err)),
 	}
 
-	errorData, marshalErr := json.Marshal(errorResponse)
-	if marshalErr != nil {
-		// If we can't even marshal the error, write a simple error
-		rfw.ResponseWriter.WriteHeader(http.StatusInternalServerError)
-		_, writeErr := rfw.ResponseWriter.Write([]byte(`{"error": "Internal server error"}`))
-		return writeErr
+	// Encode before writing any header, so an encode failure never leaves a
+	// half-written response.
+	body, encErr := jsonrpc2.EncodeMessage(errorResponse)
+	if encErr != nil {
+		// Unreachable in practice: errorResponse is always a well-formed
+		// jsonrpc2.Response built from a valid ID and message above. Fall back
+		// to a hardcoded valid JSON-RPC error body rather than writing nothing.
+		slog.Error("failed to encode JSON-RPC error response", "error", encErr)
+		body = []byte(`{"jsonrpc":"2.0","error":{"code":500,"message":"Internal server error"}}`)
 	}
 
 	rfw.ResponseWriter.WriteHeader(http.StatusInternalServerError)
-	_, writeErr := rfw.ResponseWriter.Write(errorData)
+	_, writeErr := rfw.ResponseWriter.Write(body)
 	return writeErr
+}
+
+// requestID recovers the JSON-RPC id of the original request so an error
+// response written mid-filtering can still be correlated by the client.
+// Falls back to an empty jsonrpc2.ID (which EncodeMessage omits from the
+// wire entirely) if the request was never parsed or its id doesn't convert.
+func (rfw *ResponseFilteringWriter) requestID() jsonrpc2.ID {
+	parsed := mcpparser.GetParsedMCPRequest(rfw.request.Context())
+	if parsed == nil {
+		return jsonrpc2.ID{}
+	}
+	id, err := mcpparser.ConvertToJSONRPC2ID(parsed.ID)
+	if err != nil {
+		return jsonrpc2.ID{}
+	}
+	return id
 }
 
 // filterFindToolResponse filters the tools list embedded in a find_tool tools/call

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -1138,6 +1138,11 @@ func TestResponseFilteringWriter_SSE_DisguisedResponseFrame(t *testing.T) {
 // TestResponseFilteringWriter_JSON_DisguisedResponseFrame is the application/json
 // counterpart: the disguised-result bypass is transport-independent, so the JSON
 // path must also fail closed on a smuggled result rather than write it through.
+//
+// It also pins the writeErrorResponse envelope: the error body written on this
+// path must be conformant JSON-RPC (lowercase "jsonrpc"/"id"/"error" keys, no
+// "id" key for a notification) and must carry the *original request's* id, not
+// an empty one, so the client can still correlate the denial.
 func TestResponseFilteringWriter_JSON_DisguisedResponseFrame(t *testing.T) {
 	t.Parallel()
 
@@ -1156,20 +1161,83 @@ func TestResponseFilteringWriter_JSON_DisguisedResponseFrame(t *testing.T) {
 
 	// A batch array smuggling a tools/list result. DecodeMessage rejects the
 	// array, so the pre-fix JSON path wrote it through raw.
-	smuggled := `[{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"admin_tool"}]}}]`
+	const smuggled = `[{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"admin_tool"}]}}]`
 
-	req, err := http.NewRequest(http.MethodPost, "/messages", nil)
-	require.NoError(t, err)
-	req = req.WithContext(auth.WithIdentity(req.Context(), identity))
+	// writeErrorResponse wraps the carriesResult error message with a fixed
+	// prefix and reports code 500 — an HTTP status, not a JSON-RPC error code.
+	// This test pins that current behavior; it does not assert the code is
+	// correct.
+	const wantErr = `"error":{"code":500,"message":"Error filtering response: ` +
+		`dropped a frame carrying a result outside a clean Response"}`
 
-	rr := httptest.NewRecorder()
-	rfw := NewResponseFilteringWriter(rr, authorizer, req, string(mcp.MethodToolsList), nil, nil)
-	rfw.ResponseWriter.Header().Set("Content-Type", "application/json")
+	testCases := []struct {
+		name      string
+		reqIDJSON string // raw "id" field on the *incoming* request; "" omits it (notification)
+		wantIDKey string // expected "id" fragment in the error envelope; "" if id must be absent
+	}{
+		{
+			name:      "int id is recovered onto the error envelope",
+			reqIDJSON: `"id":42,`,
+			wantIDKey: `"id":42,`,
+		},
+		{
+			name:      "string id is recovered onto the error envelope",
+			reqIDJSON: `"id":"abc",`,
+			wantIDKey: `"id":"abc",`,
+		},
+		{
+			name:      "notification (no id) omits id entirely",
+			reqIDJSON: "",
+			wantIDKey: "",
+		},
+	}
 
-	_, err = rfw.Write([]byte(smuggled))
-	require.NoError(t, err)
-	require.NoError(t, rfw.FlushAndFilter())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	assert.NotContains(t, rr.Body.String(), "admin_tool",
-		"smuggled result on the application/json transport leaked past the filter")
+			reqBody := `{"jsonrpc":"2.0",` + tc.reqIDJSON + `"method":"tools/list"}`
+			req, err := http.NewRequest(http.MethodPost, "/messages", strings.NewReader(reqBody))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req = req.WithContext(auth.WithIdentity(req.Context(), identity))
+
+			// Run the real MCP parsing middleware so the request context carries a
+			// ParsedMCPRequest, matching how the request would look at this point
+			// in the real middleware chain. writeErrorResponse's id-recovery path
+			// reads the request id back out of that context.
+			var parsedReq *http.Request
+			mcpparser.ParsingMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				parsedReq = r
+			})).ServeHTTP(httptest.NewRecorder(), req)
+			require.NotNil(t, parsedReq)
+
+			rr := httptest.NewRecorder()
+			rfw := NewResponseFilteringWriter(rr, authorizer, parsedReq, string(mcp.MethodToolsList), nil, nil)
+			rfw.ResponseWriter.Header().Set("Content-Type", "application/json")
+
+			_, err = rfw.Write([]byte(smuggled))
+			require.NoError(t, err)
+			require.NoError(t, rfw.FlushAndFilter())
+
+			assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+			body := rr.Body.String()
+			assert.NotContains(t, body, "admin_tool",
+				"smuggled result on the application/json transport leaked past the filter")
+
+			// assert.JSONEq is key-case-sensitive, so this single assertion catches
+			// "Error"/"ID" substituted for "error"/"id" (the historical bug), a
+			// missing "jsonrpc" tag, and a wrong or missing id all at once.
+			wantBody := `{"jsonrpc":"2.0",` + tc.wantIDKey + wantErr + `}`
+			assert.JSONEq(t, wantBody, body)
+
+			var decoded map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &decoded))
+			_, hasID := decoded["id"]
+			assert.Equal(t, tc.wantIDKey != "", hasID, "id key presence mismatch")
+			_, hasResult := decoded["result"]
+			assert.False(t, hasResult, "error response must not contain a result key")
+		})
+	}
 }

--- a/pkg/webhook/mutating/middleware.go
+++ b/pkg/webhook/mutating/middleware.go
@@ -316,9 +316,6 @@ func readSourceIP(r *http.Request) string {
 }
 
 func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, msgID interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-
 	id, err := mcp.ConvertToJSONRPC2ID(msgID)
 	if err != nil {
 		id = jsonrpc2.ID{} // Use empty ID if conversion fails.
@@ -329,5 +326,20 @@ func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, ms
 		ID:    id,
 		Error: jsonrpc2.NewError(int64(statusCode), message),
 	}
-	_ = json.NewEncoder(w).Encode(errResp)
+
+	// Encode before writing any header, so an encode failure never leaves a
+	// half-written response (e.g. a status header followed by a second write).
+	body, encErr := jsonrpc2.EncodeMessage(errResp)
+	if encErr != nil {
+		// Unreachable in practice: errResp is always a well-formed jsonrpc2.Response
+		// built from strings/ints above. Fall back to a hardcoded valid JSON-RPC
+		// error body rather than writing nothing.
+		slog.Error("failed to encode JSON-RPC error response", "error", encErr)
+		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, statusCode)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	//nolint:gosec // G104: writing the JSON-RPC denial body to an HTTP client; nothing to do on error
+	_, _ = w.Write(body)
 }

--- a/pkg/webhook/mutating/middleware_test.go
+++ b/pkg/webhook/mutating/middleware_test.go
@@ -50,7 +50,7 @@ func makeMCPRequest(tb testing.TB, body []byte) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
 	parsedMCP := &mcp.ParsedMCPRequest{
 		Method: "tools/call",
-		ID:     float64(1),
+		ID:     int64(1),
 	}
 	ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, parsedMCP)
 	req = req.WithContext(ctx)
@@ -405,6 +405,65 @@ func TestMutatingMiddleware_SkipNonMCPRequests(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
+// TestMutatingMiddlewareDenialIsConformantJSONRPC pins the sendErrorResponse envelope on
+// the wire: lowercase "jsonrpc"/"id"/"error" keys, no "id" key for a notification, and no
+// "result" key. assert.JSONEq is case-sensitive, so a single assertion catches "Error"/"ID"
+// substituted for "error"/"id" (the historical bug) alongside a missing "jsonrpc" tag.
+func TestMutatingMiddlewareDenialIsConformantJSONRPC(t *testing.T) {
+	t.Parallel()
+
+	// Deterministic denial: the webhook always disallows, driving sendErrorResponse
+	// through the real middleware chain rather than constructing the response by hand.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(webhook.MutatingResponse{
+			Response: webhook.Response{Version: webhook.APIVersion, UID: "resp-uid", Allowed: false},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := makeConfig(server.URL, webhook.FailurePolicyFail)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
+
+	const wantErr = `"error":{"code":403,"message":"Request denied by webhook policy"}`
+
+	testCases := []struct {
+		name     string
+		id       interface{} // ParsedMCPRequest.ID; nil for a notification
+		wantBody string
+	}{
+		{name: "int64 id", id: int64(42), wantBody: `{"jsonrpc":"2.0","id":42,` + wantErr + `}`},
+		{name: "string id", id: "abc", wantBody: `{"jsonrpc":"2.0","id":"abc",` + wantErr + `}`},
+		{name: "nil id (notification) omits id entirely", id: nil, wantBody: `{"jsonrpc":"2.0",` + wantErr + `}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{"jsonrpc":"2.0","method":"tools/call"}`)))
+			ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: tc.id})
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatal("next handler must not be called for a denied request")
+			})).ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusForbidden, rr.Code)
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			assert.JSONEq(t, tc.wantBody, rr.Body.String())
+
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &decoded))
+			_, hasID := decoded["id"]
+			assert.Equal(t, tc.id != nil, hasID, "id key presence mismatch")
+			_, hasResult := decoded["result"]
+			assert.False(t, hasResult, "denied response must not contain a result key")
+		})
+	}
+}
+
 // makeJSONBodyOfSize builds a syntactically-valid JSON body of exactly `size`
 // bytes by padding the value of a "data" field with ASCII characters. The
 // resulting bytes are valid JSON-RPC for use as an MCP request body.
@@ -435,7 +494,7 @@ func TestMutatingMiddleware_RequestBodySizeLimit(t *testing.T) {
 
 		body := makeJSONBodyOfSize(t, webhook.MaxRequestSize+1)
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
-		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: 1})
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: int64(1)})
 		req = req.WithContext(ctx)
 
 		var nextCalled bool
@@ -449,7 +508,7 @@ func TestMutatingMiddleware_RequestBodySizeLimit(t *testing.T) {
 
 		var errResp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
-		errObj, ok := errResp["Error"].(map[string]interface{})
+		errObj, ok := errResp["error"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Equal(t, float64(http.StatusRequestEntityTooLarge), errObj["code"])
 		assert.Equal(t, "Request body exceeds maximum size", errObj["message"])
@@ -466,7 +525,7 @@ func TestMutatingMiddleware_RequestBodySizeLimit(t *testing.T) {
 
 		body := makeJSONBodyOfSize(t, webhook.MaxRequestSize)
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
-		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: 1})
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: int64(1)})
 		req = req.WithContext(ctx)
 
 		var nextCalled bool
@@ -718,40 +777,6 @@ func TestMutatingMiddleware_MalformedPatchJSON(t *testing.T) {
 
 	assert.False(t, nextCalled)
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
-}
-
-//nolint:paralleltest
-func TestMutatingMiddleware_StringRequestID(t *testing.T) {
-	// Tests that the middleware correctly handles a string JSON-RPC ID.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		resp := webhook.MutatingResponse{
-			Response: webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: false},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
-
-	cfg := makeConfig(server.URL, webhook.FailurePolicyFail)
-	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{cfg}), "srv", "stdio")
-
-	reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":"string-id"}`)
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
-	// Use string ID in parsedMCP.
-	parsedMCP := &mcp.ParsedMCPRequest{Method: "tools/call", ID: "string-id"}
-	ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, parsedMCP)
-	req = req.WithContext(ctx)
-
-	rr := httptest.NewRecorder()
-	mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})).ServeHTTP(rr, req)
-
-	assert.Equal(t, http.StatusForbidden, rr.Code)
-	assert.Contains(t, rr.Body.String(), "Request denied by webhook policy")
-
-	// Confirm JSON-RPC error has the string ID.
-	var errResp map[string]interface{}
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
-	require.NotNil(t, errResp["ID"])
 }
 
 //nolint:paralleltest

--- a/pkg/webhook/validating/middleware.go
+++ b/pkg/webhook/validating/middleware.go
@@ -181,9 +181,6 @@ func readSourceIP(r *http.Request) string {
 }
 
 func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, msgID interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-
 	id, err := mcp.ConvertToJSONRPC2ID(msgID)
 	if err != nil {
 		id = jsonrpc2.ID{} // Use empty ID if conversion fails
@@ -195,5 +192,20 @@ func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, ms
 		ID:    id,
 		Error: jsonrpc2.NewError(int64(statusCode), message),
 	}
-	_ = json.NewEncoder(w).Encode(errResp)
+
+	// Encode before writing any header, so an encode failure never leaves a
+	// half-written response (e.g. a status header followed by a second write).
+	body, encErr := jsonrpc2.EncodeMessage(errResp)
+	if encErr != nil {
+		// Unreachable in practice: errResp is always a well-formed jsonrpc2.Response
+		// built from strings/ints above. Fall back to a hardcoded valid JSON-RPC
+		// error body rather than writing nothing.
+		slog.Error("failed to encode JSON-RPC error response", "error", encErr)
+		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, statusCode)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	//nolint:gosec // G104: writing the JSON-RPC denial body to an HTTP client; nothing to do on error
+	_, _ = w.Write(body)
 }

--- a/pkg/webhook/validating/middleware_test.go
+++ b/pkg/webhook/validating/middleware_test.go
@@ -77,7 +77,7 @@ func TestValidatingMiddleware(t *testing.T) {
 		// Add parsed MCP request and auth identity to context
 		parsedMCP := &mcp.ParsedMCPRequest{
 			Method: "tools/call",
-			ID:     1,
+			ID:     int64(1),
 		}
 		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, parsedMCP)
 
@@ -169,7 +169,7 @@ func TestValidatingMiddleware(t *testing.T) {
 		err := json.Unmarshal(rr.Body.Bytes(), &errResp)
 		require.NoError(t, err)
 
-		errObj, ok := errResp["Error"].(map[string]interface{})
+		errObj, ok := errResp["error"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Equal(t, float64(http.StatusForbidden), errObj["code"])
 		assert.Equal(t, "Request denied by policy", errObj["message"])
@@ -270,6 +270,76 @@ func TestValidatingMiddleware(t *testing.T) {
 	})
 }
 
+// TestValidatingMiddlewareDenialIsConformantJSONRPC pins the sendErrorResponse envelope on
+// the wire: lowercase "jsonrpc"/"id"/"error" keys, no "id" key for a notification, and no
+// "result" key. assert.JSONEq is case-sensitive, so a single assertion catches "Error"/"ID"
+// substituted for "error"/"id" (the historical bug) alongside a missing "jsonrpc" tag.
+func TestValidatingMiddlewareDenialIsConformantJSONRPC(t *testing.T) {
+	t.Parallel()
+
+	// Deterministic denial: the webhook always disallows, driving sendErrorResponse
+	// through the real middleware chain rather than constructing the response by hand.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(webhook.Response{
+			Version: webhook.APIVersion,
+			UID:     "resp-uid",
+			Allowed: false,
+			Message: "ignored", // sendErrorResponse ignores the webhook's message to avoid leaking info
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := webhook.Config{
+		Name:          "test-webhook",
+		URL:           server.URL,
+		Timeout:       webhook.DefaultTimeout,
+		FailurePolicy: webhook.FailurePolicyFail,
+		TLSConfig:     &webhook.TLSConfig{InsecureSkipVerify: true},
+	}
+	client, err := webhook.NewClient(cfg, webhook.TypeValidating, nil)
+	require.NoError(t, err)
+	mw := createValidatingHandler([]clientExecutor{{client: client, config: cfg}}, "test-server", "stdio")
+
+	const wantErr = `"error":{"code":403,"message":"Request denied by policy"}`
+
+	testCases := []struct {
+		name     string
+		id       interface{} // ParsedMCPRequest.ID; nil for a notification
+		wantBody string
+	}{
+		{name: "int64 id", id: int64(42), wantBody: `{"jsonrpc":"2.0","id":42,` + wantErr + `}`},
+		{name: "string id", id: "abc", wantBody: `{"jsonrpc":"2.0","id":"abc",` + wantErr + `}`},
+		{name: "nil id (notification) omits id entirely", id: nil, wantBody: `{"jsonrpc":"2.0",` + wantErr + `}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{"jsonrpc":"2.0","method":"tools/call"}`)))
+			ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: tc.id})
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatal("next handler must not be called for a denied request")
+			})).ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusForbidden, rr.Code)
+			assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+			assert.JSONEq(t, tc.wantBody, rr.Body.String())
+
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &decoded))
+			_, hasID := decoded["id"]
+			assert.Equal(t, tc.id != nil, hasID, "id key presence mismatch")
+			_, hasResult := decoded["result"]
+			assert.False(t, hasResult, "denied response must not contain a result key")
+		})
+	}
+}
+
 // makeJSONBodyOfSize builds a syntactically-valid JSON body of exactly `size`
 // bytes by padding the value of a "data" field with ASCII characters. The
 // resulting bytes are valid JSON-RPC for use as an MCP request body.
@@ -312,7 +382,7 @@ func TestValidatingMiddleware_RequestBodySizeLimit(t *testing.T) {
 
 		body := makeJSONBodyOfSize(t, webhook.MaxRequestSize+1)
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
-		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: 1})
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: int64(1)})
 		req = req.WithContext(ctx)
 
 		var nextCalled bool
@@ -327,7 +397,7 @@ func TestValidatingMiddleware_RequestBodySizeLimit(t *testing.T) {
 		// The error response is a JSON-RPC envelope.
 		var errResp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
-		errObj, ok := errResp["Error"].(map[string]interface{})
+		errObj, ok := errResp["error"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Equal(t, float64(http.StatusRequestEntityTooLarge), errObj["code"])
 		assert.Equal(t, "Request body exceeds maximum size", errObj["message"])
@@ -352,7 +422,7 @@ func TestValidatingMiddleware_RequestBodySizeLimit(t *testing.T) {
 
 		body := makeJSONBodyOfSize(t, webhook.MaxRequestSize)
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
-		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: 1})
+		ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: int64(1)})
 		req = req.WithContext(ctx)
 
 		var nextCalled bool
@@ -496,7 +566,7 @@ func TestCreateMiddleware_ResolvesHMACSecret(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{"jsonrpc":"2.0","method":"tools/call","id":1}`)))
 	req = req.WithContext(context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{
 		Method: "tools/call",
-		ID:     1,
+		ID:     int64(1),
 	}))
 
 	rr := httptest.NewRecorder()
@@ -550,7 +620,7 @@ func TestValidatingMiddleware_HTTP422AlwaysDenies(t *testing.T) {
 
 			reqBody := []byte(`{"jsonrpc":"2.0","method":"tools/call","id":1}`)
 			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(reqBody))
-			ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: 1})
+			ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: int64(1)})
 			req = req.WithContext(ctx)
 
 			var nextCalled bool
@@ -660,8 +730,9 @@ func TestMultiWebhookChain(t *testing.T) {
 
 		// Verify error response
 		var errResp map[string]interface{}
-		_ = json.Unmarshal(rr.Body.Bytes(), &errResp)
-		errObj := errResp["Error"].(map[string]interface{})
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
+		errObj, ok := errResp["error"].(map[string]interface{})
+		require.True(t, ok)
 		assert.Equal(t, "Request denied by policy", errObj["message"])
 	})
 
@@ -685,8 +756,9 @@ func TestMultiWebhookChain(t *testing.T) {
 
 		// Verify error response
 		var errResp map[string]interface{}
-		_ = json.Unmarshal(rr.Body.Bytes(), &errResp)
-		errObj := errResp["Error"].(map[string]interface{})
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
+		errObj, ok := errResp["error"].(map[string]interface{})
+		require.True(t, ok)
 		assert.Equal(t, "Request denied by policy", errObj["message"])
 	})
 

--- a/test/e2e/dual_era_functional_test.go
+++ b/test/e2e/dual_era_functional_test.go
@@ -5,6 +5,7 @@ package e2e_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -423,29 +424,29 @@ var _ = Describe("server/discover Authorization Guard", Label("proxy", "stateles
 		Expect(callResp.Error).To(BeNil())
 	})
 
-	It("still denies with 403 a method the Cedar policy does not permit", func() {
+	It("still denies with 403 a method the Cedar policy does not permit, with a conformant JSON-RPC envelope", func() {
 		// server/discover's always-allowed flip doesn't touch the general
 		// default-deny rule (MCPMethodToFeatureOperation's doc comment:
 		// "Methods not in this map are denied by default"). tools/call IS in
 		// the map and routes through Cedar; the policy in this BeforeEach
 		// only permits resource == Tool::"echo", so calling any other tool
-		// name still gets denied -- keeps the 403/denial path (and its
-		// non-conformant-envelope wire shape, #5950) covered by this suite.
+		// name still gets denied -- keeps the 403/denial path covered by this
+		// suite.
 		req, err := e2e.NewModernRequest("tools/call", map[string]any{
 			"name":      "notpermitted",
 			"arguments": map[string]any{"input": "shouldbedenied"},
 		})
 		Expect(err).ToNot(HaveOccurred())
+		req.WithID(int64(9001))
 
 		resp, err := client.Send(context.Background(), proxyURL, req)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(403))
 		Expect(resp.Error).ToNot(BeNil())
-		// The denial envelope is currently non-conformant JSON-RPC (capitalized
-		// Result/Error/ID, no "jsonrpc":"2.0" -- tracked in #5950); this parses
-		// only because encoding/json's unmarshal is case-insensitive. That's the
-		// envelope's job to fix, not this guard's -- here we're asserting authz
-		// *behavior* (denied, code 403), not wire conformance.
 		Expect(resp.Error.Code).To(Equal(int64(403)))
+		// The denial envelope must be conformant JSON-RPC: correct version tag
+		// and the request's id echoed back.
+		Expect(resp.JSONRPC).To(Equal("2.0"))
+		Expect(resp.ID).To(Equal(json.Number("9001")))
 	})
 })

--- a/test/e2e/mcp_raw_client.go
+++ b/test/e2e/mcp_raw_client.go
@@ -274,11 +274,12 @@ type RawRPCError struct {
 
 // RawResponse is the parsed result of sending a single (non-batch) JSON-RPC
 // request over MCP-over-HTTP. For batch responses (a JSON array), inspect
-// Body directly instead of ID/Result/Error.
+// Body directly instead of JSONRPC/ID/Result/Error.
 type RawResponse struct {
 	StatusCode int
 	Headers    http.Header
 	Body       []byte // raw response body, always populated
+	JSONRPC    string // echoed "jsonrpc" version tag; "" if absent or unparsable
 	ID         any    // echoed "id"; nil if absent, JSON null, or unparsable
 	Result     json.RawMessage
 	Error      *RawRPCError
@@ -374,20 +375,22 @@ type wireError struct {
 // wireResponse is the shape of a single JSON-RPC response object. ID is kept
 // as raw JSON so decodeID can preserve large integers exactly.
 type wireResponse struct {
-	ID     json.RawMessage `json:"id"`
-	Result json.RawMessage `json:"result"`
-	Error  *wireError      `json:"error"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *wireError      `json:"error"`
 }
 
 // populateEnvelope best-effort parses body as a single JSON-RPC response
 // object into out. A malformed or non-object body (e.g. a batch array, or
-// deliberately garbled test input) leaves ID/Result/Error at their zero
-// values; out.Body still carries the raw bytes for the caller to inspect.
+// deliberately garbled test input) leaves JSONRPC/ID/Result/Error at their
+// zero values; out.Body still carries the raw bytes for the caller to inspect.
 func populateEnvelope(body []byte, out *RawResponse) {
 	var w wireResponse
 	if err := json.Unmarshal(body, &w); err != nil {
 		return
 	}
+	out.JSONRPC = w.JSONRPC
 	out.ID = decodeID(w.ID)
 	out.Result = w.Result
 	if w.Error != nil {

--- a/test/e2e/mcp_raw_client.go
+++ b/test/e2e/mcp_raw_client.go
@@ -375,10 +375,9 @@ type wireError struct {
 // wireResponse is the shape of a single JSON-RPC response object. ID is kept
 // as raw JSON so decodeID can preserve large integers exactly.
 type wireResponse struct {
-	JSONRPC string          `json:"jsonrpc"`
-	ID      json.RawMessage `json:"id"`
-	Result  json.RawMessage `json:"result"`
-	Error   *wireError      `json:"error"`
+	ID     json.RawMessage `json:"id"`
+	Result json.RawMessage `json:"result"`
+	Error  *wireError      `json:"error"`
 }
 
 // populateEnvelope best-effort parses body as a single JSON-RPC response
@@ -390,7 +389,14 @@ func populateEnvelope(body []byte, out *RawResponse) {
 	if err := json.Unmarshal(body, &w); err != nil {
 		return
 	}
-	out.JSONRPC = w.JSONRPC
+	// encoding/json struct tags match case-insensitively as a fallback, which
+	// would let a miscased "JSONRPC" or "JsonRpc" key satisfy `json:"jsonrpc"`
+	// -- exactly the kind of malformed envelope this field exists to catch
+	// (see #5950). Read it from a raw map instead, which is case-sensitive.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err == nil {
+		_ = json.Unmarshal(raw["jsonrpc"], &out.JSONRPC)
+	}
 	out.ID = decodeID(w.ID)
 	out.Result = w.Result
 	if w.Error != nil {

--- a/test/e2e/mcp_raw_client_test.go
+++ b/test/e2e/mcp_raw_client_test.go
@@ -247,6 +247,21 @@ func TestRawClientSend(t *testing.T) {
 		require.Empty(t, resp.JSONRPC)
 	})
 
+	t.Run("a miscased jsonrpc key does not satisfy the version-tag check", func(t *testing.T) {
+		t.Parallel()
+		// encoding/json struct tags match case-insensitively as a fallback, so
+		// a naive `json:"jsonrpc"` unmarshal would let this non-conformant key
+		// through. resp.JSONRPC must only ever reflect the exact lowercase key.
+		server, _ := newCapturingServer(t, `{"JSONRPC":"2.0","id":1,"result":{}}`)
+
+		req, err := NewLegacyRequest("ping", nil)
+		require.NoError(t, err)
+		resp, err := client.Send(context.Background(), server.URL, req)
+		require.NoError(t, err)
+
+		require.Empty(t, resp.JSONRPC)
+	})
+
 	t.Run("parses error.code, error.data and a large-int64 id without precision loss", func(t *testing.T) {
 		t.Parallel()
 		const bigID = "9223372036854775807"

--- a/test/e2e/mcp_raw_client_test.go
+++ b/test/e2e/mcp_raw_client_test.go
@@ -226,6 +226,25 @@ func TestRawClientSend(t *testing.T) {
 		require.Equal(t, json.Number("42"), resp.ID)
 		require.JSONEq(t, `{"ok":true}`, string(resp.Result))
 		require.Nil(t, resp.Error)
+		require.Equal(t, "2.0", resp.JSONRPC)
+	})
+
+	t.Run("pre-fix denial shape (capitalized keys, no jsonrpc tag) leaves JSONRPC empty", func(t *testing.T) {
+		t.Parallel()
+		// This is the exact shape a jsonrpc2.Response marshaled with
+		// encoding/json's default reflection produces (no json tags, unexported
+		// ID field): pins that the harness reads it as having no version tag,
+		// rather than defaulting or being fooled into "2.0" by the stdlib's
+		// case-insensitive key matching. The case above is what actually fails
+		// if JSONRPC stops being populated.
+		server, _ := newCapturingServer(t, `{"Result":null,"Error":{"code":403,"message":"x"},"ID":{}}`)
+
+		req, err := NewLegacyRequest("ping", nil)
+		require.NoError(t, err)
+		resp, err := client.Send(context.Background(), server.URL, req)
+		require.NoError(t, err)
+
+		require.Empty(t, resp.JSONRPC)
 	})
 
 	t.Run("parses error.code, error.data and a large-int64 id without precision loss", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Authorization denials, and three sibling error paths, emitted a body that is not valid JSON-RPC 2.0. All four built a `*jsonrpc2.Response` (`golang.org/x/exp/jsonrpc2`) and serialized it with `encoding/json` directly. That struct carries no json tags and no `MarshalJSON`, so reflection produced:

```json
{"Result":null,"Error":{"code":403,"message":"unknown MCP method: ... "},"ID":{}}
```

Go-capitalized keys, no mandatory `"jsonrpc":"2.0"`, and — the part the issue under-reported — **the request id destroyed on every response**. `jsonrpc2.ID`'s only field is unexported, so `encoding/json` renders it `{}` *unconditionally*, even for a perfectly valid id. A client could not correlate a denial to the request that caused it. That is the more likely explanation for a Modern go-sdk client failing to surface these denials than the key casing alone.

The bug survived e2e for a subtle reason worth recording: only the *outer* envelope was reflected. The inner error object is a `jsonrpc2.WireError`, which does carry json tags, so assertions on `error.code` kept passing while the envelope around them was malformed.

**What changed**

- Encode via `jsonrpc2.EncodeMessage` at all four sites. It marshals through the library's `wireCombined`, which has the correct lowercase tags, stamps the version tag unconditionally, and tags `id` `omitempty`.
- Encode **before** writing any header. This removes a live double-write in `handleUnauthorized` (a 403 header followed, on encode failure, by `http.Error(..., 500)` — a second header plus garbage appended to the body), and fixes the webhook paths, which wrote the header first and swallowed the encode error, leaving a header with no body at all on failure.
- Restore the request id on the protocol-violation path in `response_filter.go`, which hardcoded an empty id, so fixing the encoder alone would have left that response uncorrelatable.
- Five test assertions pinned the broken shape and so held it in place; two were unchecked type assertions that would have panicked rather than failed. One was worse than useless: a `require.NotNil` on `errResp["ID"]` under a comment claiming the string id round-tripped. It never did — the value was `{}`, and `NotNil` passes on a non-nil empty map.
- The e2e harness could not detect this bug at all: its response struct had no `jsonrpc` field. It now has one, read case-sensitively, because `encoding/json` field matching falls back to case-insensitive and would have let `"JSONRPC":"2.0"` satisfy a `json:"jsonrpc"` tag — a hole in exactly the place the guard was added.

Fixes #5950

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Unit tests: every touched package is green (`pkg/authz/...`, `pkg/webhook/...`), re-verified after rebasing onto `main`. Note `task test` could not be used locally — it panics on a `gotestfmt` v2.5.0 bug ("BUG: Empty package name encountered") that reproduces on a clean tree, so the underlying `go test` invocation was used instead. CI runs the real thing.

Each new test was proven to be a real regression guard by reverting the production change and confirming it fails, then restoring it. Worth calling out for one case specifically: the miscased-key assertion in `mcp_raw_client_test.go` fails before the case-sensitivity fix and passes after, whereas the absent-key case passes either way and is there to pin a different property.

E2E: compile-verified only. The dual-era suite needs a built binary and live proxy/backend containers. Because of that, the new `RawResponse.JSONRPC` field also got hermetic `httptest` coverage in `TestRawClientSend`, which runs in every shard — otherwise the detector added to catch this bug would itself have been unverified before merge.

Linting not run locally; leaving it to CI.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/authz/middleware.go` | `handleUnauthorized`: `EncodeMessage`, encode before header, fix double-write and a clobbered `err` parameter |
| `pkg/authz/response_filter.go` | `writeErrorResponse`: `EncodeMessage`; new `requestID()` recovers the real id for the protocol-violation path |
| `pkg/webhook/validating/middleware.go` | `sendErrorResponse`: `EncodeMessage`, encode before header |
| `pkg/webhook/mutating/middleware.go` | same (10 call sites) |
| `pkg/authz/middleware_test.go` | New envelope test through the real parsing+authz chain |
| `pkg/authz/response_filter_test.go` | Envelope assertions on the existing disguised-frame test |
| `pkg/webhook/*/middleware_test.go` | Fix 5 assertions pinning the old shape; de-vacuum the id assertion; `int`/`float64` → `int64` fixtures; one envelope test per package |
| `test/e2e/mcp_raw_client.go` | Surface `jsonrpc` on `RawResponse`, read case-sensitively |
| `test/e2e/mcp_raw_client_test.go` | Hermetic coverage incl. a miscased-key guard |
| `test/e2e/dual_era_functional_test.go` | Replace a comment deferring conformance with the assertion it deferred |

## Does this introduce a user-facing change?

Yes. Denial and error responses from the authorization middleware, the response filter, and both webhook middlewares are now valid JSON-RPC 2.0: lowercase `jsonrpc`/`id`/`error`, the version tag present, and the request id echoed back so clients can correlate. Clients that previously tolerated the malformed body via case-insensitive unmarshal are unaffected; spec-strict clients can now parse these responses at all.

## Special notes for reviewers

**On absent ids: MCP deliberately overrides base JSON-RPC here, and this PR follows MCP.** Base JSON-RPC 2.0 §5 says a Response `id` "MUST be Null" when it cannot be determined. MCP cannot express that: `schema/2025-11-25/schema.ts` types the error response as `id?: RequestId` where `RequestId = string | number`, and both transport pages say the body "has no `id`" — including for the 403 case specifically. So an absent id is **omitted**, not emitted as `null`.

This is not theoretical. The reference TypeScript SDK enforces it: `JSONRPCErrorResponseSchema` (`packages/core/src/schemas.ts:168`) is a `.strict()` object with `id: RequestIdSchema.optional()`, which admits `undefined` but not `null` — and `JSONRPCMessageSchema.parse()`, the *throwing* variant, gates every inbound message in the client transports. A response carrying `"id":null` makes that client throw inside its transport, before the application sees the error. Please read the two paragraphs above before filing this as a bug; one review pass already flagged it, applying base JSON-RPC rather than MCP.

Note `id: 0` still round-trips correctly. `wireCombined.ID` is an `interface{}`, so `omitempty` tests `IsNil()` rather than zero-ness — a hand-rolled map plus `omitempty` would have silently dropped a zero id.

**Deliberately out of scope, each tracked:**

- **#6037** — On the SSE path, `writeErrorResponse` writes a bare JSON object into a `text/event-stream` with no `data: ` prefix. Per the WHATWG grammar that parses as an unrecognized field and is *silently discarded*, so the client hangs to its own timeout. This PR makes that payload conformant, which means it now reads as correct while remaining unreadable by any SSE client — please don't take the green bytes there as evidence the path works. Fixing it needs a design decision, not a mechanical change.
- **#6038** — *Resolved on `main` already, by #6068 ("Omit absent JSON-RPC ids instead of emitting null"), so nothing outstanding here.* It covered three hand-built envelopes that emitted `"id":null` (`session/jsonrpc_errors.go`, `ratelimit/middleware.go`, `mcp/classification_response.go`) — the same rule as above, opposite behavior. Listed only because this branch is where the rule was established and verified against the SDK.
- **#6039** — HTTP statuses used as JSON-RPC error codes (`500`/`413`/`422`). Left untouched on purpose: client-visible, asserted across `pkg/vmcp/server/*_test.go` and documented in `docs/arch/10-virtual-mcp-architecture.md`. `403` stays regardless — the draft spec blesses allocating outside the reserved range.

**No shared helper, deliberately.** The four sites keep their own encode/write blocks. A shared map-building helper was designed and rejected: the tree already has five hand-rolled envelope builders, a sixth absorbs none of them without an options struct, and an `any`-typed id parameter is precisely how a caller reintroduces the `{}` bug at the one site holding a typed `jsonrpc2.ID`. The single rule that prevents a fifth occurrence is greppable instead: never `json.Marshal` a `jsonrpc2` type. A narrower helper taking a `jsonrpc2.Message` would avoid that objection and is worth a follow-up, but it was not folded in here.

**A stale detail in the issue.** #5950's repro uses `server/discover`, which no longer reproduces — #5953 made it always-allowed (`middleware.go`), after the issue was filed. Tests use `tasks/list`, which is genuinely absent from `MCPMethodToFeatureOperation` and which the map's own comment already names as denied by default.
