### PR TITLE
Retry dual-era backend startup on a lost port-bind race

### DIFF
--- a/test/e2e/vmcp_dual_era_helpers_test.go
+++ b/test/e2e/vmcp_dual_era_helpers_test.go
@@ -47,12 +47,32 @@ func launchYardstickLegacyOnPort(config *e2e.TestConfig, groupName, backendName 
 	).ExpectSuccess()
 }
 
+// startEraBackendOnPort launches a backend via launch and waits for it to
+// become ready, retrying once with a freshly allocated port if the container
+// lost a race binding its host port. allocateVMCPPort only probes that a port
+// is free at call time and closes its own listener immediately -- the actual
+// bind happens later, asynchronously, inside the container Docker starts for
+// the detached `thv run` process, so another workload's container can grab
+// the same ephemeral port in between (observed as "address already in use").
+func startEraBackendOnPort(config *e2e.TestConfig, backendName string, port int, launch func(port int)) {
+	launch(port)
+	err := e2e.WaitForMCPServer(config, backendName, 120*time.Second)
+	if err != nil && strings.Contains(err.Error(), "address already in use") {
+		GinkgoWriter.Printf("%s lost a port-bind race on %d, retrying with a fresh port: %v\n", backendName, port, err)
+		e2e.NewTHVCommand(config, "rm", backendName).ExpectSuccess()
+		port = allocateVMCPPort()
+		launch(port)
+		err = e2e.WaitForMCPServer(config, backendName, 120*time.Second)
+	}
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("yardstick backend %q should become running", backendName))
+}
+
 // startYardstickLegacyOnPort runs launchYardstickLegacyOnPort and waits for
 // the backend to become ready.
 func startYardstickLegacyOnPort(config *e2e.TestConfig, groupName, backendName string, port int) {
-	launchYardstickLegacyOnPort(config, groupName, backendName, port)
-	err := e2e.WaitForMCPServer(config, backendName, 120*time.Second)
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("legacy yardstick backend %q should become running", backendName))
+	startEraBackendOnPort(config, backendName, port, func(p int) {
+		launchYardstickLegacyOnPort(config, groupName, backendName, p)
+	})
 }
 
 // launchYardstickModernOnPort starts a stateless (Modern-capable) yardstick
@@ -87,9 +107,9 @@ func launchYardstickModernOnPort(config *e2e.TestConfig, groupName, backendName 
 // startYardstickModernOnPort runs launchYardstickModernOnPort and waits for
 // the backend to become ready.
 func startYardstickModernOnPort(config *e2e.TestConfig, groupName, backendName string, port int) {
-	launchYardstickModernOnPort(config, groupName, backendName, port)
-	err := e2e.WaitForMCPServer(config, backendName, 120*time.Second)
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("modern yardstick backend %q should become running", backendName))
+	startEraBackendOnPort(config, backendName, port, func(p int) {
+		launchYardstickModernOnPort(config, groupName, backendName, p)
+	})
 }
 
 // healthCheckConfigYAML is appended to a `thv vmcp init`-generated config file


### PR DESCRIPTION
## Summary

- **Why:** `test/e2e/vmcp_dual_era_test.go`'s `BeforeEach` intermittently fails
  waiting for a yardstick backend to become `running`, with the container
  erroring out as `driver failed programming external connectivity ...
  bind: address already in use`. `allocateVMCPPort` (`vmcp_cli_helpers_test.go`)
  probes for a free port and closes its own listener immediately, but the
  actual bind happens later, asynchronously, inside the container Docker
  starts for the detached `thv run` process — under back-to-back workload
  churn, another container can grab the same ephemeral port first. This is a
  classic check-then-use race across process boundaries; the only way to
  make progress in the face of it is to retry, not to check earlier/later.
- **What:** `startYardstickLegacyOnPort`/`startYardstickModernOnPort` now go
  through a shared `startEraBackendOnPort` helper that retries once with a
  freshly allocated port if `WaitForMCPServer` fails with
  `"address already in use"`.

## Type of change

- [x] Bug fix

## Test plan

- [x] E2E tests (`task test-e2e`)
- [x] Manual testing (describe below)

Ran `ginkgo --label-filter='vmcp && dual-era' --repeat=20 -v` locally against
this fix. All 20 repeats (140 specs) passed. The port race fired once during
the run (visible in the log as `lost a port-bind race on <port>, retrying
with a fresh port`) and was absorbed by the retry instead of failing the
spec — confirming both that the race is real and that the fix works.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

No. Test-only change.

## Special notes for reviewers

This fix is scoped to the two call sites that actually race Docker's async
container bind. `allocateVMCPPort` is also used elsewhere for `thv vmcp
serve`'s own port, which is bound synchronously in-process by the same test
binary and isn't subject to this race, so I left `allocateVMCPPort` itself
unchanged rather than touching its other callers.

Generated with [Claude Code](https://claude.com/claude-code)