### PR TITLE
Deflake Envoy AllowPort spec's allowed-port leg

### DIFF
--- a/test/e2e/network_isolation_envoy_test.go
+++ b/test/e2e/network_isolation_envoy_test.go
@@ -243,9 +243,27 @@ var _ = Describe("NetworkIsolationEnvoy", Label("proxy", "network", "isolation",
 			server := startFetchServer("port", profile)
 
 			By("HTTPS request (port 443) must succeed")
-			httpsResult := fetchThrough(server, "https://example.com", 30*time.Second)
-			Expect(httpsResult.IsError).To(BeFalse(),
-				"https://example.com must be allowed (port 443 is in AllowPort)")
+			// The allowed leg needs a working DNS → TLS → example.com chain through
+			// Envoy's dynamic_forward_proxy. The very first egress request after
+			// startup can race the isolation stack's own warm-up (DFP DNS cache,
+			// the per-workload DNS container), failing instantly with a local 503
+			// long before anything has actually reached the network — observed in
+			// CI as an IsError result within ~40ms of readiness. The property this
+			// spec pins is steady-state reachability of an allowed port, not
+			// first-request-after-boot success (which Envoy does not promise), so
+			// retry until the deadline and surface the tool's error text — the one
+			// diagnostic that distinguishes a warm-up race from a broken AllowPort.
+			var lastHTTPSError string
+			Eventually(func() bool {
+				httpsResult := fetchThrough(server, "https://example.com", 30*time.Second)
+				if httpsResult.IsError {
+					lastHTTPSError = resultText(httpsResult)
+					return false
+				}
+				return true
+			}, 60*time.Second, 2*time.Second).Should(BeTrue(), func() string {
+				return "https://example.com must be allowed (port 443 is in AllowPort); last fetch error: " + lastHTTPSError
+			})
 
 			By("HTTP request (port 80) must be blocked")
 			httpResult := fetchThrough(server, "http://example.com", 30*time.Second)


### PR DESCRIPTION
## Summary

`E2E Tests Core (network-isolation)` failed on the pre-merge heads of both #6050 (`1588e6a4`) and #6051 (`5c901a9d`) — the latter containing zero production code — and passed on `main` minutes later. Both failures were the same spec, same assertion, within the same minute: the AllowPort spec's allowed leg, `https://example.com must be allowed (port 443 is in AllowPort)`.

Root cause: the allowed leg fetched `https://example.com` **exactly once, immediately after workload readiness**. It needs a working DNS → TLS → upstream chain through Envoy's `dynamic_forward_proxy`, and the first egress request after startup can race the isolation stack's own warm-up (DFP DNS cache, the per-workload DNS container), failing instantly with a local error. The observed failures returned **~40ms and ~190ms** after readiness — far too fast for genuine external TLS trouble — and the boolean-only assertion discarded the fetch tool's error text, so the log could not say why.

What changed:

- The allowed leg retries via `Eventually` (60s budget, 2s poll) and records the last fetch error text, which is printed on failure.

Why this is fixing an incidental assertion, not weakening a real one:

- The property this spec pins (#5915 parity: Envoy must honour `AllowPort` end-to-end) is **steady-state reachability of an allowed port**. First-request-after-boot success is not something Envoy's DFP path promises, so a single-shot first fetch asserts warm-up behaviour the product never guaranteed.
- A genuinely broken `AllowPort` still fails — after the retry budget, and now **with the fetch error text surfaced**, which is the diagnostic that distinguishes a warm-up race from a real enforcement break on the next occurrence.
- The blocked port-80 leg is untouched: denial is enforced locally and deterministically once the stack is warm, which the preceding allowed leg has just proven.

No timeout was raised; the change addresses the mechanism (first-request warm-up) and improves the failure's diagnosability.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Linting (`task lint`; `go vet ./...` run separately)
- [x] Manual testing (describe below)

Test-only change to a suite that requires a container runtime, which the dev environment lacks — the retry's effect on the flake is only observable in CI. Verified by compilation (`go vet ./test/e2e/`), lint, and by checking the failure-time evidence (both CI logs) against the retry semantics: the observed failure mode (instant `IsError` right after readiness) is exactly what the retry absorbs, and the assertion's contract is unchanged.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

The warm-up diagnosis is the best fit for the evidence (instant local failure, correlated timing across two runners, immediate pass on `main`) but could not be pinned to the exact Envoy error because the old assertion discarded the error text. If this spec ever fails again, the surfaced text settles it.

Generated with [Claude Code](https://claude.com/claude-code)