### PR TITLE
Use standard JSON-RPC error codes and scrub leaked error text

### DIFF
--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -136,12 +136,15 @@ func shouldSkipSubsequentAuthorization(method string) bool {
 	return false
 }
 
-// handleUnauthorized handles unauthorized requests.
+// handleUnauthorized handles unauthorized requests. The client always sees the fixed
+// "Unauthorized" message -- err (an authorizer failure) can carry policy detail that
+// security.md forbids returning to callers, so it is logged server-side instead.
+// Cedar's evaluation context can embed decoded JWT claim values (see the claim-keys-
+// only rule in authorizers/cedar/core.go), so err must never be promoted to a
+// structured field routed to an aggregator beyond this log line.
 func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
-	// Create an error response
-	errorMsg := "Unauthorized"
 	if err != nil {
-		errorMsg = err.Error()
+		slog.Warn("authorization denied", "error", err)
 	}
 
 	// Create a JSON-RPC error response
@@ -152,7 +155,7 @@ func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
 
 	errorResponse := &jsonrpc2.Response{
 		ID:    id,
-		Error: jsonrpc2.NewError(mcp.JSONRPCCodeDenied, errorMsg),
+		Error: jsonrpc2.NewError(mcp.JSONRPCCodeDenied, "Unauthorized"),
 	}
 
 	// Encode before writing any header, so a marshal failure never leaves a
@@ -163,7 +166,7 @@ func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
 		// jsonrpc2.Response built from strings/ints above. Fall back to a
 		// hardcoded valid JSON-RPC error body rather than writing nothing.
 		slog.Error("failed to encode JSON-RPC unauthorized response", "error", encErr)
-		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, mcp.JSONRPCCodeDenied)
+		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Unauthorized"}}`, mcp.JSONRPCCodeDenied)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -218,10 +221,13 @@ func Middleware(a authorizers.Authorizer, next http.Handler, passThroughTools ma
 		// Get the feature and operation from the method
 		featureOp, ok := MCPMethodToFeatureOperation[parsedRequest.Method]
 		if !ok {
-			// Unknown method - deny by default for security
-			// Methods must be explicitly added to MCPMethodToFeatureOperation to be allowed
-			handleUnauthorized(w, parsedRequest.ID,
-				fmt.Errorf("unknown MCP method: %s (not configured for authorization)", parsedRequest.Method))
+			// Unknown method - deny by default for security. Methods must be
+			// explicitly added to MCPMethodToFeatureOperation to be allowed.
+			// This is expected traffic (e.g. a newer-spec client), not an
+			// operational failure, so it's Debug rather than the Warn
+			// handleUnauthorized logs for an actual authorizer error.
+			slog.Debug("MCP method denied by default", "method", parsedRequest.Method)
+			handleUnauthorized(w, parsedRequest.ID, nil)
 			return
 		}
 

--- a/pkg/authz/middleware_test.go
+++ b/pkg/authz/middleware_test.go
@@ -1270,7 +1270,7 @@ func TestHandleUnauthorizedIsConformantJSONRPC(t *testing.T) {
 	})
 	middleware := mcpparser.ParsingMiddleware(Middleware(authorizer, handler, nil))
 
-	const wantErr = `"error":{"code":403,"message":"unknown MCP method: tasks/list (not configured for authorization)"}`
+	const wantErr = `"error":{"code":403,"message":"Unauthorized"}`
 
 	testCases := []struct {
 		name      string
@@ -1324,6 +1324,45 @@ func TestHandleUnauthorizedIsConformantJSONRPC(t *testing.T) {
 			assert.False(t, hasResult, "denied response must not contain a result key")
 		})
 	}
+}
+
+// TestHandleUnauthorizedScrubsAuthorizerError drives the real middleware chain
+// (parsing + authorization) for a denial caused solely by the authorizer erroring
+// while reporting allowed=true (as opposed to a clean policy deny), and asserts the
+// 403 body carries the fixed "Unauthorized" message rather than the authorizer's
+// error text. allowed is deliberately true here: authorizeAndServe's condition is
+// `err != nil || !authorized`, so with allowed=false the test would still pass via
+// the !authorized disjunct even if err were dropped somewhere -- this fixture pins
+// the err-only branch specifically.
+func TestHandleUnauthorizedScrubsAuthorizerError(t *testing.T) {
+	t.Parallel()
+
+	sensitiveErr := errors.New("cedar entity store lookup failed: secret-backend-url unreachable")
+	stub := &stubAuthorizer{allowed: true, err: sensitiveErr}
+
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("next handler must not be called for a denied request")
+	})
+	middleware := mcpparser.ParsingMiddleware(Middleware(stub, handler, nil))
+
+	reqBody := `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"data"}}`
+	req, err := http.NewRequest(http.MethodPost, "/messages", bytes.NewBufferString(reqBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{
+		Subject: "test-user",
+		Claims:  jwt.MapClaims{"sub": "test-user"},
+	}}
+	req = req.WithContext(auth.WithIdentity(req.Context(), identity))
+
+	rr := httptest.NewRecorder()
+	middleware.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	assert.JSONEq(t, `{"jsonrpc":"2.0","id":1,"error":{"code":403,"message":"Unauthorized"}}`, rr.Body.String())
+	assert.NotContains(t, rr.Body.String(), "secret-backend-url",
+		"authorizer error text must not leak to the client")
 }
 
 // TestConvertToJSONRPC2ID tests the convertToJSONRPC2ID function with various ID types
@@ -1437,6 +1476,18 @@ func TestAuthorizeAndServe(t *testing.T) {
 		{
 			name:             "authorizer error — 403, next not called",
 			allowed:          false,
+			authErr:          errors.New("policy evaluation failed"),
+			expectHandlerHit: false,
+			expectStatus:     http.StatusForbidden,
+		},
+		{
+			// allowed=true here discriminates fail-closed-on-error from
+			// fail-closed-on-deny: with allowed=false above, the 403 could come
+			// from either disjunct of `err != nil || !authorized`, so it alone
+			// doesn't pin that an authorizer error fails closed even when it
+			// also happens to report allowed.
+			name:             "authorizer error with allowed=true — still 403, next not called",
+			allowed:          true,
 			authErr:          errors.New("policy evaluation failed"),
 			expectHandlerHit: false,
 			expectStatus:     http.StatusForbidden,

--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -177,7 +177,9 @@ func (rfw *ResponseFilteringWriter) processSSEResponse(rawResponse []byte) error
 	} else if bytes.Contains(rawResponse, []byte("\r")) {
 		linesep = []byte("\r")
 	} else {
-		return fmt.Errorf("unsupported separator: %s", string(rawResponse))
+		// Length only, not the body: rawResponse is the full pre-filter payload
+		// (e.g. the unfiltered tools/list), and this error is logged upstream.
+		return fmt.Errorf("unsupported SSE line separator in %d-byte response", len(rawResponse))
 	}
 
 	var linesepTotal, linesepCount int
@@ -526,11 +528,14 @@ func (rfw *ResponseFilteringWriter) filterResourcesResponse(response *jsonrpc2.R
 	return filteredResponse, nil
 }
 
-// writeErrorResponse writes an error response
+// writeErrorResponse logs the full filtering error server-side and sends the client a
+// generic message. err can originate in policy evaluation and name tools or
+// resources, so security.md forbids returning it verbatim.
 func (rfw *ResponseFilteringWriter) writeErrorResponse(id jsonrpc2.ID, err error) error {
+	slog.Error("error filtering response", "method", rfw.method, "error", err)
 	errorResponse := &jsonrpc2.Response{
 		ID:    id,
-		Error: jsonrpc2.NewError(mcpparser.CodeInternalError, fmt.Sprintf("Error filtering response: %v", err)),
+		Error: jsonrpc2.NewError(mcpparser.CodeInternalError, "internal error"),
 	}
 
 	// Encode before writing any header, so an encode failure never leaves a
@@ -541,7 +546,7 @@ func (rfw *ResponseFilteringWriter) writeErrorResponse(id jsonrpc2.ID, err error
 		// jsonrpc2.Response built from a valid ID and message above. Fall back
 		// to a hardcoded valid JSON-RPC error body rather than writing nothing.
 		slog.Error("failed to encode JSON-RPC error response", "error", encErr)
-		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal server error"}}`, mcpparser.CodeInternalError)
+		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"internal error"}}`, mcpparser.CodeInternalError)
 	}
 
 	rfw.ResponseWriter.WriteHeader(http.StatusInternalServerError)

--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -530,7 +530,7 @@ func (rfw *ResponseFilteringWriter) filterResourcesResponse(response *jsonrpc2.R
 func (rfw *ResponseFilteringWriter) writeErrorResponse(id jsonrpc2.ID, err error) error {
 	errorResponse := &jsonrpc2.Response{
 		ID:    id,
-		Error: jsonrpc2.NewError(500, fmt.Sprintf("Error filtering response: %v", err)),
+		Error: jsonrpc2.NewError(mcpparser.CodeInternalError, fmt.Sprintf("Error filtering response: %v", err)),
 	}
 
 	// Encode before writing any header, so an encode failure never leaves a
@@ -541,7 +541,7 @@ func (rfw *ResponseFilteringWriter) writeErrorResponse(id jsonrpc2.ID, err error
 		// jsonrpc2.Response built from a valid ID and message above. Fall back
 		// to a hardcoded valid JSON-RPC error body rather than writing nothing.
 		slog.Error("failed to encode JSON-RPC error response", "error", encErr)
-		body = []byte(`{"jsonrpc":"2.0","error":{"code":500,"message":"Internal server error"}}`)
+		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal server error"}}`, mcpparser.CodeInternalError)
 	}
 
 	rfw.ResponseWriter.WriteHeader(http.StatusInternalServerError)

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -1163,11 +1163,10 @@ func TestResponseFilteringWriter_JSON_DisguisedResponseFrame(t *testing.T) {
 	// array, so the pre-fix JSON path wrote it through raw.
 	const smuggled = `[{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"admin_tool"}]}}]`
 
-	// writeErrorResponse wraps the carriesResult error message with a fixed
-	// prefix and reports code 500 — an HTTP status, not a JSON-RPC error code.
-	// This test pins that current behavior; it does not assert the code is
-	// correct.
-	const wantErr = `"error":{"code":500,"message":"Error filtering response: ` +
+	// writeErrorResponse wraps the carriesResult error message and reports the
+	// standard JSON-RPC Internal Error code (mcpparser.CodeInternalError), not
+	// the HTTP status.
+	wantErr := `"error":{"code":` + strconv.FormatInt(mcpparser.CodeInternalError, 10) + `,"message":"Error filtering response: ` +
 		`dropped a frame carrying a result outside a clean Response"}`
 
 	testCases := []struct {

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -1163,11 +1163,10 @@ func TestResponseFilteringWriter_JSON_DisguisedResponseFrame(t *testing.T) {
 	// array, so the pre-fix JSON path wrote it through raw.
 	const smuggled = `[{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"admin_tool"}]}}]`
 
-	// writeErrorResponse wraps the carriesResult error message and reports the
-	// standard JSON-RPC Internal Error code (mcpparser.CodeInternalError), not
-	// the HTTP status.
-	wantErr := `"error":{"code":` + strconv.FormatInt(mcpparser.CodeInternalError, 10) + `,"message":"Error filtering response: ` +
-		`dropped a frame carrying a result outside a clean Response"}`
+	// writeErrorResponse logs the carriesResult error server-side and sends the
+	// client a fixed generic message alongside the standard JSON-RPC Internal
+	// Error code (mcpparser.CodeInternalError), not the HTTP status.
+	wantErr := `"error":{"code":` + strconv.FormatInt(mcpparser.CodeInternalError, 10) + `,"message":"internal error"}`
 
 	testCases := []struct {
 		name      string

--- a/pkg/mcp/errors.go
+++ b/pkg/mcp/errors.go
@@ -3,6 +3,8 @@
 
 package mcp
 
+import "net/http"
+
 // JSONRPCCodeDenied is the application-space JSON-RPC error code ToolHive uses
 // when a policy denies a call, alongside HTTP 403. Both denial paths reference
 // this constant — the single-server authorization middleware
@@ -10,7 +12,38 @@ package mcp
 // is represented by one code across `thv run` and vMCP, by reference rather than
 // by two copies of the literal. It is deliberately outside the reserved
 // -32768..-32000 JSON-RPC range so it never collides with an SDK-generated code.
+// It is also deliberately untyped: it is consumed both as an int
+// (server.Denial.Code, map[string]any envelopes) and as an int64
+// (jsonrpc2.NewError, JSONRPCCodeForStatus). Typing it would break
+// assert.Equal sites on one side.
 const JSONRPCCodeDenied = 403
+
+// JSONRPCCodeForStatus maps an HTTP status code to the JSON-RPC error code
+// that belongs in a response body's error.code field. The HTTP status and the
+// JSON-RPC code are independent dimensions: ToolHive's error paths pick an
+// HTTP status per failure class, and each class has exactly one correct
+// JSON-RPC code. This function is the single place that mapping lives, so
+// callers never pass an HTTP status straight through as the JSON-RPC code.
+//
+// http.StatusUnprocessableEntity maps to JSONRPCCodeDenied because ToolHive's
+// mutating-webhook path relays a webhook's HTTP 422 always-deny response
+// (webhook.IsAlwaysDenyError) as HTTP 422 downstream — the validating path
+// relays the same condition as 403. So a 422 arriving here is semantically a
+// denial.
+//
+// Any status with no explicit case below maps to CodeInternalError, so an
+// unmapped status fails safe to a standard code instead of leaking a raw HTTP
+// status into the JSON-RPC code field.
+func JSONRPCCodeForStatus(status int) int64 {
+	switch status {
+	case http.StatusForbidden, http.StatusUnprocessableEntity:
+		return JSONRPCCodeDenied
+	case http.StatusRequestEntityTooLarge:
+		return CodeInvalidRequest
+	default:
+		return CodeInternalError
+	}
+}
 
 // CodedError is implemented by domain errors that should surface a stable error
 // code and optional structured data in an MCP tool result.

--- a/pkg/mcp/errors_test.go
+++ b/pkg/mcp/errors_test.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSONRPCCodeForStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status int
+		want   int64
+	}{
+		{name: "forbidden maps to denied", status: http.StatusForbidden, want: JSONRPCCodeDenied},
+		{name: "request entity too large maps to invalid request", status: http.StatusRequestEntityTooLarge, want: CodeInvalidRequest},
+		{name: "unprocessable entity maps to denied", status: http.StatusUnprocessableEntity, want: JSONRPCCodeDenied},
+		{name: "internal server error falls through to internal error", status: http.StatusInternalServerError, want: CodeInternalError},
+		{name: "unmapped status defaults to internal error", status: http.StatusBadGateway, want: CodeInternalError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, JSONRPCCodeForStatus(tt.status))
+		})
+	}
+}

--- a/pkg/mcp/revision.go
+++ b/pkg/mcp/revision.go
@@ -198,15 +198,16 @@ func ModernRequestMeta(clientName, clientVersion string) map[string]any {
 }
 
 // The following JSON-RPC error codes are defined by the draft MCP spec
-// (schema/draft/schema.ts) for the stateless "Modern" revision. They are
-// declared as local literals, matching this repo's existing convention for
-// JSON-RPC codes (e.g. streamable_proxy.go's -32603). The only SDK with
-// equivalents, modelcontextprotocol/go-sdk, is reachable solely as a
-// transitive dependency (via toolhive-core's mcpcompat) and is pinned to an
-// older draft snapshot (2026-06-30, CodeHeaderMismatch = -32001) with no
-// equivalents at all for the other two codes below, so importing it would
-// risk wiring in stale values. Revisit once the go-sdk dependency is bumped
-// to a revision that matches MCPVersionModern.
+// (schema/draft/schema.ts) for the stateless "Modern" revision, except for the
+// last three, which are standard JSON-RPC 2.0 codes rather than draft-spec-
+// specific ones. They are declared as local literals, matching this repo's
+// existing convention for JSON-RPC codes (e.g. streamable_proxy.go's -32603).
+// The only SDK with equivalents, modelcontextprotocol/go-sdk, is reachable
+// solely as a transitive dependency (via toolhive-core's mcpcompat) and is
+// pinned to an older draft snapshot (2026-06-30, CodeHeaderMismatch = -32001)
+// with no equivalents at all for the other two codes below, so importing it
+// would risk wiring in stale values. Revisit once the go-sdk dependency is
+// bumped to a revision that matches MCPVersionModern.
 //
 // These are exported so other packages (e.g. the HTTP layer) can reference
 // the same wire values instead of hardcoding or redeclaring them.
@@ -228,8 +229,13 @@ const (
 	// CodeInvalidRequest is the standard JSON-RPC Invalid Request code. ToolHive
 	// uses it to reject a message whose shape is not a valid single request for
 	// the negotiated protocol version — currently a JSON-RPC batch, which was
-	// removed from MCP in the 2025-06-18 revision (see batch.go).
+	// removed from MCP in the 2025-06-18 revision (see batch.go) — and also for
+	// a request body over the configured size limit (HTTP 413, see
+	// JSONRPCCodeForStatus).
 	CodeInvalidRequest int64 = -32600
+	// CodeInternalError is the standard JSON-RPC Internal Error code, used for
+	// server-side failures that are not attributable to the request's shape.
+	CodeInternalError int64 = -32603
 )
 
 // HeaderMismatchError indicates the MCP-Protocol-Version HTTP header did not match

--- a/pkg/webhook/mutating/middleware.go
+++ b/pkg/webhook/mutating/middleware.go
@@ -320,11 +320,12 @@ func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, ms
 	if err != nil {
 		id = jsonrpc2.ID{} // Use empty ID if conversion fails.
 	}
+	code := mcp.JSONRPCCodeForStatus(statusCode)
 
 	// Return a JSON-RPC 2.0 error so MCP clients can parse the denial.
 	errResp := &jsonrpc2.Response{
 		ID:    id,
-		Error: jsonrpc2.NewError(int64(statusCode), message),
+		Error: jsonrpc2.NewError(code, message),
 	}
 
 	// Encode before writing any header, so an encode failure never leaves a
@@ -335,7 +336,7 @@ func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, ms
 		// built from strings/ints above. Fall back to a hardcoded valid JSON-RPC
 		// error body rather than writing nothing.
 		slog.Error("failed to encode JSON-RPC error response", "error", encErr)
-		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, statusCode)
+		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, code)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/webhook/mutating/middleware_test.go
+++ b/pkg/webhook/mutating/middleware_test.go
@@ -244,6 +244,14 @@ func TestMutatingMiddleware_HTTP422AlwaysDenies(t *testing.T) {
 			assert.False(t, nextCalled)
 			assert.Equal(t, http.StatusUnprocessableEntity, rr.Code)
 			assert.Contains(t, rr.Body.String(), "Request denied by webhook policy")
+
+			// An HTTP 422 always-deny must carry the same JSON-RPC denial code as
+			// every other denial (mcp.JSONRPCCodeDenied), not the raw 422 status.
+			var errResp map[string]interface{}
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
+			errObj, ok := errResp["error"].(map[string]interface{})
+			require.True(t, ok)
+			assert.Equal(t, float64(mcp.JSONRPCCodeDenied), errObj["code"])
 		})
 	}
 }
@@ -277,6 +285,12 @@ func TestMutatingMiddleware_ScopeViolation_FailPolicy(t *testing.T) {
 
 	assert.False(t, nextCalled)
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	var errResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
+	errObj, ok := errResp["error"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, float64(mcp.CodeInternalError), errObj["code"])
 }
 
 func TestMutatingMiddleware_ScopeViolation_IgnorePolicy(t *testing.T) {
@@ -510,7 +524,7 @@ func TestMutatingMiddleware_RequestBodySizeLimit(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
 		errObj, ok := errResp["error"].(map[string]interface{})
 		require.True(t, ok)
-		assert.Equal(t, float64(http.StatusRequestEntityTooLarge), errObj["code"])
+		assert.Equal(t, float64(mcp.CodeInvalidRequest), errObj["code"])
 		assert.Equal(t, "Request body exceeds maximum size", errObj["message"])
 	})
 

--- a/pkg/webhook/validating/middleware.go
+++ b/pkg/webhook/validating/middleware.go
@@ -185,12 +185,13 @@ func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, ms
 	if err != nil {
 		id = jsonrpc2.ID{} // Use empty ID if conversion fails
 	}
+	code := mcp.JSONRPCCodeForStatus(statusCode)
 
 	// Return a JSON-RPC 2.0 error so MCP clients can parse the denial.
 	// The HTTP status code signals the error at the transport level; the JSON-RPC body carries the detail.
 	errResp := &jsonrpc2.Response{
 		ID:    id,
-		Error: jsonrpc2.NewError(int64(statusCode), message),
+		Error: jsonrpc2.NewError(code, message),
 	}
 
 	// Encode before writing any header, so an encode failure never leaves a
@@ -201,7 +202,7 @@ func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, ms
 		// built from strings/ints above. Fall back to a hardcoded valid JSON-RPC
 		// error body rather than writing nothing.
 		slog.Error("failed to encode JSON-RPC error response", "error", encErr)
-		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, statusCode)
+		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, code)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/webhook/validating/middleware_test.go
+++ b/pkg/webhook/validating/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -171,7 +172,7 @@ func TestValidatingMiddleware(t *testing.T) {
 
 		errObj, ok := errResp["error"].(map[string]interface{})
 		require.True(t, ok)
-		assert.Equal(t, float64(http.StatusForbidden), errObj["code"])
+		assert.Equal(t, float64(mcp.JSONRPCCodeDenied), errObj["code"])
 		assert.Equal(t, "Request denied by policy", errObj["message"])
 	})
 
@@ -399,7 +400,7 @@ func TestValidatingMiddleware_RequestBodySizeLimit(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
 		errObj, ok := errResp["error"].(map[string]interface{})
 		require.True(t, ok)
-		assert.Equal(t, float64(http.StatusRequestEntityTooLarge), errObj["code"])
+		assert.Equal(t, float64(mcp.CodeInvalidRequest), errObj["code"])
 		assert.Equal(t, "Request body exceeds maximum size", errObj["message"])
 	})
 
@@ -434,6 +435,42 @@ func TestValidatingMiddleware_RequestBodySizeLimit(t *testing.T) {
 		assert.True(t, nextCalled, "next should be called for boundary-size body (fail-open ignores webhook error)")
 		assert.Equal(t, http.StatusOK, rr.Code)
 	})
+}
+
+// errReader always fails, for exercising the io.ReadAll error path in
+// createValidatingHandler that is distinct from an http.MaxBytesError (the
+// oversized-body case already covered by TestValidatingMiddleware_RequestBodySizeLimit).
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+// TestValidatingMiddleware_BodyReadError_MapsToInternalErrorCode pins the JSON-RPC
+// code on the "Failed to read request body" HTTP 500 path (sendErrorResponse's
+// default case in mcp.JSONRPCCodeForStatus), the validating-package equivalent of
+// TestMutatingMiddleware_ScopeViolation_FailPolicy's HTTP 500 assertion.
+func TestValidatingMiddleware_BodyReadError_MapsToInternalErrorCode(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/", errReader{err: errors.New("boom")})
+	ctx := context.WithValue(req.Context(), mcp.MCPRequestContextKey, &mcp.ParsedMCPRequest{Method: "tools/call", ID: int64(1)})
+	req = req.WithContext(ctx)
+
+	mw := createValidatingHandler(nil, "srv", "stdio")
+
+	var nextCalled bool
+	nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { nextCalled = true })
+
+	rr := httptest.NewRecorder()
+	mw(nextHandler).ServeHTTP(rr, req)
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	var errResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
+	errObj, ok := errResp["error"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, float64(mcp.CodeInternalError), errObj["code"])
 }
 
 func TestMiddlewareParams_Validate(t *testing.T) {


### PR DESCRIPTION
## Summary

Two consistency problems in the same handful of denial/error functions, both found while fixing #5950 and deliberately left out of that PR because neither is the envelope bug.

**1. HTTP statuses used as JSON-RPC error codes.** Three paths passed the HTTP status straight through as `error.code`: `pkg/authz/response_filter.go` emitted a literal `500`, and both webhook middlewares emitted whatever status they were called with — 413, 422, or 500. Those values are legal, since they sit outside the reserved `-32768..-32000` range, but they are not the codes the draft MCP spec designates for general protocol failures ("MCP uses the standard JSON-RPC 2.0 error codes (-32700, -32600 to -32603) for general protocol failures"). A client that branches on `error.code` cannot recognize `500` as internal-error or `422` as a denial.

The status and the code are independent dimensions, so `mcp.JSONRPCCodeForStatus` is now the single place the mapping lives: 413 → `-32600` (an oversized body is a malformed request), 500 → `-32603`, and 422 → `JSONRPCCodeDenied`. That last one matters: the mutating path relays a webhook's HTTP 422 always-deny response downstream, while the validating path relays the *identical* condition as 403 — so emitting 422 as the code made one denial look unlike every other denial, defeating the stated purpose of the shared constant.

Deriving the code inside `sendErrorResponse` leaves all 13 call sites untouched. An explicit second parameter was considered and rejected: each status here already corresponds to exactly one failure class with exactly one correct code, so passing a redundant constant at 13 sites is 13 more places to get it wrong.

**`403` is unchanged.** It is the one case where status and code legitimately coincide, deliberately outside the reserved range so it never collides with an SDK-generated code. It stays asserted across `pkg/vmcp/server/*_test.go` and documented at `docs/arch/10-virtual-mcp-architecture.md:631`.

**2. Denial paths leaked internal error text.** `handleUnauthorized` used `err.Error()` as the client-visible message, so a Cedar evaluation error and a default-deny message disclosing "(not configured for authorization)" both reached the caller; `writeErrorResponse` sent `"Error filtering response: %v"`, where the error can originate in policy evaluation and name tools. Meanwhile `pkg/webhook/validating/middleware.go` does the exact opposite two directories over, with the comment "Prevent information leaks by ignoring the webhook's message" — so the tree contradicted itself in adjacent files.

Standardized on scrub-and-log, following `writeModernListError` in `pkg/vmcp/server/modern_dispatch.go`. The client-visible string is unchanged from what a clean deny already produced, so an authorizer *error* and a policy *deny* are now byte-identical to the caller rather than distinguishable. Scoping this honestly, as the issue does: the recipient is already authenticated, just not authorized, and what leaked was policy-engine structure — not credentials and not another user's data. This is a hardening and consistency item, not a vulnerability.

Fixes #6039

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

`task test` passed with exit code 0, plus scoped `go test ./pkg/mcp/... ./pkg/authz/... ./pkg/webhook/... ./pkg/runner/...` green on every touched package.

One caveat worth stating rather than hiding: `task test`'s command is `go test ... | gotestfmt -hide "all"`, with no `pipefail` set, so its exit code is a weaker signal than it appears and the run produces no per-package output at all. The scoped runs are the real per-package evidence.

Every new assertion was proven to be a real regression guard by reverting the production line it covers, confirming the test fails, then restoring. Two worth calling out:

- Reverting `sendErrorResponse` to `int64(statusCode)` makes the 422 test fail with `expected: 403, actual: 422` — that assertion is what pins "a denial looks like every other denial".
- Reverting `authorizeAndServe`'s `err != nil ||` disjunct makes the new `allowed=true` cases fail with the next handler having been called and a 200 returned. Nothing in the suite covered that before (see reviewer notes below).

Linting not run locally; leaving it to CI.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/mcp/errors.go` | New `JSONRPCCodeForStatus`; records why `JSONRPCCodeDenied` is deliberately untyped |
| `pkg/mcp/revision.go` | `CodeInternalError = -32603` added to the existing standard-code block; two comments resynced |
| `pkg/webhook/validating/middleware.go` | `sendErrorResponse` maps status → code; encode-failure fallback body fixed |
| `pkg/webhook/mutating/middleware.go` | Same (10 call sites, all untouched) |
| `pkg/authz/response_filter.go` | `writeErrorResponse`: `500` → `CodeInternalError`, message scrubbed + logged; `processSSEResponse` no longer interpolates the raw body |
| `pkg/authz/middleware.go` | `handleUnauthorized` always sends `"Unauthorized"` and logs the error; unknown-method deny logs at Debug from the call site |
| `pkg/mcp/errors_test.go` | New table-driven mapping test incl. the default case |
| `pkg/webhook/*/middleware_test.go` | 413 assertions updated; new 422→403, 500→-32603, and a validating-side 500 path that had no coverage |
| `pkg/authz/middleware_test.go` | New authorizer-error scrub test; new `allowed=true` fail-closed case |
| `pkg/authz/response_filter_test.go` | Disguised-result test now pins the mapped code and the generic message |

## Does this introduce a user-facing change?

Yes, and it is client-visible on two axes.

**Error codes.** Denial and error bodies from the authorization middleware, the response filter, and both webhook middlewares now carry standard JSON-RPC codes instead of HTTP statuses: `500` → `-32603`, `413` → `-32600`, `422` → `403`. Clients that branch on `error.code` can now recognize these as internal-error / invalid-request / denied. `403` is unchanged. No HTTP status changes, so anything keying off the status — including audit outcomes, which are derived from the status and not the code — behaves identically.

**Error messages.** Authorization denials now always read `Unauthorized`, and response-filter failures read `internal error`, instead of carrying the underlying error text. Operators lose nothing: the full error is logged server-side with more context than the client ever had. Anyone who was scraping the old message text for diagnostics will need to read the logs instead.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Implemented in three delegated steps (Sonnet worker, Opus reviewer per step, iterating until the reviewer had no blocking findings), landing as two commits.

**Step 0 — branch setup.** Branch off `fix-nonconformant-jsonrpc-denials` (#6055), which rewrites these exact four functions to encode via `jsonrpc2.EncodeMessage`. #6055 also de-shadowed the `err` parameter in `handleUnauthorized`, which is what makes the original error available to log in step 3.

**Step 1 — the mapping.** Reuse the existing standard-code family in `pkg/mcp/revision.go` (which already exports `CodeInvalidRequest = -32600`) rather than inventing a new home; add `CodeInternalError` alongside it and `JSONRPCCodeForStatus` next to `JSONRPCCodeDenied`. Acceptance: no constant duplicated, default fails safe to `CodeInternalError`, no new import beyond `net/http`.

**Step 2 — apply at the call sites.** Derive the code inside both `sendErrorResponse` functions and use `CodeInternalError` in `writeErrorResponse`; fix the encode-failure fallback bodies, which spliced the raw status into the `code` field and would otherwise reintroduce the bug they stand in for. Acceptance: no HTTP status changed anywhere, the 403 assertions pass unmodified, and the 422 assertion is a proven regression guard. → commit 1.

**Step 3 — scrub the error text.** `handleUnauthorized` logs and always sends `"Unauthorized"`; `writeErrorResponse` logs with the method and sends `"internal error"`. Fixing the shared handler is the root-cause fix — it covers both callers at once. Acceptance: the message string stays exactly `"Unauthorized"` so `pkg/runner/authz_audit_integration_test.go` passes unmodified, fail-closed semantics unchanged, and no scrubbed error is silently dropped. → commit 2.

**Deliberately out of scope**, each tracked: #6037 (SSE `data:` prefix), #6038 (three hand-built envelopes still emitting `"id":null`).

</details>

## Special notes for reviewers

**Was stacked on #6055; now standalone.** This was originally built on `fix-nonconformant-jsonrpc-denials` because parts of it — notably the encode-failure fallback bodies — only exist after that refactor. #6055 has since merged (`9b0d83af0`), so this is rebased onto `main` and the diff is just its own two commits.

**Three things the review pass caught that are worth knowing about, because two of them were defects in this PR's own tests:**

1. **A test that did not test what it claimed.** The first version of `TestHandleUnauthorizedScrubsAuthorizerError` used `stubAuthorizer{allowed: false, err: sensitiveErr}`. `authorizeAndServe`'s condition is `err != nil || !authorized`, so `allowed: false` takes the branch via the `!authorized` disjunct — every assertion passed identically with `err: nil`, which made the `NotContains` vacuous. Now `allowed: true`, so the denial can only come from the error. This also closed a real coverage gap: **nothing in the suite pinned that an authorizer returning `(true, err)` fails closed**, so dropping the `err != nil` disjunct would have served an erroring authorizer with the whole suite still green.

2. **A sibling leak the scrub initially missed.** `processSSEResponse` interpolated the entire buffered upstream body — for a `tools/list`, the full pre-Cedar tool list — into an error that is logged upstream by `FlushAndFilter`'s caller. Not client-visible, but it routed the exact payload this filter exists to scrub into an unbounded, caller-influenceable log line. Now reports the length only.

3. **Log-level conflation.** `handleUnauthorized`'s `slog.Warn` served two very different events: the unknown-method default deny (expected traffic from any newer-spec client hitting `tasks/list`, `sampling/createMessage`, …) and an actual authorizer failure. Since `parsedRequest.Method` is unbounded caller-controlled input, that was one attacker-chosen WARN line per request. The routine deny now logs at Debug from the call site — matching how this package already logs per-item denials, and how the webhook middlewares split `Info` for denials from `Error` for operational failures — leaving Warn for genuine authorizer errors.

**One scoping caveat on "standardize", so nobody reads more into it than is there.** This aligns `pkg/authz` with the *nearest* precedent, not with a tree-wide rule. `writeModernListError` scrubs because its errors carry aggregation and routing plumbing that `security.md` forbids exposing — the same category as the policy-engine detail `pkg/authz` was leaking, which is why it is the right precedent here. Its sibling `writeModernDispatchError` (`pkg/vmcp/server/modern_dispatch.go:618-623`) deliberately does the opposite, relaying `err.Error()` verbatim, on the documented grounds that the SDK path already exposes the raw text for the identical failure. That exception survives this PR by design. So the split that remains is a reasoned one between error *categories*, not the adjacent-files contradiction this PR removes.

**A note for whoever touches the logging next.** `handleUnauthorized`'s doc comment now warns that the logged error can embed decoded JWT *claim values*: `preprocessClaims` puts every claim into the Cedar evaluation context, and cedar-go's `decimal()`/`ip()`/`datetime()` constructors echo the offending value into `Diagnostic.Errors`. That directly contradicts the deliberate "claim keys only — never claim values, which hold user PII" rule in `authorizers/cedar/core.go`. Nothing leaks today, but this payload should not be promoted to a structured field that ships to an aggregator.

**A same-defect sibling remains, tracked as a follow-up.** `processSSEResponse` here and `processEventStream` in `pkg/mcp/tool_filter.go` carry the byte-identical `fmt.Errorf("unsupported separator: %s", <whole buffer>)` — splicing the full pre-filter payload (the unfiltered tool list, for a `tools/list`) into an error that is logged upstream. Neither is client-visible, so neither is a leak in the scrub's sense, but both route the exact payload the filter exists to scrub into an unbounded, caller-influenceable log line. This PR fixes the one in its own blast radius; the `tool_filter.go` sibling is fixed in a follow-up rather than retro-fitted here.

**Two items deliberately banked, not fixed here:**

- `pkg/authz/middleware.go:330` — a `passThroughTools` entry with an empty or non-string `tool_name` is served with **no authorization check at all**, relying on the optimizer decorator to gate downstream. Pre-existing, deliberate, and pinned by an existing test, but it deserves its own issue confirming it against the decorator's actual behavior.
- `convErr` in `handleUnauthorized` and `requestID()`'s error in `response_filter.go` are still swallowed. Both are commented, so the go-style rule is satisfied, but the consequence is a client-visible symptom — an error response with no `id`, uncorrelatable — with zero server-side trace. Those lines come from #6055, so they belong there or in a follow-up.

**Why no shared envelope helper**, in case it comes up: #6055 already argued this and it holds here too. The tree has several hand-rolled envelope builders; a shared one absorbs none of them without an options struct, and an `any`-typed id parameter is exactly how a caller reintroduces the id bug #6055 fixed. The greppable rule is the cheaper guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
