### PR TITLE
Share one JSON-RPC error writer across HTTP denial paths

### DIFF
--- a/.claude/rules/go-style.md
+++ b/.claude/rules/go-style.md
@@ -200,3 +200,18 @@ Before implementing any non-trivial functionality from scratch:
 3. **Look for existing Go packages** — search for well-maintained OSS libraries that solve the problem before writing custom implementations.
 
 Implementing from scratch should be a last resort, justified by a specific gap no existing solution fills.
+
+## JSON-RPC Envelopes
+
+Never `json.Marshal` (or `json.NewEncoder().Encode`) a `jsonrpc2` type.
+`jsonrpc2.Response` carries no json tags and `jsonrpc2.ID`'s only field is
+unexported, so reflection emits Go-capitalized keys, drops the mandatory
+`"jsonrpc":"2.0"` tag, and renders every id — valid or not — as `{}` (#5950).
+Serialize through `jsonrpc2.EncodeMessage`; for HTTP error responses use
+`pkg/mcp.EncodeJSONRPCError` / `pkg/mcp.WriteJSONRPCError`, which add
+encode-before-header ordering and a conformant fallback body.
+
+When an envelope must be hand-built as a map (only where no `jsonrpc2.ID` is
+in hand), omit the `"id"` key when the id is absent — never emit `"id":null`.
+MCP's `RequestId` is `string | number`, so null is not representable, and the
+reference TypeScript SDK client throws on it inside its transport (#6038).

--- a/pkg/authz/middleware.go
+++ b/pkg/authz/middleware.go
@@ -158,21 +158,10 @@ func handleUnauthorized(w http.ResponseWriter, msgID interface{}, err error) {
 		Error: jsonrpc2.NewError(mcp.JSONRPCCodeDenied, "Unauthorized"),
 	}
 
-	// Encode before writing any header, so a marshal failure never leaves a
-	// half-written response (e.g. a 403 header followed by a second 500 write).
-	body, encErr := jsonrpc2.EncodeMessage(errorResponse)
-	if encErr != nil {
-		// Unreachable in practice: errorResponse is always a well-formed
-		// jsonrpc2.Response built from strings/ints above. Fall back to a
-		// hardcoded valid JSON-RPC error body rather than writing nothing.
-		slog.Error("failed to encode JSON-RPC unauthorized response", "error", encErr)
-		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Unauthorized"}}`, mcp.JSONRPCCodeDenied)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusForbidden)
-	//nolint:gosec // G104: writing the JSON-RPC denial body to an HTTP client; nothing to do on error
-	_, _ = w.Write(body)
+	// The helper encodes before writing any header, so a marshal failure never
+	// leaves a half-written response (e.g. a 403 header followed by a second
+	// 500 write). Nothing to do on a write error for a denial body.
+	_ = mcp.WriteJSONRPCError(w, http.StatusForbidden, errorResponse)
 }
 
 // Middleware creates an HTTP middleware that authorizes MCP requests.

--- a/pkg/mcp/jsonrpc_write.go
+++ b/pkg/mcp/jsonrpc_write.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"log/slog"
+	"net/http"
+
+	"golang.org/x/exp/jsonrpc2"
+)
+
+// EncodeJSONRPCError returns the wire encoding of a jsonrpc2 error response.
+//
+// This is the single sanctioned way to serialize a jsonrpc2 envelope in this
+// codebase. NEVER json.Marshal (or json.NewEncoder().Encode) a jsonrpc2 type:
+// jsonrpc2.Response carries no json tags and jsonrpc2.ID's only field is
+// unexported, so reflection produces Go-capitalized keys, drops the mandatory
+// "jsonrpc":"2.0" tag, and renders every id — valid or not — as "{}" (#5950).
+// jsonrpc2.EncodeMessage marshals through the library's tagged wire struct:
+// lowercase keys, the version tag stamped unconditionally, and an id that is
+// omitted when absent (never null, which MCP cannot express and the reference
+// TypeScript SDK client rejects, #6038) while a legitimate id of 0 survives.
+//
+// EncodeMessage cannot fail for a Response built from an ID and a
+// jsonrpc2.NewError; if it somehow does, this logs and falls back to a
+// hardcoded, conformant Internal Error body rather than returning nothing —
+// the original code and id are not trustworthy at that point.
+func EncodeJSONRPCError(resp *jsonrpc2.Response) []byte {
+	body, err := jsonrpc2.EncodeMessage(resp)
+	if err != nil {
+		slog.Error("failed to encode JSON-RPC error response", "error", err)
+		return []byte(`{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error"}}`)
+	}
+	return body
+}
+
+// WriteJSONRPCError writes resp as an HTTP response: the JSON-RPC error body
+// under Content-Type application/json with the given HTTP status. The body is
+// encoded before any header is written, so an encode failure never leaves a
+// half-written response (see EncodeJSONRPCError for the fallback). Returns
+// the body write error; callers with no recovery path may discard it.
+//
+// Do not use this to write into an SSE stream — a bare JSON object in a
+// text/event-stream parses as an unrecognized field and is silently
+// discarded (#6037); SSE paths must frame the body as an event instead.
+func WriteJSONRPCError(w http.ResponseWriter, httpStatus int, resp *jsonrpc2.Response) error {
+	body := EncodeJSONRPCError(resp)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatus)
+	_, err := w.Write(body)
+	return err
+}

--- a/pkg/mcp/jsonrpc_write_test.go
+++ b/pkg/mcp/jsonrpc_write_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+)
+
+// TestEncodeJSONRPCError pins the wire properties the helper exists to
+// guarantee: lowercase keys with the version tag stamped (the #5950 bug was
+// reflection over the untagged jsonrpc2.Response), an absent id omitted
+// rather than rendered null (#6038), and a legitimate id of 0 surviving —
+// the omitempty on the library's wire struct tests IsNil, not zero-ness.
+func TestEncodeJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		id   jsonrpc2.ID
+		want string
+	}{
+		{
+			name: "int64 id",
+			id:   jsonrpc2.Int64ID(42),
+			want: `{"jsonrpc":"2.0","id":42,"error":{"code":403,"message":"denied"}}`,
+		},
+		{
+			name: "string id",
+			id:   jsonrpc2.StringID("abc"),
+			want: `{"jsonrpc":"2.0","id":"abc","error":{"code":403,"message":"denied"}}`,
+		},
+		{
+			name: "zero id survives",
+			id:   jsonrpc2.Int64ID(0),
+			want: `{"jsonrpc":"2.0","id":0,"error":{"code":403,"message":"denied"}}`,
+		},
+		{
+			name: "empty id omits the key",
+			id:   jsonrpc2.ID{},
+			want: `{"jsonrpc":"2.0","error":{"code":403,"message":"denied"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := EncodeJSONRPCError(&jsonrpc2.Response{
+				ID:    tt.id,
+				Error: jsonrpc2.NewError(JSONRPCCodeDenied, "denied"),
+			})
+
+			// assert.JSONEq is key-case-sensitive, so this single assertion
+			// catches "Error"/"ID" substituted for "error"/"id" and a missing
+			// "jsonrpc" tag; key presence is asserted separately because a
+			// decoded nil is indistinguishable from a decoded null.
+			assert.JSONEq(t, tt.want, string(body))
+
+			var decoded map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(body, &decoded))
+			_, hasID := decoded["id"]
+			assert.Equal(t, tt.id != jsonrpc2.ID{}, hasID, "id key presence mismatch")
+		})
+	}
+}
+
+func TestWriteJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	rr := httptest.NewRecorder()
+	err := WriteJSONRPCError(rr, http.StatusForbidden, &jsonrpc2.Response{
+		ID:    jsonrpc2.Int64ID(7),
+		Error: jsonrpc2.NewError(JSONRPCCodeDenied, "denied"),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"jsonrpc":"2.0","id":7,"error":{"code":403,"message":"denied"}}`, rr.Body.String())
+}

--- a/pkg/webhook/mutating/middleware.go
+++ b/pkg/webhook/mutating/middleware.go
@@ -328,19 +328,8 @@ func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, ms
 		Error: jsonrpc2.NewError(code, message),
 	}
 
-	// Encode before writing any header, so an encode failure never leaves a
-	// half-written response (e.g. a status header followed by a second write).
-	body, encErr := jsonrpc2.EncodeMessage(errResp)
-	if encErr != nil {
-		// Unreachable in practice: errResp is always a well-formed jsonrpc2.Response
-		// built from strings/ints above. Fall back to a hardcoded valid JSON-RPC
-		// error body rather than writing nothing.
-		slog.Error("failed to encode JSON-RPC error response", "error", encErr)
-		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, code)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	//nolint:gosec // G104: writing the JSON-RPC denial body to an HTTP client; nothing to do on error
-	_, _ = w.Write(body)
+	// The helper encodes before writing any header, so an encode failure never
+	// leaves a half-written response (e.g. a status header followed by a
+	// second write). Nothing to do on a write error for a denial body.
+	_ = mcp.WriteJSONRPCError(w, statusCode, errResp)
 }

--- a/pkg/webhook/validating/middleware.go
+++ b/pkg/webhook/validating/middleware.go
@@ -194,19 +194,8 @@ func sendErrorResponse(w http.ResponseWriter, statusCode int, message string, ms
 		Error: jsonrpc2.NewError(code, message),
 	}
 
-	// Encode before writing any header, so an encode failure never leaves a
-	// half-written response (e.g. a status header followed by a second write).
-	body, encErr := jsonrpc2.EncodeMessage(errResp)
-	if encErr != nil {
-		// Unreachable in practice: errResp is always a well-formed jsonrpc2.Response
-		// built from strings/ints above. Fall back to a hardcoded valid JSON-RPC
-		// error body rather than writing nothing.
-		slog.Error("failed to encode JSON-RPC error response", "error", encErr)
-		body = fmt.Appendf(nil, `{"jsonrpc":"2.0","error":{"code":%d,"message":"Internal error"}}`, code)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	//nolint:gosec // G104: writing the JSON-RPC denial body to an HTTP client; nothing to do on error
-	_, _ = w.Write(body)
+	// The helper encodes before writing any header, so an encode failure never
+	// leaves a half-written response (e.g. a status header followed by a
+	// second write). Nothing to do on a write error for a denial body.
+	_ = mcp.WriteJSONRPCError(w, statusCode, errResp)
 }


### PR DESCRIPTION
## Summary

**Why.** Three HTTP denial paths — authz `handleUnauthorized` and both webhook `sendErrorResponse`s — each carry a private copy of the same block: encode a `*jsonrpc2.Response` via `jsonrpc2.EncodeMessage` before writing any header, fall back to a hardcoded conformant body on the (unreachable) encode failure, set `Content-Type`, write status, write body. That block exists because of #5950: `encoding/json` on a `jsonrpc2` type reflects Go-capitalized keys, drops the mandatory `"jsonrpc":"2.0"` tag, and renders every id as `{}` — and the only enforcement of "never `json.Marshal` a `jsonrpc2` type" has been a greppable convention across hand-rolled copies. #6055's reviewer notes rejected a *map-building* shared helper (an `any`-typed id parameter is exactly how a caller reintroduces the `{}` id bug) but said a narrower helper taking a jsonrpc2 message "is worth a follow-up". This is that follow-up.

**What.** `mcp.EncodeJSONRPCError` and `mcp.WriteJSONRPCError` (`pkg/mcp/jsonrpc_write.go`) take a typed `*jsonrpc2.Response` — no `any`-typed id anywhere — encode before any header is written, and fall back to a hardcoded conformant `-32603` body on encode failure. The three sites collapse onto them; each keeps its own semantics (status, code via #6066's `mcp.JSONRPCCodeForStatus`, message policy). Behavior is unchanged except the per-site fallback bodies, which were unreachable and now uniformly report `-32603` rather than echoing a code whose integrity is unknown once encoding has failed.

**Scope: deliberately three sites, not four.** The fourth carrier of this block, `pkg/authz/response_filter.go`, is being rewritten upstream — #6087 restructures its error write path and #6088 rewrites it again — so collapsing it here would guarantee conflicts and duplicate that work. It keeps its private copy for now and can adopt the helper in a follow-up once those land; this PR touches that file **zero** lines. Three of four sites is still real consolidation, and the helper is the landing spot for the fourth.

**Honest scoping against #6066**: it changed *which* code each site emits and scrubbed leaked text, but kept each site's private copy of the encode-fallback-write block — so the duplication is still real. Had #6066 centralized the write path, the honest answer here would have been "no longer worth it"; it didn't.

**Convention + lint stance**: the "never `json.Marshal` a `jsonrpc2` type" rule is recorded in `.claude/rules/go-style.md` (with the omit-absent-id corollary from #6038/#6068). A lint gate was considered and deliberately **not** added: forbidigo matches call-expression text and cannot see argument types, so it cannot distinguish marshaling a `jsonrpc2` value from any other `json.Marshal`; the only precise option is wiring gocritic/ruleguard, which is not worth the infrastructure for one rule. The helper plus the recorded convention is the enforcement.

Part of the #5950/#6038/#6039 error-contract cleanup line; the helper follow-up named in #6055's "Special notes for reviewers".

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests — new `pkg/mcp/jsonrpc_write_test.go` pins the helper's wire properties (lowercase keys + version tag via case-sensitive `JSONEq`; absent id omitted, never `"id":null`; `id: 0` survives — `omitempty` on the wire struct tests `IsNil`, not zero-ness; status + `Content-Type` on the write path). All three collapsed sites remain covered by their existing envelope-conformance tests (`pkg/authz`, `pkg/webhook/...` — all green), which is the point: a behavior-preserving refactor should need no assertion changes, and it didn't.
- [x] Linting (`task lint-fix`) — 0 issues.

`task test` not used locally (known gotestfmt v2.5.0 panic); CI runs the real thing.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/mcp/jsonrpc_write.go` | The two helpers + the doc comment that carries the #5950 rationale |
| `pkg/mcp/jsonrpc_write_test.go` | Wire-property pins (key case, id omission, zero id, status/content-type) |
| `pkg/authz/middleware.go` | `handleUnauthorized` collapses onto `mcp.WriteJSONRPCError` |
| `pkg/webhook/{validating,mutating}/middleware.go` | `sendErrorResponse` collapses onto the helper; keeps #6066's `mcp.JSONRPCCodeForStatus` |
| `.claude/rules/go-style.md` | "JSON-RPC Envelopes" convention section |

## Does this introduce a user-facing change?

No. Wire behavior at all three sites is unchanged; only the unreachable encode-failure fallbacks are unified.

## Special notes for reviewers

- The helper deliberately does not absorb the tree's remaining *map-based* envelope builders (session not-found, rate-limit, classification, tool-filter): those hold `any`-typed ids and no `jsonrpc2.ID`, which is precisely the shape #6055's objection warned about; they were made conformant by #6068 and stay as they are.
- `pkg/authz/response_filter.go` is intentionally absent (see the scope note above) — #6087/#6088 own that file's error path right now; the natural follow-up after they land is a two-line adoption of `mcp.EncodeJSONRPCError` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5WXPQr5Da9Cox2nZWhg6n