### PR TITLE
Stop trimming binary HMAC secrets before use

### DIFF
--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -378,8 +378,12 @@ func loadHMACSecrets(files []string) (*servercrypto.HMACSecrets, error) {
 		return nil, fmt.Errorf("failed to read HMAC secret from %s: %w", files[0], err)
 	}
 
-	// Trim whitespace (Kubernetes Secret mounts may include trailing newlines)
-	current = bytes.TrimSpace(current)
+	// HMAC secrets are raw binary (see MCPExternalAuthConfig.HMACSecretRefs doc) — do not
+	// trim; any byte, including whitespace-valued ones, may be genuine key material.
+	if len(current) < servercrypto.MinSecretLength {
+		return nil, fmt.Errorf("HMAC secret in %s is %d bytes, but must be at least %d bytes",
+			files[0], len(current), servercrypto.MinSecretLength)
+	}
 
 	secrets := &servercrypto.HMACSecrets{
 		Current: current,
@@ -395,7 +399,11 @@ func loadHMACSecrets(files []string) (*servercrypto.HMACSecrets, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read rotated HMAC secret from %s: %w", file, err)
 		}
-		secrets.Rotated = append(secrets.Rotated, bytes.TrimSpace(secret))
+		if len(secret) < servercrypto.MinSecretLength {
+			return nil, fmt.Errorf("rotated HMAC secret in %s is %d bytes, but must be at least %d bytes",
+				file, len(secret), servercrypto.MinSecretLength)
+		}
+		secrets.Rotated = append(secrets.Rotated, secret)
 	}
 
 	return secrets, nil

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -167,12 +167,12 @@ func TestLoadHMACSecrets(t *testing.T) {
 		assert.Equal(t, []byte(rotatedSecret), secrets.Rotated[0])
 	})
 
-	t.Run("trims whitespace from secrets", func(t *testing.T) {
+	t.Run("preserves leading and trailing whitespace bytes in secrets", func(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
 		secretFile := filepath.Join(tmpDir, "hmac-secret")
-		secretValue := "  secret-with-whitespace  \n"
+		secretValue := "  secret-with-whitespace-that-is-at-least-32-bytes  \n"
 
 		err := os.WriteFile(secretFile, []byte(secretValue), 0600)
 		require.NoError(t, err)
@@ -181,7 +181,88 @@ func TestLoadHMACSecrets(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, secrets)
 
-		assert.Equal(t, []byte("secret-with-whitespace"), secrets.Current)
+		assert.Equal(t, []byte(secretValue), secrets.Current)
+	})
+
+	t.Run("does not corrupt binary secrets with whitespace-valued edge bytes", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		secretFile := filepath.Join(tmpDir, "hmac-secret")
+
+		original := make([]byte, 32)
+		for i := range original {
+			original[i] = 0xAB
+		}
+		original[0] = 0x20
+		original[31] = 0x0A
+
+		require.NoError(t, os.WriteFile(secretFile, original, 0600))
+
+		secrets, err := loadHMACSecrets([]string{secretFile})
+		require.NoError(t, err)
+		require.NotNil(t, secrets)
+
+		require.Len(t, secrets.Current, 32)
+		assert.Equal(t, original, secrets.Current)
+	})
+
+	t.Run("does not corrupt rotated binary secrets with whitespace-valued edge bytes", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		currentFile := filepath.Join(tmpDir, "hmac-current")
+		rotatedFile := filepath.Join(tmpDir, "hmac-rotated")
+
+		require.NoError(t, os.WriteFile(currentFile, []byte("current-secret-32-bytes-minimum!"), 0600))
+
+		original := make([]byte, 32)
+		for i := range original {
+			original[i] = 0xAB
+		}
+		original[0] = 0x20
+		original[31] = 0x0A
+
+		require.NoError(t, os.WriteFile(rotatedFile, original, 0600))
+
+		secrets, err := loadHMACSecrets([]string{currentFile, rotatedFile})
+		require.NoError(t, err)
+		require.NotNil(t, secrets)
+
+		require.Len(t, secrets.Rotated, 1)
+		assert.Equal(t, original, secrets.Rotated[0])
+	})
+
+	t.Run("short current secret returns error naming file and byte counts", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		secretFile := filepath.Join(tmpDir, "hmac-secret")
+
+		require.NoError(t, os.WriteFile(secretFile, make([]byte, 31), 0600))
+
+		_, err := loadHMACSecrets([]string{secretFile})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), secretFile)
+		assert.Contains(t, err.Error(), "31")
+		assert.Contains(t, err.Error(), "32")
+	})
+
+	t.Run("short rotated secret returns error naming file and byte counts", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		currentFile := filepath.Join(tmpDir, "hmac-current")
+		rotatedFile := filepath.Join(tmpDir, "hmac-rotated")
+
+		require.NoError(t, os.WriteFile(currentFile, []byte("current-secret-32-bytes-minimum!"), 0600))
+		require.NoError(t, os.WriteFile(rotatedFile, make([]byte, 31), 0600))
+
+		_, err := loadHMACSecrets([]string{currentFile, rotatedFile})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), rotatedFile)
+		assert.Contains(t, err.Error(), "31")
+		assert.Contains(t, err.Error(), "32")
 	})
 
 	t.Run("skips empty paths in rotated files", func(t *testing.T) {

--- a/pkg/authserver/server/crypto/keys.go
+++ b/pkg/authserver/server/crypto/keys.go
@@ -26,7 +26,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/go-jose/go-jose/v4"
 )
@@ -226,63 +225,4 @@ func DeriveSigningKeyParams(key crypto.Signer, keyID, algorithm string) (*Signin
 	}
 
 	return params, nil
-}
-
-// loadHMACSecretFile loads an HMAC secret from a file (internal helper).
-// Returns nil if path is empty (triggers random generation in toInternalConfig).
-// The secret must be at least 32 bytes after trimming whitespace.
-func loadHMACSecretFile(secretPath string) ([]byte, error) {
-	if secretPath == "" {
-		return nil, nil
-	}
-
-	data, err := os.ReadFile(secretPath) // #nosec G304 - secretPath is provided by user via CLI flag or config
-	if err != nil {
-		return nil, fmt.Errorf("failed to read HMAC secret file: %w", err)
-	}
-
-	// Trim whitespace (common in Kubernetes Secret mounts which often add trailing newlines)
-	secret := []byte(strings.TrimSpace(string(data)))
-
-	if len(secret) < MinSecretLength {
-		return nil, fmt.Errorf("HMAC secret must be at least %d bytes", MinSecretLength)
-	}
-
-	return secret, nil
-}
-
-// LoadHMACSecrets loads HMAC secrets from file paths for rotation support.
-// paths[0] is the current (signing) secret; paths[1:] are rotated (verification) secrets.
-// Returns nil if paths is empty (caller should generate random secret).
-func LoadHMACSecrets(paths []string) (*HMACSecrets, error) {
-	if len(paths) == 0 {
-		return nil, nil
-	}
-
-	// Load current secret (required, cannot be empty path)
-	if paths[0] == "" {
-		return nil, fmt.Errorf("current HMAC secret path cannot be empty")
-	}
-	current, err := loadHMACSecretFile(paths[0])
-	if err != nil {
-		return nil, fmt.Errorf("failed to load current HMAC secret: %w", err)
-	}
-
-	// Load rotated secrets (optional, skip empty paths)
-	var rotated [][]byte
-	for i, path := range paths[1:] {
-		if path == "" {
-			continue
-		}
-		secret, err := loadHMACSecretFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load rotated HMAC secret [%d]: %w", i+1, err)
-		}
-		rotated = append(rotated, secret)
-	}
-
-	return &HMACSecrets{
-		Current: current,
-		Rotated: rotated,
-	}, nil
 }

--- a/pkg/authserver/server/crypto/keys_test.go
+++ b/pkg/authserver/server/crypto/keys_test.go
@@ -25,7 +25,6 @@ import (
 	"encoding/pem"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -286,137 +285,6 @@ func TestDeriveKeyID(t *testing.T) {
 	assert.NotEqual(t, id1, id3, "different keys should produce different IDs")
 }
 
-func TestLoadHMACSecrets(t *testing.T) {
-	t.Parallel()
-
-	validSecret := strings.Repeat("a", 32)
-	validSecret2 := strings.Repeat("b", 32)
-	tooShortSecret := strings.Repeat("a", 31)
-
-	tests := []struct {
-		name        string
-		setup       func(t *testing.T, dir string) []string
-		wantCurrent []byte
-		wantRotated [][]byte
-		wantErr     string
-	}{
-		{
-			name:        "empty paths",
-			setup:       func(_ *testing.T, _ string) []string { return []string{} },
-			wantCurrent: nil,
-			wantRotated: nil,
-		},
-		{
-			name: "single secret",
-			setup: func(_ *testing.T, dir string) []string {
-				return []string{writeFileNamed(t, dir, "current", validSecret)}
-			},
-			wantCurrent: []byte(validSecret),
-			wantRotated: nil,
-		},
-		{
-			name: "with rotated secrets",
-			setup: func(_ *testing.T, dir string) []string {
-				return []string{
-					writeFileNamed(t, dir, "current", validSecret),
-					writeFileNamed(t, dir, "rotated1", validSecret2),
-				}
-			},
-			wantCurrent: []byte(validSecret),
-			wantRotated: [][]byte{[]byte(validSecret2)},
-		},
-		{
-			name: "empty current path",
-			setup: func(_ *testing.T, _ string) []string {
-				return []string{""}
-			},
-			wantErr: "current HMAC secret path cannot be empty",
-		},
-		{
-			name: "invalid current secret file",
-			setup: func(_ *testing.T, _ string) []string {
-				return []string{"/nonexistent/secret"}
-			},
-			wantErr: "failed to load current",
-		},
-		{
-			name: "invalid rotated secret",
-			setup: func(_ *testing.T, dir string) []string {
-				return []string{
-					writeFileNamed(t, dir, "current", validSecret),
-					"/nonexistent/rotated",
-				}
-			},
-			wantErr: "failed to load rotated HMAC secret [1]",
-		},
-		{
-			name: "skip empty rotated paths",
-			setup: func(_ *testing.T, dir string) []string {
-				return []string{
-					writeFileNamed(t, dir, "current", validSecret),
-					"",
-					writeFileNamed(t, dir, "rotated2", validSecret2),
-				}
-			},
-			wantCurrent: []byte(validSecret),
-			wantRotated: [][]byte{[]byte(validSecret2)},
-		},
-		{
-			name: "whitespace trimmed",
-			setup: func(_ *testing.T, dir string) []string {
-				return []string{
-					writeFileNamed(t, dir, "current", "  "+validSecret+"  \n\n"),
-					writeFileNamed(t, dir, "rotated", "\t"+validSecret2+"\n"),
-				}
-			},
-			wantCurrent: []byte(validSecret),
-			wantRotated: [][]byte{[]byte(validSecret2)},
-		},
-		{
-			name: "current too short",
-			setup: func(_ *testing.T, dir string) []string {
-				return []string{writeFileNamed(t, dir, "current", tooShortSecret)}
-			},
-			wantErr: "HMAC secret must be at least",
-		},
-		{
-			name: "rotated too short",
-			setup: func(_ *testing.T, dir string) []string {
-				return []string{
-					writeFileNamed(t, dir, "current", validSecret),
-					writeFileNamed(t, dir, "rotated", tooShortSecret),
-				}
-			},
-			wantErr: "failed to load rotated HMAC secret [1]",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			dir := t.TempDir()
-			paths := tt.setup(t, dir)
-
-			secrets, err := LoadHMACSecrets(paths)
-
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
-				assert.Nil(t, secrets)
-			} else {
-				require.NoError(t, err)
-				if tt.wantCurrent == nil {
-					assert.Nil(t, secrets)
-				} else {
-					require.NotNil(t, secrets)
-					assert.Equal(t, tt.wantCurrent, secrets.Current)
-					assert.Equal(t, tt.wantRotated, secrets.Rotated)
-				}
-			}
-		})
-	}
-}
-
 // Helpers
 
 func writePEM(t *testing.T, dir, pemType string, der []byte) string {
@@ -424,12 +292,5 @@ func writePEM(t *testing.T, dir, pemType string, der []byte) string {
 	path := filepath.Join(dir, "key.pem")
 	data := pem.EncodeToMemory(&pem.Block{Type: pemType, Bytes: der})
 	require.NoError(t, os.WriteFile(path, data, 0600))
-	return path
-}
-
-func writeFileNamed(t *testing.T, dir, name, content string) string {
-	t.Helper()
-	path := filepath.Join(dir, name)
-	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 	return path
 }


### PR DESCRIPTION
## Summary

`loadHMACSecrets` (embedded vMCP OAuth authorization server) ran
`bytes.TrimSpace` on raw HMAC secret file bytes before using them as key
material. HMAC secrets are documented (`HMACSecretRefs` on
`MCPExternalAuthConfig`) as **raw binary**, "at least 32 bytes and
cryptographically random" — not text or base64. `TrimSpace` strips any
leading/trailing byte that happens to be ASCII whitespace
(`0x09 0x0A 0x0B 0x0C 0x0D 0x20`), which corrupts (shortens) a random
32-byte secret with probability ≈4.6% (`1-(250/256)^2`, empirically
confirmed at 4.74% over 200k trials). When that happens the secret drops
below the 32-byte minimum, `Config.Validate()` rejects it with a generic
"HMAC secret must be at least 32 bytes" error, and the safe
ephemeral-secret fallback never runs because it only triggers when
`HMACSecrets == nil`, not "non-nil but short". Net effect: roughly 1 in 21
embedded-auth-server pods fail to boot on a perfectly valid secret, with an
error that gives no hint the real cause is byte-trimming.

Found while investigating an intermittent e2e failure ("Redis-Backed
Session Sharing" spec) that looked like a CI flake but was root-caused to
this deterministic, probabilistic production bug.

What changed:
- `loadHMACSecrets` no longer trims — file bytes are used verbatim for
  both the current and rotated secrets.
- Added explicit length checks that name the file path and actual/required
  byte counts, so a genuinely short secret fails loudly and clearly instead
  of via a generic error three layers away.
- Deleted an unused, independent, identically-buggy duplicate loader
  (`loadHMACSecretFile` / `LoadHMACSecrets` in `server/crypto/keys.go`) —
  confirmed zero callers anywhere in the repo besides its own test.
- Added regression tests covering binary secrets with whitespace-valued
  edge bytes (current and rotated paths) and the new short-secret error
  messages; flipped the one existing test that had encoded the old
  (buggy) trimming behavior as correct.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Ran `go test ./pkg/authserver/...` (all packages `ok`) and a fresh
`-count=1 -v -run TestLoadHMACSecrets` pass confirming all 10 subtests in
`pkg/authserver/runner` succeed, including the 4 new regression cases, and
that the dead duplicate test in `pkg/authserver/server/crypto` is fully
gone ("no tests to run").

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/authserver/runner/embeddedauthserver.go` | Remove both `bytes.TrimSpace` calls (current + rotated secrets); add explicit length checks with descriptive errors |
| `pkg/authserver/runner/embeddedauthserver_test.go` | Flip the old "trims whitespace" test; add 4 regression subtests |
| `pkg/authserver/server/crypto/keys.go` | Delete unused, identically-buggy duplicate loader (`loadHMACSecretFile`, `LoadHMACSecrets`) |
| `pkg/authserver/server/crypto/keys_test.go` | Delete the matching dead test and helper |

## Does this introduce a user-facing change?

Yes. The embedded auth server's `HMACSecretRefs`-based HMAC secret files
are now read verbatim instead of being whitespace-trimmed. Practical
impact: secrets exactly at the documented 32-byte minimum that previously
crash-looped the pod (the bug this PR fixes) now boot correctly. The
narrower case of an already-deployed secret *longer* than 32 bytes with an
incidental leading/trailing whitespace byte will pick up a different
(correct, full) key on upgrade — any auth codes/refresh tokens issued
before the upgrade become invalid, a one-time and harmless side effect
(short-lived tokens, no data loss).

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

# Fix: `loadHMACSecrets` corrupts binary HMAC secrets via `bytes.TrimSpace`

## Context

The embedded vMCP OAuth authorization server reads HMAC signing secrets from
mounted Kubernetes Secret files. `loadHMACSecrets` in
`pkg/authserver/runner/embeddedauthserver.go` runs the raw file bytes through
`bytes.TrimSpace` before using them as key material. HMAC secrets are
documented (`cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go:383-390`,
the `HMACSecretRefs` doc comment) as **raw binary**, "at least 32 bytes and
cryptographically random" — not text or base64. `TrimSpace` strips any
leading/trailing byte that happens to fall in the 6-byte ASCII-whitespace set
(`0x09 0x0A 0x0B 0x0C 0x0D 0x20`), which happens to a random 32-byte secret
with probability ≈4.6% (`1-(250/256)^2`, empirically confirmed at 4.74% over
200k trials). When that happens, the secret shrinks below the 32-byte minimum,
`Config.Validate()` (`pkg/authserver/config.go:709-711`) rejects it with "HMAC
secret must be at least 32 bytes", and the safe ephemeral-secret fallback in
`applyDefaults()` (`config.go:1010-1018`) never runs because it only triggers
on `HMACSecrets == nil`, not "non-nil but short". Net effect: roughly 1 in 21
vMCP embedded-auth-server pods fail to boot on a perfectly valid secret, with
an error that gives no hint the cause is byte-trimming.

This was found while investigating an intermittent e2e failure in PR #6056
(`test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go`, "Redis-
Backed Session Sharing" spec) and confirmed as a real production bug, not a
test artifact — the handover doc and follow-up research verified every step
of the chain against the actual code (call order, validation gate, fallback
bypass) and found a second, independent, identically-buggy implementation
sitting unused in the tree.

Decisions confirmed with the user:
- **Remove trimming entirely** (no heuristic trim of any kind) rather than a
  narrower `TrimSuffix("\n")` — any byte-level heuristic still has residual
  corruption risk on raw binary data; the CRD contract already documents
  these as opaque bytes with no encoding, so verbatim use is the only
  approach with zero residual risk. This is a pure runtime-behavior fix, no
  CRD/schema change. Practical impact: already-deployed secrets exactly at
  the 32-byte minimum with an edge whitespace byte currently crash-loop and
  will now boot correctly (pure fix, nothing to invalidate); the narrower case
  of secrets deployed *longer* than 32 bytes with such an edge byte will get
  a new (correct) key on upgrade, invalidating any auth codes/refresh tokens
  issued before the upgrade — one-time, harmless, worth a one-line PR note.
- **Delete the dead duplicate** in `pkg/authserver/server/crypto/keys.go`
  (`loadHMACSecretFile`, exported `LoadHMACSecrets`) in this same PR — same
  root-cause bug, confirmed zero callers anywhere in the repo (only its own
  definition and its own test reference it), and leaving it risks a future
  contributor wiring it up and reintroducing the exact bug just fixed.

## Changes

### 1. `pkg/authserver/runner/embeddedauthserver.go` — the fix

In `loadHMACSecrets` (~lines 366-410):
- Delete `current = bytes.TrimSpace(current)` (current-secret path).
- Delete the `bytes.TrimSpace(...)` wrapper around `secret` in the
  `files[1:]` rotated-secrets loop — keep the bytes as read.
- Replace the now-wrong comment ("Trim whitespace (Kubernetes Secret mounts
  may include trailing newlines)") with one explaining why trimming is
  wrong: these are raw binary secrets per `HMACSecretRefs`'s documented
  contract, and any byte — including whitespace-valued ones — may be
  genuine key material.
- Add an explicit length check right after each `os.ReadFile`, before the
  bytes are used, so a too-short secret fails with a message naming the
  file and the actual byte count instead of relying on the generic error
  from `Config.Validate()` three layers away:
  - Current: `fmt.Errorf("HMAC secret in %s is %d bytes, but must be at least %d bytes", files[0], len(current), servercrypto.MinSecretLength)`.
  - Rotated: same pattern, worded for "rotated HMAC secret in %s".
- Leave `Config.Validate()`'s existing length check untouched — it remains
  valid defense-in-depth for any caller that builds `Config.HMACSecrets`
  directly without going through `loadHMACSecrets`.
- The `bytes` import stays — still used by the unrelated `resolveSecret`
  (~line 666), which trims a text-based OAuth client secret and is
  correctly out of scope.

### 2. `pkg/authserver/runner/embeddedauthserver_test.go` — regression coverage

- **Flip the existing "trims whitespace from secrets" subtest** (~lines
  170-185): it currently asserts trimming happens for a text secret with
  leading/trailing spaces/newlines — that's the old, now-wrong behavior.
  Rename to something like `"preserves leading and trailing whitespace
  bytes in secrets"` and assert the loaded value equals the **full,
  untrimmed** input bytes.
- **Add a pathological-binary-bytes subtest**: build a 32-byte slice with
  `secret[0] = 0x20` and `secret[31] = 0x0A` (fixed non-whitespace filler in
  between), write it raw via `os.WriteFile`, load via `loadHMACSecrets`, and
  assert the result is exactly 32 bytes and byte-for-byte equal to the
  original. This is the direct regression pin for the corruption bug.
- **Cover the rotated-secret path the same way** — a second file with the
  same pathological edge bytes used as a rotated secret, asserting
  `secrets.Rotated[0]` is untouched.
- **Add short-secret error-message subtests** for both current and rotated
  paths: write a 31-byte file, assert the returned error mentions the file
  path and both the actual (31) and required (32) byte counts.
- Leave the other existing subtests (single file, multiple files, empty
  paths skipped, missing file, empty file) unchanged — none exercise
  whitespace bytes.

### 3. Delete dead duplicate in `pkg/authserver/server/crypto/keys.go`

- Remove `loadHMACSecretFile` and exported `LoadHMACSecrets` (same
  `strings.TrimSpace`-on-raw-bytes bug, zero production callers repo-wide).
- Remove the now-unused `"strings"` import (confirmed its only use in this
  file is inside the deleted function).

### 4. `pkg/authserver/server/crypto/keys_test.go` — drop the matching test

- Remove `TestLoadHMACSecrets` and the `writeFileNamed` helper (used only by
  that test).
- Remove the now-unused `"strings"` import (confirmed its only uses —
  `strings.Repeat`, three call sites — are inside the deleted test). Keep
  `writePEM` and everything else in the file untouched.

## Out of scope (confirmed, don't touch)

- The sibling signing-key file path (`servercrypto.LoadSigningKey`) — reads
  raw bytes straight into `pem.Decode` with no trimming; PEM is a text
  format tolerant of surrounding whitespace by design, no bug there.
- `cmd/thv/app/auth_flags.go:35` and `cmd/thv/app/secret.go:429` — trim
  interactively-typed/CLI-flag secret input, a different trust context
  (human-typed text, not file-mounted binary key material).
- `test/e2e/thv-operator/virtualmcp/virtualmcp_redis_session_test.go` — its
  existing `rand.Read(32)` raw-bytes setup is already the most adversarial
  realistic input; once the production fix lands this path is safe by
  construction, and the new deterministic unit test is a stronger, cheaper
  regression pin than re-running a probabilistic e2e spec. No test change
  needed there.

## Verification

- `task test` scoped to the two touched packages (or the full suite if
  path-filtering isn't convenient): `pkg/authserver/runner` and
  `pkg/authserver/server/crypto`. The new pathological-byte subtest is
  deterministic, so a single green run is real proof (unlike the e2e spec,
  which passes ~95% of the time even when broken).
- `task lint-fix` before submitting — also catches any missed unused-import
  cleanup.
- No e2e re-run needed for this fix specifically (see "Out of scope" above).

## PR

Single PR, one logical change ("fix HMAC secret file loading corruption"),
net deletion overall (~+20/-8 in the two fixed files, ~-190 in the two
dead-code files) — 4 files touched, comfortably within the 400-line/10-file
guideline. Mention the one-time-token-reissue side effect (see Context) in
the PR description as a one-line note, not a code change.

</details>

## Special notes for reviewers

- **Public API removal**: `LoadHMACSecrets` in `pkg/authserver/server/crypto`
  was exported but had zero callers anywhere in this repo (confirmed via
  full-repo grep — only its own definition and its own test referenced it).
  It shared the exact same `TrimSpace`-on-raw-bytes bug as the code being
  fixed. Deleted rather than fixed in place to avoid leaving a second,
  dormant copy of the same defect. Flagging in case any external consumer
  of this module depends on it (none found in-tree).
- No issue was filed for this bug before starting — it was root-caused
  while investigating an unrelated e2e failure in #6056; happy to file one
  retroactively if preferred for tracking.
- No file overlap with #6063 (in-flight CI-deflake PR) — checked directly.

Generated with [Claude Code](https://claude.com/claude-code)
