### PR TITLE
Stop deriving the ingress proxy port from a fixed upstream port

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -1638,9 +1638,11 @@ func mergeEnvVars(base, extra map[string]string) map[string]string {
 // the workload and returns the host-side port it is bound on.
 func (c *Client) setupIngressContainer(ctx context.Context, containerName string, upstreamPort int, attachStdio bool,
 	externalEndpointsConfig map[string]*network.EndpointSettings, networkPermissions *permissions.NetworkPermissions) (int, error) {
-	squidPort, err := networking.FindOrUsePort(upstreamPort + 1)
+	// A random port avoids every same-image workload racing to bind the same
+	// preferred port when starting concurrently (see #6063).
+	squidPort, err := networking.FindOrUsePort(0)
 	if err != nil {
-		return 0, fmt.Errorf("failed to find or use port %d: %w", squidPort, err)
+		return 0, fmt.Errorf("failed to find an available port: %w", err)
 	}
 	squidExposedPorts := map[string]struct{}{
 		fmt.Sprintf("%d/tcp", squidPort): {},

--- a/pkg/container/docker/envoy.go
+++ b/pkg/container/docker/envoy.go
@@ -886,7 +886,9 @@ func (e *envoyProxy) SetupIngress(ctx context.Context, spec proxySpec, _ egressR
 
 	var ingressPort int
 	if spec.TransportType != "stdio" && spec.UpstreamPort > 0 {
-		port, err := networking.FindOrUsePort(spec.UpstreamPort + 1)
+		// A random port avoids every same-image workload racing to bind the
+		// same preferred port when starting concurrently (see #6063).
+		port, err := networking.FindOrUsePort(0)
 		if err != nil {
 			return 0, fmt.Errorf("failed to find ingress port: %w", err)
 		}

--- a/pkg/container/docker/envoy_test.go
+++ b/pkg/container/docker/envoy_test.go
@@ -6,10 +6,12 @@ package docker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -818,6 +820,70 @@ func TestEnvoyProxy_SetupOrchestration(t *testing.T) {
 				assert.Zero(t, ingressPort, "stdio must not reserve an ingress port")
 			}
 		})
+	}
+}
+
+// TestEnvoyProxy_SetupIngress_ConcurrentSameUpstreamPort guards against a
+// deterministic ingress port collision: two workloads built from the same
+// image share the same fixed UpstreamPort, so deriving the ingress port from
+// UpstreamPort+1 made every concurrently-starting instance request the
+// identical host port. The fix picks a random port instead, so concurrent
+// SetupIngress calls sharing UpstreamPort must land on different ports.
+func TestEnvoyProxy_SetupIngress_ConcurrentSameUpstreamPort(t *testing.T) {
+	t.Parallel()
+
+	const upstreamPort = 8080
+	const workloadCount = 4
+
+	ports := make([]int, workloadCount)
+	errs := make([]error, workloadCount)
+
+	var wg sync.WaitGroup
+	for i := range workloadCount {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			api := &fakeDockerAPI{
+				createFunc: func(_ context.Context, _ *container.Config, _ *container.HostConfig,
+					_ *network.NetworkingConfig, _ *v1.Platform, _ string) (container.CreateResponse, error) {
+					return container.CreateResponse{ID: "cid-envoy"}, nil
+				},
+				startFunc: func(_ context.Context, _ string, _ mobyclient.ContainerStartOptions) error { return nil },
+			}
+			e := &envoyProxy{client: &Client{
+				api:          api,
+				imageManager: &fakeImageManager{availableImages: map[string]struct{}{defaultEnvoyImage: {}}},
+			}}
+			spec := proxySpec{
+				WorkloadName:  fmt.Sprintf("app-%d", idx),
+				TransportType: "streamable-http",
+				UpstreamPort:  upstreamPort,
+				GatewayIP:     dockerDefaultBridgeGatewayIP,
+				Endpoints:     map[string]*network.EndpointSettings{},
+			}
+			port, err := e.SetupIngress(t.Context(), spec, egressResult{})
+			ports[idx] = port
+			errs[idx] = err
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for concurrent SetupIngress calls")
+	}
+
+	seen := make(map[int]bool, workloadCount)
+	for i, port := range ports {
+		require.NoError(t, errs[i])
+		assert.NotEqual(t, upstreamPort+1, port, "ingress port must not be derived from UpstreamPort+1")
+		assert.False(t, seen[port], "port %d was reserved by more than one concurrent workload", port)
+		seen[port] = true
 	}
 }
 


### PR DESCRIPTION
## Summary

- The `group_rm_test.go` / `rm_group_test.go` e2e specs that create several
  workloads of the same MCP server image back-to-back have been failing on
  almost every PR: workloads observed stuck in `starting` or flipped to a bare
  `error` status, timing out after 2 minutes even though the underlying
  container started and logged readiness within seconds. Related to #6040
  (closed against an earlier, incomplete diagnosis) and the diagnostics added
  in #6063, whose new proxy-log dump captured the actual Docker error:
  `Bind for 127.0.0.1:8081 failed: port is already allocated`.
- Root cause: `setupIngressContainer` (Squid backend) and `envoyProxy.SetupIngress`
  (Envoy backend) both picked the ingress reverse-proxy's host port as
  `UpstreamPort + 1`, where `UpstreamPort` is the container's *fixed internal*
  MCP listen port (e.g. 8080 for the `fetch`/gofetch test image) — identical
  across every workload instance of that image. Every concurrently-starting
  workload of the same image therefore requested the *same* preferred port.
  `networking.FindOrUsePort`'s availability check is a bind-then-close probe
  with no reservation, so it can't see a sibling process's in-flight (not yet
  bound) intent to use that port — all instances see it as free, and whichever
  one's Docker networking setup runs last loses with "port is already allocated".
- Fix: pick the ingress port at random (`FindOrUsePort(0)`) instead of deriving
  it from the container's fixed internal port, matching how the per-workload
  host proxy port is already chosen elsewhere in the codebase. This doesn't
  eliminate the underlying TOCTOU in `pkg/networking/port.go` in principle, but
  removes the *deterministic* same-image collision, making an actual collision
  astronomically unlikely for a handful of concurrently-starting workloads.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Added `TestEnvoyProxy_SetupIngress_ConcurrentSameUpstreamPort`, which runs 4
goroutines through `SetupIngress` sharing the same `UpstreamPort` and asserts
every returned ingress port is distinct and none equals `upstreamPort+1`. Fails
against the old code, passes with the fix. Full `task build` / `task test`
green.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/container/docker/client.go` | `setupIngressContainer` picks the Squid ingress port at random instead of `upstreamPort + 1` |
| `pkg/container/docker/envoy.go` | `envoyProxy.SetupIngress` picks the ingress port at random instead of `spec.UpstreamPort + 1` |
| `pkg/container/docker/envoy_test.go` | New regression test proving concurrent same-image workloads no longer collide on the ingress port |

## Does this introduce a user-facing change?

No. The ingress proxy port is an internal container-to-container detail (clients connect to the workload's regular host proxy port, unaffected by this change).

## Special notes for reviewers

This is **not** a fixup of #6063 — it doesn't touch any file #6063 changes, and #6063 is diagnostics-only by design (its own description states the readiness-stall root cause was still unknown). This PR is the root-cause fix that #6063's new proxy-log diagnostic made possible to find. The two can merge in either order; no dependency between them.

Generated with [Claude Code](https://claude.com/claude-code)