### PR TITLE
Deflake CI: TUF warn mode, readiness diagnostics, test races

### DIFF
--- a/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_compositetool_watch_test.go
+++ b/cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_compositetool_watch_test.go
@@ -393,6 +393,39 @@ var _ = Describe("VirtualMCPServer CompositeToolDefinition Watch Integration Tes
 		})
 
 		It("Should NOT trigger VirtualMCPServer reconciliation when unrelated composite tool definition is created", func() {
+			// BeforeAll only gates on ObservedGeneration > 0, so the controller
+			// may still be settling (the Ready condition flipping as discovery
+			// and config generation complete) when this spec starts. A baseline
+			// captured mid-settle fails the timestamp assertion below even
+			// though the unrelated create never triggered anything. Wait until
+			// the Ready condition has held the same transition time across
+			// several consecutive polls before taking the baseline.
+			var lastSeenReadyTime metav1.Time
+			stablePolls := 0
+			Eventually(func() bool {
+				vmcpNow := &mcpv1beta1.VirtualMCPServer{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      vmcpName,
+					Namespace: namespace,
+				}, vmcpNow); err != nil {
+					return false
+				}
+				for _, cond := range vmcpNow.Status.Conditions {
+					if cond.Type == conditionReady {
+						if cond.LastTransitionTime.Equal(&lastSeenReadyTime) {
+							stablePolls++
+						} else {
+							lastSeenReadyTime = cond.LastTransitionTime
+							stablePolls = 0
+						}
+						// ~2s of stability at the 250ms poll interval: the
+						// observed flake transitioned ~2s after the baseline.
+						return stablePolls >= 8
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "Ready condition should settle before capturing the baseline")
+
 			// Get initial generation and observed generation
 			initialVMCP := &mcpv1beta1.VirtualMCPServer{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{

--- a/pkg/runner/retriever/retriever.go
+++ b/pkg/runner/retriever/retriever.go
@@ -358,16 +358,25 @@ func VerifyImage(image string, server *types.ImageMetadata, verifySetting string
 			return verifier.ErrProvenanceServerInformationNotSet
 		}
 
-		// Create a new verifier
+		// Create a new verifier. In warn mode this must not block the run:
+		// construction reaches out to the sigstore TUF repository, so a CDN
+		// outage or connection reset would otherwise hard-fail a mode whose
+		// contract is "warn and continue" — an actual failed verification
+		// below only warns, so an unreachable verifier must not be stricter.
 		v, err := verifier.New(server.Provenance, images.NewCompositeKeychain())
 		if err != nil {
+			if verifySetting == VerifyImageWarn {
+				slog.Warn("image verification unavailable, continuing without it", "image", image, "reason", err)
+				return nil
+			}
 			return err
 		}
 
-		// Verify the image passing the provenance info
+		// Verify the image passing the provenance info. Warn mode downgrades
+		// every failure — signature mismatches and transient registry errors
+		// alike — to a warning; only enabled mode fails closed.
 		if err = v.VerifyServer(image, server.Provenance); err != nil {
-			if (errors.Is(err, verifier.ErrImageNotSigned) || errors.Is(err, verifier.ErrProvenanceMismatch)) &&
-				verifySetting == VerifyImageWarn {
+			if verifySetting == VerifyImageWarn {
 				slog.Warn("MCP server failed image verification", "image", image, "reason", err)
 				return nil
 			}

--- a/pkg/runner/retriever/retriever_test.go
+++ b/pkg/runner/retriever/retriever_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive-core/container/verifier"
 	regtypes "github.com/stacklok/toolhive-core/registry/types"
 	"github.com/stacklok/toolhive/pkg/runner"
 )
@@ -130,6 +131,74 @@ func TestHasLatestTag(t *testing.T) {
 
 			result := hasLatestTag(tt.imageRef)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestVerifyImage(t *testing.T) {
+	t.Parallel()
+
+	const testImage = "ghcr.io/example/server:v1.0.0"
+
+	// A SigstoreURL with no embedded TUF root makes verifier.New fail
+	// deterministically without touching the network — the same "verifier
+	// cannot be constructed" return path a sigstore TUF CDN outage takes.
+	unreachableVerifier := &regtypes.ImageMetadata{
+		Provenance: &regtypes.Provenance{SigstoreURL: "tuf.invalid.example"},
+	}
+
+	tests := []struct {
+		name          string
+		server        *regtypes.ImageMetadata
+		verifySetting string
+		expectErr     string
+	}{
+		{
+			name:          "disabled skips verification",
+			server:        unreachableVerifier,
+			verifySetting: VerifyImageDisabled,
+		},
+		{
+			name:          "warn without provenance continues",
+			server:        &regtypes.ImageMetadata{},
+			verifySetting: VerifyImageWarn,
+		},
+		{
+			name:          "enabled without provenance fails",
+			server:        &regtypes.ImageMetadata{},
+			verifySetting: VerifyImageEnabled,
+			expectErr:     verifier.ErrProvenanceServerInformationNotSet.Error(),
+		},
+		{
+			name:          "warn with unavailable verifier continues",
+			server:        unreachableVerifier,
+			verifySetting: VerifyImageWarn,
+		},
+		{
+			name:          "enabled with unavailable verifier fails",
+			server:        unreachableVerifier,
+			verifySetting: VerifyImageEnabled,
+			expectErr:     "root.json",
+		},
+		{
+			name:          "invalid setting fails",
+			server:        &regtypes.ImageMetadata{},
+			verifySetting: "sometimes",
+			expectErr:     "invalid value for --image-verification",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := VerifyImage(testImage, tt.server, tt.verifySetting)
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1052,6 +1052,15 @@ func waitForInitializeSuccess(
 	delay := 100 * time.Millisecond
 	maxDelay := 2 * time.Second // Cap at 2 seconds between retries
 
+	// Per-attempt outcomes below log at DEBUG, which is invisible in a default
+	// deployment — a workload stuck in `starting` for minutes then shows no
+	// trace of WHY the probe kept failing. Surface a periodic INFO progress
+	// line (long-running operation) carrying the last observed outcome.
+	// Every loop iteration assigns lastObserved before it is read.
+	var lastObserved string
+	const progressInterval = 30 * time.Second
+	nextProgressLog := progressInterval
+
 	slog.Info("Waiting for MCP server to be ready", "endpoint", endpoint, "timeout", maxWaitTime)
 
 	// Create HTTP client with a reasonable timeout for requests
@@ -1073,6 +1082,7 @@ func waitForInitializeSuccess(
 
 		if err != nil {
 			slog.Debug("Failed to create request", "attempt", attempt, "error", err)
+			lastObserved = fmt.Sprintf("failed to create request: %v", err)
 		} else {
 			if method == "POST" {
 				req.Header.Set("Content-Type", "application/json")
@@ -1097,15 +1107,24 @@ func waitForInitializeSuccess(
 
 				slog.Debug("Server returned status", //nolint:gosec // G706: status code and attempt are integers
 					"status_code", resp.StatusCode, "attempt", attempt)
+				lastObserved = fmt.Sprintf("HTTP %d", resp.StatusCode)
 			} else {
 				slog.Debug("Failed to reach endpoint", "attempt", attempt, "error", err)
+				lastObserved = fmt.Sprintf("unreachable: %v", err)
 			}
 		}
 
 		// Check if we've exceeded the maximum wait time
 		elapsed := time.Since(startTime)
 		if elapsed >= maxWaitTime {
-			return fmt.Errorf("initialize not successful after %v (%d attempts)", elapsed, attempt)
+			return fmt.Errorf("initialize not successful after %v (%d attempts, last observed: %s)",
+				elapsed, attempt, lastObserved)
+		}
+
+		if elapsed >= nextProgressLog {
+			slog.Info("Still waiting for MCP server to be ready", //nolint:gosec // G706: attempt is an integer
+				"endpoint", endpoint, "elapsed", elapsed.Round(time.Second), "attempt", attempt, "last_observed", lastObserved)
+			nextProgressLog += progressInterval
 		}
 
 		// Wait before retrying

--- a/pkg/workloads/manager.go
+++ b/pkg/workloads/manager.go
@@ -793,7 +793,7 @@ func (d *DefaultManager) spawnDetached(ctx context.Context, runConfig *runner.Ru
 	}
 
 	if err := detachedCmd.Start(); err != nil {
-		if statusErr := d.statuses.SetWorkloadStatus(ctx, runConfig.BaseName, rt.WorkloadStatusError, ""); statusErr != nil {
+		if statusErr := d.statuses.SetWorkloadStatus(ctx, runConfig.BaseName, rt.WorkloadStatusError, err.Error()); statusErr != nil {
 			slog.Warn("Failed to set workload status to error", "workload", runConfig.BaseName, "error", statusErr)
 		}
 		return 0, err
@@ -1554,8 +1554,12 @@ func (d *DefaultManager) startWorkload(ctx context.Context, name string, mcpRunn
 	}
 
 	if err != nil {
-		// If we could not start the workload, set the status to error before returning
-		if statusErr := d.statuses.SetWorkloadStatus(ctx, name, rt.WorkloadStatusError, ""); statusErr != nil {
+		// If we could not start the workload, set the status to error before
+		// returning. Record err itself as the status context: RunWorkload's
+		// retry loop has already written the failure reason there, and an
+		// empty context here would clobber it — CI debug output then shows a
+		// bare status "error" with no way to tell what actually failed.
+		if statusErr := d.statuses.SetWorkloadStatus(ctx, name, rt.WorkloadStatusError, err.Error()); statusErr != nil {
 			slog.Warn("Failed to set workload status to error", "workload", name, "error", statusErr)
 		}
 	}

--- a/test/conformance/run-conformance.sh
+++ b/test/conformance/run-conformance.sh
@@ -266,25 +266,32 @@ npx -y "@modelcontextprotocol/conformance@${CONFORMANCE_VERSION}" server \
 suite_rc=${PIPESTATUS[0]}
 set -e
 
-# Quarantine: tools-call-sampling and tools-call-elicitation flake intermittently
-# (~1/3) due to an upstream reference-server bug, NOT a ToolHive defect. The
-# everything-server sends its server->client request (sampling/createMessage or
-# elicitation/create) on the client's standalone GET SSE stream without a
-# relatedRequestId, so it races the tools/call handler; when the handler wins,
-# the request is dropped and the client times out at 60s. See:
+# Quarantine: the scenarios that drive a server->client request flake
+# intermittently (~1/3) due to an upstream reference-server bug, NOT a ToolHive
+# defect. The everything-server sends its server->client request
+# (sampling/createMessage or elicitation/create) on the client's standalone GET
+# SSE stream without a relatedRequestId, so it races the tools/call handler;
+# when the handler wins, the request is dropped and the client times out at 60s.
+# In suite v0.1.16 exactly four scenarios register client-side handlers for
+# server->client requests (src/scenarios/server/tools.ts and
+# elicitation-{defaults,enums}.ts) and are therefore exposed to the race:
+#   tools-call-sampling, tools-call-elicitation,
+#   elicitation-sep1034-defaults, elicitation-sep1330-enums
+# See:
 #   upstream: https://github.com/modelcontextprotocol/conformance/issues/407
 #   toolhive: #5886 (ingress Squid cold-start mitigation, reduces but can't
 #             eliminate the client-side ordering race)
 # We can't use expected-failures.yaml (a flaky entry stale-fails the ~2/3 of runs
-# where it passes), so ignore ONLY these two scenarios in the gating here; every
+# where it passes), so ignore ONLY these scenarios in the gating here; every
 # other scenario still fails the job. Remove this block once #407 is fixed
 # upstream and CONFORMANCE_VERSION is bumped to a release that contains the fix.
+quarantined='tools-call-sampling|tools-call-elicitation|elicitation-sep1034-defaults|elicitation-sep1330-enums'
 if [ "${suite_rc}" -ne 0 ]; then
   unexpected="$(sed -n '/Unexpected failures (not in baseline):/,$p' "${RESULTS_DIR}/suite-output.log" \
     | grep -oE '✗ [a-z0-9-]+' | sed 's/✗ //' | sort -u)"
-  others="$(printf '%s\n' "${unexpected}" | grep -vE '^(tools-call-sampling|tools-call-elicitation)?$' || true)"
+  others="$(printf '%s\n' "${unexpected}" | grep -vE "^(${quarantined})?\$" || true)"
   if [ -n "${unexpected}" ] && [ -z "${others}" ]; then
-    echo "==> Ignoring quarantined flaky scenarios 'tools-call-sampling'/'tools-call-elicitation' (upstream conformance#407 / toolhive#5886); no other unexpected failures."
+    echo "==> Ignoring quarantined flaky server->client scenarios (${quarantined}) per upstream conformance#407 / toolhive#5886; no other unexpected failures."
     exit 0
   fi
   exit "${suite_rc}"

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -349,6 +349,18 @@ func DebugServerState(config *TestConfig, serverName string) {
 		GinkgoWriter.Printf("Server logs:\n%s\n", logs)
 	}
 
+	// The container log alone has repeatedly been useless for readiness
+	// timeouts: a workload stuck in `starting` or flipped to `error` fails
+	// inside the detached supervisor (transport start, readiness probe,
+	// restart loop), whose output goes to the proxy log file — not to the
+	// container. Dump it too so a CI failure names the actual blocker.
+	proxyLogs, stderr, err := NewTHVCommand(config, "logs", serverName, "--proxy").Run()
+	if err != nil {
+		GinkgoWriter.Printf("Failed to get proxy logs: %v\nStderr: %s\n", err, stderr)
+	} else {
+		GinkgoWriter.Printf("Proxy logs:\n%s\n", proxyLogs)
+	}
+
 	GinkgoWriter.Printf("=== End debugging for %s ===\n", serverName)
 }
 


### PR DESCRIPTION
## Summary

The merge queue was being blocked by recurring CI flakes. Analysis of three weeks of `Main build` runs on `main` (146 runs, 75 failed) ranked the group-workload readiness family as the top three flakes, with a conformance gating gap and an envtest watch-test race behind them. This PR fixes one proven product bug (TUF outages hard-failing `thv run` in warn mode), closes the conformance gating gap, fixes one racy test baseline, and adds the startup diagnosability that turned the group-readiness failures from mysteries into named causes.

**Correction — this PR body previously claimed a different mechanism for the group-readiness failures, and that claim is withdrawn.** An earlier revision asserted that #6043's workload-name lengthening introduced a deterministic >63-char name-length failure, and that "every PR based on ≥`be0e0c34` fails the core shard deterministically". Both statements were wrong. The instrumented run on this very PR refuted them: a **56-character** workload failed the same way, and the 62-vs-66-char split observed across seven earlier runs was just which participant lost a 4-way startup race. What the diagnostics in this PR actually captured, on this PR's own first core-shard run:

- `status "error"` mode — the (previously clobbered, now visible) status context read: `failed to create ingress container: ... Bind for 127.0.0.1:8081 failed: port is already allocated`. The ingress proxy port was derived as `UpstreamPort + 1`, so four concurrently starting workloads all contended for 8081. Root-cause fixed on main by **#6069** ("Stop deriving the ingress proxy port from a fixed upstream port").
- `status "starting"` mode — the new probe-progress lines showed `last_observed: "HTTP 502"` at attempts 20/35/50/65 across the full 121s while the workload's own container had been listening within ~1s: the ingress proxy never recovered its route to the backend. Root-cause fixed on main by **#6071** ("Fix concurrent isolated-startup races (network create + ingress DNS latch)").

Credit for both product fixes goes to #6069/#6071; this PR's contribution to that story is the instrumentation that exposed the mechanisms (and will name the next one). Relatedly: issue #6040 tracked exactly these failures and was closed against #6043, which did not fix them — the failures had a genuine product cause that #6069/#6071 have now addressed.

What remains in this PR after rebasing onto main (`57e681f1`):

**1. Sigstore TUF outages hard-failed `thv run` in warn mode (product bug, root-caused here).** In run [30297766499](https://github.com/stacklok/toolhive/actions/runs/30297766499), five specs across THVIgnore, List Group, and the group suites failed in one job while `tuf-repo-cdn.sigstore.dev` was resetting connections: `thv run fetch` exited 1 with `failed to create TUF client ... connection reset by peer`. The cause is an inconsistency in `VerifyImage`: in the **default `warn` mode**, an actual failed verification only warns, but a verifier *construction* failure (TUF unreachable) and any non-signature verification error were returned as fatal. Warn mode now warns and continues on every verification failure; `enabled` still fails closed. The new unit test forces the same construction-failure path deterministically (a `SigstoreURL` with no embedded TUF root) with no network involved — it fails against the old code and passes with the fix.

**2. Workload-startup diagnosability (proven useful by this PR's own CI run).** Three gaps had made the group-readiness failures undiagnosable from CI output:
- `startWorkload` and the detached-spawn failure path set status `error` with an **empty** context, clobbering the failure reason `RunWorkload`'s retry loop had just recorded. They now record `err.Error()` — this is what surfaced the 8081 bind race.
- The readiness probe (`waitForInitializeSuccess`) logged per-attempt outcomes at DEBUG only. It now logs an INFO progress line every 30s with the last observed outcome and includes it in the timeout error — this is what surfaced the persistent ingress 502.
- `DebugServerState` dumped only container logs, which show a healthy server precisely in these failures; the supervisor's own output goes to the proxy log file. It now dumps `thv logs --proxy` too.

**3. Conformance quarantine list was incomplete.** Suite v0.1.16 has exactly **four** scenarios that register client-side handlers for server→client requests and are therefore exposed to the upstream ordering race (modelcontextprotocol/conformance#407): `tools-call-sampling`, `tools-call-elicitation`, `elicitation-sep1034-defaults`, `elicitation-sep1330-enums` — verified from the suite source (`src/scenarios/server/tools.ts`, `elicitation-{defaults,enums}.ts`), not by name-matching. The gate only ignored the first two; on #6054 the race hit `tools-call-sampling` *and* `elicitation-sep1034-defaults` (both timing out at exactly 60s), so the job hard-failed. The intermittency was directly observed, not just inferred: the same commit failed on `elicitation-sep1034-defaults` on one run and passed it on the re-run. The alternation now covers all four; anything else still fails the job, and the block still documents its removal condition (#407 fixed upstream + `CONFORMANCE_VERSION` bump).

**4. CompositeToolDefinition watch test races controller settle (3 main failures since 2026-07-06).** The "should NOT trigger reconciliation" spec captures a Ready-condition-timestamp baseline right after a `BeforeAll` gate that only proves `ObservedGeneration > 0`, so a still-settling controller flips the condition inside the 2s observation window and fails the spec (confirmed in run [30250838615](https://github.com/stacklok/toolhive/actions/runs/30250838615): timestamp changed within the 2.78s spec). The spec now waits for the Ready condition's transition time to hold stable across ~2s of polls before taking the baseline. This is unrelated to the #6069/#6071 fixes and still needed.

**Dropped during rebase:** the `dual_era_k8s_test.go` fix that was previously in this PR (bare `Expect` on reconcile-lagging `MCPServer.Status`) — fully superseded by #6057, which shipped the same Eventually-wrap plus stricter replica-count gates.

References: #6040 (closed), #6043, #6069, #6071, #6057, #5886, #5888, modelcontextprotocol/conformance#407.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- After the rebase onto `57e681f1`: `go build ./...`, `go vet`, and `go test` on every touched package (`pkg/runner/retriever`, `pkg/runner`, `pkg/workloads`) are green; `task lint-fix` reports 0 issues. `task test` was not used — it panics locally on the known gotestfmt v2.5.0 bug — so the underlying `go test` was run directly; CI runs the real thing.
- The new `TestVerifyImage` case `warn with unavailable verifier continues` was proven to be a real regression guard: it fails against the pre-fix `retriever.go` (verified by stashing the fix) and passes after.
- The conformance gate change was exercised with a scripted reproduction feeding synthetic suite output through the exact `sed`/`grep` pipeline, old regex vs new: the #6054 combination (sampling + sep1034) fails old / passes new; a quarantined-only failure passes both; a genuine regression — alone, alongside a quarantined flake, or as a prefix-lookalike scenario id (`tools-call-sampling-extended`) — fails both.
- The diagnostics commit was validated by this PR's own pre-rebase CI run (job 90109089450): it captured the 8081 bind-race error context and the ingress 502 probe history described above. A maintainer's merge of main (with #6069/#6071) into this branch then turned `E2E Tests Core (core)` green.
- **Not run locally** (no cluster/docker in this environment): the k8s operator suites and the CLI e2e suites. The `virtualmcpserver_compositetool_watch_test.go` change is compile-verified (`go vet`) and runs in Operator CI on this PR.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/runner/retriever/retriever.go` | Warn-mode `VerifyImage` warns and continues on verifier construction and verification errors; `enabled` unchanged (fails closed) |
| `pkg/runner/retriever/retriever_test.go` | Table-driven `TestVerifyImage`: warn vs enabled vs disabled vs invalid, incl. a deterministic offline verifier-construction failure |
| `pkg/workloads/manager.go` | Record `err.Error()` as status context in `startWorkload` and the detached-spawn failure path instead of clobbering it with `""` |
| `pkg/runner/runner.go` | Readiness probe: 30s INFO progress line with last observed outcome; timeout error includes it |
| `test/e2e/helpers.go` | `DebugServerState` also dumps `thv logs --proxy` |
| `test/conformance/run-conformance.sh` | Quarantine alternation extended to all four server→client scenarios; comment records the source-verified set |
| `cmd/thv-operator/test-integration/virtualmcp/virtualmcpserver_compositetool_watch_test.go` | Wait for Ready-condition transition time to settle before capturing the no-reconcile baseline |

## Does this introduce a user-facing change?

Yes. With the default `--image-verification=warn`, `thv run` no longer fails when the sigstore TUF repository is unreachable (e.g. offline or a CDN outage) — it logs a warning and continues, consistent with how a failed verification already behaved in warn mode. `--image-verification=enabled` still fails closed. Additionally, a workload that fails to start now records the failure reason in its status context, and a slow-starting workload logs readiness-probe progress every 30s.

## Special notes for reviewers

- **What is a root-cause fix vs not:** items 1 and 4 are root-cause fixes. Item 3 is a quarantine extension of a documented upstream bug, same reasoning as the existing block (#5888). Item 2 is diagnosability only — the underlying startup races were fixed by #6069/#6071, not here.
- The warn-mode semantics change in `retriever.go` is the one behavioral change worth scrutiny: previously warn mode failed closed on *infrastructure* errors while failing open on *verification* errors. If anyone relies on warn mode blocking runs when sigstore is unreachable, this changes that — but that behavior is what broke CI during a CDN outage, and it contradicts the mode's documented intent ("prints a warning when image validation fails").
- The branch was rebased onto `57e681f1` and force-pushed (dropping three interim "merge main" commits whose content is included in the new base, and the superseded dual_era commit); history before that reflects the withdrawn name-length analysis and should not be relied on.
- Verified no file overlap with in-flight PRs #6050, #6033, #6051, #6052, #6054, #6055.

Generated with [Claude Code](https://claude.com/claude-code)
