### PR TITLE
Drop ambiguous prompt names instead of failing aggregation

### DIFF
--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -150,19 +150,48 @@ policies that deliberately differ by what the identity *is*:
   in `priorityOrder` keep their bare prompt names, a bare-name collision among
   listed backends resolves to the highest-priority one, and unlisted backends
   stay always-prefixed — deliberately stricter than tool priority resolution,
-  which lets a conflict-free unlisted tool keep its bare name. The invariant
-  both modes preserve: the advertised name is a pure function of the
-  aggregation config and (backendID, name), so it never shifts because an
-  unrelated backend joined or left the group. That stability matters beyond
-  naming: authorization matches on the advertised name (Cedar builds
-  `Prompt::"<advertised name>"` entities), so a membership-dependent rename
-  would detach `permit` and `forbid` policies from the prompt they were
-  written for — names move only on an explicit config edit. A `manual`
-  configuration changes tool resolution only. If two backends' advertised
-  names compose to the same string (backend `b1` prompt `x_y` vs backend
-  `b1_x` prompt `y`, or a prefixed name hitting a listed backend's literal
-  name), the name would be ambiguous between backends and aggregation fails
-  loudly instead of dropping one.
+  which lets a conflict-free unlisted tool keep its bare name. A `manual`
+  configuration changes tool resolution only.
+
+  The invariant both modes preserve, scoped precisely: the advertised name of a
+  given (backendID, name) **pair** is a pure function of the aggregation config
+  and that pair, so it never shifts because an unrelated backend joined or left
+  the group. That stability matters beyond naming: authorization matches on the
+  advertised name (Cedar builds `Prompt::"<advertised name>"` entities), so a
+  membership-dependent rename would detach `permit` and `forbid` policies from
+  the prompt they were written for — names move only on an explicit config
+  edit.
+
+  The invariant does **not** promise that an advertised *string* keeps naming
+  the same prompt. Under `priority`, two listed backends can claim the same
+  bare name and the higher-ranked one takes it, so a
+  `permit(... resource == Prompt::"review")` written while `b1` owned `review`
+  silently begins authorizing `b2`'s **different** prompt once a higher-ranked
+  `b2` advertising that name deploys — no config edit involved. Cedar's
+  resource identity is the advertised name and nothing else (it carries no
+  backend attribute), so whoever wins a shared name inherits every policy
+  written for it. `forbid` still fails closed, because the priority loser is
+  **dropped rather than aliased**; it is `permit` that gets redirected. Keep
+  `priorityOrder` and name-scoped `permit` policies under review together.
+
+  The loser being dropped instead of re-prefixed is deliberate: prefixing it so
+  "nothing is lost" would re-advertise that prompt under a name no policy
+  mentions, putting it beyond any `forbid` written on the bare name — the
+  fail-open this design exists to avoid.
+
+  When two advertised names compose to the same string and no backend owns it —
+  backend `b1` prompt `x_y` vs backend `b1_x` prompt `y`, or a prefixed name
+  hitting a listed backend's literal name — the name is **ambiguous**, and
+  **every** colliding prompt is dropped with the collision logged at `ERROR`.
+  Aggregation does not fail:
+  erroring would take the group's entire aggregated view down (tools,
+  resources, templates, prompts, backend visibility) over one prompt name that
+  needs no conflict-resolution config to reach — just an unlucky combination of
+  operator-chosen workload names and backend-chosen prompt names. Keeping one
+  claimant is not an option either, since the survivor would inherit whatever
+  policy was written for the prompt it collided with. With the name advertised
+  by nobody, every `permit` and `forbid` on it is vacuous and the rest of the
+  group keeps serving.
 - **Resource URIs and template strings are locators, not names.** The client
   passes them back verbatim (`resources/read`, `resources/subscribe`,
   completion refs), backends emit them in notifications and embedded resource

--- a/pkg/vmcp/aggregator/capability_conflicts.go
+++ b/pkg/vmcp/aggregator/capability_conflicts.go
@@ -4,7 +4,6 @@
 package aggregator
 
 import (
-	"fmt"
 	"log/slog"
 	"maps"
 	"slices"
@@ -56,16 +55,52 @@ import (
 //     than the tool priority resolver, which lets a conflict-free unlisted
 //     tool keep its bare name.
 //
-//     The invariant both modes preserve: an advertised prompt name is a pure
-//     function of the aggregation config and (backendID, prompt name) — it
-//     NEVER shifts because an unrelated backend joined or left the group.
-//     That stability is a security property, not cosmetics: the advertised
-//     name is what authorization matches on (Cedar builds
-//     Prompt::"<advertised name>" entities — see pkg/vmcp/core/admission.go),
-//     so a membership-dependent rename would silently detach permit AND
-//     forbid policies from the prompt they were written for, the forbid case
-//     failing open. Names move only on an explicit config edit — the moment
-//     an operator reviews policy anyway.
+//     Under priority the losing prompt is DROPPED, never re-prefixed. That is
+//     deliberate and must stay that way: re-prefixing the loser to "save" it
+//     would re-advertise the same prompt under a name no policy mentions, so
+//     a forbid written against the bare name would stop matching it — a
+//     fail-open. Do not "improve" this by prefixing the loser instead of
+//     dropping it.
+//
+//     The invariant both modes preserve, scoped precisely: the advertised
+//     name of a given (backendID, prompt name) PAIR is a pure function of the
+//     aggregation config and that pair — it NEVER shifts because an unrelated
+//     backend joined or left the group. That stability is a security property,
+//     not cosmetics: the advertised name is what authorization matches on
+//     (Cedar builds Prompt::"<advertised name>" entities — see
+//     pkg/vmcp/core/admission.go), so a membership-dependent rename would
+//     silently detach permit AND forbid policies from the prompt they were
+//     written for, the forbid case failing open. Names move only on an
+//     explicit config edit — the moment an operator reviews policy anyway.
+//
+//     What the invariant does NOT promise is that a given advertised STRING
+//     keeps naming the same prompt. Under priority two listed backends can
+//     claim the same bare name, and the higher-ranked one takes it: a
+//     permit(... resource == Prompt::"review") written while b1 owned "review"
+//     silently begins authorizing b2's DIFFERENT prompt once a higher-ranked
+//     b2 advertising that name deploys, with no config edit. Cedar's resource
+//     identity is Prompt::<advertised name> and nothing else — it carries no
+//     backend attribute — so whoever wins a shared name inherits every policy
+//     written for it. forbid still fails closed, because the loser is dropped
+//     rather than aliased; it is permit that gets redirected. Operators who
+//     write name-scoped permits must therefore review priorityOrder and their
+//     policy set together.
+//
+//     A name no single backend can own is advertised by NOBODY. When two
+//     distinct (backendID, name) pairs compose to the same advertised string
+//     (backend "b1" prompt "x_y" and backend "b1_x" prompt "y" both compose to
+//     "b1_x_y"), EVERY colliding prompt is dropped and the collision is logged
+//     at ERROR. Failing the aggregation instead would take out tools/list,
+//     resources/list, resource-templates/list, prompts/list, Discover's
+//     presence flags and backend visibility for the whole group over one
+//     ambiguous prompt name — and that name needs no conflict-resolution
+//     config to reach, just an unlucky combination of operator-chosen workload
+//     names and backend-chosen prompt names. Dropping every claimant is the
+//     safe outcome rather than the convenient one: keeping a survivor would
+//     hand it the ambiguous name and with it any policy written for the other
+//     prompt, whereas an unadvertised name makes every permit and forbid on it
+//     vacuous, so nothing is reachable under an ambiguous identity and the
+//     rest of the group keeps serving.
 //
 //     Prompt-set changes on a live backend propagate to connected sessions
 //     through the list_changed resync path
@@ -115,17 +150,20 @@ func resolveResourceTemplateConflicts(
 // identically, so nothing reachable is lost. A bare-name collision among
 // priority-listed backends resolves to the highest-priority one (lowest
 // rank), dropping the others with a warning, mirroring the tool priority
-// strategy. Any other collision — two prefixed names composing to the same
+// strategy. Any other collision — two advertised names composing to the same
 // string (backend "b1" prompt "x_y" vs backend "b1_x" prompt "y"), or a
-// prefixed name hitting a listed backend's literal bare name — is ambiguous
-// between backends and returns ErrUnresolvedConflicts rather than silently
-// dropping a prompt. backendIDs supplies the deterministic (sorted) iteration
+// prefixed name hitting a listed backend's literal bare name — has no defined
+// owner, so EVERY prompt claiming that name is dropped and the collision is
+// logged at ERROR. This never fails: the group keeps serving the prompts it
+// can name unambiguously, and the ambiguous name is advertised by nobody. See
+// the file header for why dropping all claimants beats both erroring and
+// keeping a survivor. backendIDs supplies the deterministic (sorted) iteration
 // order; the result is sorted by resolved name.
 func resolvePromptConflicts(
 	naming promptNaming,
 	backendIDs []string,
 	capabilities map[string]*BackendCapabilities,
-) ([]ResolvedPrompt, error) {
+) []ResolvedPrompt {
 	// candidate is one backend's claim on an advertised prompt name.
 	type candidate struct {
 		prompt    vmcp.Prompt
@@ -162,23 +200,39 @@ func resolvePromptConflicts(
 	resolved := make([]ResolvedPrompt, 0, len(byName))
 	for _, resolvedName := range slices.Sorted(maps.Keys(byName)) {
 		candidates := byName[resolvedName]
+
+		// Distinct backends claiming one advertised name is resolvable only
+		// when every claimant is priority-listed: then all claims are the same
+		// bare name and rank decides. Anything else — prefix composition
+		// ambiguity, or a prefixed name hitting a listed backend's literal
+		// name — has no defined owner, so no claimant may keep the name.
+		// Promoting one would give it whatever policy was written for the
+		// others, since Cedar authorizes on the advertised name alone.
+		if len(candidates) > 1 && slices.ContainsFunc(candidates, func(c candidate) bool { return !c.listed }) {
+			// Index-aligned with droppedPrompts: entry i names the backend that
+			// claimed original prompt name i.
+			droppedBackends := make([]string, 0, len(candidates))
+			droppedPrompts := make([]string, 0, len(candidates))
+			for _, c := range candidates {
+				droppedBackends = append(droppedBackends, c.backendID)
+				droppedPrompts = append(droppedPrompts, c.prompt.Name)
+			}
+			slog.Error("advertised prompt name is ambiguous between backends, dropping every colliding prompt; "+
+				"rename one of them to make the name reachable again",
+				"prompt", resolvedName,
+				"dropped_backends", droppedBackends,
+				"dropped_prompts", droppedPrompts)
+			continue
+		}
+
 		winner := candidates[0]
 		for _, contender := range candidates[1:] {
-			// Distinct backends claim the same advertised name. Resolvable
-			// only when both are priority-listed (then both claims are the
-			// same bare name and rank decides); anything else — prefix
-			// composition ambiguity, or a prefixed name hitting a listed
-			// backend's literal name — has no defined owner.
-			if !winner.listed || !contender.listed {
-				return nil, fmt.Errorf(
-					"%w: prompt %q from backend %q and prompt %q from backend %q are both advertised as %q; rename one of them",
-					ErrUnresolvedConflicts,
-					winner.prompt.Name, winner.backendID, contender.prompt.Name, contender.backendID, resolvedName)
-			}
 			loser := contender
 			if contender.rank < winner.rank {
 				loser, winner = winner, contender
 			}
+			// The loser is dropped, not re-prefixed; see the file header for
+			// why re-prefixing it would fail policy open.
 			slog.Warn("prompt name advertised by multiple priority-listed backends, keeping highest priority",
 				"prompt", resolvedName, "kept_backend", winner.backendID, "dropped_backend", loser.backendID)
 		}
@@ -187,7 +241,7 @@ func resolvePromptConflicts(
 		resolvedPrompt.Name = resolvedName
 		resolved = append(resolved, resolvedPrompt)
 	}
-	return resolved, nil
+	return resolved
 }
 
 // dedupeByKey collects items of one capability kind across backends in the

--- a/pkg/vmcp/aggregator/capability_conflicts_test.go
+++ b/pkg/vmcp/aggregator/capability_conflicts_test.go
@@ -241,25 +241,115 @@ func TestDefaultAggregator_ResolveConflicts_PromptConflicts(t *testing.T) {
 	}
 }
 
-// TestDefaultAggregator_ResolveConflicts_PromptPrefixAmbiguity pins the one
-// residual collision unconditional prefixing cannot rule out: two distinct
-// (backendID, name) pairs composing to the same prefixed string. That name
-// would be ambiguous between backends, so aggregation must fail loudly
-// instead of silently dropping one of the prompts.
-func TestDefaultAggregator_ResolveConflicts_PromptPrefixAmbiguity(t *testing.T) {
+// TestDefaultAggregator_PromptAmbiguityDropsEveryClaimant pins the drop-all
+// policy for the one residual collision unconditional prefixing cannot rule
+// out: distinct (backendID, name) pairs whose advertised names compose to the
+// same string. Two properties matter and both are asserted below. Aggregation
+// must NOT fail — an error here would take down the group's whole aggregated
+// view (tools, resources, templates, prompts, backend visibility) over one
+// prompt name reachable without any conflict-resolution config. And no
+// claimant may keep the name: Cedar authorizes on the advertised name alone,
+// so a survivor would inherit every policy written for the prompt it collided
+// with. Dropping all of them leaves the name advertised by nobody.
+func TestDefaultAggregator_PromptAmbiguityDropsEveryClaimant(t *testing.T) {
 	t.Parallel()
 
-	capabilities := map[string]*BackendCapabilities{
-		// "b1" + "x_y" and "b1_x" + "y" both advertise as "b1_x_y".
-		"b1":   {BackendID: "b1", Prompts: []vmcp.Prompt{newTestPrompt("x_y", "b1")}},
-		"b1_x": {BackendID: "b1_x", Prompts: []vmcp.Prompt{newTestPrompt("y", "b1_x")}},
+	priorityCfg := &config.AggregationConfig{
+		ConflictResolution: vmcp.ConflictStrategyPriority,
+		ConflictResolutionConfig: &config.ConflictResolutionConfig{
+			PriorityOrder: []string{"b1"},
+		},
 	}
 
-	agg := NewDefaultAggregator(nil, nil, nil, nil)
-	resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
-	require.ErrorIs(t, err, ErrUnresolvedConflicts)
-	assert.Contains(t, err.Error(), "b1_x_y")
-	assert.Nil(t, resolved)
+	tests := []struct {
+		name   string
+		aggCfg *config.AggregationConfig
+		// promptsByBackend maps backend ID -> the prompt names it serves.
+		promptsByBackend map[string][]string
+		// wantAdvertised maps every SURVIVING advertised name -> {owning
+		// backend, original name}. Compared for exact equality, so a claimant
+		// that wrongly survives the ambiguity shows up here.
+		wantAdvertised map[string][2]string
+		// wantAmbiguous is the name no backend may advertise or route.
+		wantAmbiguous string
+	}{
+		{
+			// "b1" + "x_y" and "b1_x" + "y" both compose to "b1_x_y".
+			name: "two backends compose to the same prefixed name",
+			promptsByBackend: map[string][]string{
+				"b1":   {"x_y", "safe"},
+				"b1_x": {"y"},
+			},
+			wantAdvertised: map[string][2]string{"b1_safe": {"b1", "safe"}},
+			wantAmbiguous:  "b1_x_y",
+		},
+		{
+			// Three-way: "b1"+"x_y_z", "b1_x"+"y_z" and "b1_x_y"+"z" all
+			// compose to "b1_x_y_z". Dropping "the other one" is not enough.
+			name: "three backends compose to the same prefixed name",
+			promptsByBackend: map[string][]string{
+				"b1":     {"x_y_z"},
+				"b1_x":   {"y_z"},
+				"b1_x_y": {"z", "safe"},
+			},
+			wantAdvertised: map[string][2]string{"b1_x_y_safe": {"b1_x_y", "safe"}},
+			wantAmbiguous:  "b1_x_y_z",
+		},
+		{
+			// Priority-listed b1 advertises the literal name "ext_helper";
+			// unlisted ext's "helper" prefixes to the same string. Listed
+			// status does not make a composition collision resolvable, so both
+			// go, while b1's other bare name is untouched.
+			name:   "prefixed name hits a listed backend's literal bare name",
+			aggCfg: priorityCfg,
+			promptsByBackend: map[string][]string{
+				"b1":  {"ext_helper", "kept"},
+				"ext": {"helper"},
+			},
+			wantAdvertised: map[string][2]string{"kept": {"b1", "kept"}},
+			wantAmbiguous:  "ext_helper",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			backends := make([]vmcp.Backend, 0, len(tt.promptsByBackend))
+			capsByID := make(map[string]*vmcp.CapabilityList, len(tt.promptsByBackend))
+			for backendID, names := range tt.promptsByBackend {
+				backends = append(backends, newTestBackend(backendID))
+				prompts := make([]vmcp.Prompt, 0, len(names))
+				for _, name := range names {
+					prompts = append(prompts, newTestPrompt(name, backendID))
+				}
+				capsByID[backendID] = newTestCapabilityList(withPrompts(prompts...))
+			}
+
+			ctrl := gomock.NewController(t)
+			mockClient := mocks.NewMockBackendClient(ctrl)
+			expectListCapabilities(mockClient, capsByID)
+
+			agg := NewDefaultAggregator(mockClient, nil, tt.aggCfg, nil)
+			result, err := agg.AggregateCapabilities(context.Background(), backends)
+			require.NoError(t, err, "one ambiguous prompt name must not fail the group's aggregation")
+
+			// Survivors are read back through the routing table so the case
+			// also pins that each still translates to its backend's own name.
+			got := make(map[string][2]string, len(result.Prompts))
+			for _, prompt := range result.Prompts {
+				target := result.RoutingTable.Prompts[prompt.Name]
+				require.NotNilf(t, target, "advertised prompt %q must be routable", prompt.Name)
+				got[prompt.Name] = [2]string{prompt.BackendID, target.GetBackendCapabilityName(prompt.Name)}
+			}
+			assert.Equal(t, tt.wantAdvertised, got)
+			assert.NotContains(t, result.RoutingTable.Prompts, tt.wantAmbiguous,
+				"an ambiguous prompt name must not be routable either")
+			assert.Equal(t, len(tt.wantAdvertised), result.Metadata.PromptCount)
+			ctrl.Finish()
+		})
+	}
 }
 
 // TestDefaultAggregator_ResolveConflicts_PromptPriority pins the priority
@@ -280,56 +370,42 @@ func TestDefaultAggregator_ResolveConflicts_PromptPriority(t *testing.T) {
 		},
 	}
 
-	t.Run("listed backends keep bare names, rank resolves collisions", func(t *testing.T) {
-		t.Parallel()
-		capabilities := map[string]*BackendCapabilities{
-			"b1": {BackendID: "b1", Prompts: []vmcp.Prompt{
-				newTestPrompt("review", "b1"), newTestPrompt("unique", "b1"),
-			}},
-			"b2":  {BackendID: "b2", Prompts: []vmcp.Prompt{newTestPrompt("review", "b2")}},
-			"ext": {BackendID: "ext", Prompts: []vmcp.Prompt{newTestPrompt("helper", "ext")}},
-		}
+	capabilities := map[string]*BackendCapabilities{
+		"b1": {BackendID: "b1", Prompts: []vmcp.Prompt{
+			newTestPrompt("review", "b1"), newTestPrompt("unique", "b1"),
+		}},
+		"b2":  {BackendID: "b2", Prompts: []vmcp.Prompt{newTestPrompt("review", "b2")}},
+		"ext": {BackendID: "ext", Prompts: []vmcp.Prompt{newTestPrompt("helper", "ext")}},
+	}
 
-		agg := NewDefaultAggregator(nil, nil, aggCfg, nil)
-		for range 5 {
-			resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
-			require.NoError(t, err)
-
-			got := make(map[string][2]string, len(resolved.Prompts))
-			for _, prompt := range resolved.Prompts {
-				got[prompt.Name] = [2]string{prompt.BackendID, prompt.OriginalName}
-			}
-			assert.Equal(t, map[string][2]string{
-				// "review" goes to b2: first in priorityOrder, even though b1
-				// sorts first. b1's colliding prompt is dropped.
-				"review": {"b2", "review"},
-				// Listed backends keep bare names even for unique prompts.
-				"unique": {"b1", "unique"},
-				// Unlisted backends are ALWAYS prefixed, collision or not:
-				// exempting them would let a later join shift the name.
-				"ext_helper": {"ext", "helper"},
-			}, got)
-			assert.NotContains(t, got, "helper")
-			assert.NotContains(t, got, "b1_review")
-		}
-	})
-
-	t.Run("prefixed name hitting a listed backend's literal name errors", func(t *testing.T) {
-		t.Parallel()
-		capabilities := map[string]*BackendCapabilities{
-			// Listed b1 advertises the literal name "ext_helper"; unlisted
-			// ext's "helper" prefixes to the same string. Ambiguous between
-			// backends -> loud failure, not a silent drop.
-			"b1":  {BackendID: "b1", Prompts: []vmcp.Prompt{newTestPrompt("ext_helper", "b1")}},
-			"ext": {BackendID: "ext", Prompts: []vmcp.Prompt{newTestPrompt("helper", "ext")}},
-		}
-
-		agg := NewDefaultAggregator(nil, nil, aggCfg, nil)
+	agg := NewDefaultAggregator(nil, nil, aggCfg, nil)
+	for range 5 {
 		resolved, err := agg.ResolveConflicts(context.Background(), capabilities)
-		require.ErrorIs(t, err, ErrUnresolvedConflicts)
-		assert.Contains(t, err.Error(), "ext_helper")
-		assert.Nil(t, resolved)
-	})
+		require.NoError(t, err)
+
+		got := make(map[string][2]string, len(resolved.Prompts))
+		for _, prompt := range resolved.Prompts {
+			got[prompt.Name] = [2]string{prompt.BackendID, prompt.OriginalName}
+		}
+		assert.Equal(t, map[string][2]string{
+			// "review" goes to b2: first in priorityOrder, even though b1
+			// sorts first. b1's colliding prompt is dropped.
+			"review": {"b2", "review"},
+			// Listed backends keep bare names even for unique prompts.
+			"unique": {"b1", "unique"},
+			// Unlisted backends are ALWAYS prefixed, collision or not:
+			// exempting them would let a later join shift the name.
+			"ext_helper": {"ext", "helper"},
+		}, got)
+		assert.NotContains(t, got, "helper")
+		// The priority loser is dropped, not re-prefixed: re-advertising it as
+		// "b1_review" would put it beyond any forbid written on "review".
+		assert.NotContains(t, got, "b1_review")
+	}
+
+	// A prefixed name colliding with a listed backend's literal bare name is
+	// covered by TestDefaultAggregator_PromptAmbiguityDropsEveryClaimant,
+	// alongside the other composition collisions.
 }
 
 // TestDefaultAggregator_ResolveConflicts_PromptPrefixFormat verifies prompt

--- a/pkg/vmcp/aggregator/default_aggregator.go
+++ b/pkg/vmcp/aggregator/default_aggregator.go
@@ -274,10 +274,7 @@ func (a *defaultAggregator) ResolveConflicts(
 	backendIDs := slices.Sorted(maps.Keys(capabilities))
 	resolved.Resources = resolveResourceConflicts(backendIDs, capabilities)
 	resolved.ResourceTemplates = resolveResourceTemplateConflicts(backendIDs, capabilities)
-	resolved.Prompts, err = resolvePromptConflicts(a.promptNaming, backendIDs, capabilities)
-	if err != nil {
-		return nil, fmt.Errorf("prompt conflict resolution failed: %w", err)
-	}
+	resolved.Prompts = resolvePromptConflicts(a.promptNaming, backendIDs, capabilities)
 
 	for _, caps := range capabilities {
 		// Aggregate logging/sampling support (OR logic - enabled if any backend supports)


### PR DESCRIPTION
## Summary

Addresses post-merge review feedback on #6075 ([discussion_r3665086460](https://github.com/stacklok/toolhive/pull/6075#discussion_r3665086460)), which landed ~12 minutes before that PR merged and was never applied.

- **The hard error's blast radius was wildly out of proportion to its trigger.** `ErrUnresolvedConflicts` from `resolvePromptConflicts` propagated out of `ResolveConflicts` before the already-computed tools, resources and templates were ever returned, so one ambiguous prompt name failed the *entire* aggregated view: `tools/list`, `resources/list`, `resource-templates/list`, `prompts/list`, `Discover`'s presence flags, and backend visibility through `authorizedBackends`. Errors are never cached, so while the condition persisted every request re-swept every backend and failed again. And the condition needs no conflict-resolution config to reach — an unlucky combination of operator-chosen workload names and backend-chosen prompt names is enough (backend `b1` prompt `x_y` and backend `b1_x` prompt `y` both compose to `b1_x_y`). Now **every** prompt claiming an ambiguous name is dropped and the collision is logged at `ERROR`; aggregation succeeds and the rest of the group keeps serving.
- **Dropping *all* claimants, not just the loser, is the load-bearing part.** The tool precedent (`prefix_resolver.go`) drops only the loser, which does not work here: the survivor would inherit the ambiguous name and with it any policy written for the prompt it collided with, since Cedar's resource identity is `Prompt::"<advertised name>"` and nothing else. With the name advertised by nobody, every `permit` and `forbid` on it is vacuous and nothing is reachable under an ambiguous identity.
- **The header docstring overclaimed its own invariant.** It asserted a blanket "the advertised name never moves". That holds per `(backendID, name)` *pair*, but not for a shared *string*: under `priority`, a `permit(... resource == Prompt::"review")` written while `b1` owned that name silently begins authorizing `b2`'s **different** prompt once a higher-ranked `b2` deploys, with no config edit. The invariant is now scoped to the pair and the permit-redirection caveat is stated explicitly. `forbid` still fails closed, because the loser is dropped rather than aliased.
- **The drop-not-re-prefix decision is now protected in the comment.** The obvious future "improvement" — don't drop the priority loser, prefix it so nothing is lost — is exactly what reopens the fail-open, and nothing warned against it. The header now says the drop is deliberate and why.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

`task test` passes; the only failures are three pre-existing environment-dependent ones in this sandbox (`TestNewServer_ReadTimeoutConfigured`, `TestSecurityHeaders` — both "no available runtime found" — and `TestCompositeProvider_RealProviders`), all unrelated to this change. `task lint-fix` reports 0 issues. `task docs` produces no diff (no CLI-facing text changed).

`TestDefaultAggregator_ResolveConflicts_PromptPrefixAmbiguity` pinned the hard error; it is replaced by `TestDefaultAggregator_PromptAmbiguityDropsEveryClaimant`, which runs the **full** `AggregateCapabilities` pipeline so it can assert the ambiguous name is absent from both the advertised list and the routing table, that surviving prompts still translate back to their backend's own name, and that aggregation returns no error. Three cases: a two-way composition collision, a three-way one, and a prefixed name hitting a priority-listed backend's literal bare name (that last case moved here from `..._PromptPriority`, which no longer has a competing error assertion).

Both mutations the fix must be robust against were checked against the new tests:

| Mutation | Result |
|---|---|
| Keep the first claimant instead of dropping all (the tool precedent) | All three subtests fail — the ambiguous name appears in the advertised map and in `RoutingTable.Prompts` |
| Revert to returning `ErrUnresolvedConflicts` | `require.NoError` fails; `AggregateCapabilities` propagates any `ResolveConflicts` error verbatim (`default_aggregator.go:466-469`) |

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/aggregator/capability_conflicts.go` | Drop-all on ambiguity with an `ERROR` log naming the name, the colliding backends and their original prompt names; `resolvePromptConflicts` loses its error return; header rewritten for the three review points |
| `pkg/vmcp/aggregator/default_aggregator.go` | Prompt resolution no longer produces an error to propagate |
| `pkg/vmcp/aggregator/capability_conflicts_test.go` | Ambiguity test rewritten to pin drop-both over the full pipeline, three-way case added, priority-loser drop assertion given its rationale |
| `docs/arch/10-virtual-mcp-architecture.md` | Conflict Resolution section: drop-both instead of hard error, per-pair invariant, permit-redirection caveat, drop-not-re-prefix rationale |

`ErrUnresolvedConflicts` itself is untouched and still used by the manual tool resolver (`manual_resolver.go:166`). Tool resolution is unchanged.

## Does this introduce a user-facing change?

Yes. A vMCP group whose backends produce an ambiguous advertised prompt name previously served nothing at all — every list verb failed until an operator renamed something. It now serves everything except the colliding prompts, which are dropped and reported at `ERROR`. No configuration change is needed to pick this up.

## Special notes for reviewers

**On surfacing (the one open item from the review).** The reviewer's caveat was that "the hard error is impossible to miss and drop-both isn't... If you take it, surface it somewhere an operator actually sees, not only `slog.Warn`." This PR logs at `ERROR` rather than `WARN`, and richer surfacing is **deliberately deferred** — every candidate surface needs new plumbing that would dwarf the fix:

- `/status` (`pkg/vmcp/server/status.go`) is built from the backend registry and the health monitor. The server holds no reference to the aggregation result — the caching aggregator owns it and hands it back per request — so routing dropped-prompt state there means new server-held state plus its invalidation.
- `AggregationMetadata` exists but is consumed only for trace-span attributes and `Debug` logs; nothing operator-facing reads it. Making it operator-visible is the same plumbing problem one layer down.
- `VirtualMCPServer.Status` would be the right home, but the operator observes discovered backends, not the running aggregator's per-request conflict outcomes. That is a CRD field plus a controller feedback path.
- The aggregator has no meter, so a metric means threading a `MeterProvider` through `NewDefaultAggregator` and its call sites.

Happy to open a follow-up for whichever of these you consider the right long-term surface — my instinct is a counter on `AggregationMetadata` exposed through `/status` — but it wants its own PR and its own design discussion rather than riding along here.

**On the mixed-listed case.** A group where *some* claimants are priority-listed and some are not is treated as ambiguous and all claimants are dropped, matching the pre-existing resolvability condition (`!winner.listed || !contender.listed`). Priority rank only decides when *every* claimant is listed, i.e. when all claims are literally the same bare name.

Generated with [Claude Code](https://claude.com/claude-code)