### PR TITLE
Gate dual-era e2e on the full replica count

### DIFF
--- a/test/e2e/thv-operator/acceptance_tests/dual_era_k8s_test.go
+++ b/test/e2e/thv-operator/acceptance_tests/dual_era_k8s_test.go
@@ -104,8 +104,12 @@ import (
 // correct, not a bug.
 var _ = Describe("Dual-Era Multi-Replica Backend", Ordered, func() {
 	const (
-		testNamespace   = "dual-era-k8s"
-		serverName      = "dual-era-echo"
+		testNamespace = "dual-era-k8s"
+		serverName    = "dual-era-echo"
+		// Replicas drives the proxy runner Deployment, BackendReplicas the backend
+		// StatefulSet -- independent counts, and Status.ReadyReplicas reports the proxy
+		// one only ("number of ready proxy replicas", mcpserver_types.go).
+		proxyReplicas   = 2
 		backendReplicas = 2
 		timeout         = 3 * time.Minute
 		pollingInterval = 2 * time.Second
@@ -145,7 +149,7 @@ var _ = Describe("Dual-Era Multi-Replica Backend", Ordered, func() {
 				Transport:       "streamable-http",
 				ProxyPort:       8080,
 				MCPPort:         8080,
-				Replicas:        ptr.To(int32(2)),
+				Replicas:        ptr.To(int32(proxyReplicas)),
 				BackendReplicas: ptr.To(int32(backendReplicas)),
 				SessionAffinity: "None",
 				Env: []mcpv1beta1.EnvVar{
@@ -195,26 +199,43 @@ var _ = Describe("Dual-Era Multi-Replica Backend", Ordered, func() {
 	})
 
 	It("brings up both proxy and backend replicas ready, with Redis wired", func() {
-		By("proxy runner pods are ready")
+		// Gate on the full replica count, not just "something is up": CheckPodsReady
+		// passes on a single ready pod, so it would clear here with 1 of 2 replicas and
+		// leave the multi-replica premise of this whole suite unverified.
+		By(fmt.Sprintf("all %d proxy runner pods are ready", proxyReplicas))
 		Eventually(func() error {
-			return testutil.CheckPodsReady(ctx, k8sClient, testNamespace, map[string]string{
+			return testutil.CheckPodsReadyCount(ctx, k8sClient, testNamespace, map[string]string{
 				"app.kubernetes.io/name":     "mcpserver",
 				"app.kubernetes.io/instance": serverName,
-			})
+			}, proxyReplicas)
 		}, timeout, pollingInterval).Should(Succeed())
 
-		By("backend (yardstick) pods are ready")
+		By(fmt.Sprintf("all %d backend (yardstick) pods are ready", backendReplicas))
 		Eventually(func() error {
-			return testutil.CheckPodsReady(ctx, k8sClient, testNamespace, backendPodLabels)
+			return testutil.CheckPodsReadyCount(ctx, k8sClient, testNamespace, backendPodLabels, backendReplicas)
 		}, timeout, pollingInterval).Should(Succeed())
 
-		By("Redis session storage is wired without a warning")
+		By("Redis session storage is wired without a warning, with both replicas ready in status")
+		// Status is written by the reconciler, so it trails the pods above by up to one
+		// reconcile even now that the gates wait for the full count. Poll rather than
+		// reading once.
 		server := &mcpv1beta1.MCPServer{}
-		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: serverName, Namespace: testNamespace}, server)).To(Succeed())
-		cond := meta.FindStatusCondition(server.Status.Conditions, "SessionStorageWarning")
-		Expect(cond).ToNot(BeNil(), "expected a SessionStorageWarning condition once sessionStorage is set")
-		Expect(cond.Status).To(Equal(metav1.ConditionFalse), "Redis session storage should be configured cleanly: %s", cond.Message)
-		Expect(server.Status.ReadyReplicas).To(BeEquivalentTo(2))
+		Eventually(func() error {
+			if err := k8sClient.Get(ctx, client.ObjectKey{Name: serverName, Namespace: testNamespace}, server); err != nil {
+				return err
+			}
+			cond := meta.FindStatusCondition(server.Status.Conditions, "SessionStorageWarning")
+			if cond == nil {
+				return fmt.Errorf("expected a SessionStorageWarning condition once sessionStorage is set")
+			}
+			if cond.Status != metav1.ConditionFalse {
+				return fmt.Errorf("Redis session storage should be configured cleanly: %s", cond.Message)
+			}
+			if server.Status.ReadyReplicas != proxyReplicas {
+				return fmt.Errorf("status.readyReplicas is %d, want %d", server.Status.ReadyReplicas, proxyReplicas)
+			}
+			return nil
+		}, timeout, pollingInterval).Should(Succeed())
 	})
 
 	It("configures SessionAffinity:None and serves many Modern requests across the multi-replica deployment", func() {
@@ -276,25 +297,12 @@ var _ = Describe("Dual-Era Multi-Replica Backend", Ordered, func() {
 			return resp.StatusCode, nil
 		}, timeout, pollingInterval).Should(Equal(http.StatusOK))
 
-		// CheckPodsReady only requires ONE ready pod, so it would pass the
-		// instant the surviving pod is observed -- it never proves the
-		// StatefulSet actually replaced the evicted one. Assert the full
-		// count is back AND all of them are Ready.
+		// CheckPodsReady only requires ONE ready pod, so it would pass the instant the
+		// surviving pod is observed -- it never proves the StatefulSet actually replaced
+		// the evicted one. Assert the full count is back AND all of them are Ready.
 		By("the StatefulSet replaces the evicted pod -- full replica count, all Ready")
-		Eventually(func() (int, error) {
-			pods := backendPods()
-			ready := 0
-			for _, p := range pods {
-				for _, c := range p.Status.Conditions {
-					if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
-						ready++
-					}
-				}
-			}
-			if len(pods) != backendReplicas {
-				return 0, fmt.Errorf("expected %d backend pods, got %d", backendReplicas, len(pods))
-			}
-			return ready, nil
-		}, timeout, pollingInterval).Should(Equal(backendReplicas))
+		Eventually(func() error {
+			return testutil.CheckPodsReadyCount(ctx, k8sClient, testNamespace, backendPodLabels, backendReplicas)
+		}, timeout, pollingInterval).Should(Succeed())
 	})
 })

--- a/test/e2e/thv-operator/testutil/k8s.go
+++ b/test/e2e/thv-operator/testutil/k8s.go
@@ -26,32 +26,40 @@ import (
 )
 
 // CheckPodsReady checks that at least one pod matching the given labels is running and ready.
+//
+// It passes the instant a single pod is observed ready, so it cannot gate on a multi-replica
+// rollout -- use CheckPodsReadyCount when the workload has a known replica count.
 func CheckPodsReady(ctx context.Context, c client.Client, namespace string, labels map[string]string) error {
-	podList := &corev1.PodList{}
-	if err := c.List(ctx, podList,
-		client.InNamespace(namespace),
-		client.MatchingLabels(labels)); err != nil {
-		return fmt.Errorf("failed to list pods: %w", err)
+	ready, total, err := countReadyPods(ctx, c, namespace, labels)
+	if err != nil {
+		return err
 	}
-
-	if len(podList.Items) == 0 {
+	if total == 0 {
 		return fmt.Errorf("no pods found with labels %v", labels)
 	}
-
-	runningPods := 0
-	for _, pod := range podList.Items {
-		if pod.Status.Phase != corev1.PodRunning {
-			continue
-		}
-		for _, cond := range pod.Status.Conditions {
-			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-				runningPods++
-				break
-			}
-		}
-	}
-	if runningPods == 0 {
+	if ready == 0 {
 		return fmt.Errorf("no running and ready pods found with labels %v", labels)
+	}
+	return nil
+}
+
+// CheckPodsReadyCount checks that exactly want pods matching the given labels are running and
+// ready. Use this over CheckPodsReady whenever the expected replica count is known, so a gate
+// on "the workload is up" cannot be satisfied by a partial rollout.
+func CheckPodsReadyCount(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	labels map[string]string,
+	want int,
+) error {
+	ready, total, err := countReadyPods(ctx, c, namespace, labels)
+	if err != nil {
+		return err
+	}
+	if ready != want {
+		return fmt.Errorf("expected %d running and ready pods with labels %v, got %d ready of %d",
+			want, labels, ready, total)
 	}
 	return nil
 }
@@ -169,4 +177,36 @@ func GetNodePort(
 	}, timeout, pollingInterval).Should(gomega.Succeed())
 
 	return nodePort
+}
+
+// countReadyPods returns how many pods matching labels are both Running and Ready, alongside the
+// total number matched. Terminating pods count towards the total but never towards ready: they can
+// still report Ready while shutting down, and the operator excludes them from its own status counts
+// for that reason (categorizePodStatus in mcpserver_controller.go, issue #4498), so counting them
+// would let a gate pass on a pod that is going away.
+func countReadyPods(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	labels map[string]string,
+) (ready, total int, err error) {
+	podList := &corev1.PodList{}
+	if err := c.List(ctx, podList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(labels)); err != nil {
+		return 0, 0, fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	for _, pod := range podList.Items {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				ready++
+				break
+			}
+		}
+	}
+	return ready, len(podList.Items), nil
 }


### PR DESCRIPTION
## Summary

`Dual-Era Multi-Replica Backend` failed intermittently on the `v1.33.7` lifecycle leg, asserting `status.readyReplicas == 2` and reading `1`:

```
[FAILED] Expected
    <int32>: 1
to be equivalent to
    <int>: 2
dual_era_k8s_test.go:217
```

**The value was accurate, not stale.** `testutil.CheckPodsReady` returns as soon as *one* matching pod is ready — its own doc comment says "at least one pod", and it bails only on `runningPods == 0`. The spec used it as a **two**-replica gate:

```go
Eventually(... CheckPodsReady(proxy labels) ...)     // clears at 1 of 2
Eventually(... CheckPodsReady(backendPodLabels) ...) // clears at 1 of 2
Expect(server.Status.ReadyReplicas).To(BeEquivalentTo(2)) // runs anyway
```

So the assertion ran while the second proxy replica genuinely had not come up. The test never waited for two replicas at all.

The same file already documented this trap — its pod-eviction spec says *"CheckPodsReady only requires ONE ready pod ... it never proves the StatefulSet actually replaced the evicted one"* — and the gates above it were tripping over exactly that.

A consequence worth calling out: the **backend** replica count was asserted nowhere, so the following spec ("serves many Modern requests across the multi-replica deployment") could run against a single-replica backend and silently void the premise of the suite.

**What changed**

- Add `testutil.CheckPodsReadyCount` for workloads with a known replica count, and use it for both gates so the spec waits for what its name claims. Terminating pods are excluded from the ready count, matching the operator's own accounting in `categorizePodStatus` (#4498), so a pod on its way out cannot satisfy a gate.
- `CheckPodsReady` keeps its one-pod contract — single-replica callers in the vMCP suite rely on it deliberately, so it was left alone rather than tightened.
- Poll the status block instead of reading it once. The reconciler writes `Status`, so it trails pod readiness by up to one reconcile even with correct gates. This part is necessary but was not the cause.
- Replace the hand-rolled counting loop in the pod-eviction spec with the new helper.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Test-only change. Verified with `go build ./test/e2e/...` and `go vet` on both touched packages.

The count logic was checked against a fake client rather than assumed, in a throwaway harness (not committed), confirming: 1-of-2 ready fails with `got 1 ready of 2`; the same state *passes* the old `CheckPodsReady`, which is the flake mechanism reproduced directly; 2-of-2 passes; a terminating-but-Ready pod does not count; an over-count fails rather than silently passing.

The suite itself needs a kind cluster with NodePort mappings and runs in CI only (`test-e2e-lifecycle.yml`), so CI here is the real signal.

On intermittency: a rerun of the original failing job on #6055 — which contains **no** fix — passed all three legs including `v1.33.7`. So a green run does not by itself prove this fixed; what the change does is make the gate assert the condition it was always supposed to.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

Deliberately does **not** raise `timeout` (3m) or add a sleep.

Two things found while diagnosing this and left out to keep the PR test-only:

1. `cmd/thv-operator/api/v1beta1/mcpserver_types.go:398` says `BackendReplicas` "controls the backend **Deployment**", but the backend is a **StatefulSet** (`pkg/runner/config.go:316`, `pkg/container/runtime/types.go:300`, created in `pkg/container/kubernetes/client.go:567`). Doc comment only, no behavior impact.
2. `.claude/rules/testing.md` says nothing about polling or replica counts, so "never gate a multi-replica workload with a one-pod helper" is not written down anywhere a future spec author would see it.

An earlier revision of this PR attributed the flake to reconciler status lag and fixed only the polling. That diagnosis was wrong; the branch has been rewritten to tell the correct story in one commit.

Generated with [Claude Code](https://claude.com/claude-code)
