### PR TITLE
Omit absent JSON-RPC ids instead of emitting null

### DIFF
--- a/pkg/mcp/batch.go
+++ b/pkg/mcp/batch.go
@@ -49,9 +49,11 @@ func IsBatchRequest(body []byte) bool {
 }
 
 // WriteBatchUnsupportedError writes an HTTP 400 response carrying a JSON-RPC
-// "Invalid Request" error for a rejected batch. The JSON-RPC id is null: a
-// batch has no single request id to echo. Use this where an http.ResponseWriter
-// is available (the streamable proxy, ParsingMiddleware).
+// "Invalid Request" error for a rejected batch. A batch has no single request
+// id to echo, so the "id" key is omitted entirely (schema/2025-11-25 types the
+// error response's id as optional, not nullable; see session.HasJSONRPCID).
+// Use this where an http.ResponseWriter is available (the streamable proxy,
+// ParsingMiddleware).
 func WriteBatchUnsupportedError(w http.ResponseWriter) {
 	body := classificationErrorBody(nil, batchUnsupported)
 	w.Header().Set("Content-Type", "application/json")
@@ -63,7 +65,7 @@ func WriteBatchUnsupportedError(w http.ResponseWriter) {
 // BatchUnsupportedResponse builds an *http.Response carrying the batch-rejection
 // JSON-RPC error, for proxies that intercept at the RoundTripper layer (the
 // transparent proxy) where no http.ResponseWriter is available. Mirrors
-// ClassificationErrorResponse; the JSON-RPC id is null.
+// ClassificationErrorResponse; the JSON-RPC id is omitted, not null.
 func BatchUnsupportedResponse(req *http.Request) *http.Response {
 	return jsonRPCErrorResponse(req, nil, batchUnsupported)
 }

--- a/pkg/mcp/batch_test.go
+++ b/pkg/mcp/batch_test.go
@@ -62,7 +62,6 @@ func TestWriteBatchUnsupportedError(t *testing.T) {
 
 	var resp struct {
 		JSONRPC string `json:"jsonrpc"`
-		ID      any    `json:"id"`
 		Error   struct {
 			Code    int64  `json:"code"`
 			Message string `json:"message"`
@@ -70,7 +69,15 @@ func TestWriteBatchUnsupportedError(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, "2.0", resp.JSONRPC)
-	assert.Nil(t, resp.ID)
 	assert.Equal(t, CodeInvalidRequest, resp.Error.Code)
 	assert.NotEmpty(t, resp.Error.Message)
+
+	// A batch has no single request id to echo. A tagged-struct decode
+	// (above) can't tell an absent "id" key from a present null -- both
+	// decode to the zero value -- so the omission is checked via a map
+	// decode instead.
+	var asMap map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &asMap))
+	_, hasID := asMap["id"]
+	assert.False(t, hasID, `"id" key must be omitted, not present as null`)
 }

--- a/pkg/mcp/classification_response.go
+++ b/pkg/mcp/classification_response.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/stacklok/toolhive/pkg/transport/session"
 )
 
 // WriteClassificationError writes an HTTP 400 response with a JSON-RPC error
@@ -65,6 +67,11 @@ func jsonRPCErrorResponse(req *http.Request, requestID any, err error) *http.Res
 // the error implements CodedError, falling back to the standard JSON-RPC
 // Invalid Params code otherwise -- a fallback that is currently unreachable,
 // since every error ClassifyRevision returns implements CodedError.
+//
+// MCP narrows base JSON-RPC 2.0 here: schema/2025-11-25 types the error
+// response as `id?: RequestId` where RequestId = string | number, so an
+// absent id is encoded by omitting the "id" key, never as null. See
+// session.HasJSONRPCID.
 func classificationErrorBody(requestID any, err error) []byte {
 	code := CodeInvalidParams
 	var coded CodedError
@@ -84,14 +91,16 @@ func classificationErrorBody(requestID any, err error) []byte {
 	resp := map[string]any{
 		"jsonrpc": "2.0",
 		"error":   errBody,
-		"id":      requestID,
+	}
+	if session.HasJSONRPCID(requestID) {
+		resp["id"] = requestID
 	}
 
 	body, marshalErr := json.Marshal(resp)
 	if marshalErr != nil {
 		// This should never happen with simple map types, but return a
 		// hand-crafted fallback to guarantee a valid JSON-RPC error.
-		return []byte(`{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"},"id":null}`)
+		return []byte(`{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"}}`)
 	}
 	return body
 }

--- a/pkg/mcp/classification_response_test.go
+++ b/pkg/mcp/classification_response_test.go
@@ -10,59 +10,106 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClassificationError(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		requestID any
-		err       error
-		wantCode  int64
-		wantData  bool
+		name       string
+		requestID  any
+		err        error
+		wantCode   int64
+		wantData   bool
+		wantIDKey  bool
+		wantIDEcho string // substring the body must contain, verbatim, when wantIDKey
 	}{
 		{
-			name:      "header mismatch",
-			requestID: "req-1",
-			err:       &HeaderMismatchError{Header: "2026-07-28", Body: "2025-11-25"},
-			wantCode:  CodeHeaderMismatch,
-			wantData:  true,
+			name:       "header mismatch",
+			requestID:  "req-1",
+			err:        &HeaderMismatchError{Header: "2026-07-28", Body: "2025-11-25"},
+			wantCode:   CodeHeaderMismatch,
+			wantData:   true,
+			wantIDKey:  true,
+			wantIDEcho: `"id":"req-1"`,
 		},
 		{
-			name:      "unsupported version",
-			requestID: float64(42),
-			err:       &UnsupportedVersionError{Requested: "1999-01-01", Supported: []string{MCPVersionModern}},
-			wantCode:  CodeUnsupportedProtocolVersion,
-			wantData:  true,
+			name:       "unsupported version",
+			requestID:  float64(42),
+			err:        &UnsupportedVersionError{Requested: "1999-01-01", Supported: []string{MCPVersionModern}},
+			wantCode:   CodeUnsupportedProtocolVersion,
+			wantData:   true,
+			wantIDKey:  true,
+			wantIDEcho: `"id":42`,
 		},
 		{
-			name:      "missing client capability",
-			requestID: "req-3",
-			err:       &MissingClientCapabilityError{RequiredCapabilities: map[string]any{}},
-			wantCode:  CodeMissingClientCapability,
-			wantData:  true,
+			name:       "missing client capability",
+			requestID:  "req-3",
+			err:        &MissingClientCapabilityError{RequiredCapabilities: map[string]any{}},
+			wantCode:   CodeMissingClientCapability,
+			wantData:   true,
+			wantIDKey:  true,
+			wantIDEcho: `"id":"req-3"`,
 		},
 		{
-			name:      "missing modern metadata",
-			requestID: "req-4",
-			err:       &MissingModernMetadataError{},
-			wantCode:  CodeInvalidParams,
-			wantData:  false, // Data() returns an empty (non-nil) map, so len(data) == 0
+			name:       "missing modern metadata",
+			requestID:  "req-4",
+			err:        &MissingModernMetadataError{},
+			wantCode:   CodeInvalidParams,
+			wantData:   false, // Data() returns an empty (non-nil) map, so len(data) == 0
+			wantIDKey:  true,
+			wantIDEcho: `"id":"req-4"`,
 		},
 		{
-			name:      "nil request id",
+			// A nil requestID means the caller couldn't determine an id at
+			// all (e.g. the request failed to parse). MCP narrows base
+			// JSON-RPC to omit the "id" key here rather than emit
+			// "id":null: see session.HasJSONRPCID.
+			name:      "nil request id omits the id key",
 			requestID: nil,
 			err:       &HeaderMismatchError{Header: "a", Body: "b"},
 			wantCode:  CodeHeaderMismatch,
 			wantData:  true,
+			wantIDKey: false,
 		},
 		{
-			name:      "plain non-coded error falls back to invalid params",
-			requestID: "req-6",
-			err:       errors.New("boom"),
-			wantCode:  CodeInvalidParams,
-			wantData:  false,
+			// The transparent proxy threads the incoming id through as raw
+			// bytes; literal null must be treated the same as a missing id.
+			name:      "raw null request id omits the id key",
+			requestID: json.RawMessage(`null`),
+			err:       &HeaderMismatchError{Header: "a", Body: "b"},
+			wantCode:  CodeHeaderMismatch,
+			wantData:  true,
+			wantIDKey: false,
+		},
+		{
+			name:      "nil RawMessage omits the id key",
+			requestID: json.RawMessage(nil),
+			err:       &HeaderMismatchError{Header: "a", Body: "b"},
+			wantCode:  CodeHeaderMismatch,
+			wantData:  true,
+			wantIDKey: false,
+		},
+		{
+			name:       "zero request id is still present",
+			requestID:  float64(0),
+			err:        &HeaderMismatchError{Header: "a", Body: "b"},
+			wantCode:   CodeHeaderMismatch,
+			wantData:   true,
+			wantIDKey:  true,
+			wantIDEcho: `"id":0`,
+		},
+		{
+			name:       "plain non-coded error falls back to invalid params",
+			requestID:  "req-6",
+			err:        errors.New("boom"),
+			wantCode:   CodeInvalidParams,
+			wantData:   false,
+			wantIDKey:  true,
+			wantIDEcho: `"id":"req-6"`,
 		},
 	}
 
@@ -115,7 +162,6 @@ func TestClassificationError(t *testing.T) {
 					Message string         `json:"message"`
 					Data    map[string]any `json:"data"`
 				} `json:"error"`
-				ID any `json:"id"`
 			}
 			if err := json.Unmarshal(wireBody, &decoded); err != nil {
 				t.Fatalf("unmarshaling response body: %v", err)
@@ -137,13 +183,19 @@ func TestClassificationError(t *testing.T) {
 				t.Errorf("expected no data, got %v", decoded.Error.Data)
 			}
 
-			gotID, wantID := decoded.ID, tt.requestID
-			if wantID == nil {
-				if gotID != nil {
-					t.Errorf("id = %v, want nil", gotID)
-				}
-			} else if gotID != wantID {
-				t.Errorf("id = %v (%T), want %v (%T)", gotID, gotID, wantID, wantID)
+			// Decoding into map[string]any (rather than a tagged struct) is
+			// the only way to tell an absent "id" key apart from a present
+			// null: a struct field would read as the zero value either way.
+			var asMap map[string]any
+			require.NoError(t, json.Unmarshal(wireBody, &asMap))
+			_, hasID := asMap["id"]
+			assert.Equal(t, tt.wantIDKey, hasID, `"id" key presence`)
+			if tt.wantIDKey {
+				require.NotEmpty(t, tt.wantIDEcho, "table entry must set wantIDEcho when wantIDKey is true")
+				// A map decode would coerce a numeric id to float64, losing
+				// the verbatim-echo guarantee #5945 pinned -- so check the
+				// raw wire bytes instead.
+				assert.Contains(t, string(wireBody), tt.wantIDEcho)
 			}
 		})
 	}
@@ -157,7 +209,7 @@ func TestClassificationError(t *testing.T) {
 func TestClassificationErrorBodyMarshalFallback(t *testing.T) {
 	t.Parallel()
 
-	const want = `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"},"id":null}`
+	const want = `{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"}}`
 	got := classificationErrorBody(make(chan int), errors.New("boom"))
 	if string(got) != want {
 		t.Fatalf("fallback body = %s, want %s", got, want)

--- a/pkg/mcp/parser_test.go
+++ b/pkg/mcp/parser_test.go
@@ -284,7 +284,6 @@ func TestParsingMiddlewareRejectsBatch(t *testing.T) {
 
 			var resp struct {
 				JSONRPC string `json:"jsonrpc"`
-				ID      any    `json:"id"`
 				Error   struct {
 					Code    int64  `json:"code"`
 					Message string `json:"message"`
@@ -292,9 +291,17 @@ func TestParsingMiddlewareRejectsBatch(t *testing.T) {
 			}
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			assert.Equal(t, "2.0", resp.JSONRPC)
-			assert.Nil(t, resp.ID, "batch rejection carries a null JSON-RPC id")
 			assert.Equal(t, CodeInvalidRequest, resp.Error.Code)
 			assert.NotEmpty(t, resp.Error.Message)
+
+			// A batch has no single request id to echo. A tagged-struct
+			// decode (above) can't tell an absent "id" key apart from a
+			// present null -- both decode to the zero value -- so the
+			// omission is checked via a map decode instead.
+			var asMap map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &asMap))
+			_, hasID := asMap["id"]
+			assert.False(t, hasID, `"id" key must be omitted, not present as null`)
 		})
 	}
 }

--- a/pkg/mcp/tool_filter.go
+++ b/pkg/mcp/tool_filter.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
@@ -388,6 +389,11 @@ func writeFilteredToolCallError(w http.ResponseWriter, id any) {
 // tool call, modeled on classificationErrorBody: the body is marshaled first
 // (with a hand-crafted fallback on marshal failure) so the caller only writes
 // headers/status once a valid body is ready.
+//
+// MCP narrows base JSON-RPC 2.0 here: schema/2025-11-25 types the error
+// response as `id?: RequestId` where RequestId = string | number, so an
+// absent id is encoded by omitting the "id" key, never as null. See
+// session.HasJSONRPCID.
 func filteredToolCallErrorBody(id any) []byte {
 	resp := map[string]any{
 		"jsonrpc": "2.0",
@@ -395,14 +401,16 @@ func filteredToolCallErrorBody(id any) []byte {
 			"code":    CodeInvalidParams,
 			"message": filteredToolNotFoundMessage,
 		},
-		"id": id,
+	}
+	if session.HasJSONRPCID(id) {
+		resp["id"] = id
 	}
 
 	body, err := json.Marshal(resp)
 	if err != nil {
 		// This should never happen with simple map types, but return a
 		// hand-crafted fallback to guarantee a valid JSON-RPC error.
-		return []byte(`{"jsonrpc":"2.0","error":{"code":-32602,"message":"tool not found"},"id":null}`)
+		return []byte(`{"jsonrpc":"2.0","error":{"code":-32602,"message":"tool not found"}}`)
 	}
 	return body
 }

--- a/pkg/mcp/tool_filter_test.go
+++ b/pkg/mcp/tool_filter_test.go
@@ -1946,6 +1946,16 @@ func TestNewToolCallMappingMiddleware_FilteredTool(t *testing.T) {
 			expectJSONRPC: true,
 		},
 		{
+			// Zero is a valid JSON-RPC id and must stay present, not be
+			// mistaken for absent.
+			name:          "Accept: application/json - zero id is still present",
+			accept:        "application/json",
+			setAccept:     true,
+			id:            0,
+			expectStatus:  http.StatusOK,
+			expectJSONRPC: true,
+		},
+		{
 			name:          "Accept: application/json, text/event-stream",
 			accept:        "application/json, text/event-stream",
 			setAccept:     true,
@@ -1968,7 +1978,11 @@ func TestNewToolCallMappingMiddleware_FilteredTool(t *testing.T) {
 			expectJSONRPC: true,
 		},
 		{
-			name:          "null id is echoed as null",
+			// MCP narrows base JSON-RPC 2.0 here: schema/2025-11-25 types the
+			// error response id as optional, not nullable, so a request with
+			// no usable id gets an error body that omits the "id" key
+			// entirely rather than echoing "id":null (session.HasJSONRPCID).
+			name:          "null id omits the id key",
 			accept:        "application/json",
 			setAccept:     true,
 			id:            nil,
@@ -2024,6 +2038,16 @@ func TestNewToolCallMappingMiddleware_FilteredTool(t *testing.T) {
 			assert.Equal(t, "tool not found", errObj["message"])
 			assert.NotContains(t, errObj["message"], "filter",
 				"a filtered tool must look the same as a nonexistent one")
+
+			// Map decode is the only way to tell an absent "id" key apart
+			// from a present null -- response["id"] reads back as the same
+			// nil interface value either way.
+			_, hasID := response["id"]
+			if tt.id == nil {
+				assert.False(t, hasID, `"id" key must be omitted for a nil request id, not present as null`)
+				return
+			}
+			assert.True(t, hasID, `"id" key must be present`)
 
 			expectedID, err := json.Marshal(tt.id)
 			require.NoError(t, err)

--- a/pkg/ratelimit/middleware.go
+++ b/pkg/ratelimit/middleware.go
@@ -20,6 +20,7 @@ import (
 	v1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/transport/types"
 )
 
@@ -160,7 +161,13 @@ func writeRateLimited(w http.ResponseWriter, requestID any, retryAfter time.Dura
 	_, _ = w.Write(rateLimitedBody(requestID, retryAfter))
 }
 
-// rateLimitedBody returns the JSON-encoded body for a rate-limited JSON-RPC error.
+// rateLimitedBody returns the JSON-encoded body for a rate-limited JSON-RPC
+// error.
+//
+// MCP narrows base JSON-RPC 2.0 here: schema/2025-11-25 types the error
+// response as `id?: RequestId` where RequestId = string | number, so an
+// absent id is encoded by omitting the "id" key, never as null. See
+// session.HasJSONRPCID.
 func rateLimitedBody(requestID any, retryAfter time.Duration) []byte {
 	retrySeconds := math.Ceil(retryAfter.Seconds())
 	resp := map[string]any{
@@ -172,12 +179,14 @@ func rateLimitedBody(requestID any, retryAfter time.Duration) []byte {
 				"retryAfterSeconds": retrySeconds,
 			},
 		},
-		"id": requestID,
+	}
+	if session.HasJSONRPCID(requestID) {
+		resp["id"] = requestID
 	}
 	data, err := json.Marshal(resp)
 	if err != nil {
 		return []byte(fmt.Sprintf(
-			`{"jsonrpc":"2.0","error":{"code":-32029,"message":"Rate limit exceeded","data":{"retryAfterSeconds":%.0f}},"id":null}`,
+			`{"jsonrpc":"2.0","error":{"code":-32029,"message":"Rate limit exceeded","data":{"retryAfterSeconds":%.0f}}}`,
 			retrySeconds,
 		))
 	}

--- a/pkg/ratelimit/middleware_test.go
+++ b/pkg/ratelimit/middleware_test.go
@@ -115,6 +115,98 @@ func TestRateLimitHandler_ToolCallRejected(t *testing.T) {
 	assert.Equal(t, float64(42), resp["id"])
 }
 
+// TestRateLimitHandler_NotificationRejected is the live regression case:
+// rateLimitHandler has no notification guard (unlike dispatchModern), so a
+// well-formed tools/call notification (no id) that gets rate-limited reaches
+// writeRateLimited with a nil requestID. Before the fix this emitted
+// "id":null at HTTP 429; it must now omit the key entirely.
+func TestRateLimitHandler_NotificationRejected(t *testing.T) {
+	t.Parallel()
+
+	limiter := &dummyLimiter{decision: &Decision{Allowed: false, RetryAfter: 5 * time.Second}}
+	handler := rateLimitHandler(limiter)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("next handler should not be called when rate limited")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req = withParsedMCPRequest(req, "tools/call", "echo", nil) // no id: a notification
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	body, err := io.ReadAll(w.Body)
+	require.NoError(t, err)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(body, &resp))
+	_, hasID := resp["id"]
+	assert.False(t, hasID, `"id" key must be absent for a notification, never "id":null`)
+}
+
+// TestRateLimitedBody covers the "id" key's presence/absence per
+// session.HasJSONRPCID: MCP narrows base JSON-RPC 2.0 so an absent id is
+// encoded by omitting the key entirely, never as "id":null (schema/2025-11-25
+// types the error response id as optional string|number).
+func TestRateLimitedBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		requestID  any
+		wantIDKey  bool
+		wantIDEcho string // substring the body must contain, verbatim, when wantIDKey
+	}{
+		{name: "nil id is omitted", requestID: nil, wantIDKey: false},
+		{name: "null RawMessage id is omitted", requestID: json.RawMessage("null"), wantIDKey: false},
+		{name: "nil RawMessage id is omitted", requestID: json.RawMessage(nil), wantIDKey: false},
+		// int64 matches the real wire type: parsed.ID comes from jsonrpc2.ID.Raw(),
+		// which yields nil | int64 | string, never float64.
+		{name: "zero id is still present", requestID: int64(0), wantIDKey: true, wantIDEcho: `"id":0`},
+		{name: "present id is present", requestID: int64(42), wantIDKey: true, wantIDEcho: `"id":42`},
+		{name: "string id is present", requestID: "req-1", wantIDKey: true, wantIDEcho: `"id":"req-1"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := rateLimitedBody(tt.requestID, 5*time.Second)
+
+			// Decoding into map[string]any (rather than a tagged struct) is
+			// the only way to tell an absent "id" key apart from a present
+			// null: a struct field would read as the zero value either way.
+			var asMap map[string]any
+			require.NoError(t, json.Unmarshal(body, &asMap))
+			_, hasID := asMap["id"]
+			assert.Equal(t, tt.wantIDKey, hasID, `"id" key presence`)
+			if tt.wantIDKey {
+				// A map decode would coerce a numeric id to float64, losing
+				// the verbatim-echo guarantee -- so check the raw wire bytes
+				// instead.
+				assert.Contains(t, string(body), tt.wantIDEcho)
+			}
+		})
+	}
+}
+
+// TestRateLimitedBodyMarshalFallback verifies the defensive fallback: if the
+// response fails to marshal (unreachable in production, where requestID is
+// always a simple value), rateLimitedBody still returns a valid JSON-RPC
+// error with no "id" key (never "id":null) and the retryAfterSeconds value
+// correctly interpolated. A channel is not JSON-marshalable and, being
+// non-nil, satisfies session.HasJSONRPCID -- forcing the map's marshal to
+// fail after "id" was already added.
+func TestRateLimitedBodyMarshalFallback(t *testing.T) {
+	t.Parallel()
+
+	const want = `{"jsonrpc":"2.0","error":{"code":-32029,"message":"Rate limit exceeded","data":{"retryAfterSeconds":5}}}`
+	got := rateLimitedBody(make(chan int), 5*time.Second)
+	assert.Equal(t, want, string(got))
+	assert.NotContains(t, string(got), `"id"`)
+}
+
 func TestRateLimitHandler_RedisErrorFailOpen(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/transport/middleware/origin/origin.go
+++ b/pkg/transport/middleware/origin/origin.go
@@ -36,7 +36,7 @@ const (
 
 	// forbiddenBodyFallback is returned if JSON marshalling of the error body
 	// fails (should never happen with simple map types).
-	forbiddenBodyFallback = `{"jsonrpc":"2.0","error":{"code":-32600,"message":"Origin not allowed"},"id":null}`
+	forbiddenBodyFallback = `{"jsonrpc":"2.0","error":{"code":-32600,"message":"Origin not allowed"}}`
 )
 
 // MiddlewareParams holds the parameters for the origin middleware factory.
@@ -256,7 +256,12 @@ func isLoopbackHost(host string) bool {
 	return false
 }
 
-// writeForbidden emits a 403 response with a JSON-RPC error body (id: null).
+// writeForbidden emits a 403 response with a JSON-RPC error body. The "id"
+// key is omitted: this rejection happens on the Origin header alone, before
+// any JSON-RPC body is parsed, so there is no incoming id to echo. MCP
+// narrows base JSON-RPC 2.0 here -- schema/2025-11-25 types the error
+// response id as optional, string|number (no null), so an absent id must be
+// encoded by omitting the key, never as "id":null.
 func writeForbidden(w http.ResponseWriter) {
 	body, err := json.Marshal(map[string]any{
 		"jsonrpc": "2.0",
@@ -264,7 +269,6 @@ func writeForbidden(w http.ResponseWriter) {
 			"code":    jsonRPCCodeInvalidRequest,
 			"message": "Origin not allowed",
 		},
-		"id": nil,
 	})
 	if err != nil {
 		// Marshal of a static map should never fail; fall back to a literal.

--- a/pkg/transport/middleware/origin/origin_test.go
+++ b/pkg/transport/middleware/origin/origin_test.go
@@ -5,7 +5,6 @@ package origin
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -175,27 +174,36 @@ func TestOriginMiddleware_MultipleOriginHeadersRejected(t *testing.T) {
 
 // assertForbiddenJSONRPC validates that rec carries a 403 with a canonical
 // JSON-RPC error body and that the inner handler was never invoked.
+//
+// The JSONEq below already catches an extra "id":null (it wouldn't match the
+// expected body), so the explicit key-absence check that follows is
+// belt-and-suspenders -- kept because it names the failure directly, whereas
+// a JSONEq diff would just show an unexpected field.
 func assertForbiddenJSONRPC(t *testing.T, rec *httptest.ResponseRecorder, nextCalled bool) {
 	t.Helper()
 	assert.False(t, nextCalled, "next handler must NOT be invoked")
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"jsonrpc":"2.0","error":{"code":-32600,"message":"Origin not allowed"}}`, rec.Body.String())
 
-	body, err := io.ReadAll(rec.Body)
-	require.NoError(t, err)
-	var parsed struct {
-		JSONRPC string `json:"jsonrpc"`
-		Error   struct {
-			Code    int64  `json:"code"`
-			Message string `json:"message"`
-		} `json:"error"`
-		ID any `json:"id"`
-	}
-	require.NoError(t, json.Unmarshal(body, &parsed))
-	assert.Equal(t, "2.0", parsed.JSONRPC)
-	assert.Equal(t, jsonRPCCodeInvalidRequest, parsed.Error.Code)
-	assert.Equal(t, "Origin not allowed", parsed.Error.Message)
-	assert.Nil(t, parsed.ID)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	_, hasID := parsed["id"]
+	assert.False(t, hasID, "forbidden body must omit \"id\" entirely, never send it as null")
+}
+
+// TestForbiddenBodyFallback verifies the hand-written fallback literal used
+// when json.Marshal fails (unreachable in practice with static map types, so
+// this is the only path that exercises it) has the same shape as the
+// marshaled body: no "id" key, never "null".
+func TestForbiddenBodyFallback(t *testing.T) {
+	t.Parallel()
+	assert.JSONEq(t, `{"jsonrpc":"2.0","error":{"code":-32600,"message":"Origin not allowed"}}`, forbiddenBodyFallback)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(forbiddenBodyFallback), &parsed))
+	_, hasID := parsed["id"]
+	assert.False(t, hasID, "fallback body must omit \"id\" entirely, never send it as null")
 }
 
 func TestNewHandler_RejectsDisallowedOrigin(t *testing.T) {

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -769,6 +769,11 @@ func (p *HTTPProxy) writeSingleRequestSSEFinalResponse(
 // data: frame, for a request whose response headers (200 + text/event-stream)
 // have already been sent -- an HTTP error status can no longer be set at this
 // point, so the error must be communicated in-band as the response payload.
+//
+// The "id" key is included only if id.IsValid(); MCP narrows base JSON-RPC
+// 2.0 here (schema/2025-11-25 types the error response id as optional,
+// string|number, no null), so an invalid/absent id must be encoded by
+// omitting the key, never as "id":null.
 func writeSSEErrorEvent(w http.ResponseWriter, flusher http.Flusher, id jsonrpc2.ID, err error) {
 	errMsg := "Internal error"
 	code := -32603
@@ -778,11 +783,13 @@ func writeSSEErrorEvent(w http.ResponseWriter, flusher http.Flusher, id jsonrpc2
 	}
 	errObj := map[string]any{
 		"jsonrpc": "2.0",
-		"id":      id.Raw(),
 		"error": map[string]any{
 			"code":    code,
 			"message": errMsg,
 		},
+	}
+	if id.IsValid() {
+		errObj["id"] = id.Raw()
 	}
 	data, mErr := json.Marshal(errObj)
 	if mErr != nil {

--- a/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
@@ -254,7 +254,16 @@ func TestBatchRequestsRejected(t *testing.T) {
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			assert.Contains(t, string(body), `"code":-32600`)
-			assert.Contains(t, string(body), `"id":null`)
+
+			// A batch has no single request id to echo. MCP encodes that by
+			// omitting the "id" key entirely (schema/2025-11-25 types the
+			// error response id as optional, not nullable), never as null --
+			// a substring check for "id":null would miss the key being
+			// present-but-null, so the key's absence is checked directly.
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal(body, &parsed))
+			_, hasID := parsed["id"]
+			assert.False(t, hasID, `"id" key must be omitted, not present as null`)
 		})
 	}
 }

--- a/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_spec_test.go
@@ -282,7 +282,13 @@ func TestDeleteUnknownSessionReturnsJSONRPCError(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"code":-32001`)
-	assert.Contains(t, string(body), `"id":null`)
+
+	// A DELETE carries no JSON-RPC id, and MCP encodes an absent id by
+	// omitting the "id" key entirely (schema/2025-11-25), never as null.
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	_, ok := parsed["id"]
+	assert.False(t, ok, `"id" key should be absent`)
 }
 
 // TestSingleRequestWithStaleSessionIncludesRequestID verifies that a single

--- a/pkg/transport/proxy/streamable/streamable_proxy_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_test.go
@@ -6,9 +6,12 @@ package streamable
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -549,6 +552,51 @@ func TestHandleGet_SessionDecisionMatrix(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// TestWriteSSEErrorEvent verifies the "id" key is present and echoed for a
+// valid jsonrpc2.ID, and omitted entirely -- never sent as "id":null -- for
+// the zero-value ID (jsonrpc2.ID{}.IsValid() == false), in both cases
+// preserving the SSE "data: ...\n\n" framing writeSSEData produces.
+//
+// The body is decoded to map[string]any rather than a tagged struct: a
+// struct field of type `any` cannot distinguish an absent key from a
+// present-but-null one, so it would not detect a regression to "id":null.
+func TestWriteSSEErrorEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		id     jsonrpc2.ID
+		wantID bool
+	}{
+		{name: "valid id is present and echoed", id: jsonrpc2.Int64ID(7), wantID: true},
+		{name: "zero-value id is omitted, not sent as null", id: jsonrpc2.ID{}, wantID: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+
+			writeSSEErrorEvent(rec, rec, tt.id, errors.New("boom"))
+
+			assert.True(t, rec.Flushed, "writeSSEErrorEvent must flush the SSE frame to the client")
+
+			body := rec.Body.String()
+			require.True(t, strings.HasPrefix(body, "data: "), "SSE frame must carry the data: prefix, got %q", body)
+			require.True(t, strings.HasSuffix(body, "\n\n"), "SSE frame must end with a blank line, got %q", body)
+			payload := strings.TrimSuffix(strings.TrimPrefix(body, "data: "), "\n\n")
+
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal([]byte(payload), &parsed))
+			_, hasID := parsed["id"]
+			assert.Equal(t, tt.wantID, hasID)
+			if tt.wantID {
+				assert.EqualValues(t, tt.id.Raw(), parsed["id"])
+			}
 		})
 	}
 }

--- a/pkg/transport/proxy/transparent/backend_routing_test.go
+++ b/pkg/transport/proxy/transparent/backend_routing_test.go
@@ -204,36 +204,42 @@ func TestRoundTripReturns404ForUnknownSession(t *testing.T) {
 // same RoundTrip already echoed it.
 //
 // Note TestRoundTripReturns404ForUnknownSession above cannot catch this: its body
-// carries no "id", so it renders a null id either way.
+// carries no "id" key either way, so it can't tell a present-but-omitted id apart
+// from this test's cases.
 func TestRoundTrip404EchoesRequestID(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		body   string
-		wantID string
+		name      string
+		body      string
+		wantIDKey bool
+		wantID    string // only checked when wantIDKey
 	}{
 		{
-			name:   "numeric id is echoed verbatim",
-			body:   `{"jsonrpc":"2.0","id":7,"method":"tools/list"}`,
-			wantID: `"id":7`,
+			name:      "numeric id is echoed verbatim",
+			body:      `{"jsonrpc":"2.0","id":7,"method":"tools/list"}`,
+			wantIDKey: true,
+			wantID:    `"id":7`,
 		},
 		{
-			name:   "string id is echoed verbatim",
-			body:   `{"jsonrpc":"2.0","id":"abc-123","method":"tools/list"}`,
-			wantID: `"id":"abc-123"`,
+			name:      "string id is echoed verbatim",
+			body:      `{"jsonrpc":"2.0","id":"abc-123","method":"tools/list"}`,
+			wantIDKey: true,
+			wantID:    `"id":"abc-123"`,
 		},
 		{
-			// A notification has no id by definition, so JSON-RPC requires null.
-			name:   "notification renders a null id",
-			body:   `{"jsonrpc":"2.0","method":"notifications/initialized"}`,
-			wantID: `"id":null`,
+			// A notification has no id by definition. MCP encodes that by
+			// omitting the "id" key entirely, not by emitting null.
+			name:      "notification omits the id key",
+			body:      `{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+			wantIDKey: false,
 		},
 		{
-			// An explicit null id is not a correlatable id either.
-			name:   "explicit null id stays null",
-			body:   `{"jsonrpc":"2.0","id":null,"method":"tools/list"}`,
-			wantID: `"id":null`,
+			// An explicit null id is not a correlatable id either, so it is
+			// also encoded by omitting the key.
+			name:      "explicit null id omits the id key",
+			body:      `{"jsonrpc":"2.0","id":null,"method":"tools/list"}`,
+			wantIDKey: false,
 		},
 	}
 
@@ -269,13 +275,18 @@ func TestRoundTrip404EchoesRequestID(t *testing.T) {
 			_ = resp.Body.Close()
 
 			assert.Contains(t, string(body), `"code":-32001`)
-			assert.Contains(t, string(body), tt.wantID)
 
 			// The body must remain a single valid JSON-RPC error object -- echoing
 			// a raw id must not corrupt the envelope.
 			var decoded map[string]any
 			require.NoError(t, json.Unmarshal(body, &decoded))
 			assert.Equal(t, "2.0", decoded["jsonrpc"])
+
+			_, ok := decoded["id"]
+			assert.Equal(t, tt.wantIDKey, ok, `"id" key presence`)
+			if tt.wantIDKey {
+				assert.Contains(t, string(body), tt.wantID)
+			}
 		})
 	}
 }

--- a/pkg/transport/proxy/transparent/backend_routing_test.go
+++ b/pkg/transport/proxy/transparent/backend_routing_test.go
@@ -383,7 +383,16 @@ func TestRoundTripRejectsBatch(t *testing.T) {
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			assert.Contains(t, string(body), `"code":-32600`)
-			assert.Contains(t, string(body), `"id":null`)
+
+			// A batch has no single request id to echo. MCP encodes that by
+			// omitting the "id" key entirely (schema/2025-11-25 types the
+			// error response id as optional, not nullable), never as null --
+			// a substring check for "id":null would miss the key being
+			// present-but-null, so the key's absence is checked directly.
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal(body, &parsed))
+			_, hasID := parsed["id"]
+			assert.False(t, hasID, `"id" key must be omitted, not present as null`)
 		})
 	}
 }

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -602,7 +602,10 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	// can echo it, letting a client correlate the error with its request. It is set
 	// only when parseRPCRequest reports a single request, which by construction
 	// means the id is present and non-null; it stays nil for a notification, a
-	// batch, or a bodiless GET/DELETE, where JSON-RPC requires a null id.
+	// batch, or a bodiless GET/DELETE. session.NotFoundResponse (via NotFoundBody)
+	// omits the "id" key entirely for a nil requestID rather than emitting a null
+	// id — MCP narrows base JSON-RPC to make that omission the correct encoding
+	// of "no id" (see session.HasJSONRPCID).
 	var requestID any
 
 	if len(reqBody) > 0 &&

--- a/pkg/transport/session/jsonrpc_errors.go
+++ b/pkg/transport/session/jsonrpc_errors.go
@@ -27,10 +27,17 @@ const (
 // JSON-RPC request, echoed so a client correlating by id can match this error
 // to the request that caused it.
 //
-// Pass nil only when the request genuinely carries no id, in which case
-// JSON-RPC requires a null id: a bodiless GET (standalone SSE) or DELETE, a
-// notification, or a batch. Do NOT pass nil merely because threading the id to
-// the call site is inconvenient — that was the asymmetry fixed in #5945.
+// MCP narrows base JSON-RPC 2.0 here: schema/2025-11-25 types the error
+// response as `id?: RequestId` where RequestId = string | number, so an
+// absent id is encoded by omitting the "id" key entirely, never as null. The
+// reference TypeScript SDK enforces this with a .strict() schema and a
+// throwing parse(), so an "id":null response crashes a conformant client's
+// transport. See HasJSONRPCID.
+//
+// Pass nil only when the request genuinely carries no id: a bodiless GET
+// (standalone SSE) or DELETE, a notification, or a batch. Do NOT pass nil
+// merely because threading the id to the call site is inconvenient — that
+// was the asymmetry fixed in #5945.
 func NotFoundBody(requestID any) []byte {
 	resp := map[string]any{
 		"jsonrpc": "2.0",
@@ -38,15 +45,39 @@ func NotFoundBody(requestID any) []byte {
 			"code":    CodeSessionNotFound,
 			"message": MessageSessionNotFound,
 		},
-		"id": requestID,
+	}
+	if HasJSONRPCID(requestID) {
+		resp["id"] = requestID
 	}
 	data, err := json.Marshal(resp)
 	if err != nil {
 		// This should never happen with simple map types, but return a
 		// hand-crafted fallback to guarantee a valid JSON-RPC error.
-		return []byte(`{"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}`)
+		return []byte(`{"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"}}`)
 	}
 	return data
+}
+
+// HasJSONRPCID reports whether requestID is a usable JSON-RPC id, i.e. whether
+// callers should emit an "id" key at all.
+//
+// MCP narrows base JSON-RPC here: schema/2025-11-25 types the error response as
+// `id?: RequestId` where RequestId = string | number, so an absent id is encoded
+// by omitting the key, never as null. The reference TypeScript SDK enforces this
+// with a .strict() schema and a throwing parse(), so "id":null crashes a
+// conformant client's transport.
+//
+// The transparent proxy threads the incoming id through as raw bytes, so a
+// json.RawMessage holding literal null -- or nothing -- is an absent id even
+// though the interface value is non-nil.
+func HasJSONRPCID(requestID any) bool {
+	if requestID == nil {
+		return false
+	}
+	if raw, ok := requestID.(json.RawMessage); ok {
+		return len(raw) > 0 && string(raw) != "null"
+	}
+	return true
 }
 
 // WriteNotFound writes an HTTP 404 response with a JSON-RPC error body

--- a/pkg/transport/session/jsonrpc_errors.go
+++ b/pkg/transport/session/jsonrpc_errors.go
@@ -70,6 +70,10 @@ func NotFoundBody(requestID any) []byte {
 // The transparent proxy threads the incoming id through as raw bytes, so a
 // json.RawMessage holding literal null -- or nothing -- is an absent id even
 // though the interface value is non-nil.
+//
+// Do not pass a typed jsonrpc2.ID here: its zero value is a non-nil interface
+// holding an empty struct, so this predicate would (wrongly) report it as
+// present and callers would emit "id":{}. Use id.IsValid() instead.
 func HasJSONRPCID(requestID any) bool {
 	if requestID == nil {
 		return false

--- a/pkg/transport/session/jsonrpc_errors_test.go
+++ b/pkg/transport/session/jsonrpc_errors_test.go
@@ -20,26 +20,46 @@ func TestNotFoundBody(t *testing.T) {
 	tests := []struct {
 		name       string
 		requestID  any
-		expectedID any // expected value after JSON round-trip
+		wantIDKey  bool
+		expectedID any // expected value after JSON round-trip, only checked when wantIDKey
 	}{
 		{
-			name:       "nil request ID",
-			requestID:  nil,
-			expectedID: nil,
+			name:      "nil request ID omits id key",
+			requestID: nil,
+			wantIDKey: false,
+		},
+		{
+			name:      "raw null request ID omits id key",
+			requestID: json.RawMessage(`null`),
+			wantIDKey: false,
+		},
+		{
+			name:      "nil RawMessage omits id key",
+			requestID: json.RawMessage(nil),
+			wantIDKey: false,
 		},
 		{
 			name:       "integer request ID",
 			requestID:  42,
+			wantIDKey:  true,
 			expectedID: float64(42), // JSON numbers decode as float64
+		},
+		{
+			name:       "zero request ID is still present",
+			requestID:  0,
+			wantIDKey:  true,
+			expectedID: float64(0),
 		},
 		{
 			name:       "string request ID",
 			requestID:  "abc-123",
+			wantIDKey:  true,
 			expectedID: "abc-123",
 		},
 		{
 			name:       "float64 request ID",
 			requestID:  float64(7),
+			wantIDKey:  true,
 			expectedID: float64(7),
 		},
 	}
@@ -56,7 +76,12 @@ func TestNotFoundBody(t *testing.T) {
 
 			// Check JSON-RPC fields
 			assert.Equal(t, "2.0", parsed["jsonrpc"])
-			assert.Equal(t, tt.expectedID, parsed["id"])
+
+			id, ok := parsed["id"]
+			assert.Equal(t, tt.wantIDKey, ok, `"id" key presence`)
+			if tt.wantIDKey {
+				assert.Equal(t, tt.expectedID, id)
+			}
 
 			errObj, ok := parsed["error"].(map[string]any)
 			require.True(t, ok, "error field should be an object")
@@ -65,6 +90,54 @@ func TestNotFoundBody(t *testing.T) {
 
 			// Verify the raw body contains the detection string that MCP clients check
 			assert.Contains(t, string(body), `"code":-32001`)
+		})
+	}
+}
+
+func TestNotFoundBodyMarshalFallback(t *testing.T) {
+	t.Parallel()
+
+	// A channel is not JSON-marshalable, forcing json.Marshal to fail so the
+	// hand-crafted fallback literal is exercised. Since requestID is non-nil
+	// and not a json.RawMessage, HasJSONRPCID reports it as present, so the
+	// fallback must still omit "id" per the marshal-failure branch, not echo it.
+	body := NotFoundBody(make(chan int))
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	assert.Equal(t, "2.0", parsed["jsonrpc"])
+	_, ok := parsed["id"]
+	assert.False(t, ok, `fallback body must omit "id" key`)
+
+	errObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok, "error field should be an object")
+	assert.Equal(t, float64(CodeSessionNotFound), errObj["code"])
+	assert.Equal(t, MessageSessionNotFound, errObj["message"])
+}
+
+func TestHasJSONRPCID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		requestID any
+		want      bool
+	}{
+		{name: "nil", requestID: nil, want: false},
+		{name: "raw null", requestID: json.RawMessage(`null`), want: false},
+		{name: "raw nil slice", requestID: json.RawMessage(nil), want: false},
+		{name: "raw empty slice", requestID: json.RawMessage(""), want: false},
+		{name: "raw numeric", requestID: json.RawMessage(`42`), want: true},
+		{name: "raw string", requestID: json.RawMessage(`"abc"`), want: true},
+		{name: "string", requestID: "abc-123", want: true},
+		{name: "integer zero", requestID: 0, want: true},
+		{name: "integer", requestID: 42, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, HasJSONRPCID(tt.requestID))
 		})
 	}
 }
@@ -87,19 +160,40 @@ func TestNotFoundResponse(t *testing.T) {
 	tests := []struct {
 		name      string
 		requestID any
-		wantID    string
+		wantIDKey bool
+		wantID    string // only checked when wantIDKey
 	}{
 		{
 			// A request with no id of its own: bodiless GET/DELETE, or a
-			// notification. JSON-RPC requires a null id here.
-			name:      "nil id renders null",
+			// notification. MCP narrows base JSON-RPC to omit the key here
+			// rather than emit "id":null (schema/2025-11-25, HasJSONRPCID).
+			name:      "nil id omits the id key",
 			requestID: nil,
-			wantID:    `"id":null`,
+			wantIDKey: false,
+		},
+		{
+			// The transparent proxy threads the incoming id through as raw
+			// bytes; literal null must be treated the same as a missing id.
+			name:      "raw null id omits the id key",
+			requestID: json.RawMessage(`null`),
+			wantIDKey: false,
+		},
+		{
+			name:      "nil RawMessage omits the id key",
+			requestID: json.RawMessage(nil),
+			wantIDKey: false,
 		},
 		{
 			name:      "string id is echoed",
 			requestID: "req-1",
+			wantIDKey: true,
 			wantID:    `"id":"req-1"`,
+		},
+		{
+			name:      "zero id is echoed, not treated as absent",
+			requestID: 0,
+			wantIDKey: true,
+			wantID:    `"id":0`,
 		},
 		{
 			// The shape the transparent proxy passes: the raw bytes of the
@@ -107,11 +201,13 @@ func TestNotFoundResponse(t *testing.T) {
 			// rather than being coerced to a float or a string (#5945).
 			name:      "raw numeric id is echoed verbatim",
 			requestID: json.RawMessage(`42`),
+			wantIDKey: true,
 			wantID:    `"id":42`,
 		},
 		{
 			name:      "raw string id is echoed verbatim",
 			requestID: json.RawMessage(`"abc"`),
+			wantIDKey: true,
 			wantID:    `"id":"abc"`,
 		},
 	}
@@ -130,7 +226,15 @@ func TestNotFoundResponse(t *testing.T) {
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			assert.Contains(t, string(body), `"code":-32001`)
-			assert.Contains(t, string(body), tt.wantID)
+
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal(body, &parsed))
+			_, ok := parsed["id"]
+			assert.Equal(t, tt.wantIDKey, ok, `"id" key presence`)
+			if tt.wantIDKey {
+				assert.Contains(t, string(body), tt.wantID)
+			}
+
 			// ContentLength must match the body actually written, or a client
 			// reading exactly that many bytes truncates or blocks.
 			assert.Equal(t, int64(len(body)), resp.ContentLength)

--- a/pkg/vmcp/server/modern_dispatch_test.go
+++ b/pkg/vmcp/server/modern_dispatch_test.go
@@ -180,18 +180,41 @@ func TestDispatchModern_ControlFlow(t *testing.T) {
 		parsed     *mcpparser.ParsedMCPRequest
 		wantStatus int
 		wantCode   float64
+		wantIDKey  bool
 	}{
 		{
 			name:       "batch request returns -32600 invalid request",
 			parsed:     &mcpparser.ParsedMCPRequest{Method: "tools/call", IsRequest: true, IsBatch: true, ID: "1"},
 			wantStatus: http.StatusOK,
 			wantCode:   -32600,
+			wantIDKey:  true,
+		},
+		{
+			// A batch with a raw-null id exercises writeModernError's
+			// absent-id path through the real dispatch route, not just the
+			// unit-level writer tests in modern_envelope_test.go:
+			// schema/2025-11-25 types the error id as optional string|number,
+			// so MCP omits the "id" key entirely here, never "id":null.
+			//
+			// The real parser can never actually produce this state: it sets ID
+			// from jsonrpc2.ID.Raw(), which yields only nil, int64, or string
+			// (parser.go), and a plain Go nil id can't reach this branch either --
+			// dispatchModern's earlier `parsed.ID == nil` notification guard (an
+			// interface nil check, :54) would short-circuit it to 202 first.
+			// json.RawMessage("null") is constructed directly here solely to drive
+			// the writer's defensive absent-id backstop through this route.
+			name:       "batch request with raw-null id omits the id key",
+			parsed:     &mcpparser.ParsedMCPRequest{Method: "tools/call", IsRequest: true, IsBatch: true, ID: json.RawMessage("null")},
+			wantStatus: http.StatusOK,
+			wantCode:   -32600,
+			wantIDKey:  false,
 		},
 		{
 			name:       "unknown method returns -32601 method not found",
 			parsed:     &mcpparser.ParsedMCPRequest{Method: "roots/list", IsRequest: true, ID: "1"},
 			wantStatus: http.StatusNotFound,
 			wantCode:   -32601,
+			wantIDKey:  true,
 		},
 	}
 
@@ -205,6 +228,9 @@ func TestDispatchModern_ControlFlow(t *testing.T) {
 			errObj, ok := body["error"].(map[string]any)
 			require.True(t, ok, "expected a JSON-RPC error envelope")
 			assert.Equal(t, tt.wantCode, errObj["code"])
+
+			_, hasID := body["id"]
+			assert.Equal(t, tt.wantIDKey, hasID, `"id" key presence`)
 		})
 	}
 }

--- a/pkg/vmcp/server/modern_envelope.go
+++ b/pkg/vmcp/server/modern_envelope.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
 	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+	transportsession "github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/conversion"
 )
@@ -483,6 +484,13 @@ func modernPromptFromDomain(p vmcp.Prompt) mcp.Prompt {
 // {"jsonrpc":"2.0","id":<id>,"result":<result>} as a single HTTP 200
 // application/json response -- never SSE, no Mcp-Session-Id -- matching the
 // Modern stateless wire contract.
+//
+// Unlike writeModernError/writeModernDenied below, id is ALWAYS emitted here,
+// never conditionally omitted: MCP's JSONRPCResultResponse schema keeps id
+// required (only the error response narrows it to optional), and dispatchModern
+// never reaches this builder for a notification -- it returns 202 before
+// dispatch when parsed.ID is nil (modern_dispatch.go). Making this conditional
+// would be as wrong as emitting "id":null on an error response.
 func writeModernResult(w http.ResponseWriter, id, result any) {
 	writeModernEnvelope(w, http.StatusOK, map[string]any{
 		"jsonrpc": "2.0",
@@ -504,6 +512,11 @@ func writeModernResult(w http.ResponseWriter, id, result any) {
 //
 // This is a protocol-level mapping, unrelated to authorization: only
 // writeModernDenied changes status for a POLICY reason (403).
+//
+// MCP narrows base JSON-RPC 2.0 here: schema/2025-11-25 types the error
+// response as `id?: RequestId` where RequestId = string | number, so an
+// absent id is encoded by omitting the "id" key, never as null. See
+// transportsession.HasJSONRPCID.
 func writeModernError(w http.ResponseWriter, id any, code int, msg string) {
 	status := http.StatusOK
 	switch code {
@@ -512,29 +525,38 @@ func writeModernError(w http.ResponseWriter, id any, code int, msg string) {
 	case jsonRPCCodeInvalidParams:
 		status = http.StatusBadRequest
 	}
-	writeModernEnvelope(w, status, map[string]any{
+	envelope := map[string]any{
 		"jsonrpc": "2.0",
-		"id":      id,
 		"error": map[string]any{
 			"code":    code,
 			"message": msg,
 		},
-	})
+	}
+	if transportsession.HasJSONRPCID(id) {
+		envelope["id"] = id
+	}
+	writeModernEnvelope(w, status, envelope)
 }
 
 // writeModernDenied writes a JSON-RPC error envelope at HTTP 403 with
 // mcpparser.JSONRPCCodeDenied, mirroring the Legacy call gate
 // (call_gate.go) and pkg/authz.handleUnauthorized: the 403 status is what
 // makes the audit middleware log the request as denied rather than failed.
+//
+// id follows writeModernError: absent (via transportsession.HasJSONRPCID) is
+// encoded by omitting the "id" key, never as null.
 func writeModernDenied(w http.ResponseWriter, id any, msg string) {
-	writeModernEnvelope(w, http.StatusForbidden, map[string]any{
+	envelope := map[string]any{
 		"jsonrpc": "2.0",
-		"id":      id,
 		"error": map[string]any{
 			"code":    mcpparser.JSONRPCCodeDenied,
 			"message": msg,
 		},
-	})
+	}
+	if transportsession.HasJSONRPCID(id) {
+		envelope["id"] = id
+	}
+	writeModernEnvelope(w, http.StatusForbidden, envelope)
 }
 
 // writeModernEnvelope marshals envelope before writing headers/status, so a
@@ -548,7 +570,7 @@ func writeModernEnvelope(w http.ResponseWriter, status int, envelope map[string]
 		// all JSON-marshalable. Fall back to a valid JSON-RPC error body
 		// rather than writing nothing.
 		slog.Error("failed to marshal Modern JSON-RPC envelope", "error", err)
-		body = []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Internal error"}}`)
+		body = []byte(`{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error"}}`)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	// Belt-and-suspenders behind the JSON-level cacheScope:"private" hint:

--- a/pkg/vmcp/server/modern_envelope_test.go
+++ b/pkg/vmcp/server/modern_envelope_test.go
@@ -538,6 +538,62 @@ func TestModernWriters(t *testing.T) {
 		require.Equal(t, true, decoded.Result["ok"])
 	})
 
+	// writeModernResult must ALWAYS emit "id", unlike writeModernError/
+	// writeModernDenied below -- a result response's id is required by the
+	// MCP schema, not optional. This pins that a future refactor doesn't
+	// "helpfully" make it conditional to match its error-writing siblings.
+	t.Run("writeModernResult always emits id, even absent", func(t *testing.T) {
+		t.Parallel()
+
+		rec := httptest.NewRecorder()
+		writeModernResult(rec, nil, map[string]any{"ok": true})
+
+		var asMap map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &asMap))
+		_, hasID := asMap["id"]
+		require.True(t, hasID, `"id" key must be present on a result response even when id is nil`)
+	})
+
+	// writeModernError's "id" key follows transportsession.HasJSONRPCID: MCP
+	// narrows base JSON-RPC 2.0 so an absent id is encoded by omitting the
+	// key, never as "id":null (schema/2025-11-25 types the error response id
+	// as optional string|number). A map decode (not a tagged struct) is the
+	// only way to tell an absent key apart from a present null.
+	t.Run("writeModernError id presence", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name       string
+			id         any
+			wantIDKey  bool
+			wantIDEcho string // substring the body must contain, verbatim, when wantIDKey
+		}{
+			{name: "nil id is omitted", id: nil, wantIDKey: false},
+			{name: "zero id is still present", id: int64(0), wantIDKey: true, wantIDEcho: `"id":0`},
+			{name: "present id is present", id: "req-2", wantIDKey: true, wantIDEcho: `"id":"req-2"`},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				rec := httptest.NewRecorder()
+				writeModernError(rec, tt.id, jsonRPCCodeInternalError, "some message")
+
+				var asMap map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &asMap))
+				_, hasID := asMap["id"]
+				require.Equal(t, tt.wantIDKey, hasID, `"id" key presence`)
+				if tt.wantIDKey {
+					// A map decode would coerce a numeric id to float64,
+					// losing the verbatim-echo guarantee -- check the raw
+					// wire bytes instead.
+					require.Contains(t, rec.Body.String(), tt.wantIDEcho)
+				}
+			})
+		}
+	})
+
 	t.Run("writeModernError", func(t *testing.T) {
 		t.Parallel()
 
@@ -591,6 +647,54 @@ func TestModernWriters(t *testing.T) {
 		require.Equal(t, int(mcpparser.JSONRPCCodeDenied), decoded.Error.Code)
 		require.Equal(t, "denied by policy", decoded.Error.Message)
 	})
+
+	// writeModernDenied's "id" key follows the same HasJSONRPCID rule as
+	// writeModernError above.
+	t.Run("writeModernDenied id presence", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name       string
+			id         any
+			wantIDKey  bool
+			wantIDEcho string
+		}{
+			{name: "nil id is omitted", id: nil, wantIDKey: false},
+			{name: "zero id is still present", id: int64(0), wantIDKey: true, wantIDEcho: `"id":0`},
+			{name: "present id is present", id: "req-3", wantIDKey: true, wantIDEcho: `"id":"req-3"`},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				rec := httptest.NewRecorder()
+				writeModernDenied(rec, tt.id, "denied by policy")
+
+				var asMap map[string]any
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &asMap))
+				_, hasID := asMap["id"]
+				require.Equal(t, tt.wantIDKey, hasID, `"id" key presence`)
+				if tt.wantIDKey {
+					require.Contains(t, rec.Body.String(), tt.wantIDEcho)
+				}
+			})
+		}
+	})
+}
+
+// TestWriteModernEnvelopeMarshalFallback verifies the defensive fallback
+// drops the "id" key (never "id":null) when the envelope fails to marshal.
+// A channel is not JSON-marshalable, forcing json.Marshal to fail.
+func TestWriteModernEnvelopeMarshalFallback(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	writeModernEnvelope(rec, http.StatusOK, map[string]any{"bad": make(chan int)})
+
+	const want = `{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error"}}`
+	require.Equal(t, want, rec.Body.String())
+	require.NotContains(t, rec.Body.String(), `"id"`)
 }
 
 // TestModernDiscover asserts server/discover's capability-flags shape: a

--- a/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
+++ b/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
@@ -126,7 +126,13 @@ var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http"
 			body, err := io.ReadAll(resp.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(body)).To(ContainSubstring(`"code":-32600`), "Should carry a JSON-RPC Invalid Request error")
-			Expect(string(body)).To(ContainSubstring(`"id":null`), "Batch rejection carries a null JSON-RPC id")
+
+			// A batch has no single request id to echo. MCP encodes that by
+			// omitting the "id" key entirely (schema/2025-11-25 types the
+			// error response id as optional, not nullable), never as null.
+			var parsed map[string]any
+			Expect(json.Unmarshal(body, &parsed)).To(Succeed())
+			Expect(parsed).ToNot(HaveKey("id"), "Batch rejection omits the JSON-RPC id key rather than emitting null")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Seven hand-built JSON-RPC error envelopes dropped the raw request id straight into a `map[string]any`, so an absent id marshaled to `"id":null`. MCP does not allow that, and the reference client enforces it.

- **The rule.** MCP narrows base JSON-RPC 2.0 for error responses: `schema/2025-11-25` types them `id?: RequestId` where `RequestId = string | number`. `null` is not in the union, and the key is optional only on the *error* response — it stays required on `JSONRPCResultResponse`. Base JSON-RPC 2.0 §5 says the id "MUST be Null" when it cannot be determined; MCP deliberately overrides that, because its schema cannot express null. Both transport pages say the body "has no `id`", once specifically for the 403 Origin-check case. So an absent id is encoded by **omitting the key**.
- **Why it bites.** The reference TypeScript SDK's `JSONRPCErrorResponseSchema` is a `.strict()` object with `id: RequestIdSchema.optional()` — which admits `undefined` but not `null` — and it gates every inbound message through `parse()`, the *throwing* variant, in all five client transports. An `"id":null` body makes a conformant client throw inside its transport before the application ever sees the error. For session-not-found that is especially costly: clients use code `-32001` to trigger automatic session recovery, so they lose recovery, not merely an error message.
- **One reachable path, confirmed.** `rateLimitHandler` gates only on the method being `tools/call` and has no notification guard, so a rate-limited `tools/call` notification reached `writeRateLimited` with a nil id and emitted `"id":null` at HTTP 429. This was verified end-to-end through the real `ParsingMiddleware`. The issue did not identify this site as reachable; it surfaced during review.
- **A shared predicate, because a nil check is not enough.** `session.HasJSONRPCID` is the single definition of an absent id. Two sites receive the id as raw bytes threaded from the transparent proxy, where both `json.RawMessage("null")` and `json.RawMessage(nil)` are non-nil interfaces that marshal to `null`. A zero id still round-trips — the predicate tests nil-ness, not zero-ness.
- **Two sites deliberately do not use it.** The origin 403 has no incoming id at all (rejected on the header before any body is parsed), so the key is simply deleted. `writeSSEErrorEvent` holds a typed `jsonrpc2.ID` and uses `id.IsValid()`: passing that struct through the `any`-typed predicate would report it present and emit `"id":{}`, which is neither absent nor a valid `RequestId`. `HasJSONRPCID` now documents that.
- **Tests that could not see the bug.** Three tests decoded the id into a tagged struct and asserted `Nil`, which holds whether the key is absent *or* null. One of them passed with the bug deliberately reintroduced. All now decode into a map and assert key absence. Where an id is present, assertions check verbatim echo against the wire bytes, since a map decode coerces a numeric id to `float64` and would drop the guarantee pinned in #5945.

Fixes #6038

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Every touched package is green, including under `-race`: `pkg/transport/session`, `pkg/mcp`, `pkg/ratelimit`, `pkg/vmcp/server`, `pkg/transport/middleware/origin`, `pkg/transport/proxy/streamable`, `pkg/transport/proxy/transparent`.

`task test` could not be scoped — the Taskfile's `test` target runs the whole suite over `go list ./...` with no package filter — so the underlying `go test -count=1` invocation was used per package. CI runs the real thing. **Linting was not run locally; leaving it to CI.**

Every new and flipped assertion was proven to be a real regression guard by mutation: the production change was reverted or inverted, the test confirmed to fail, then restored. This was not ceremony — it caught two tests that passed with the bug present (`TestParsingMiddlewareRejectsBatch`, and the pre-existing origin test), and confirmed that swapping test fixtures from `float64` to `int64` had not silently rendered the zero-id rows inert.

Manual testing: the reachable rate-limit path was driven end-to-end through the real `ParsingMiddleware` with a `tools/call` notification, confirming `429 {"error":{...},"id":null,"jsonrpc":"2.0"}` before the fix and the same body without the `id` key after.

E2E: compile-verified only (`go vet ./test/e2e/...`). The batch-rejection assertion in `stdio_proxy_over_streamable_http_mcp_server_test.go` was updated but needs a built binary and live containers to run.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/transport/session/jsonrpc_errors.go` | New `HasJSONRPCID`; `NotFoundBody` omits the key; doc rewritten (#6031 had asserted null was required) |
| `pkg/mcp/classification_response.go` | `classificationErrorBody`: conditional id; fallback literal |
| `pkg/mcp/tool_filter.go` | `filteredToolCallErrorBody`: same |
| `pkg/mcp/batch.go` | Doc comments only — both said "the JSON-RPC id is null" |
| `pkg/ratelimit/middleware.go` | `rateLimitedBody`: conditional id; `fmt.Sprintf` fallback |
| `pkg/vmcp/server/modern_envelope.go` | `writeModernError` / `writeModernDenied`: conditional id; `writeModernResult` deliberately unchanged, with a comment saying why |
| `pkg/transport/middleware/origin/origin.go` | `writeForbidden`: `"id": nil` deleted outright; fallback literal and doc |
| `pkg/transport/proxy/streamable/streamable_proxy.go` | `writeSSEErrorEvent`: gates on `id.IsValid()` |
| `pkg/transport/proxy/transparent/transparent_proxy.go` | Comment sync — the `requestID` doc still claimed JSON-RPC requires a null id |

## Does this introduce a user-facing change?

Yes. Error responses from session-not-found, classification failures, batch rejection, filtered tool calls, rate limiting, the vMCP Modern path, the origin 403, and SSE error events now omit the `id` key when there is no id to echo, instead of sending `"id":null`. Spec-strict MCP clients can parse these responses at all rather than throwing in their transport layer; in particular, `-32001`-driven automatic session recovery starts working for them. Clients that tolerated the non-conformant body are unaffected — a present id is still echoed verbatim, including `id: 0`.

## Special notes for reviewers

**On the two halves of the vMCP/rate-limit commit.** These have different exposure and the commit message says so. `pkg/ratelimit` fixes a path a real client can hit. `pkg/vmcp/server` is defense-in-depth on a path that is currently unreachable: every call site of `writeModernError`/`writeModernDenied` sits downstream of `dispatchModern`'s `parsed.ID == nil` guard, which answers 202 before any error envelope is built, and vMCP ids arrive from `jsonrpc2.ID.Raw()` as `nil | int64 | string`, never raw bytes. The writers take `id any`, so guarding them is still right — but no client was receiving a null id from that path, and the PR should not be read as claiming otherwise.

**Scope is wider than the issue.** #6038 named three sites; there are seven. The extra four are `pkg/mcp/tool_filter.go`, `pkg/transport/middleware/origin/origin.go`, `pkg/vmcp/server/modern_envelope.go`, and `writeSSEErrorEvent`. The origin one is arguably the most clear-cut of all of them: it hardcoded `"id": nil`, and its 403 is the case the transport spec names explicitly.

**Deliberately untouched:**

- `pkg/vmcp/server/server.go:1372` hardcodes `"id":"server-error"` — a *fabricated* id, arguably worse than an absent one since a client may correlate it against a real request. Separate issue.
- `writeModernResult` still always emits `id`. A result response requires one; omitting there would be as wrong as null. A test pins this, because the obvious future refactor is to make it match its siblings.
- `pkg/authz/handleUnauthorized` emits `{"Result":null,...,"ID":{}}` — no `jsonrpc` field, capitalized keys, id discarded. Not a #6038 violation (it never writes `"id":null`), and open PR #6055 already fixes exactly those lines.
- #6037 (bare JSON into a `text/event-stream` with no `data:` prefix) and #6039 (HTTP statuses used as JSON-RPC error codes) remain open. The new `writeSSEErrorEvent` test asserts the `data: ` framing specifically so this change cannot drift into the #6037 failure mode.

**No shared envelope builder, deliberately.** Only the id predicate is shared. PR #6055 designed and rejected a full envelope helper; that reasoning still holds — the maps genuinely differ (rate-limit carries `data`, vMCP sets `Cache-Control`, statuses vary). Sharing just the predicate is what the two raw-bytes sites actually needed.

**Where I would want the most scrutiny:** whether `session` is the right home for `HasJSONRPCID`. It was chosen because that package already owns this envelope shape and is a near-leaf every affected package already imports, so it adds no new dependency edges. But a generic JSON-RPC predicate living in a package named `session` is a naming wart, and a small `jsonrpcerr` package would read better at the cost of one new import path.

Generated with [Claude Code](https://claude.com/claude-code)
