### PR TITLE
Recreate the shared external network on a lost teardown race

### DIFF
--- a/pkg/container/docker/client.go
+++ b/pkg/container/docker/client.go
@@ -1458,7 +1458,34 @@ func (c *Client) createContainer(
 		EndpointsConfig: endpointsConfig,
 	}
 
-	// Create the container
+	id, err := c.createAndStartContainer(ctx, containerName, config, hostConfig, networkConfig)
+	if err != nil && errdefs.IsNotFound(err) {
+		if _, sharesExternalNetwork := endpointsConfig["toolhive-external"]; sharesExternalNetwork {
+			// "toolhive-external" is shared, concurrency-created infrastructure
+			// reused by every workload; deleteNetworks removes it opportunistically
+			// once it looks like no workload needs it anymore. Under concurrent
+			// `thv` processes that teardown can race this container's own creation,
+			// so the network can vanish between our create-time existence check and
+			// this container actually attaching to it, surfacing as a not-found
+			// error from either Create or Start. Recreate it and retry once instead
+			// of failing the whole workload for what is a transient condition.
+			if recreateErr := c.createExternalNetworks(ctx); recreateErr == nil {
+				id, err = c.createAndStartContainer(ctx, containerName, config, hostConfig, networkConfig)
+			}
+		}
+	}
+	return id, err
+}
+
+// createAndStartContainer creates and starts a container, wrapping any
+// Docker API error with contextual information.
+func (c *Client) createAndStartContainer(
+	ctx context.Context,
+	containerName string,
+	config *container.Config,
+	hostConfig *container.HostConfig,
+	networkConfig *network.NetworkingConfig,
+) (string, error) {
 	resp, err := c.api.ContainerCreate(ctx, mobyclient.ContainerCreateOptions{
 		Config:           config,
 		HostConfig:       hostConfig,
@@ -1477,6 +1504,12 @@ func (c *Client) createContainer(
 	// Start the container
 	_, err = c.api.ContainerStart(ctx, resp.ID, mobyclient.ContainerStartOptions{})
 	if err != nil {
+		// Docker leaves the container behind in a "created" state on a failed
+		// start (e.g. its network vanished underneath it). Clean it up so a
+		// caller-driven retry under the same name doesn't collide with it.
+		if _, rmErr := c.api.ContainerRemove(ctx, resp.ID, mobyclient.ContainerRemoveOptions{Force: true}); rmErr != nil {
+			slog.Debug("failed to remove container after failed start", "id", resp.ID, "error", rmErr)
+		}
 		return "", NewContainerError(err, resp.ID, fmt.Sprintf("failed to start container: %v", err))
 	}
 


### PR DESCRIPTION
## Summary

- **Why:** `pkg/container/docker/client.go`'s `deleteNetworks` removes the
  shared `toolhive-external` Docker network opportunistically whenever a
  workload teardown observes zero remaining `toolhive=true`-labeled
  containers — a point-in-time check with no cross-process synchronization.
  Since concurrent Ginkgo processes (or any concurrent `thv run` invocations
  on one host) share a single Docker daemon, one process's teardown can
  delete the network while another process's container is mid-creation and
  still needs it, surfacing as `network toolhive-external not found` from
  `ContainerCreate`/`ContainerStart`. Hit live in CI on PR #6080: a DNS
  sidecar container failed this way in the `E2E Tests Core (core)` job after
  it moved to 4 concurrent Ginkgo processes (#6070) sharing one daemon.
- **What:** `createContainer` now retries once, recreating
  `toolhive-external` first, if container create/start fails with a
  not-found error and the container's endpoint config references that
  network. `createAndStartContainer` (extracted from the existing
  create+start logic, unchanged) also force-removes a container Docker
  leaves behind in "created" state after a failed start, so the retry
  doesn't collide with it on the same name.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

`go build ./...` and `go vet ./pkg/container/docker/...` both pass cleanly.
Not yet covered by a unit or e2e test — this was root-caused and fixed from
a single CI occurrence rather than a local stress reproduction. Suggested
verification: run the "core" e2e suite with concurrent procs against a
workload-churn script that creates/removes workloads on the same daemon
while another spec is mid-creation, to force the teardown-vs-creation race
directly (e.g. `ginkgo --label-filter='core && groups' --repeat=20 -v
./test/e2e/ -- --procs=4`).

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

No. Internal container-runtime resilience fix; no API or CLI surface change.

## Special notes for reviewers

This closes the loop on the opposite side of the same shared-network
lifecycle that #6071 already made resilient to concurrent *creation* races
(treating `NetworkCreate` conflict as success). This PR handles the
teardown side: a concurrent *deletion* racing another workload's creation.

No local stress reproduction was performed for this one (unlike the
port-bind-race fix in #6080) — the root cause and fix were derived from
tracing the actual CI failure and the relevant code paths. Flagging this
explicitly since it means the fix is confidence-based on code inspection
rather than confirmed-live-under-stress; happy to attempt a local repro if
useful before merge.

Generated with [Claude Code](https://claude.com/claude-code)