### PR TITLE
Resolve aggregator conflicts for resources, templates and prompts

### DIFF
--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1017,7 +1017,9 @@ spec:
                           prefixFormat:
                             default: '{workload}_'
                             description: |-
-                              PrefixFormat defines the prefix format for the "prefix" strategy.
+                              PrefixFormat defines the prefix format for the "prefix" tool strategy
+                              and for prompt names, which are always backend-prefixed regardless of
+                              the tool strategy.
                               Supports placeholders: {workload}, {workload}_, {workload}.
                             type: string
                           priorityOrder:
@@ -4464,7 +4466,9 @@ spec:
                           prefixFormat:
                             default: '{workload}_'
                             description: |-
-                              PrefixFormat defines the prefix format for the "prefix" strategy.
+                              PrefixFormat defines the prefix format for the "prefix" tool strategy
+                              and for prompt names, which are always backend-prefixed regardless of
+                              the tool strategy.
                               Supports placeholders: {workload}, {workload}_, {workload}.
                             type: string
                           priorityOrder:

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1018,13 +1018,16 @@ spec:
                             default: '{workload}_'
                             description: |-
                               PrefixFormat defines the prefix format for the "prefix" tool strategy
-                              and for prompt names, which are always backend-prefixed regardless of
-                              the tool strategy.
+                              and for backend-prefixed prompt names (the default for every prompt;
+                              under the "priority" strategy, backends listed in priorityOrder keep
+                              their own prompt names).
                               Supports placeholders: {workload}, {workload}_, {workload}.
                             type: string
                           priorityOrder:
-                            description: PriorityOrder defines the workload priority
-                              order for the "priority" strategy.
+                            description: |-
+                              PriorityOrder defines the workload priority order for the "priority" strategy.
+                              Listed workloads also keep their own prompt names (unlisted workloads'
+                              prompts stay backend-prefixed).
                             items:
                               type: string
                             type: array
@@ -4467,13 +4470,16 @@ spec:
                             default: '{workload}_'
                             description: |-
                               PrefixFormat defines the prefix format for the "prefix" tool strategy
-                              and for prompt names, which are always backend-prefixed regardless of
-                              the tool strategy.
+                              and for backend-prefixed prompt names (the default for every prompt;
+                              under the "priority" strategy, backends listed in priorityOrder keep
+                              their own prompt names).
                               Supports placeholders: {workload}, {workload}_, {workload}.
                             type: string
                           priorityOrder:
-                            description: PriorityOrder defines the workload priority
-                              order for the "priority" strategy.
+                            description: |-
+                              PriorityOrder defines the workload priority order for the "priority" strategy.
+                              Listed workloads also keep their own prompt names (unlisted workloads'
+                              prompts stay backend-prefixed).
                             items:
                               type: string
                             type: array

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1021,13 +1021,16 @@ spec:
                             default: '{workload}_'
                             description: |-
                               PrefixFormat defines the prefix format for the "prefix" tool strategy
-                              and for prompt names, which are always backend-prefixed regardless of
-                              the tool strategy.
+                              and for backend-prefixed prompt names (the default for every prompt;
+                              under the "priority" strategy, backends listed in priorityOrder keep
+                              their own prompt names).
                               Supports placeholders: {workload}, {workload}_, {workload}.
                             type: string
                           priorityOrder:
-                            description: PriorityOrder defines the workload priority
-                              order for the "priority" strategy.
+                            description: |-
+                              PriorityOrder defines the workload priority order for the "priority" strategy.
+                              Listed workloads also keep their own prompt names (unlisted workloads'
+                              prompts stay backend-prefixed).
                             items:
                               type: string
                             type: array
@@ -4470,13 +4473,16 @@ spec:
                             default: '{workload}_'
                             description: |-
                               PrefixFormat defines the prefix format for the "prefix" tool strategy
-                              and for prompt names, which are always backend-prefixed regardless of
-                              the tool strategy.
+                              and for backend-prefixed prompt names (the default for every prompt;
+                              under the "priority" strategy, backends listed in priorityOrder keep
+                              their own prompt names).
                               Supports placeholders: {workload}, {workload}_, {workload}.
                             type: string
                           priorityOrder:
-                            description: PriorityOrder defines the workload priority
-                              order for the "priority" strategy.
+                            description: |-
+                              PriorityOrder defines the workload priority order for the "priority" strategy.
+                              Listed workloads also keep their own prompt names (unlisted workloads'
+                              prompts stay backend-prefixed).
                             items:
                               type: string
                             type: array

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -1020,7 +1020,9 @@ spec:
                           prefixFormat:
                             default: '{workload}_'
                             description: |-
-                              PrefixFormat defines the prefix format for the "prefix" strategy.
+                              PrefixFormat defines the prefix format for the "prefix" tool strategy
+                              and for prompt names, which are always backend-prefixed regardless of
+                              the tool strategy.
                               Supports placeholders: {workload}, {workload}_, {workload}.
                             type: string
                           priorityOrder:
@@ -4467,7 +4469,9 @@ spec:
                           prefixFormat:
                             default: '{workload}_'
                             description: |-
-                              PrefixFormat defines the prefix format for the "prefix" strategy.
+                              PrefixFormat defines the prefix format for the "prefix" tool strategy
+                              and for prompt names, which are always backend-prefixed regardless of
+                              the tool strategy.
                               Supports placeholders: {workload}, {workload}_, {workload}.
                             type: string
                           priorityOrder:

--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -136,17 +136,36 @@ When backends expose tools with the same name, vMCP resolves the conflict using 
 | **priority** | First backend in priority order wins, others hidden |
 | **manual** | Explicit mapping for each conflict |
 
-**Conflict resolution covers tools only.** Resources, resource templates, and
-prompts are concatenated across backends with no de-duplication
-(`default_aggregator.go`, "no conflict resolution for these yet"), so
-`Resource.URI`, `ResourceTemplate.URITemplate` and `Prompt.Name` can each repeat
-in the aggregated view — two backends both exposing `file:///README.md` is
-enough. Only `Tool.Name` is unique, because tool resolution keys a map.
+The three strategies above cover **tools**. Resources, resource templates, and
+prompts are resolved separately (`aggregator/capability_conflicts.go`), with
+policies that deliberately differ by what the identity *is*:
 
-Anything that treats one of those fields as an identity must account for that.
-The Modern list paginator does: its cursor names a position within a run of equal
-keys rather than assuming keys are distinct, because a plain "resume after this
-key" scan silently dropped an item whenever a duplicate landed on a page boundary
+- **Prompt names are names**, like tool names: `prompts/get` is translated back
+  to the backend's own name via `BackendTarget.GetBackendCapabilityName`, so
+  renaming is lossless. A name advertised by exactly one backend passes through
+  unchanged; a name advertised by several is renamed to `{backendID}_{name}`
+  for **every** colliding backend, and the bare duplicated name is no longer
+  advertised.
+- **Resource URIs and template strings are locators, not names.** The client
+  passes them back verbatim (`resources/read`, `resources/subscribe`,
+  completion refs), backends emit them in notifications and embedded resource
+  contents, and template-matched reads forward the client's concrete URI
+  untranslated — so vMCP never rewrites them. A URI (or template string)
+  advertised by several backends is instead advertised **once**: the backend
+  earliest in sorted-backend-ID order wins, later duplicates are dropped with a
+  warning. Nothing reachable is lost — the routing table keys by URI, so only
+  one backend was ever served per URI; the fix makes that pick deterministic
+  and the advertised list agree with it.
+
+After aggregation, every capability identity (`Tool.Name`, `Resource.URI`,
+`ResourceTemplate.URITemplate`, `Prompt.Name`) is unique in the aggregated view,
+and backends are processed in sorted-ID order so collision outcomes are stable
+across runs.
+
+The Modern list paginator still does **not** rely on that uniqueness: its cursor
+names a position within a run of equal keys rather than assuming keys are
+distinct, because the paginator is generic and a plain "resume after this key"
+scan silently dropped an item whenever a duplicate landed on a page boundary
 (see [Client-facing list pagination](#client-facing-list-pagination)).
 
 ### Tool Filtering
@@ -435,11 +454,12 @@ Three properties worth knowing:
   aggregator's fan-out order is not stable between calls, so Modern list results
   are sorted by the item's key (`Tool.Name`, `Resource.URI`,
   `ResourceTemplate.URITemplate`, `Prompt.Name`). Legacy ordering is unchanged.
-- **Duplicate keys are tolerated, not assumed away.** Only tool names are unique
-  (see [Conflict Resolution](#conflict-resolution)); resource URIs, template
-  strings and prompt names can repeat. The cursor therefore resumes *within* a run
-  of equal keys, because a plain "resume after this key" scan skipped every copy
-  and permanently dropped items whose key collided at a page boundary.
+- **Duplicate keys are tolerated, not assumed away.** The aggregator makes all
+  four keys unique (see [Conflict Resolution](#conflict-resolution)), but the
+  paginator is generic and does not depend on that caller invariant. The cursor
+  resumes *within* a run of equal keys, because a plain "resume after this key"
+  scan skipped every copy and permanently dropped items whose key collided at a
+  page boundary.
 - **End of results omits `nextCursor` entirely.** The draft states that "an empty
   string is a valid cursor and thus MUST NOT be treated as the end of results", so
   emitting `""` would make a conformant client re-request and loop on page one.

--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -142,20 +142,27 @@ policies that deliberately differ by what the identity *is*:
 
 - **Prompt names are names**, like tool names: `prompts/get` is translated back
   to the backend's own name via `BackendTarget.GetBackendCapabilityName`, so a
-  rename does not break invocation. Every prompt is renamed
-  **unconditionally** to its backend-prefixed form —
-  `conflictResolutionConfig.prefixFormat` applied to the backend ID (default
-  `{workload}_`), the same formatting path the tool prefix strategy uses. The
-  advertised name is therefore a pure function of (backendID, name) and never
-  shifts when unrelated backends join or leave the group. That stability
-  matters beyond naming: authorization matches on the advertised name (Cedar
-  builds `Prompt::"<advertised name>"` entities), so a membership-dependent
-  rename would detach `permit` and `forbid` policies from the prompt they were
-  written for. Prompts are prefixed under **every** strategy — a `priority` or
-  `manual` configuration changes tool resolution only. If two distinct
-  (backendID, name) pairs compose to the same prefixed string (backend `b1`
-  prompt `x_y` vs backend `b1_x` prompt `y`), the name would be ambiguous
-  between backends and aggregation fails loudly instead of dropping one.
+  rename does not break invocation. By **default** every prompt is renamed to
+  its backend-prefixed form — `conflictResolutionConfig.prefixFormat` applied
+  to the backend ID (default `{workload}_`), the same formatting path the tool
+  prefix strategy uses. The **priority** strategy is the escape hatch for
+  clients that pin prompt names, exactly as it is for tools: backends listed
+  in `priorityOrder` keep their bare prompt names, a bare-name collision among
+  listed backends resolves to the highest-priority one, and unlisted backends
+  stay always-prefixed — deliberately stricter than tool priority resolution,
+  which lets a conflict-free unlisted tool keep its bare name. The invariant
+  both modes preserve: the advertised name is a pure function of the
+  aggregation config and (backendID, name), so it never shifts because an
+  unrelated backend joined or left the group. That stability matters beyond
+  naming: authorization matches on the advertised name (Cedar builds
+  `Prompt::"<advertised name>"` entities), so a membership-dependent rename
+  would detach `permit` and `forbid` policies from the prompt they were
+  written for — names move only on an explicit config edit. A `manual`
+  configuration changes tool resolution only. If two backends' advertised
+  names compose to the same string (backend `b1` prompt `x_y` vs backend
+  `b1_x` prompt `y`, or a prefixed name hitting a listed backend's literal
+  name), the name would be ambiguous between backends and aggregation fails
+  loudly instead of dropping one.
 - **Resource URIs and template strings are locators, not names.** The client
   passes them back verbatim (`resources/read`, `resources/subscribe`,
   completion refs), backends emit them in notifications and embedded resource

--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -141,11 +141,21 @@ prompts are resolved separately (`aggregator/capability_conflicts.go`), with
 policies that deliberately differ by what the identity *is*:
 
 - **Prompt names are names**, like tool names: `prompts/get` is translated back
-  to the backend's own name via `BackendTarget.GetBackendCapabilityName`, so
-  renaming is lossless. A name advertised by exactly one backend passes through
-  unchanged; a name advertised by several is renamed to `{backendID}_{name}`
-  for **every** colliding backend, and the bare duplicated name is no longer
-  advertised.
+  to the backend's own name via `BackendTarget.GetBackendCapabilityName`, so a
+  rename does not break invocation. Every prompt is renamed
+  **unconditionally** to its backend-prefixed form —
+  `conflictResolutionConfig.prefixFormat` applied to the backend ID (default
+  `{workload}_`), the same formatting path the tool prefix strategy uses. The
+  advertised name is therefore a pure function of (backendID, name) and never
+  shifts when unrelated backends join or leave the group. That stability
+  matters beyond naming: authorization matches on the advertised name (Cedar
+  builds `Prompt::"<advertised name>"` entities), so a membership-dependent
+  rename would detach `permit` and `forbid` policies from the prompt they were
+  written for. Prompts are prefixed under **every** strategy — a `priority` or
+  `manual` configuration changes tool resolution only. If two distinct
+  (backendID, name) pairs compose to the same prefixed string (backend `b1`
+  prompt `x_y` vs backend `b1_x` prompt `y`), the name would be ambiguous
+  between backends and aggregation fails loudly instead of dropping one.
 - **Resource URIs and template strings are locators, not names.** The client
   passes them back verbatim (`resources/read`, `resources/subscribe`,
   completion refs), backends emit them in notifications and embedded resource
@@ -153,14 +163,19 @@ policies that deliberately differ by what the identity *is*:
   untranslated — so vMCP never rewrites them. A URI (or template string)
   advertised by several backends is instead advertised **once**: the backend
   earliest in sorted-backend-ID order wins, later duplicates are dropped with a
-  warning. Nothing reachable is lost — the routing table keys by URI, so only
-  one backend was ever served per URI; the fix makes that pick deterministic
-  and the advertised list agree with it.
+  warning. Reads are unchanged — the routing table keys by URI, so only one
+  backend was ever served per URI; the fix makes that pick deterministic and
+  the advertised list agree with it. Only the winning backend's `name`,
+  `description` and `mimeType` are advertised for that URI, so a duplicate that
+  differed in those fields loses them along with its entry.
 
 After aggregation, every capability identity (`Tool.Name`, `Resource.URI`,
-`ResourceTemplate.URITemplate`, `Prompt.Name`) is unique in the aggregated view,
-and backends are processed in sorted-ID order so collision outcomes are stable
-across runs.
+`ResourceTemplate.URITemplate`, `Prompt.Name`) is unique in the aggregated view.
+Resources, resource templates and prompts are processed in sorted-backend-ID
+order, so their outcomes are stable across runs; tool resolution
+(`prefix_resolver.go`, `manual_resolver.go`) still iterates backends in map
+order, so a tool collision *after* prefixing or a manual override picks a
+nondeterministic winner.
 
 The Modern list paginator still does **not** rely on that uniqueness: its cursor
 names a position within a run of equal keys rather than assuming keys are

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -433,8 +433,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `prefixFormat` _string_ | PrefixFormat defines the prefix format for the "prefix" tool strategy<br />and for prompt names, which are always backend-prefixed regardless of<br />the tool strategy.<br />Supports placeholders: \{workload\}, \{workload\}_, \{workload\}. | \{workload\}_ | Optional: \{\} <br /> |
-| `priorityOrder` _string array_ | PriorityOrder defines the workload priority order for the "priority" strategy. |  | Optional: \{\} <br /> |
+| `prefixFormat` _string_ | PrefixFormat defines the prefix format for the "prefix" tool strategy<br />and for backend-prefixed prompt names (the default for every prompt;<br />under the "priority" strategy, backends listed in priorityOrder keep<br />their own prompt names).<br />Supports placeholders: \{workload\}, \{workload\}_, \{workload\}. | \{workload\}_ | Optional: \{\} <br /> |
+| `priorityOrder` _string array_ | PriorityOrder defines the workload priority order for the "priority" strategy.<br />Listed workloads also keep their own prompt names (unlisted workloads'<br />prompts stay backend-prefixed). |  | Optional: \{\} <br /> |
 
 
 

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -433,7 +433,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `prefixFormat` _string_ | PrefixFormat defines the prefix format for the "prefix" strategy.<br />Supports placeholders: \{workload\}, \{workload\}_, \{workload\}. | \{workload\}_ | Optional: \{\} <br /> |
+| `prefixFormat` _string_ | PrefixFormat defines the prefix format for the "prefix" tool strategy<br />and for prompt names, which are always backend-prefixed regardless of<br />the tool strategy.<br />Supports placeholders: \{workload\}, \{workload\}_, \{workload\}. | \{workload\}_ | Optional: \{\} <br /> |
 | `priorityOrder` _string array_ | PriorityOrder defines the workload priority order for the "priority" strategy. |  | Optional: \{\} <br /> |
 
 

--- a/pkg/vmcp/aggregator/aggregator.go
+++ b/pkg/vmcp/aggregator/aggregator.go
@@ -88,20 +88,27 @@ type BackendCapabilities struct {
 }
 
 // ResolvedCapabilities contains capabilities after conflict resolution.
-// Tool names are now unique (after prefixing, priority, or manual resolution).
+// Every capability identity (tool name, resource URI, resource template
+// string, prompt name) is unique within its list.
 type ResolvedCapabilities struct {
 	// Tools are the conflict-resolved tools.
 	// Map key is the resolved tool name, value contains original name and backend.
 	Tools map[string]*ResolvedTool
 
-	// Resources are passed through (conflicts rare, namespaced by URI).
+	// Resources are de-duplicated by URI: a URI advertised by multiple backends
+	// appears once, from the backend earliest in sorted-backend-ID order. URIs
+	// are locators the client passes back verbatim, so they are never rewritten.
+	// See resolveResourceConflicts.
 	Resources []vmcp.Resource
 
-	// ResourceTemplates are passed through (conflicts rare, namespaced by URI template).
+	// ResourceTemplates are de-duplicated by URI template string, with the same
+	// locator-identity policy as Resources. See resolveResourceTemplateConflicts.
 	ResourceTemplates []vmcp.ResourceTemplate
 
-	// Prompts are passed through (conflicts rare, namespaced by name).
-	Prompts []vmcp.Prompt
+	// Prompts are conflict-resolved by name: unique names pass through, while a
+	// name advertised by multiple backends is renamed to "{backendID}_{name}"
+	// for every colliding backend. See resolvePromptConflicts.
+	Prompts []ResolvedPrompt
 
 	// SupportsLogging is true if any backend supports logging.
 	SupportsLogging bool
@@ -135,6 +142,19 @@ type ResolvedTool struct {
 
 	// ConflictResolutionApplied indicates which strategy was used.
 	ConflictResolutionApplied vmcp.ConflictResolutionStrategy
+}
+
+// ResolvedPrompt represents a prompt after conflict resolution. The embedded
+// Prompt is the advertised form: Name holds the resolved (client-visible)
+// name. OriginalName is the name the backend itself uses; prompts/get and
+// completion requests are translated back to it via
+// BackendTarget.GetBackendCapabilityName, exactly like renamed tools.
+type ResolvedPrompt struct {
+	vmcp.Prompt
+
+	// OriginalName is the prompt's name in the backend (equal to Name when no
+	// rename was needed).
+	OriginalName string
 }
 
 // AggregatedCapabilities is the final unified view of all backend capabilities.

--- a/pkg/vmcp/aggregator/aggregator.go
+++ b/pkg/vmcp/aggregator/aggregator.go
@@ -105,9 +105,11 @@ type ResolvedCapabilities struct {
 	// locator-identity policy as Resources. See resolveResourceTemplateConflicts.
 	ResourceTemplates []vmcp.ResourceTemplate
 
-	// Prompts are conflict-resolved by name: unique names pass through, while a
-	// name advertised by multiple backends is renamed to "{backendID}_{name}"
-	// for every colliding backend. See resolvePromptConflicts.
+	// Prompts are conflict-resolved by name: every prompt is renamed to its
+	// backend-prefixed form (the configured prefixFormat applied to the
+	// backend ID), so the advertised name is a pure function of
+	// (backendID, name) and never shifts with group membership. See
+	// resolvePromptConflicts.
 	Prompts []ResolvedPrompt
 
 	// SupportsLogging is true if any backend supports logging.
@@ -152,8 +154,8 @@ type ResolvedTool struct {
 type ResolvedPrompt struct {
 	vmcp.Prompt
 
-	// OriginalName is the prompt's name in the backend (equal to Name when no
-	// rename was needed).
+	// OriginalName is the prompt's name in the backend (Name is always its
+	// backend-prefixed form).
 	OriginalName string
 }
 

--- a/pkg/vmcp/aggregator/aggregator.go
+++ b/pkg/vmcp/aggregator/aggregator.go
@@ -105,10 +105,11 @@ type ResolvedCapabilities struct {
 	// locator-identity policy as Resources. See resolveResourceTemplateConflicts.
 	ResourceTemplates []vmcp.ResourceTemplate
 
-	// Prompts are conflict-resolved by name: every prompt is renamed to its
-	// backend-prefixed form (the configured prefixFormat applied to the
-	// backend ID), so the advertised name is a pure function of
-	// (backendID, name) and never shifts with group membership. See
+	// Prompts are conflict-resolved by name: by default every prompt is
+	// renamed to its backend-prefixed form; under the priority strategy,
+	// backends listed in priorityOrder keep their bare names. Either way the
+	// advertised name is a pure function of the aggregation config and
+	// (backendID, name) — it never shifts with group membership. See
 	// resolvePromptConflicts.
 	Prompts []ResolvedPrompt
 
@@ -154,8 +155,9 @@ type ResolvedTool struct {
 type ResolvedPrompt struct {
 	vmcp.Prompt
 
-	// OriginalName is the prompt's name in the backend (Name is always its
-	// backend-prefixed form).
+	// OriginalName is the prompt's name in the backend (equal to Name only
+	// for priority-listed backends; otherwise Name is the backend-prefixed
+	// form).
 	OriginalName string
 }
 

--- a/pkg/vmcp/aggregator/capability_conflicts.go
+++ b/pkg/vmcp/aggregator/capability_conflicts.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregator
+
+import (
+	"log/slog"
+	"sort"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// This file resolves cross-backend identity conflicts for the list
+// capabilities NOT covered by the ConflictResolver strategies: resources
+// (identity: URI), resource templates (identity: URITemplate) and prompts
+// (identity: Name). Tools are resolved separately through
+// ConflictResolver.ResolveToolConflicts.
+//
+// The policies deliberately differ per type:
+//
+//   - Resource URIs and template strings are LOCATORS, not names. The client
+//     passes them back verbatim (resources/read, resources/subscribe,
+//     completion refs), backends emit them in notifications and embedded
+//     resource contents, and a template-matched read forwards the client's
+//     concrete URI untranslated (see MergeCapabilities). Rewriting them would
+//     break those round trips, so a duplicated URI is instead advertised
+//     ONCE: the backend earliest in sorted-backend-ID order wins and later
+//     duplicates are dropped with a warning naming the URI and both backends.
+//     Reads strictly improve — the routing table keys by URI, so at most one
+//     backend was ever served per URI, previously a nondeterministically-
+//     chosen one, now a stable one. Listing does regress from N
+//     indistinguishable entries to one, but the protocol gives a client no
+//     way to address the other N-1, so the extra entries promised reads that
+//     could never be honoured.
+//
+//   - Prompt names are NAMES, like tool names: prompts/get is translated back
+//     to the backend's own name via BackendTarget.GetBackendCapabilityName,
+//     so renaming is lossless. A name advertised by multiple backends is
+//     renamed to "{backendID}_{name}" for EVERY colliding backend (symmetric,
+//     mirroring PriorityConflictResolver's prefix fallback); the bare
+//     duplicated name is no longer advertised.
+//
+//     Collision-only renaming trades name stability for minimal change: what
+//     a prompt is advertised as depends on what else is deployed. A backend
+//     joining with a colliding prompt renames the incumbent out from under a
+//     client that pinned the bare name — which then fails prompts/get with
+//     not-found, a defined outcome, where it previously silently routed to an
+//     arbitrary backend. An in-place backend prompt-set change propagates to
+//     live sessions through the list_changed resync path
+//     (pkg/vmcp/server/serve_list_changed.go); a backend joining or leaving
+//     the group emits no push signal today, so staleness there is bounded by
+//     the aggregator cache TTL for routing and by the client's next
+//     prompts/list for listing.
+//
+// All functions iterate backends in the caller-supplied deterministic order
+// and return key-sorted slices, so the aggregated view (and therefore the
+// routing table built from it) is stable run to run.
+
+// resolveResourceConflicts de-duplicates resources by URI across backends.
+// backendIDs supplies the deterministic (sorted) iteration order.
+func resolveResourceConflicts(
+	backendIDs []string,
+	capabilities map[string]*BackendCapabilities,
+) []vmcp.Resource {
+	return dedupeByKey(backendIDs, capabilities, "resource",
+		func(caps *BackendCapabilities) []vmcp.Resource { return caps.Resources },
+		func(resource vmcp.Resource) string { return resource.URI })
+}
+
+// resolveResourceTemplateConflicts de-duplicates resource templates by URI
+// template string across backends. backendIDs supplies the deterministic
+// (sorted) iteration order.
+func resolveResourceTemplateConflicts(
+	backendIDs []string,
+	capabilities map[string]*BackendCapabilities,
+) []vmcp.ResourceTemplate {
+	return dedupeByKey(backendIDs, capabilities, "resource_template",
+		func(caps *BackendCapabilities) []vmcp.ResourceTemplate { return caps.ResourceTemplates },
+		func(template vmcp.ResourceTemplate) string { return template.URITemplate })
+}
+
+// resolvePromptConflicts resolves prompt name conflicts across backends.
+// A name advertised by exactly one backend passes through unchanged; a name
+// advertised by multiple backends is renamed to "{backendID}_{name}" for each
+// of them. If a prefixed name still collides (the same backend advertises a
+// name twice, or another backend advertises the literal prefixed name), the
+// first occurrence in deterministic order wins and later ones are dropped
+// with a warning. backendIDs supplies the deterministic (sorted) iteration
+// order; the result is sorted by resolved name.
+func resolvePromptConflicts(
+	backendIDs []string,
+	capabilities map[string]*BackendCapabilities,
+) []ResolvedPrompt {
+	// First pass: count occurrences per name, so a collision renames ALL of
+	// its participants (symmetric), not just the ones encountered later.
+	nameCounts := make(map[string]int)
+	for _, backendID := range backendIDs {
+		for _, prompt := range capabilities[backendID].Prompts {
+			nameCounts[prompt.Name]++
+		}
+	}
+
+	seen := make(map[string]string) // resolved name -> winning backend ID
+	resolved := make([]ResolvedPrompt, 0, len(nameCounts))
+	for _, backendID := range backendIDs {
+		for _, prompt := range capabilities[backendID].Prompts {
+			resolvedName := prompt.Name
+			if nameCounts[prompt.Name] > 1 {
+				resolvedName = backendID + "_" + prompt.Name
+				slog.Warn("prompt name duplicated across backends, advertising with backend prefix",
+					"prompt", prompt.Name, "backend", backendID, "advertised_name", resolvedName)
+			}
+			if winner, duplicate := seen[resolvedName]; duplicate {
+				slog.Warn("prompt name still duplicated after prefixing, dropping later duplicate",
+					"advertised_name", resolvedName, "kept_backend", winner, "dropped_backend", backendID)
+				continue
+			}
+			seen[resolvedName] = backendID
+
+			resolvedPrompt := ResolvedPrompt{Prompt: prompt, OriginalName: prompt.Name}
+			resolvedPrompt.Name = resolvedName
+			resolved = append(resolved, resolvedPrompt)
+		}
+	}
+
+	sort.Slice(resolved, func(i, j int) bool { return resolved[i].Name < resolved[j].Name })
+	return resolved
+}
+
+// dedupeByKey collects items of one capability kind across backends in the
+// given deterministic order, keeping the first item seen for each key and
+// dropping later duplicates with a warning. The result is sorted by key.
+func dedupeByKey[T any](
+	backendIDs []string,
+	capabilities map[string]*BackendCapabilities,
+	kind string,
+	itemsOf func(*BackendCapabilities) []T,
+	keyOf func(T) string,
+) []T {
+	seen := make(map[string]string) // key -> winning backend ID
+	var deduped []T
+	for _, backendID := range backendIDs {
+		for _, item := range itemsOf(capabilities[backendID]) {
+			key := keyOf(item)
+			if winner, duplicate := seen[key]; duplicate {
+				slog.Warn("duplicate capability identity across backends, keeping first in sorted backend order",
+					"capability", kind, "key", key, "kept_backend", winner, "dropped_backend", backendID)
+				continue
+			}
+			seen[key] = backendID
+			deduped = append(deduped, item)
+		}
+	}
+
+	sort.Slice(deduped, func(i, j int) bool { return keyOf(deduped[i]) < keyOf(deduped[j]) })
+	return deduped
+}

--- a/pkg/vmcp/aggregator/capability_conflicts.go
+++ b/pkg/vmcp/aggregator/capability_conflicts.go
@@ -6,6 +6,8 @@ package aggregator
 import (
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 	"sort"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
@@ -43,17 +45,27 @@ import (
 //
 //   - Prompt names are NAMES, like tool names: prompts/get is translated back
 //     to the backend's own name via BackendTarget.GetBackendCapabilityName,
-//     so renaming is lossless. Every prompt is renamed UNCONDITIONALLY to its
+//     so renaming is lossless. By DEFAULT every prompt is renamed to its
 //     backend-prefixed form — the configured prefixFormat applied to the
 //     backend ID (default "{workload}_") — mirroring what
-//     PrefixConflictResolver does for every tool. The advertised name is
-//     therefore a pure function of (backendID, prompt name) and never shifts
-//     when unrelated backends join or leave the group. That stability is a
-//     security property, not cosmetics: the advertised name is what
-//     authorization matches on (Cedar builds Prompt::"<advertised name>"
-//     entities — see pkg/vmcp/core/admission.go), so a membership-dependent
-//     rename would silently detach permit AND forbid policies from the
-//     prompt they were written for, the forbid case failing open.
+//     PrefixConflictResolver does for every tool. Under the PRIORITY strategy
+//     (the same escape hatch tools have for clients that pin names), backends
+//     listed in priorityOrder keep their bare prompt names, a bare-name
+//     collision among listed backends resolves to the highest-priority one,
+//     and unlisted backends stay ALWAYS prefixed — deliberately stricter
+//     than the tool priority resolver, which lets a conflict-free unlisted
+//     tool keep its bare name.
+//
+//     The invariant both modes preserve: an advertised prompt name is a pure
+//     function of the aggregation config and (backendID, prompt name) — it
+//     NEVER shifts because an unrelated backend joined or left the group.
+//     That stability is a security property, not cosmetics: the advertised
+//     name is what authorization matches on (Cedar builds
+//     Prompt::"<advertised name>" entities — see pkg/vmcp/core/admission.go),
+//     so a membership-dependent rename would silently detach permit AND
+//     forbid policies from the prompt they were written for, the forbid case
+//     failing open. Names move only on an explicit config edit — the moment
+//     an operator reviews policy anyway.
 //
 //     Prompt-set changes on a live backend propagate to connected sessions
 //     through the list_changed resync path
@@ -91,51 +103,90 @@ func resolveResourceTemplateConflicts(
 		func(template vmcp.ResourceTemplate) string { return template.URITemplate })
 }
 
-// resolvePromptConflicts renames EVERY prompt to its backend-prefixed form:
-// prefixFormat applied to the backend ID (see applyPrefixFormat), prepended
-// to the prompt's own name. Renaming unconditionally keeps the advertised
-// name independent of group membership; see the file header for why that
-// matters to authorization.
+// resolvePromptConflicts forms every prompt's advertised name per the naming
+// config: backends listed in naming.priorityRank keep their bare name, all
+// others get the backend-prefixed form (prefixFormat applied to the backend
+// ID, see applyPrefixFormat). With no priority configuration every prompt is
+// prefixed. Either way the advertised name never depends on what else is
+// deployed; see the file header for why that matters to authorization.
 //
 // An exact duplicate within one backend (same backend advertises a name
 // twice) is dropped with a warning — both entries would advertise and route
-// identically, so nothing reachable is lost. Any other residual collision,
-// i.e. two distinct (backendID, name) pairs composing to the same prefixed
-// string (backend "b1" prompt "x_y" vs backend "b1_x" prompt "y"), is
-// ambiguous between backends and returns ErrUnresolvedConflicts rather than
-// silently dropping a prompt. backendIDs supplies the deterministic (sorted)
-// iteration order; the result is sorted by resolved name.
+// identically, so nothing reachable is lost. A bare-name collision among
+// priority-listed backends resolves to the highest-priority one (lowest
+// rank), dropping the others with a warning, mirroring the tool priority
+// strategy. Any other collision — two prefixed names composing to the same
+// string (backend "b1" prompt "x_y" vs backend "b1_x" prompt "y"), or a
+// prefixed name hitting a listed backend's literal bare name — is ambiguous
+// between backends and returns ErrUnresolvedConflicts rather than silently
+// dropping a prompt. backendIDs supplies the deterministic (sorted) iteration
+// order; the result is sorted by resolved name.
 func resolvePromptConflicts(
-	prefixFormat string,
+	naming promptNaming,
 	backendIDs []string,
 	capabilities map[string]*BackendCapabilities,
 ) ([]ResolvedPrompt, error) {
-	type advertiser struct{ backendID, originalName string }
-	seen := make(map[string]advertiser) // resolved name -> first advertiser
-	var resolved []ResolvedPrompt
-	for _, backendID := range backendIDs {
-		for _, prompt := range capabilities[backendID].Prompts {
-			resolvedName := applyPrefixFormat(prefixFormat, backendID, prompt.Name)
-			if first, duplicate := seen[resolvedName]; duplicate {
-				if first.backendID == backendID {
-					slog.Warn("backend advertises the same prompt name twice, dropping later duplicate",
-						"backend", backendID, "prompt", prompt.Name)
-					continue
-				}
-				return nil, fmt.Errorf(
-					"%w: prompt %q from backend %q and prompt %q from backend %q are both advertised as %q; rename one of them",
-					ErrUnresolvedConflicts,
-					first.originalName, first.backendID, prompt.Name, backendID, resolvedName)
-			}
-			seen[resolvedName] = advertiser{backendID: backendID, originalName: prompt.Name}
+	// candidate is one backend's claim on an advertised prompt name.
+	type candidate struct {
+		prompt    vmcp.Prompt
+		backendID string
+		rank      int // priority rank (lower wins); meaningful only when listed
+		listed    bool
+	}
 
-			resolvedPrompt := ResolvedPrompt{Prompt: prompt, OriginalName: prompt.Name}
-			resolvedPrompt.Name = resolvedName
-			resolved = append(resolved, resolvedPrompt)
+	byName := make(map[string][]candidate)
+	for _, backendID := range backendIDs {
+		rank, listed := naming.priorityRank[backendID]
+		for _, prompt := range capabilities[backendID].Prompts {
+			resolvedName := prompt.Name
+			if !listed {
+				resolvedName = applyPrefixFormat(naming.prefixFormat, backendID, prompt.Name)
+			}
+			// The advertised name is injective per backend (bare, or a fixed
+			// prefix plus the name), so a same-backend claim on this name can
+			// only be an exact duplicate of the same prompt.
+			duplicate := slices.ContainsFunc(byName[resolvedName], func(c candidate) bool {
+				return c.backendID == backendID
+			})
+			if duplicate {
+				slog.Warn("backend advertises the same prompt name twice, dropping later duplicate",
+					"backend", backendID, "prompt", prompt.Name)
+				continue
+			}
+			byName[resolvedName] = append(byName[resolvedName], candidate{
+				prompt: prompt, backendID: backendID, rank: rank, listed: listed,
+			})
 		}
 	}
 
-	sort.Slice(resolved, func(i, j int) bool { return resolved[i].Name < resolved[j].Name })
+	resolved := make([]ResolvedPrompt, 0, len(byName))
+	for _, resolvedName := range slices.Sorted(maps.Keys(byName)) {
+		candidates := byName[resolvedName]
+		winner := candidates[0]
+		for _, contender := range candidates[1:] {
+			// Distinct backends claim the same advertised name. Resolvable
+			// only when both are priority-listed (then both claims are the
+			// same bare name and rank decides); anything else — prefix
+			// composition ambiguity, or a prefixed name hitting a listed
+			// backend's literal name — has no defined owner.
+			if !winner.listed || !contender.listed {
+				return nil, fmt.Errorf(
+					"%w: prompt %q from backend %q and prompt %q from backend %q are both advertised as %q; rename one of them",
+					ErrUnresolvedConflicts,
+					winner.prompt.Name, winner.backendID, contender.prompt.Name, contender.backendID, resolvedName)
+			}
+			loser := contender
+			if contender.rank < winner.rank {
+				loser, winner = winner, contender
+			}
+			slog.Warn("prompt name advertised by multiple priority-listed backends, keeping highest priority",
+				"prompt", resolvedName, "kept_backend", winner.backendID, "dropped_backend", loser.backendID)
+		}
+
+		resolvedPrompt := ResolvedPrompt{Prompt: winner.prompt, OriginalName: winner.prompt.Name}
+		resolvedPrompt.Name = resolvedName
+		resolved = append(resolved, resolvedPrompt)
+	}
 	return resolved, nil
 }
 

--- a/pkg/vmcp/aggregator/capability_conflicts.go
+++ b/pkg/vmcp/aggregator/capability_conflicts.go
@@ -4,6 +4,7 @@
 package aggregator
 
 import (
+	"fmt"
 	"log/slog"
 	"sort"
 
@@ -15,6 +16,13 @@ import (
 // (identity: URI), resource templates (identity: URITemplate) and prompts
 // (identity: Name). Tools are resolved separately through
 // ConflictResolver.ResolveToolConflicts.
+//
+// ResolveConflicts is the ENFORCEMENT POINT for these policies: after it
+// runs, every identity is unique within its list. The first-wins guards in
+// the merge helpers (mergeResources/mergeResourceTemplates/mergePrompts in
+// default_aggregator.go) re-check the same invariant, but only as defence in
+// depth for direct MergeCapabilities callers — in the aggregation pipeline
+// they can never fire. Policy changes belong here, not there.
 //
 // The policies deliberately differ per type:
 //
@@ -35,22 +43,26 @@ import (
 //
 //   - Prompt names are NAMES, like tool names: prompts/get is translated back
 //     to the backend's own name via BackendTarget.GetBackendCapabilityName,
-//     so renaming is lossless. A name advertised by multiple backends is
-//     renamed to "{backendID}_{name}" for EVERY colliding backend (symmetric,
-//     mirroring PriorityConflictResolver's prefix fallback); the bare
-//     duplicated name is no longer advertised.
+//     so renaming is lossless. Every prompt is renamed UNCONDITIONALLY to its
+//     backend-prefixed form — the configured prefixFormat applied to the
+//     backend ID (default "{workload}_") — mirroring what
+//     PrefixConflictResolver does for every tool. The advertised name is
+//     therefore a pure function of (backendID, prompt name) and never shifts
+//     when unrelated backends join or leave the group. That stability is a
+//     security property, not cosmetics: the advertised name is what
+//     authorization matches on (Cedar builds Prompt::"<advertised name>"
+//     entities — see pkg/vmcp/core/admission.go), so a membership-dependent
+//     rename would silently detach permit AND forbid policies from the
+//     prompt they were written for, the forbid case failing open.
 //
-//     Collision-only renaming trades name stability for minimal change: what
-//     a prompt is advertised as depends on what else is deployed. A backend
-//     joining with a colliding prompt renames the incumbent out from under a
-//     client that pinned the bare name — which then fails prompts/get with
-//     not-found, a defined outcome, where it previously silently routed to an
-//     arbitrary backend. An in-place backend prompt-set change propagates to
-//     live sessions through the list_changed resync path
-//     (pkg/vmcp/server/serve_list_changed.go); a backend joining or leaving
-//     the group emits no push signal today, so staleness there is bounded by
-//     the aggregator cache TTL for routing and by the client's next
-//     prompts/list for listing.
+//     Prompt-set changes on a live backend propagate to connected sessions
+//     through the list_changed resync path
+//     (pkg/vmcp/server/serve_list_changed.go), but that path is add-only for
+//     prompts, so a removed prompt stays advertised on already-registered
+//     sessions until they reconnect (stacklok/toolhive-core#184). A backend
+//     joining or leaving the group emits no push signal today, so staleness
+//     there is bounded by the aggregator cache TTL for routing and by the
+//     client's next prompts/list for listing.
 //
 // All functions iterate backends in the caller-supplied deterministic order
 // and return key-sorted slices, so the aggregated view (and therefore the
@@ -79,43 +91,43 @@ func resolveResourceTemplateConflicts(
 		func(template vmcp.ResourceTemplate) string { return template.URITemplate })
 }
 
-// resolvePromptConflicts resolves prompt name conflicts across backends.
-// A name advertised by exactly one backend passes through unchanged; a name
-// advertised by multiple backends is renamed to "{backendID}_{name}" for each
-// of them. If a prefixed name still collides (the same backend advertises a
-// name twice, or another backend advertises the literal prefixed name), the
-// first occurrence in deterministic order wins and later ones are dropped
-// with a warning. backendIDs supplies the deterministic (sorted) iteration
-// order; the result is sorted by resolved name.
+// resolvePromptConflicts renames EVERY prompt to its backend-prefixed form:
+// prefixFormat applied to the backend ID (see applyPrefixFormat), prepended
+// to the prompt's own name. Renaming unconditionally keeps the advertised
+// name independent of group membership; see the file header for why that
+// matters to authorization.
+//
+// An exact duplicate within one backend (same backend advertises a name
+// twice) is dropped with a warning — both entries would advertise and route
+// identically, so nothing reachable is lost. Any other residual collision,
+// i.e. two distinct (backendID, name) pairs composing to the same prefixed
+// string (backend "b1" prompt "x_y" vs backend "b1_x" prompt "y"), is
+// ambiguous between backends and returns ErrUnresolvedConflicts rather than
+// silently dropping a prompt. backendIDs supplies the deterministic (sorted)
+// iteration order; the result is sorted by resolved name.
 func resolvePromptConflicts(
+	prefixFormat string,
 	backendIDs []string,
 	capabilities map[string]*BackendCapabilities,
-) []ResolvedPrompt {
-	// First pass: count occurrences per name, so a collision renames ALL of
-	// its participants (symmetric), not just the ones encountered later.
-	nameCounts := make(map[string]int)
+) ([]ResolvedPrompt, error) {
+	type advertiser struct{ backendID, originalName string }
+	seen := make(map[string]advertiser) // resolved name -> first advertiser
+	var resolved []ResolvedPrompt
 	for _, backendID := range backendIDs {
 		for _, prompt := range capabilities[backendID].Prompts {
-			nameCounts[prompt.Name]++
-		}
-	}
-
-	seen := make(map[string]string) // resolved name -> winning backend ID
-	resolved := make([]ResolvedPrompt, 0, len(nameCounts))
-	for _, backendID := range backendIDs {
-		for _, prompt := range capabilities[backendID].Prompts {
-			resolvedName := prompt.Name
-			if nameCounts[prompt.Name] > 1 {
-				resolvedName = backendID + "_" + prompt.Name
-				slog.Warn("prompt name duplicated across backends, advertising with backend prefix",
-					"prompt", prompt.Name, "backend", backendID, "advertised_name", resolvedName)
+			resolvedName := applyPrefixFormat(prefixFormat, backendID, prompt.Name)
+			if first, duplicate := seen[resolvedName]; duplicate {
+				if first.backendID == backendID {
+					slog.Warn("backend advertises the same prompt name twice, dropping later duplicate",
+						"backend", backendID, "prompt", prompt.Name)
+					continue
+				}
+				return nil, fmt.Errorf(
+					"%w: prompt %q from backend %q and prompt %q from backend %q are both advertised as %q; rename one of them",
+					ErrUnresolvedConflicts,
+					first.originalName, first.backendID, prompt.Name, backendID, resolvedName)
 			}
-			if winner, duplicate := seen[resolvedName]; duplicate {
-				slog.Warn("prompt name still duplicated after prefixing, dropping later duplicate",
-					"advertised_name", resolvedName, "kept_backend", winner, "dropped_backend", backendID)
-				continue
-			}
-			seen[resolvedName] = backendID
+			seen[resolvedName] = advertiser{backendID: backendID, originalName: prompt.Name}
 
 			resolvedPrompt := ResolvedPrompt{Prompt: prompt, OriginalName: prompt.Name}
 			resolvedPrompt.Name = resolvedName
@@ -124,7 +136,7 @@ func resolvePromptConflicts(
 	}
 
 	sort.Slice(resolved, func(i, j int) bool { return resolved[i].Name < resolved[j].Name })
-	return resolved
+	return resolved, nil
 }
 
 // dedupeByKey collects items of one capability kind across backends in the

--- a/pkg/vmcp/aggregator/capability_conflicts_test.go
+++ b/pkg/vmcp/aggregator/capability_conflicts_test.go
@@ -262,6 +262,76 @@ func TestDefaultAggregator_ResolveConflicts_PromptPrefixAmbiguity(t *testing.T) 
 	assert.Nil(t, resolved)
 }
 
+// TestDefaultAggregator_ResolveConflicts_PromptPriority pins the priority
+// escape hatch: backends listed in priorityOrder keep their bare prompt
+// names (a bare-name collision resolves by rank), while unlisted backends
+// stay always-prefixed even without a collision — the advertised name must
+// be decidable from config plus (backendID, name) alone, never from what
+// else happens to be deployed.
+func TestDefaultAggregator_ResolveConflicts_PromptPriority(t *testing.T) {
+	t.Parallel()
+
+	// b2 outranks b1 deliberately: sorted-backend-ID order would pick b1, so
+	// any regression from rank to encounter order flips the winner.
+	aggCfg := &config.AggregationConfig{
+		ConflictResolution: vmcp.ConflictStrategyPriority,
+		ConflictResolutionConfig: &config.ConflictResolutionConfig{
+			PriorityOrder: []string{"b2", "b1"},
+		},
+	}
+
+	t.Run("listed backends keep bare names, rank resolves collisions", func(t *testing.T) {
+		t.Parallel()
+		capabilities := map[string]*BackendCapabilities{
+			"b1": {BackendID: "b1", Prompts: []vmcp.Prompt{
+				newTestPrompt("review", "b1"), newTestPrompt("unique", "b1"),
+			}},
+			"b2":  {BackendID: "b2", Prompts: []vmcp.Prompt{newTestPrompt("review", "b2")}},
+			"ext": {BackendID: "ext", Prompts: []vmcp.Prompt{newTestPrompt("helper", "ext")}},
+		}
+
+		agg := NewDefaultAggregator(nil, nil, aggCfg, nil)
+		for range 5 {
+			resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
+			require.NoError(t, err)
+
+			got := make(map[string][2]string, len(resolved.Prompts))
+			for _, prompt := range resolved.Prompts {
+				got[prompt.Name] = [2]string{prompt.BackendID, prompt.OriginalName}
+			}
+			assert.Equal(t, map[string][2]string{
+				// "review" goes to b2: first in priorityOrder, even though b1
+				// sorts first. b1's colliding prompt is dropped.
+				"review": {"b2", "review"},
+				// Listed backends keep bare names even for unique prompts.
+				"unique": {"b1", "unique"},
+				// Unlisted backends are ALWAYS prefixed, collision or not:
+				// exempting them would let a later join shift the name.
+				"ext_helper": {"ext", "helper"},
+			}, got)
+			assert.NotContains(t, got, "helper")
+			assert.NotContains(t, got, "b1_review")
+		}
+	})
+
+	t.Run("prefixed name hitting a listed backend's literal name errors", func(t *testing.T) {
+		t.Parallel()
+		capabilities := map[string]*BackendCapabilities{
+			// Listed b1 advertises the literal name "ext_helper"; unlisted
+			// ext's "helper" prefixes to the same string. Ambiguous between
+			// backends -> loud failure, not a silent drop.
+			"b1":  {BackendID: "b1", Prompts: []vmcp.Prompt{newTestPrompt("ext_helper", "b1")}},
+			"ext": {BackendID: "ext", Prompts: []vmcp.Prompt{newTestPrompt("helper", "ext")}},
+		}
+
+		agg := NewDefaultAggregator(nil, nil, aggCfg, nil)
+		resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
+		require.ErrorIs(t, err, ErrUnresolvedConflicts)
+		assert.Contains(t, err.Error(), "ext_helper")
+		assert.Nil(t, resolved)
+	})
+}
+
 // TestDefaultAggregator_ResolveConflicts_PromptPrefixFormat verifies prompt
 // renaming honours conflictResolutionConfig.prefixFormat — the same knob the
 // tool prefix strategy uses — rather than a hardcoded "_" separator.

--- a/pkg/vmcp/aggregator/capability_conflicts_test.go
+++ b/pkg/vmcp/aggregator/capability_conflicts_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
 )
 
@@ -150,18 +151,22 @@ func TestDefaultAggregator_ResolveConflicts_PromptConflicts(t *testing.T) {
 		wantAbsent []string
 	}{
 		{
-			name: "unique prompt names pass through unchanged",
+			// Prefixing is unconditional: the advertised name is a pure
+			// function of (backendID, name), so it cannot shift under a
+			// client (or a Cedar policy) when unrelated backends join.
+			name: "unique prompt names are prefixed too",
 			capabilities: map[string]*BackendCapabilities{
 				"b1": {BackendID: "b1", Prompts: []vmcp.Prompt{newTestPrompt("review", "b1")}},
 				"b2": {BackendID: "b2", Prompts: []vmcp.Prompt{newTestPrompt("summarize", "b2")}},
 			},
 			want: map[string][2]string{
-				"review":    {"b1", "review"},
-				"summarize": {"b2", "summarize"},
+				"b1_review":    {"b1", "review"},
+				"b2_summarize": {"b2", "summarize"},
 			},
+			wantAbsent: []string{"review", "summarize"},
 		},
 		{
-			name: "name shared by two backends is prefixed for both",
+			name: "name shared by two backends stays unambiguous",
 			capabilities: map[string]*BackendCapabilities{
 				"b2": {BackendID: "b2", Prompts: []vmcp.Prompt{newTestPrompt("review", "b2")}},
 				"b1": {
@@ -172,27 +177,30 @@ func TestDefaultAggregator_ResolveConflicts_PromptConflicts(t *testing.T) {
 			want: map[string][2]string{
 				"b1_review": {"b1", "review"},
 				"b2_review": {"b2", "review"},
-				"unique":    {"b1", "unique"},
+				"b1_unique": {"b1", "unique"},
 			},
-			wantAbsent: []string{"review"},
+			wantAbsent: []string{"review", "unique"},
 		},
 		{
-			name: "collision with a literal prefixed name keeps first in backend order",
+			// Under collision-only renaming this shape dropped a prompt: b2's
+			// literal "b1_review" collided with b1's renamed "review".
+			// Unconditional prefixing keeps all three reachable.
+			name: "literal prefixed name from another backend no longer collides",
 			capabilities: map[string]*BackendCapabilities{
-				// b1's and b3's "review" collide, so b1's is renamed to
-				// "b1_review" -- which b2 advertises literally. b1 sorts before
-				// b2, so b1's renamed prompt wins and b2's literal is dropped.
 				"b1": {BackendID: "b1", Prompts: []vmcp.Prompt{newTestPrompt("review", "b1")}},
 				"b2": {BackendID: "b2", Prompts: []vmcp.Prompt{newTestPrompt("b1_review", "b2")}},
 				"b3": {BackendID: "b3", Prompts: []vmcp.Prompt{newTestPrompt("review", "b3")}},
 			},
 			want: map[string][2]string{
-				"b1_review": {"b1", "review"},
-				"b3_review": {"b3", "review"},
+				"b1_review":    {"b1", "review"},
+				"b2_b1_review": {"b2", "b1_review"},
+				"b3_review":    {"b3", "review"},
 			},
 			wantAbsent: []string{"review"},
 		},
 		{
+			// An exact intra-backend duplicate advertises and routes
+			// identically, so the later occurrence is dropped, not an error.
 			name: "same backend advertises a prompt name twice",
 			capabilities: map[string]*BackendCapabilities{
 				"solo": {
@@ -200,7 +208,6 @@ func TestDefaultAggregator_ResolveConflicts_PromptConflicts(t *testing.T) {
 					Prompts:   []vmcp.Prompt{newTestPrompt("dup", "solo"), newTestPrompt("dup", "solo")},
 				},
 			},
-			// Both occurrences prefix to "solo_dup"; the second is dropped.
 			want:       map[string][2]string{"solo_dup": {"solo", "dup"}},
 			wantAbsent: []string{"dup"},
 		},
@@ -234,11 +241,55 @@ func TestDefaultAggregator_ResolveConflicts_PromptConflicts(t *testing.T) {
 	}
 }
 
+// TestDefaultAggregator_ResolveConflicts_PromptPrefixAmbiguity pins the one
+// residual collision unconditional prefixing cannot rule out: two distinct
+// (backendID, name) pairs composing to the same prefixed string. That name
+// would be ambiguous between backends, so aggregation must fail loudly
+// instead of silently dropping one of the prompts.
+func TestDefaultAggregator_ResolveConflicts_PromptPrefixAmbiguity(t *testing.T) {
+	t.Parallel()
+
+	capabilities := map[string]*BackendCapabilities{
+		// "b1" + "x_y" and "b1_x" + "y" both advertise as "b1_x_y".
+		"b1":   {BackendID: "b1", Prompts: []vmcp.Prompt{newTestPrompt("x_y", "b1")}},
+		"b1_x": {BackendID: "b1_x", Prompts: []vmcp.Prompt{newTestPrompt("y", "b1_x")}},
+	}
+
+	agg := NewDefaultAggregator(nil, nil, nil, nil)
+	resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
+	require.ErrorIs(t, err, ErrUnresolvedConflicts)
+	assert.Contains(t, err.Error(), "b1_x_y")
+	assert.Nil(t, resolved)
+}
+
+// TestDefaultAggregator_ResolveConflicts_PromptPrefixFormat verifies prompt
+// renaming honours conflictResolutionConfig.prefixFormat — the same knob the
+// tool prefix strategy uses — rather than a hardcoded "_" separator.
+func TestDefaultAggregator_ResolveConflicts_PromptPrefixFormat(t *testing.T) {
+	t.Parallel()
+
+	capabilities := map[string]*BackendCapabilities{
+		"github": {BackendID: "github", Prompts: []vmcp.Prompt{newTestPrompt("review", "github")}},
+	}
+	aggCfg := &config.AggregationConfig{
+		ConflictResolutionConfig: &config.ConflictResolutionConfig{PrefixFormat: "{workload}."},
+	}
+
+	agg := NewDefaultAggregator(nil, nil, aggCfg, nil)
+	resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
+	require.NoError(t, err)
+
+	require.Len(t, resolved.Prompts, 1)
+	assert.Equal(t, "github.review", resolved.Prompts[0].Name)
+	assert.Equal(t, "review", resolved.Prompts[0].OriginalName)
+}
+
 // TestDefaultAggregator_AggregateCapabilities_CollisionRouting exercises the
 // full pipeline with colliding identities across two backends and asserts the
 // client-visible outcome: one advertised entry per resource URI routed to a
-// deterministic backend, and both colliding prompts advertised under prefixed
-// names whose routing translates back to the backend's own prompt name.
+// deterministic backend, and both prompts advertised under their (always
+// prefixed) names whose routing translates back to the backend's own prompt
+// name.
 func TestDefaultAggregator_AggregateCapabilities_CollisionRouting(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/vmcp/aggregator/capability_conflicts_test.go
+++ b/pkg/vmcp/aggregator/capability_conflicts_test.go
@@ -1,0 +1,384 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package aggregator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/mocks"
+)
+
+// These tests are deliberately adversarial: the bug they pin (#6060) survived
+// because every earlier fixture minted strictly unique keys and therefore
+// could not express a collision. Each case here makes at least two backends
+// share an identity.
+
+func TestDefaultAggregator_ResolveConflicts_ResourceAndTemplateDedup(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		capabilities map[string]*BackendCapabilities
+		// wantResources maps advertised URI -> owning backend; the advertised
+		// list must contain exactly these URIs, sorted.
+		wantResources map[string]string
+		// wantTemplates maps advertised URI template -> owning backend.
+		wantTemplates map[string]string
+	}{
+		{
+			name: "two backends share a URI, first sorted backend wins",
+			capabilities: map[string]*BackendCapabilities{
+				"beta": {
+					BackendID: "beta",
+					Resources: []vmcp.Resource{newTestResource("file:///README.md", "beta")},
+				},
+				"alpha": {
+					BackendID: "alpha",
+					Resources: []vmcp.Resource{
+						newTestResource("file:///README.md", "alpha"),
+						newTestResource("res://only-alpha", "alpha"),
+					},
+				},
+			},
+			wantResources: map[string]string{
+				"file:///README.md": "alpha",
+				"res://only-alpha":  "alpha",
+			},
+		},
+		{
+			name: "three backends share one URI",
+			capabilities: map[string]*BackendCapabilities{
+				"b3": {BackendID: "b3", Resources: []vmcp.Resource{newTestResource("res://shared", "b3")}},
+				"b1": {BackendID: "b1", Resources: []vmcp.Resource{newTestResource("res://shared", "b1")}},
+				"b2": {BackendID: "b2", Resources: []vmcp.Resource{newTestResource("res://shared", "b2")}},
+			},
+			wantResources: map[string]string{"res://shared": "b1"},
+		},
+		{
+			name: "same backend advertises a URI twice, first occurrence wins",
+			capabilities: map[string]*BackendCapabilities{
+				"solo": {
+					BackendID: "solo",
+					Resources: []vmcp.Resource{
+						{URI: "res://twice", Name: "first", BackendID: "solo"},
+						{URI: "res://twice", Name: "second", BackendID: "solo"},
+					},
+				},
+			},
+			wantResources: map[string]string{"res://twice": "solo"},
+		},
+		{
+			name: "two backends share a resource template string",
+			capabilities: map[string]*BackendCapabilities{
+				"b2": {
+					BackendID: "b2",
+					ResourceTemplates: []vmcp.ResourceTemplate{
+						{URITemplate: "file:///logs/{date}.txt", Name: "b2 logs", BackendID: "b2"},
+					},
+				},
+				"b1": {
+					BackendID: "b1",
+					ResourceTemplates: []vmcp.ResourceTemplate{
+						{URITemplate: "file:///logs/{date}.txt", Name: "b1 logs", BackendID: "b1"},
+						{URITemplate: "file:///cfg/{name}.yaml", Name: "b1 cfg", BackendID: "b1"},
+					},
+				},
+			},
+			wantTemplates: map[string]string{
+				"file:///logs/{date}.txt": "b1",
+				"file:///cfg/{name}.yaml": "b1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agg := NewDefaultAggregator(nil, nil, nil, nil)
+
+			// Repeat: map iteration order is re-randomized per call, and the
+			// dedup winner must not depend on it.
+			for range 5 {
+				resolved, err := agg.ResolveConflicts(context.Background(), tt.capabilities)
+				require.NoError(t, err)
+
+				gotResources := make(map[string]string, len(resolved.Resources))
+				var lastURI string
+				for _, res := range resolved.Resources {
+					_, dup := gotResources[res.URI]
+					assert.Falsef(t, dup, "URI %q advertised more than once", res.URI)
+					assert.LessOrEqual(t, lastURI, res.URI, "resources must be sorted by URI")
+					lastURI = res.URI
+					gotResources[res.URI] = res.BackendID
+				}
+				if tt.wantResources != nil {
+					assert.Equal(t, tt.wantResources, gotResources)
+				}
+
+				gotTemplates := make(map[string]string, len(resolved.ResourceTemplates))
+				for _, tmpl := range resolved.ResourceTemplates {
+					_, dup := gotTemplates[tmpl.URITemplate]
+					assert.Falsef(t, dup, "template %q advertised more than once", tmpl.URITemplate)
+					gotTemplates[tmpl.URITemplate] = tmpl.BackendID
+				}
+				if tt.wantTemplates != nil {
+					assert.Equal(t, tt.wantTemplates, gotTemplates)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultAggregator_ResolveConflicts_PromptConflicts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		capabilities map[string]*BackendCapabilities
+		// want maps advertised prompt name -> {owning backend, original name}.
+		want map[string][2]string
+		// wantAbsent lists names that must NOT be advertised.
+		wantAbsent []string
+	}{
+		{
+			name: "unique prompt names pass through unchanged",
+			capabilities: map[string]*BackendCapabilities{
+				"b1": {BackendID: "b1", Prompts: []vmcp.Prompt{newTestPrompt("review", "b1")}},
+				"b2": {BackendID: "b2", Prompts: []vmcp.Prompt{newTestPrompt("summarize", "b2")}},
+			},
+			want: map[string][2]string{
+				"review":    {"b1", "review"},
+				"summarize": {"b2", "summarize"},
+			},
+		},
+		{
+			name: "name shared by two backends is prefixed for both",
+			capabilities: map[string]*BackendCapabilities{
+				"b2": {BackendID: "b2", Prompts: []vmcp.Prompt{newTestPrompt("review", "b2")}},
+				"b1": {
+					BackendID: "b1",
+					Prompts:   []vmcp.Prompt{newTestPrompt("review", "b1"), newTestPrompt("unique", "b1")},
+				},
+			},
+			want: map[string][2]string{
+				"b1_review": {"b1", "review"},
+				"b2_review": {"b2", "review"},
+				"unique":    {"b1", "unique"},
+			},
+			wantAbsent: []string{"review"},
+		},
+		{
+			name: "collision with a literal prefixed name keeps first in backend order",
+			capabilities: map[string]*BackendCapabilities{
+				// b1's and b3's "review" collide, so b1's is renamed to
+				// "b1_review" -- which b2 advertises literally. b1 sorts before
+				// b2, so b1's renamed prompt wins and b2's literal is dropped.
+				"b1": {BackendID: "b1", Prompts: []vmcp.Prompt{newTestPrompt("review", "b1")}},
+				"b2": {BackendID: "b2", Prompts: []vmcp.Prompt{newTestPrompt("b1_review", "b2")}},
+				"b3": {BackendID: "b3", Prompts: []vmcp.Prompt{newTestPrompt("review", "b3")}},
+			},
+			want: map[string][2]string{
+				"b1_review": {"b1", "review"},
+				"b3_review": {"b3", "review"},
+			},
+			wantAbsent: []string{"review"},
+		},
+		{
+			name: "same backend advertises a prompt name twice",
+			capabilities: map[string]*BackendCapabilities{
+				"solo": {
+					BackendID: "solo",
+					Prompts:   []vmcp.Prompt{newTestPrompt("dup", "solo"), newTestPrompt("dup", "solo")},
+				},
+			},
+			// Both occurrences prefix to "solo_dup"; the second is dropped.
+			want:       map[string][2]string{"solo_dup": {"solo", "dup"}},
+			wantAbsent: []string{"dup"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agg := NewDefaultAggregator(nil, nil, nil, nil)
+
+			for range 5 {
+				resolved, err := agg.ResolveConflicts(context.Background(), tt.capabilities)
+				require.NoError(t, err)
+
+				got := make(map[string][2]string, len(resolved.Prompts))
+				var lastName string
+				for _, prompt := range resolved.Prompts {
+					_, dup := got[prompt.Name]
+					assert.Falsef(t, dup, "prompt %q advertised more than once", prompt.Name)
+					assert.LessOrEqual(t, lastName, prompt.Name, "prompts must be sorted by resolved name")
+					lastName = prompt.Name
+					got[prompt.Name] = [2]string{prompt.BackendID, prompt.OriginalName}
+				}
+				assert.Equal(t, tt.want, got)
+				for _, absent := range tt.wantAbsent {
+					assert.NotContains(t, got, absent)
+				}
+			}
+		})
+	}
+}
+
+// TestDefaultAggregator_AggregateCapabilities_CollisionRouting exercises the
+// full pipeline with colliding identities across two backends and asserts the
+// client-visible outcome: one advertised entry per resource URI routed to a
+// deterministic backend, and both colliding prompts advertised under prefixed
+// names whose routing translates back to the backend's own prompt name.
+func TestDefaultAggregator_AggregateCapabilities_CollisionRouting(t *testing.T) {
+	t.Parallel()
+
+	backends := []vmcp.Backend{
+		newTestBackend("backend1", withBackendName("Backend 1")),
+		newTestBackend("backend2", withBackendName("Backend 2")),
+	}
+	capsByID := map[string]*vmcp.CapabilityList{
+		"backend1": newTestCapabilityList(
+			withResources(newTestResource("file:///README.md", "backend1")),
+			withPrompts(newTestPrompt("review", "backend1")),
+		),
+		"backend2": newTestCapabilityList(
+			withResources(newTestResource("file:///README.md", "backend2")),
+			withPrompts(newTestPrompt("review", "backend2")),
+		),
+	}
+
+	// Aggregate repeatedly: the collision winner must be stable across runs,
+	// not whichever backend won a map write.
+	for run := range 5 {
+		ctrl := gomock.NewController(t)
+		mockClient := mocks.NewMockBackendClient(ctrl)
+		expectListCapabilities(mockClient, capsByID)
+
+		agg := NewDefaultAggregator(mockClient, nil, nil, nil)
+		result, err := agg.AggregateCapabilities(context.Background(), backends)
+		require.NoError(t, err)
+
+		// The duplicated URI is advertised once and reads route to backend1
+		// (first in sorted backend order) -- a defined, stable outcome.
+		require.Lenf(t, result.Resources, 1, "run %d", run)
+		assert.Equal(t, "file:///README.md", result.Resources[0].URI)
+		assert.Equal(t, "backend1", result.Resources[0].BackendID)
+		target := result.RoutingTable.Resources["file:///README.md"]
+		require.NotNil(t, target)
+		assert.Equal(t, "backend1", target.WorkloadID)
+
+		// Both colliding prompts survive under prefixed names; the bare name is
+		// neither advertised nor routable; prompts/get on a prefixed name
+		// forwards the backend's own prompt name.
+		require.Lenf(t, result.Prompts, 2, "run %d", run)
+		assert.Equal(t, "backend1_review", result.Prompts[0].Name)
+		assert.Equal(t, "backend2_review", result.Prompts[1].Name)
+		assert.NotContains(t, result.RoutingTable.Prompts, "review")
+		for _, advertised := range []string{"backend1_review", "backend2_review"} {
+			promptTarget := result.RoutingTable.Prompts[advertised]
+			require.NotNilf(t, promptTarget, "routing target for %q", advertised)
+			assert.Equal(t, "review", promptTarget.GetBackendCapabilityName(advertised),
+				"prompts/get on %q must forward the backend's own name", advertised)
+		}
+
+		assert.Equal(t, 1, result.Metadata.ResourceCount)
+		assert.Equal(t, 2, result.Metadata.PromptCount)
+		ctrl.Finish()
+	}
+}
+
+// TestDefaultAggregator_ResolveConflicts_DuplicateAtPageBoundary places the
+// collision at the Modern paginator's page boundary (page size 1000): the exact
+// shape that permanently dropped items before the paginator was made
+// collision-safe. The aggregator must now hand the paginator a corpus with no
+// duplicate keys at all, boundary included.
+func TestDefaultAggregator_ResolveConflicts_DuplicateAtPageBoundary(t *testing.T) {
+	t.Parallel()
+
+	const total = 1100
+	const pageBoundary = 1000 // pkg/vmcp/server modernPageSize
+
+	// backend-a advertises 1100 resources whose URIs sort to their index.
+	// backend-b re-advertises the URIs at sorted positions 999 and 1000, so the
+	// duplicates straddle the page-1/page-2 boundary.
+	resourcesA := make([]vmcp.Resource, 0, total)
+	for i := range total {
+		resourcesA = append(resourcesA, newTestResource(fmt.Sprintf("res://%05d", i), "backend-a"))
+	}
+	capabilities := map[string]*BackendCapabilities{
+		"backend-a": {BackendID: "backend-a", Resources: resourcesA},
+		"backend-b": {BackendID: "backend-b", Resources: []vmcp.Resource{
+			newTestResource(fmt.Sprintf("res://%05d", pageBoundary-1), "backend-b"),
+			newTestResource(fmt.Sprintf("res://%05d", pageBoundary), "backend-b"),
+		}},
+	}
+
+	agg := NewDefaultAggregator(nil, nil, nil, nil)
+	resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
+	require.NoError(t, err)
+
+	require.Len(t, resolved.Resources, total, "duplicates must collapse, nothing else may be lost")
+	for i, res := range resolved.Resources {
+		assert.Equal(t, fmt.Sprintf("res://%05d", i), res.URI, "output must be sorted and duplicate-free")
+		assert.Equal(t, "backend-a", res.BackendID, "backend-a sorts first and owns every duplicated URI")
+	}
+}
+
+// TestDefaultAggregator_MergeCapabilities_FirstWinsOnDuplicates pins the
+// defence-in-depth guard: MergeCapabilities is independently callable, and if
+// it is handed unresolved duplicates anyway, the first entry wins in BOTH the
+// routing table and the advertised list -- never a silent map overwrite that
+// leaves advertising and routing disagreeing.
+func TestDefaultAggregator_MergeCapabilities_FirstWinsOnDuplicates(t *testing.T) {
+	t.Parallel()
+
+	resolved := &ResolvedCapabilities{
+		Tools: map[string]*ResolvedTool{},
+		Resources: []vmcp.Resource{
+			newTestResource("res://dup", "backend1"),
+			newTestResource("res://dup", "backend2"),
+		},
+		ResourceTemplates: []vmcp.ResourceTemplate{
+			{URITemplate: "res://tmpl/{id}", Name: "first", BackendID: "backend1"},
+			{URITemplate: "res://tmpl/{id}", Name: "second", BackendID: "backend2"},
+		},
+		Prompts: []ResolvedPrompt{
+			{Prompt: vmcp.Prompt{Name: "dup_prompt", BackendID: "backend1"}, OriginalName: "dup_prompt"},
+			{Prompt: vmcp.Prompt{Name: "dup_prompt", BackendID: "backend2"}, OriginalName: "dup_prompt"},
+		},
+	}
+	registry := vmcp.NewImmutableRegistry([]vmcp.Backend{
+		newTestBackend("backend1"),
+		newTestBackend("backend2"),
+	})
+
+	agg := NewDefaultAggregator(nil, nil, nil, nil)
+	aggregated, err := agg.MergeCapabilities(context.Background(), resolved, registry)
+	require.NoError(t, err)
+
+	require.Len(t, aggregated.Resources, 1)
+	assert.Equal(t, "backend1", aggregated.Resources[0].BackendID)
+	assert.Equal(t, "backend1", aggregated.RoutingTable.Resources["res://dup"].WorkloadID)
+
+	require.Len(t, aggregated.ResourceTemplates, 1)
+	assert.Equal(t, "backend1", aggregated.ResourceTemplates[0].BackendID)
+	assert.Equal(t, "backend1", aggregated.RoutingTable.ResourceTemplates["res://tmpl/{id}"].WorkloadID)
+
+	require.Len(t, aggregated.Prompts, 1)
+	assert.Equal(t, "backend1", aggregated.Prompts[0].BackendID)
+	assert.Equal(t, "backend1", aggregated.RoutingTable.Prompts["dup_prompt"].WorkloadID)
+
+	assert.Equal(t, 1, aggregated.Metadata.ResourceCount)
+	assert.Equal(t, 1, aggregated.Metadata.ResourceTemplateCount)
+	assert.Equal(t, 1, aggregated.Metadata.PromptCount)
+}

--- a/pkg/vmcp/aggregator/conflict_resolver.go
+++ b/pkg/vmcp/aggregator/conflict_resolver.go
@@ -27,16 +27,52 @@ func applyPrefixFormat(prefixFormat, backendID, name string) string {
 	return strings.ReplaceAll(prefixFormat, "{workload}", backendID) + name
 }
 
-// promptPrefixFormatFromConfig returns the prefix format prompts are renamed
-// with: conflictResolutionConfig.prefixFormat when set, defaultPrefixFormat
-// otherwise. Prompts are always prefixed (the strategy knob selects a TOOL
-// strategy only), so the format is honoured under every strategy.
-func promptPrefixFormatFromConfig(aggregationConfig *config.AggregationConfig) string {
-	if aggregationConfig != nil && aggregationConfig.ConflictResolutionConfig != nil &&
-		aggregationConfig.ConflictResolutionConfig.PrefixFormat != "" {
-		return aggregationConfig.ConflictResolutionConfig.PrefixFormat
+// promptNaming captures how advertised prompt names are formed by
+// resolvePromptConflicts. prefixFormat is the format backend-prefixed names
+// use. priorityRank maps the backend IDs listed in
+// conflictResolutionConfig.priorityOrder to their rank (lower wins); listed
+// backends keep their bare prompt names. It is non-nil only under the
+// priority strategy — nil means every prompt is prefixed.
+type promptNaming struct {
+	prefixFormat string
+	priorityRank map[string]int
+}
+
+// promptNamingFromConfig derives prompt naming from the aggregation config.
+// Default (prefix or manual strategy, or no config): every prompt is
+// prefixed with prefixFormat (conflictResolutionConfig.prefixFormat when
+// set), so the advertised name is a pure function of (backendID, name).
+// Under the priority strategy, backends listed in priorityOrder keep their
+// bare prompt names while unlisted backends stay ALWAYS prefixed — stricter
+// than the tool priority resolver, which lets a conflict-free unlisted tool
+// keep its bare name. Prompts cannot afford that laxity: their advertised
+// name is an authorization identity (see capability_conflicts.go), so the
+// only membership-independent choices are "bare because listed" and
+// "prefixed because not".
+func promptNamingFromConfig(aggregationConfig *config.AggregationConfig) promptNaming {
+	naming := promptNaming{prefixFormat: defaultPrefixFormat}
+	if aggregationConfig == nil {
+		return naming
 	}
-	return defaultPrefixFormat
+	if aggregationConfig.ConflictResolutionConfig != nil &&
+		aggregationConfig.ConflictResolutionConfig.PrefixFormat != "" {
+		naming.prefixFormat = aggregationConfig.ConflictResolutionConfig.PrefixFormat
+	}
+	if aggregationConfig.ConflictResolution == vmcp.ConflictStrategyPriority &&
+		aggregationConfig.ConflictResolutionConfig != nil {
+		priorityOrder := aggregationConfig.ConflictResolutionConfig.PriorityOrder
+		if len(priorityOrder) > 0 {
+			naming.priorityRank = make(map[string]int, len(priorityOrder))
+			for rank, backendID := range priorityOrder {
+				// A backend duplicated in priorityOrder keeps its first
+				// (highest-priority) position.
+				if _, seen := naming.priorityRank[backendID]; !seen {
+					naming.priorityRank[backendID] = rank
+				}
+			}
+		}
+	}
+	return naming
 }
 
 // NewConflictResolver creates the appropriate conflict resolver based on configuration.

--- a/pkg/vmcp/aggregator/conflict_resolver.go
+++ b/pkg/vmcp/aggregator/conflict_resolver.go
@@ -10,22 +10,46 @@ package aggregator
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/config"
 )
+
+// defaultPrefixFormat is the prefix format applied when none is configured.
+const defaultPrefixFormat = "{workload}_"
+
+// applyPrefixFormat expands the {workload} placeholder in prefixFormat with
+// backendID and prepends the result to name. Shared by tool prefixing
+// (PrefixConflictResolver) and unconditional prompt prefixing
+// (resolvePromptConflicts) so both compose advertised names identically.
+func applyPrefixFormat(prefixFormat, backendID, name string) string {
+	return strings.ReplaceAll(prefixFormat, "{workload}", backendID) + name
+}
+
+// promptPrefixFormatFromConfig returns the prefix format prompts are renamed
+// with: conflictResolutionConfig.prefixFormat when set, defaultPrefixFormat
+// otherwise. Prompts are always prefixed (the strategy knob selects a TOOL
+// strategy only), so the format is honoured under every strategy.
+func promptPrefixFormatFromConfig(aggregationConfig *config.AggregationConfig) string {
+	if aggregationConfig != nil && aggregationConfig.ConflictResolutionConfig != nil &&
+		aggregationConfig.ConflictResolutionConfig.PrefixFormat != "" {
+		return aggregationConfig.ConflictResolutionConfig.PrefixFormat
+	}
+	return defaultPrefixFormat
+}
 
 // NewConflictResolver creates the appropriate conflict resolver based on configuration.
 func NewConflictResolver(aggregationConfig *config.AggregationConfig) (ConflictResolver, error) {
 	if aggregationConfig == nil {
 		// Default to prefix strategy with default format
 		slog.Info("no aggregation config provided, using default prefix strategy")
-		return NewPrefixConflictResolver("{workload}_"), nil
+		return NewPrefixConflictResolver(defaultPrefixFormat), nil
 	}
 
 	switch aggregationConfig.ConflictResolution {
 	case vmcp.ConflictStrategyPrefix:
-		prefixFormat := "{workload}_" // Default
+		prefixFormat := defaultPrefixFormat
 		if aggregationConfig.ConflictResolutionConfig != nil &&
 			aggregationConfig.ConflictResolutionConfig.PrefixFormat != "" {
 			prefixFormat = aggregationConfig.ConflictResolutionConfig.PrefixFormat

--- a/pkg/vmcp/aggregator/default_aggregator.go
+++ b/pkg/vmcp/aggregator/default_aggregator.go
@@ -29,11 +29,11 @@ type defaultAggregator struct {
 	conflictResolver ConflictResolver
 	toolConfigMap    map[string]*config.WorkloadToolConfig // Maps backend ID to tool config
 	excludeAllTools  bool                                  // Global flag to exclude all tools
-	// promptPrefixFormat is the prefix format every prompt is renamed with
-	// (see resolvePromptConflicts). Derived from
-	// conflictResolutionConfig.prefixFormat at construction.
-	promptPrefixFormat string
-	tracer             trace.Tracer
+	// promptNaming controls how advertised prompt names are formed (see
+	// resolvePromptConflicts). Derived from the aggregation config at
+	// construction.
+	promptNaming promptNaming
+	tracer       trace.Tracer
 }
 
 // NewDefaultAggregator creates a new default aggregator implementation.
@@ -68,12 +68,12 @@ func NewDefaultAggregator(
 	}
 
 	return &defaultAggregator{
-		backendClient:      backendClient,
-		conflictResolver:   conflictResolver,
-		toolConfigMap:      toolConfigMap,
-		excludeAllTools:    excludeAllTools,
-		promptPrefixFormat: promptPrefixFormatFromConfig(aggregationConfig),
-		tracer:             tracer,
+		backendClient:    backendClient,
+		conflictResolver: conflictResolver,
+		toolConfigMap:    toolConfigMap,
+		excludeAllTools:  excludeAllTools,
+		promptNaming:     promptNamingFromConfig(aggregationConfig),
+		tracer:           tracer,
 	}
 }
 
@@ -274,7 +274,7 @@ func (a *defaultAggregator) ResolveConflicts(
 	backendIDs := slices.Sorted(maps.Keys(capabilities))
 	resolved.Resources = resolveResourceConflicts(backendIDs, capabilities)
 	resolved.ResourceTemplates = resolveResourceTemplateConflicts(backendIDs, capabilities)
-	resolved.Prompts, err = resolvePromptConflicts(a.promptPrefixFormat, backendIDs, capabilities)
+	resolved.Prompts, err = resolvePromptConflicts(a.promptNaming, backendIDs, capabilities)
 	if err != nil {
 		return nil, fmt.Errorf("prompt conflict resolution failed: %w", err)
 	}

--- a/pkg/vmcp/aggregator/default_aggregator.go
+++ b/pkg/vmcp/aggregator/default_aggregator.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 	"sort"
 	"sync"
 
@@ -256,18 +258,19 @@ func (a *defaultAggregator) ResolveConflicts(
 
 	// Build resolved capabilities
 	resolved := &ResolvedCapabilities{
-		Tools:             resolvedTools,
-		Resources:         []vmcp.Resource{},
-		ResourceTemplates: []vmcp.ResourceTemplate{},
-		Prompts:           []vmcp.Prompt{},
+		Tools: resolvedTools,
 	}
 
-	// Collect resources, resource templates, and prompts (no conflict resolution for these yet)
-	for _, caps := range capabilities {
-		resolved.Resources = append(resolved.Resources, caps.Resources...)
-		resolved.ResourceTemplates = append(resolved.ResourceTemplates, caps.ResourceTemplates...)
-		resolved.Prompts = append(resolved.Prompts, caps.Prompts...)
+	// Resolve conflicts for resources, resource templates, and prompts.
+	// Backends are iterated in sorted-ID order so that collision outcomes are
+	// deterministic across runs (map iteration order is not). See
+	// capability_conflicts.go for the per-type policies.
+	backendIDs := slices.Sorted(maps.Keys(capabilities))
+	resolved.Resources = resolveResourceConflicts(backendIDs, capabilities)
+	resolved.ResourceTemplates = resolveResourceTemplateConflicts(backendIDs, capabilities)
+	resolved.Prompts = resolvePromptConflicts(backendIDs, capabilities)
 
+	for _, caps := range capabilities {
 		// Aggregate logging/sampling support (OR logic - enabled if any backend supports)
 		resolved.SupportsLogging = resolved.SupportsLogging || caps.SupportsLogging
 		resolved.SupportsSampling = resolved.SupportsSampling || caps.SupportsSampling
@@ -362,65 +365,14 @@ func (a *defaultAggregator) MergeCapabilities(
 		return tools[i].Name < tools[j].Name
 	})
 
-	// Add resources to routing table
-	for _, resource := range resolved.Resources {
-		backend := registry.Get(ctx, resource.BackendID)
-		if backend == nil {
-			slog.Warn("backend not found in registry for resource, creating minimal target",
-				"backend", resource.BackendID, "resource", resource.URI)
-			routingTable.Resources[resource.URI] = &vmcp.BackendTarget{
-				WorkloadID:             resource.BackendID,
-				OriginalCapabilityName: resource.URI,
-			}
-		} else {
-			target := vmcp.BackendToTarget(backend)
-			// Store the original resource URI for forwarding to backend
-			target.OriginalCapabilityName = resource.URI
-			routingTable.Resources[resource.URI] = target
-		}
-	}
-
-	// Add resource templates to routing table, keyed by URI-template string.
-	// Pass-through, mirroring resources: no URI-template rewriting.
-	//
-	// OriginalCapabilityName is intentionally left empty. A resources/read routed
-	// via a template carries the client's CONCRETE, already-expanded URI (e.g.
-	// file:///logs/2025-01-01.txt); the backend performs its own template
-	// expansion, so that concrete URI must reach it verbatim. Setting
-	// OriginalCapabilityName to the template string would make
-	// GetBackendCapabilityName replace the concrete URI with the unexpanded
-	// template, and the backend would return unsubstituted content. vMCP does not
-	// rename templates, so no name translation is needed here.
-	for _, template := range resolved.ResourceTemplates {
-		backend := registry.Get(ctx, template.BackendID)
-		if backend == nil {
-			slog.Warn("backend not found in registry for resource template, creating minimal target",
-				"backend", template.BackendID, "resource_template", template.URITemplate)
-			routingTable.ResourceTemplates[template.URITemplate] = &vmcp.BackendTarget{
-				WorkloadID: template.BackendID,
-			}
-		} else {
-			routingTable.ResourceTemplates[template.URITemplate] = vmcp.BackendToTarget(backend)
-		}
-	}
-
-	// Add prompts to routing table
-	for _, prompt := range resolved.Prompts {
-		backend := registry.Get(ctx, prompt.BackendID)
-		if backend == nil {
-			slog.Warn("backend not found in registry for prompt, creating minimal target",
-				"backend", prompt.BackendID, "prompt", prompt.Name)
-			routingTable.Prompts[prompt.Name] = &vmcp.BackendTarget{
-				WorkloadID:             prompt.BackendID,
-				OriginalCapabilityName: prompt.Name,
-			}
-		} else {
-			target := vmcp.BackendToTarget(backend)
-			// Store the original prompt name for forwarding to backend
-			target.OriginalCapabilityName = prompt.Name
-			routingTable.Prompts[prompt.Name] = target
-		}
-	}
+	// Add resources, resource templates, and prompts to the routing table.
+	// ResolveConflicts already makes their identities unique, but Merge is
+	// independently callable, so each merge helper keeps a duplicate out of
+	// both the routing table and the advertised list (first wins, loudly)
+	// rather than silently overwriting the earlier routing entry.
+	resources := mergeResources(ctx, resolved.Resources, registry, routingTable)
+	templates := mergeResourceTemplates(ctx, resolved.ResourceTemplates, registry, routingTable)
+	prompts := mergePrompts(ctx, resolved.Prompts, registry, routingTable)
 
 	// Determine conflict strategy used
 	conflictStrategy := vmcp.ConflictStrategyPrefix // Default
@@ -432,21 +384,23 @@ func (a *defaultAggregator) MergeCapabilities(
 		}
 	}
 
-	// Create final aggregated view
+	// Create final aggregated view. The advertised lists are the ones built
+	// alongside the routing tables above, so advertising and routing always
+	// agree on which entry owns a duplicated identity.
 	aggregated := &AggregatedCapabilities{
 		Tools:             tools,
-		Resources:         resolved.Resources,
-		ResourceTemplates: resolved.ResourceTemplates,
-		Prompts:           resolved.Prompts,
+		Resources:         resources,
+		ResourceTemplates: templates,
+		Prompts:           prompts,
 		SupportsLogging:   resolved.SupportsLogging,
 		SupportsSampling:  resolved.SupportsSampling,
 		RoutingTable:      routingTable,
 		Metadata: &AggregationMetadata{
 			BackendCount:          0, // Will be set by caller
 			ToolCount:             len(tools),
-			ResourceCount:         len(resolved.Resources),
-			ResourceTemplateCount: len(resolved.ResourceTemplates),
-			PromptCount:           len(resolved.Prompts),
+			ResourceCount:         len(resources),
+			ResourceTemplateCount: len(templates),
+			PromptCount:           len(prompts),
 			ConflictStrategy:      conflictStrategy,
 		},
 	}
@@ -528,6 +482,120 @@ func (a *defaultAggregator) AggregateCapabilities(
 		"resources", aggregated.Metadata.ResourceCount, "prompts", aggregated.Metadata.PromptCount)
 
 	return aggregated, nil
+}
+
+// mergeResources adds resources to the routing table (keyed by URI) and
+// returns the advertised resource list. A URI already present in the routing
+// table is dropped from both, with a warning (first wins), so advertising and
+// routing always agree on which backend owns a URI.
+func mergeResources(
+	ctx context.Context,
+	resolved []vmcp.Resource,
+	registry vmcp.BackendRegistry,
+	routingTable *vmcp.RoutingTable,
+) []vmcp.Resource {
+	resources := make([]vmcp.Resource, 0, len(resolved))
+	for _, resource := range resolved {
+		if existing, duplicate := routingTable.Resources[resource.URI]; duplicate {
+			slog.Warn("duplicate resource URI in resolved capabilities, keeping first",
+				"uri", resource.URI, "kept_backend", existing.WorkloadID, "dropped_backend", resource.BackendID)
+			continue
+		}
+		resources = append(resources, resource)
+		backend := registry.Get(ctx, resource.BackendID)
+		if backend == nil {
+			slog.Warn("backend not found in registry for resource, creating minimal target",
+				"backend", resource.BackendID, "resource", resource.URI)
+			routingTable.Resources[resource.URI] = &vmcp.BackendTarget{
+				WorkloadID:             resource.BackendID,
+				OriginalCapabilityName: resource.URI,
+			}
+		} else {
+			target := vmcp.BackendToTarget(backend)
+			// Store the original resource URI for forwarding to backend
+			target.OriginalCapabilityName = resource.URI
+			routingTable.Resources[resource.URI] = target
+		}
+	}
+	return resources
+}
+
+// mergeResourceTemplates adds resource templates to the routing table (keyed
+// by URI-template string) and returns the advertised template list.
+// Pass-through, mirroring resources: no URI-template rewriting, and the same
+// first-wins guard against duplicate template strings.
+//
+// OriginalCapabilityName is intentionally left empty. A resources/read routed
+// via a template carries the client's CONCRETE, already-expanded URI (e.g.
+// file:///logs/2025-01-01.txt); the backend performs its own template
+// expansion, so that concrete URI must reach it verbatim. Setting
+// OriginalCapabilityName to the template string would make
+// GetBackendCapabilityName replace the concrete URI with the unexpanded
+// template, and the backend would return unsubstituted content. vMCP does not
+// rename templates, so no name translation is needed here.
+func mergeResourceTemplates(
+	ctx context.Context,
+	resolved []vmcp.ResourceTemplate,
+	registry vmcp.BackendRegistry,
+	routingTable *vmcp.RoutingTable,
+) []vmcp.ResourceTemplate {
+	templates := make([]vmcp.ResourceTemplate, 0, len(resolved))
+	for _, template := range resolved {
+		if existing, duplicate := routingTable.ResourceTemplates[template.URITemplate]; duplicate {
+			slog.Warn("duplicate resource template in resolved capabilities, keeping first",
+				"resource_template", template.URITemplate,
+				"kept_backend", existing.WorkloadID, "dropped_backend", template.BackendID)
+			continue
+		}
+		templates = append(templates, template)
+		backend := registry.Get(ctx, template.BackendID)
+		if backend == nil {
+			slog.Warn("backend not found in registry for resource template, creating minimal target",
+				"backend", template.BackendID, "resource_template", template.URITemplate)
+			routingTable.ResourceTemplates[template.URITemplate] = &vmcp.BackendTarget{
+				WorkloadID: template.BackendID,
+			}
+		} else {
+			routingTable.ResourceTemplates[template.URITemplate] = vmcp.BackendToTarget(backend)
+		}
+	}
+	return templates
+}
+
+// mergePrompts adds prompts to the routing table, keyed by resolved
+// (advertised) name, and returns the advertised prompt list, with the same
+// first-wins guard against duplicate resolved names.
+func mergePrompts(
+	ctx context.Context,
+	resolved []ResolvedPrompt,
+	registry vmcp.BackendRegistry,
+	routingTable *vmcp.RoutingTable,
+) []vmcp.Prompt {
+	prompts := make([]vmcp.Prompt, 0, len(resolved))
+	for _, prompt := range resolved {
+		if existing, duplicate := routingTable.Prompts[prompt.Name]; duplicate {
+			slog.Warn("duplicate prompt name in resolved capabilities, keeping first",
+				"prompt", prompt.Name, "kept_backend", existing.WorkloadID, "dropped_backend", prompt.BackendID)
+			continue
+		}
+		prompts = append(prompts, prompt.Prompt)
+		backend := registry.Get(ctx, prompt.BackendID)
+		if backend == nil {
+			slog.Warn("backend not found in registry for prompt, creating minimal target",
+				"backend", prompt.BackendID, "prompt", prompt.Name)
+			routingTable.Prompts[prompt.Name] = &vmcp.BackendTarget{
+				WorkloadID:             prompt.BackendID,
+				OriginalCapabilityName: prompt.OriginalName,
+			}
+		} else {
+			target := vmcp.BackendToTarget(backend)
+			// Store the backend's own prompt name so prompts/get on a renamed
+			// prompt forwards the name the backend actually knows.
+			target.OriginalCapabilityName = prompt.OriginalName
+			routingTable.Prompts[prompt.Name] = target
+		}
+	}
+	return prompts
 }
 
 // actualBackendCapabilityName returns the real capability name the backend uses,

--- a/pkg/vmcp/aggregator/default_aggregator.go
+++ b/pkg/vmcp/aggregator/default_aggregator.go
@@ -29,7 +29,11 @@ type defaultAggregator struct {
 	conflictResolver ConflictResolver
 	toolConfigMap    map[string]*config.WorkloadToolConfig // Maps backend ID to tool config
 	excludeAllTools  bool                                  // Global flag to exclude all tools
-	tracer           trace.Tracer
+	// promptPrefixFormat is the prefix format every prompt is renamed with
+	// (see resolvePromptConflicts). Derived from
+	// conflictResolutionConfig.prefixFormat at construction.
+	promptPrefixFormat string
+	tracer             trace.Tracer
 }
 
 // NewDefaultAggregator creates a new default aggregator implementation.
@@ -64,11 +68,12 @@ func NewDefaultAggregator(
 	}
 
 	return &defaultAggregator{
-		backendClient:    backendClient,
-		conflictResolver: conflictResolver,
-		toolConfigMap:    toolConfigMap,
-		excludeAllTools:  excludeAllTools,
-		tracer:           tracer,
+		backendClient:      backendClient,
+		conflictResolver:   conflictResolver,
+		toolConfigMap:      toolConfigMap,
+		excludeAllTools:    excludeAllTools,
+		promptPrefixFormat: promptPrefixFormatFromConfig(aggregationConfig),
+		tracer:             tracer,
 	}
 }
 
@@ -233,11 +238,12 @@ func (a *defaultAggregator) ResolveConflicts(
 			return nil, fmt.Errorf("conflict resolution failed: %w", err)
 		}
 	} else {
-		// Fallback: no conflict resolution (first wins, log warnings)
+		// Fallback: no conflict resolution (first wins in sorted backend
+		// order, so the winner is deterministic; log warnings)
 		slog.Warn("no conflict resolver configured, using fallback (first wins)")
 		resolvedTools = make(map[string]*ResolvedTool)
-		for backendID, tools := range toolsByBackend {
-			for _, tool := range tools {
+		for _, backendID := range slices.Sorted(maps.Keys(toolsByBackend)) {
+			for _, tool := range toolsByBackend[backendID] {
 				if existing, exists := resolvedTools[tool.Name]; exists {
 					slog.Warn("tool name conflict, keeping first",
 						"tool", tool.Name, "existing_backend", existing.BackendID, "conflicting_backend", backendID)
@@ -268,7 +274,10 @@ func (a *defaultAggregator) ResolveConflicts(
 	backendIDs := slices.Sorted(maps.Keys(capabilities))
 	resolved.Resources = resolveResourceConflicts(backendIDs, capabilities)
 	resolved.ResourceTemplates = resolveResourceTemplateConflicts(backendIDs, capabilities)
-	resolved.Prompts = resolvePromptConflicts(backendIDs, capabilities)
+	resolved.Prompts, err = resolvePromptConflicts(a.promptPrefixFormat, backendIDs, capabilities)
+	if err != nil {
+		return nil, fmt.Errorf("prompt conflict resolution failed: %w", err)
+	}
 
 	for _, caps := range capabilities {
 		// Aggregate logging/sampling support (OR logic - enabled if any backend supports)
@@ -366,10 +375,12 @@ func (a *defaultAggregator) MergeCapabilities(
 	})
 
 	// Add resources, resource templates, and prompts to the routing table.
-	// ResolveConflicts already makes their identities unique, but Merge is
-	// independently callable, so each merge helper keeps a duplicate out of
-	// both the routing table and the advertised list (first wins, loudly)
-	// rather than silently overwriting the earlier routing entry.
+	// ResolveConflicts is the enforcement point that makes their identities
+	// unique (see the capability_conflicts.go header), but Merge is
+	// independently callable, so as defence in depth each merge helper keeps
+	// a duplicate out of both the routing table and the advertised list
+	// (first wins, loudly) rather than silently overwriting the earlier
+	// routing entry.
 	resources := mergeResources(ctx, resolved.Resources, registry, routingTable)
 	templates := mergeResourceTemplates(ctx, resolved.ResourceTemplates, registry, routingTable)
 	prompts := mergePrompts(ctx, resolved.Prompts, registry, routingTable)

--- a/pkg/vmcp/aggregator/default_aggregator_test.go
+++ b/pkg/vmcp/aggregator/default_aggregator_test.go
@@ -240,8 +240,8 @@ func TestDefaultAggregator_MergeCapabilities(t *testing.T) {
 			Resources: []vmcp.Resource{
 				{URI: "test://resource1", BackendID: "backend1"},
 			},
-			Prompts: []vmcp.Prompt{
-				{Name: "prompt1", BackendID: "backend1"},
+			Prompts: []ResolvedPrompt{
+				{Prompt: vmcp.Prompt{Name: "prompt1", BackendID: "backend1"}, OriginalName: "prompt1"},
 			},
 			SupportsLogging:  true,
 			SupportsSampling: false,

--- a/pkg/vmcp/aggregator/default_aggregator_test.go
+++ b/pkg/vmcp/aggregator/default_aggregator_test.go
@@ -175,19 +175,22 @@ func TestDefaultAggregator_ResolveConflicts(t *testing.T) {
 		}
 
 		agg := NewDefaultAggregator(nil, nil, nil, nil)
-		resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
 
-		require.NoError(t, err)
-		assert.NotNil(t, resolved)
-		// In Phase 1, we just collect tools - conflict is detected but first one wins
-		assert.Contains(t, resolved.Tools, "tool1")
-		assert.Contains(t, resolved.Tools, "tool2")
-		assert.Contains(t, resolved.Tools, "shared_tool")
-		// Shared tool should have one backend (whichever was encountered first in map iteration)
-		// Map iteration order is non-deterministic, so accept either backend
-		sharedToolBackend := resolved.Tools["shared_tool"].BackendID
-		assert.True(t, sharedToolBackend == "backend1" || sharedToolBackend == "backend2",
-			"shared_tool should belong to either backend1 or backend2, got: %s", sharedToolBackend)
+		// Repeat: map iteration order is re-randomized per call, and the
+		// fallback winner must not depend on it.
+		for range 5 {
+			resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
+
+			require.NoError(t, err)
+			assert.NotNil(t, resolved)
+			// The no-resolver fallback keeps the first tool per name in sorted
+			// backend order, so the conflict winner is deterministic.
+			assert.Contains(t, resolved.Tools, "tool1")
+			assert.Contains(t, resolved.Tools, "tool2")
+			assert.Contains(t, resolved.Tools, "shared_tool")
+			assert.Equal(t, "backend1", resolved.Tools["shared_tool"].BackendID,
+				"fallback must keep the first backend in sorted-ID order")
+		}
 	})
 
 	t.Run("no conflicts", func(t *testing.T) {
@@ -351,6 +354,31 @@ func TestDefaultAggregator_MergeCapabilities(t *testing.T) {
 		assert.Equal(t, "file:///logs/2025-01-01.txt",
 			target.GetBackendCapabilityName("file:///logs/2025-01-01.txt"),
 			"a concrete expanded URI must pass through to the backend unchanged")
+	})
+
+	t.Run("registry miss still translates a renamed prompt", func(t *testing.T) {
+		t.Parallel()
+		// The minimal-target fallback (backend absent from the registry) must
+		// carry the backend's OWN prompt name, not the advertised one —
+		// otherwise prompts/get on the renamed prompt forwards a name the
+		// backend does not know.
+		resolved := &ResolvedCapabilities{
+			Tools: map[string]*ResolvedTool{},
+			Prompts: []ResolvedPrompt{
+				{Prompt: vmcp.Prompt{Name: "b1_review", BackendID: "b1"}, OriginalName: "review"},
+			},
+		}
+		registry := vmcp.NewImmutableRegistry(nil)
+
+		agg := NewDefaultAggregator(nil, nil, nil, nil)
+		aggregated, err := agg.MergeCapabilities(context.Background(), resolved, registry)
+		require.NoError(t, err)
+
+		target := aggregated.RoutingTable.Prompts["b1_review"]
+		require.NotNil(t, target)
+		assert.Equal(t, "b1", target.WorkloadID)
+		assert.Equal(t, "review", target.GetBackendCapabilityName("b1_review"),
+			"prompts/get on the advertised name must forward the backend's own name")
 	})
 }
 

--- a/pkg/vmcp/aggregator/prefix_resolver.go
+++ b/pkg/vmcp/aggregator/prefix_resolver.go
@@ -6,7 +6,6 @@ package aggregator
 import (
 	"context"
 	"log/slog"
-	"strings"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
 )
@@ -26,7 +25,7 @@ type PrefixConflictResolver struct {
 // NewPrefixConflictResolver creates a new prefix-based conflict resolver.
 func NewPrefixConflictResolver(prefixFormat string) *PrefixConflictResolver {
 	if prefixFormat == "" {
-		prefixFormat = "{workload}_" // Default format
+		prefixFormat = defaultPrefixFormat
 	}
 	return &PrefixConflictResolver{
 		PrefixFormat: prefixFormat,
@@ -79,10 +78,5 @@ func (r *PrefixConflictResolver) ResolveToolConflicts(
 
 // applyPrefix applies the configured prefix format to a tool name.
 func (r *PrefixConflictResolver) applyPrefix(backendID, toolName string) string {
-	prefix := r.PrefixFormat
-
-	// Replace {workload} placeholder with actual backend ID
-	prefix = strings.ReplaceAll(prefix, "{workload}", backendID)
-
-	return prefix + toolName
+	return applyPrefixFormat(r.PrefixFormat, backendID, toolName)
 }

--- a/pkg/vmcp/aggregator/priority_resolver.go
+++ b/pkg/vmcp/aggregator/priority_resolver.go
@@ -46,7 +46,7 @@ func NewPriorityConflictResolver(priorityOrder []string) (*PriorityConflictResol
 	return &PriorityConflictResolver{
 		PriorityOrder:  priorityOrder,
 		priorityMap:    priorityMap,
-		prefixResolver: NewPrefixConflictResolver("{workload}_"), // Fallback for unmapped backends
+		prefixResolver: NewPrefixConflictResolver(defaultPrefixFormat), // Fallback for unmapped backends
 	}, nil
 }
 

--- a/pkg/vmcp/cli/init.go
+++ b/pkg/vmcp/cli/init.go
@@ -73,8 +73,9 @@ outgoingAuth:
 
 # aggregation: controls how tools from multiple backends are combined.
 # conflictResolution: prefix prepends the backend name to each tool name.
-# Prompt names are always backend-prefixed with prefixFormat, regardless
-# of the strategy chosen here.
+# Prompt names are prefixed with the backend name by default; under the
+# priority strategy, backends listed in priorityOrder keep their own
+# prompt names.
 aggregation:
   conflictResolution: prefix
   conflictResolutionConfig:

--- a/pkg/vmcp/cli/init.go
+++ b/pkg/vmcp/cli/init.go
@@ -73,6 +73,8 @@ outgoingAuth:
 
 # aggregation: controls how tools from multiple backends are combined.
 # conflictResolution: prefix prepends the backend name to each tool name.
+# Prompt names are always backend-prefixed with prefixFormat, regardless
+# of the strategy chosen here.
 aggregation:
   conflictResolution: prefix
   conflictResolutionConfig:

--- a/pkg/vmcp/config/config.go
+++ b/pkg/vmcp/config/config.go
@@ -466,7 +466,9 @@ type AggregationConfig struct {
 // +kubebuilder:object:generate=true
 // +gendoc
 type ConflictResolutionConfig struct {
-	// PrefixFormat defines the prefix format for the "prefix" strategy.
+	// PrefixFormat defines the prefix format for the "prefix" tool strategy
+	// and for prompt names, which are always backend-prefixed regardless of
+	// the tool strategy.
 	// Supports placeholders: {workload}, {workload}_, {workload}.
 	// +kubebuilder:default="{workload}_"
 	// +optional

--- a/pkg/vmcp/config/config.go
+++ b/pkg/vmcp/config/config.go
@@ -467,14 +467,17 @@ type AggregationConfig struct {
 // +gendoc
 type ConflictResolutionConfig struct {
 	// PrefixFormat defines the prefix format for the "prefix" tool strategy
-	// and for prompt names, which are always backend-prefixed regardless of
-	// the tool strategy.
+	// and for backend-prefixed prompt names (the default for every prompt;
+	// under the "priority" strategy, backends listed in priorityOrder keep
+	// their own prompt names).
 	// Supports placeholders: {workload}, {workload}_, {workload}.
 	// +kubebuilder:default="{workload}_"
 	// +optional
 	PrefixFormat string `json:"prefixFormat,omitempty" yaml:"prefixFormat,omitempty"`
 
 	// PriorityOrder defines the workload priority order for the "priority" strategy.
+	// Listed workloads also keep their own prompt names (unlisted workloads'
+	// prompts stay backend-prefixed).
 	// +optional
 	PriorityOrder []string `json:"priorityOrder,omitempty" yaml:"priorityOrder,omitempty"`
 }

--- a/pkg/vmcp/server/modern_pagination.go
+++ b/pkg/vmcp/server/modern_pagination.go
@@ -215,15 +215,13 @@ func decodeModernCursor(wantKind, cursor string) (string, int, error) {
 // KEY UNIQUENESS IS NOT ASSUMED, and this is the subtle part. An earlier version
 // documented these keys as globally unique "since the aggregator's conflict
 // resolver has already de-duplicated them across backends", and skipped forward
-// with a bare `key > lastKey`. That precondition holds for exactly ONE of the
-// four callers:
-//
-//   - Tool.Name IS unique: ResolveToolConflicts returns map[string]*ResolvedTool,
-//     and the no-resolver fallback also keys a map (aggregator/default_aggregator.go).
-//   - Resource.URI, ResourceTemplate.URITemplate and Prompt.Name are NOT: they
-//     are plain-appended across backends under the comment "no conflict
-//     resolution for these yet", and nothing dedups them downstream (FilterResources
-//     only filters). Two honest backends both exposing file:///README.md collide.
+// with a bare `key > lastKey`. At the time that precondition held for exactly
+// ONE of the four callers (Tool.Name; resource URIs, template strings and
+// prompt names were plain-appended across backends with no de-duplication).
+// The aggregator has since been fixed to resolve all four (#6060:
+// aggregator/capability_conflicts.go), but this paginator is generic and MUST
+// NOT depend on that caller invariant — its signature cannot enforce it, and a
+// future caller may not uphold it. The collision-safety below stays.
 //
 // With a bare `>` scan, a collision at a page boundary permanently DROPS an item:
 // the page ends on the first copy, the cursor names that key, and the scan then

--- a/pkg/vmcp/server/modern_pagination_test.go
+++ b/pkg/vmcp/server/modern_pagination_test.go
@@ -40,10 +40,10 @@ func makeKeys(n int) []string {
 }
 
 // makeKeysWithDuplicates builds an adversarial corpus of n items whose keys
-// deliberately collide at positions that matter. Resources, resource templates
-// and prompts are plain-appended across backends with no conflict resolution, so
-// this is the realistic shape rather than a synthetic edge case: two backends
-// exposing the same URI produce exactly this.
+// deliberately collide at positions that matter. The aggregator now resolves
+// resource/template/prompt conflicts (#6060), but paginateModern is generic and
+// deliberately does not depend on that caller invariant, so collisions remain
+// the shape these completeness properties must be proven against.
 //
 // The collisions are placed by SORTED position, which is the subtle part and the
 // reason a first attempt at this fixture was useless. paginateModern sorts before
@@ -174,11 +174,11 @@ func TestPaginateModern_StaticSetDeliveredExactlyOnce(t *testing.T) {
 // key at a page boundary caused BOTH to be skipped, so an item appeared on no
 // page at all. A 1100-item resource corpus with one duplicated URI delivered 1099.
 //
-// Key uniqueness holds only for tools (ResolveToolConflicts keys a map). Resource
-// URIs, resource-template URI templates and prompt names are plain-appended
-// across backends with no conflict resolution, so collisions are ordinary -- two
-// backends exposing file:///README.md is enough. The paginator therefore must not
-// depend on uniqueness, and this test is what holds it to that.
+// When this defect shipped, key uniqueness held only for tools; resource URIs,
+// resource-template URI templates and prompt names were plain-appended across
+// backends with no conflict resolution. The aggregator now resolves those too
+// (#6060), but the paginator is generic and must not depend on any caller's
+// uniqueness invariant, and this test is what holds it to that.
 //
 // The corpus is adversarial by construction (see makeKeysWithDuplicates): a pair
 // straddling the page-1 boundary, a run spanning it, and a three-way tie. Total


### PR DESCRIPTION
## Summary

The aggregator resolved name conflicts for **tools only**. Resources, resource templates and prompts were plain-appended across backends ("no conflict resolution for these yet"), so two backends exposing the same `Resource.URI`, `ResourceTemplate.URITemplate` or `Prompt.Name` both appeared in the aggregated view, undiagnosed. Worse, `MergeCapabilities` keys the routing table by those identities, so duplicates **silently collapsed to a nondeterministically-chosen backend for reads** — whichever backend won the map write, potentially varying between runs. Two instances of the same server type were enough to hit this.

This PR resolves conflicts for the remaining three capability types, with policies that deliberately differ by what the identity *is*:

- **Prompt names are names**, like tool names: `prompts/get` already translates the advertised name back to the backend's own name via `BackendTarget.GetBackendCapabilityName`, so renaming does not break invocation. Every prompt is renamed **unconditionally** to its backend-prefixed form — `conflictResolutionConfig.prefixFormat` applied to the backend ID (default `{workload}_`), the same formatting path `PrefixConflictResolver` uses for tools. The advertised name is therefore a pure function of (backendID, name) and never shifts when unrelated backends join or leave the group. That stability is a security property, not cosmetics: the advertised name is what authorization matches on (`pkg/vmcp/core/admission.go` passes it to Cedar, which builds `Prompt::"<advertised name>"` entities), so a membership-dependent rename would silently detach `permit` **and** `forbid` policies from the prompt they were written for — the `forbid` case failing open. This PR's first revision renamed only on collision and had exactly that instability; review caught it. An exact intra-backend duplicate (a backend advertising the same prompt name twice) is dropped with a WARN — both entries advertise and route identically, so nothing reachable is lost. The one residual collision unconditional prefixing cannot rule out — two distinct (backendID, name) pairs composing to the same string, e.g. backend `b1` prompt `x_y` vs backend `b1_x` prompt `y`, both `b1_x_y` — is ambiguous between backends and now **fails aggregation loudly** with `ErrUnresolvedConflicts` instead of silently dropping a prompt.
- **Resource URIs and template strings are locators, not names** — the client passes them back verbatim (`resources/read`, `resources/subscribe`, completion refs), backends emit them in notifications and embedded resource contents, and template-matched reads forward the client's concrete URI untranslated. Rewriting them would break those round trips, so a duplicated URI/template is instead advertised **once**: the backend earliest in sorted-backend-ID order wins; later duplicates are dropped with a WARN naming the URI and both backend IDs. The trade-off, stated plainly: **reads strictly improve** (the routing table keys by URI, so at most one backend was ever readable per URI — previously an arbitrary one, now a stable one), while **discoverability regresses** (a URI existing on N backends is listed once instead of N times, and only the winning backend's `name`/`description`/`mimeType` are advertised — a duplicate that differed in those fields loses them along with its entry). Dropping is still right because the protocol gives a client no way to address the other N−1 entries — they promised reads that could never be honoured. Surfacing collisions beyond the log (e.g. in aggregation metadata or a status endpoint) is possible follow-up, not built here.

In effect prompts get the tool **prefix** strategy applied unconditionally. `priority` and `manual` remain tool-only knobs (their configuration is tool-shaped); `prefixFormat` is honoured for prompts under **every** strategy, since it is the only prefix-format knob.

Because prefixing is unconditional, group-membership changes no longer rename anything. Prompt-set changes on a live backend propagate to connected sessions through the list_changed resync path (`pkg/vmcp/server/serve_list_changed.go`, #5748/#5969), which is add-only for prompts — a removed prompt stays advertised on already-registered sessions until they reconnect (toolhive-core#184). A backend joining or leaving the group emits no push signal today, so staleness there is bounded by the aggregator cache TTL for routing and by the client's next `prompts/list` for listing; that gap predates this PR and applies to tools equally.

Closes #6060

### Client-visible behaviour, before → after (both revisions, including Legacy)

| Type | Before | After |
|------|--------|-------|
| Prompts, unique name | advertised as-is; `prompts/get` works | advertised as `{backendID}_{name}` (per `prefixFormat`); `prompts/get` on the prefixed name forwards the backend's own name; the bare name → not found |
| Prompts, name in N backends | listed N times under one name; `prompts/get` hit a nondeterministic backend | N distinct prefixed names, each routing deterministically to its backend |
| Prompts, prefix ambiguity (`b1`+`x_y` vs `b1_x`+`y`) | both listed under distinct names; fine by accident | aggregation fails with `ErrUnresolvedConflicts` naming both backends and both prompts |
| Resources, duplicated URI | listed once per backend; `resources/read` hit a nondeterministic backend | listed once, owned by the first backend in sorted-ID order; reads route there deterministically |
| Resource templates, duplicated template | same as resources | same as resources |
| Resource/template/prompt list ordering | unspecified (backend-map iteration order; a Legacy client could see a different order per process) | sorted by URI / template string / resolved name |
| Tools (list, order, routing) | sorted by name since #5709 | unchanged in production; the no-resolver fallback (reachable only in tests — both production call sites always pass a resolver) now picks first-wins in sorted backend order |

### How routing became deterministic

- `ResolveConflicts` iterates backends in **sorted-ID order** (map iteration order was the nondeterminism source) and emits key-sorted, duplicate-free lists. It is the **enforcement point** for these policies (stated in the `capability_conflicts.go` header).
- `MergeCapabilities` no longer silently last-wins-overwrites routing entries: duplicate identities get a **first-wins guard with a warning**, applied to the routing table and the advertised list together so they can never disagree. This is defence in depth for direct `MergeCapabilities` callers — in the pipeline these guards can never fire, because `ResolveConflicts` runs first.
- Known residual nondeterminism, now documented instead of overclaimed: the prefix and manual **tool** resolvers still iterate the backend map, so a tool collision *after* prefixing or a manual override picks a nondeterministic winner (`docs/arch/10-virtual-mcp-architecture.md` says so). Fixing those touches the tools path and is left for a follow-up PR.

Every drop or rename is logged at WARN with the colliding key and both backend IDs.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — passes except the three pre-existing environment-dependent failures (`TestNewServer_ReadTimeoutConfigured`, `TestSecurityHeaders`, `TestCompositeProvider_RealProviders`)
- [x] Linting (`task lint`) — 0 issues; `go vet ./...` clean

Not run: e2e suites (no container runtime in this environment). No existing e2e or unit test asserted the old duplicate-tolerant list behaviour; the Modern paginator's duplicate-key tests exercise the *generic paginator* with synthetic collisions and are intentionally kept — the paginator must not depend on the aggregator's new uniqueness invariant.

New tests are adversarial by construction (the original bug survived because fixtures minted strictly unique keys): two backends sharing a URI, three sharing one, same-backend duplicates, prompts unique and shared, another backend literally advertising `b1_review` (no longer collides — pinned as all-reachable), the `b1`+`x_y` / `b1_x`+`y` ambiguity (pinned as a loud error), `prefixFormat: "{workload}."` honoured for prompts, a routing-table merge against an **empty registry** asserting `GetBackendCapabilityName("b1_review") == "review"` (the registry-miss branch this PR actually fixed), a duplicate placed exactly at the Modern page-size boundary (index 999/1000 of an 1100-item corpus), and repeated runs asserting winners never vary with map iteration order.

Mutation-verified (each mutant fails at least one test): reverting unconditional prefixing to bare names; turning the ambiguity error into a silent drop; dropping the intra-backend duplicate guard (must drop, not error); reverting the no-resolver fallback to map-order iteration; forwarding the advertised name on registry miss; ignoring the configured `prefixFormat`; disabling the URI/template dedupe.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/aggregator/capability_conflicts.go` | Per-type conflict resolution: unconditional backend-prefixing for prompts (ambiguity → `ErrUnresolvedConflicts`), URI/template dedupe; policy rationale + enforcement-point note in the header |
| `pkg/vmcp/aggregator/conflict_resolver.go` | Shared `applyPrefixFormat` helper, `defaultPrefixFormat` const, `promptPrefixFormatFromConfig` |
| `pkg/vmcp/aggregator/prefix_resolver.go`, `priority_resolver.go` | Delegate to the shared helper/const (no behaviour change) |
| `pkg/vmcp/aggregator/default_aggregator.go` | Prompt prefix-format wiring; no-resolver fallback iterates sorted backend IDs; merge guards documented as defence in depth |
| `pkg/vmcp/aggregator/aggregator.go` | `ResolvedCapabilities.Prompts` becomes `[]ResolvedPrompt` (embeds `vmcp.Prompt` + `OriginalName`); docs reflect unconditional prefixing |
| `pkg/vmcp/config/config.go` + generated CRDs + `docs/operator/crd-api.md` | `prefixFormat` field doc now covers prompts (CRD YAML/docs regenerated) |
| `pkg/vmcp/cli/init.go` | Generated-config template comment mentions prompt prefixing |
| `pkg/vmcp/server/modern_pagination.go` | Comment-only: keys are now unique upstream, but the generic paginator keeps its collision-safety (defence in depth) |
| `docs/arch/10-virtual-mcp-architecture.md` | Conflict Resolution section documents the per-type policies; determinism claim scoped honestly |

## Does this introduce a user-facing change?

Yes — **every prompt advertised through vMCP is renamed**. Prompts are now always advertised as `{backendID}_{name}` (or per `conflictResolutionConfig.prefixFormat`), whether or not their name collides. Anything referencing an advertised prompt name must be updated:

- **Cedar authorization policies on prompts**: `Prompt::"review"` must become `Prompt::"github_review"` (etc.). This matters most for `forbid` policies — a stale name silently stops matching, and a broad `permit` would then admit the call.
- **Clients that pin prompt names** must switch to the prefixed names (`prompts/list` advertises them).

Additionally: duplicated resource URIs / resource templates are advertised once and reads deterministically route to the first backend in sorted-backend-ID order (previously listed per-backend with reads hitting an arbitrary backend that could change between runs), and aggregation now fails with an explicit error if two backends' prefixed prompt names compose to the same string.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Per-type conflict policies (the issue's "mirror the tool path" option is wrong for URIs):

1. **Prompts** — rename, lossless. `prompts/get`/completions already translate advertised → backend name via `BackendTarget.GetBackendCapabilityName` (`pkg/vmcp/client/client.go`), identical to renamed tools. *Revised in review round 1:* renaming is **unconditional** (initially collision-only) — the advertised name is what Cedar authorizes on, and a membership-dependent rename detaches `forbid` policies (fails open). Every prompt becomes `prefixFormat(backendID) + name`; exact intra-backend duplicates drop with a WARN; cross-backend prefix ambiguity aborts aggregation with `ErrUnresolvedConflicts`.
2. **Resources / resource templates** — dedupe, never rewrite. URIs are locators: template-matched reads forward the client's concrete URI verbatim (template targets deliberately have empty `OriginalCapabilityName`), subscriptions and `notifications/resources/updated` carry backend-native URIs, and embedded resource links in tool/prompt results are not rewritten by vMCP. Winner = first backend in sorted-backend-ID order; losers dropped with WARN. Reads strictly improve (routing could only ever serve one backend per URI); listing regresses from N indistinguishable entries to one.
3. **Determinism** — `ResolveConflicts` iterates backends in sorted-ID order and emits key-sorted lists; `MergeCapabilities` gets first-wins-with-WARN guards (defence in depth for direct callers), keeping the advertised lists and routing table in agreement. *Revised in review round 1:* the no-resolver tool fallback also iterates sorted backend IDs.
4. **Out of scope, unchanged** — production tools path (all three resolver strategies; their residual map-order iteration is now documented rather than overclaimed), Modern paginator collision-safety (generic code must not depend on a caller invariant).

</details>

## Special notes for reviewers

- The production tools path is behaviourally untouched (`ConflictResolver`, all three strategies, and `MergeCapabilities`' tool handling); the only tools-path code change is the test-only no-resolver fallback becoming deterministic. The prefix and manual resolvers still iterate the backend map — fixing that is left to a follow-up so this PR stays scoped to the non-tool capability types.
- The Modern paginator's `(LastKey, Delivered)` collision-safe cursor is deliberately retained even though aggregated keys are now unique — `paginateModern` is generic and its signature cannot enforce a caller invariant.
- Prompt prefixing intentionally applies even to a single-backend group: exempting it would reintroduce membership-dependent names (the second backend joining would rename the first backend's prompts).

Generated with [Claude Code](https://claude.com/claude-code)