### PR TITLE
test(e2e): quarantine uvx arxiv test broken by Python mcp 2.0.0

### DIFF
--- a/test/e2e/protocol_builds_e2e_test.go
+++ b/test/e2e/protocol_builds_e2e_test.go
@@ -206,6 +206,18 @@ var _ = Describe("Protocol Builds E2E", Label("mcp", "mcp-protocol", "protocols"
 			})
 
 			It("should build and start successfully and provide arxiv tools [Serial]", func() {
+				// Quarantined 2026-07-28: arxiv-mcp-server declares an unbounded
+				// mcp>=1.27.0, so every fresh uvx build now resolves the Python
+				// mcp 2.0.0 major (released 2026-07-28T13:45Z) and crashes at
+				// import ('Server' object has no attribute 'list_prompts'),
+				// failing this test repo-wide for every PR. The official
+				// reference servers (mcp-server-fetch/time/git) are equally
+				// unbounded and equally broken, so there is no safe swap-in
+				// target. Unskip when upstream bounds or updates its mcp
+				// dependency, or when the uvx builder supports dependency
+				// constraints. See stacklok/toolhive#6108.
+				Skip("arxiv-mcp-server import-crashes under Python mcp 2.0.0; see #6108")
+
 				By("Starting the ArXiv MCP server using uvx:// protocol")
 				stdout, stderr := e2e.NewTHVCommand(config, "run",
 					"--name", serverName,


### PR DESCRIPTION
Fixes the repo-wide `E2E Tests Core (mcp-protocol)` failure diagnosed in #6108: Python `mcp` 2.0.0 (released today 13:45Z) breaks `arxiv-mcp-server` at import via its unbounded `mcp>=1.27.0`, so every fresh `uvx` build crashes and the proxy port refuses connections — deterministically, on every PR.

This skips the one affected test with a full rationale comment and a pointer to #6108. Verified there is no safe swap-in target: the official reference servers (`mcp-server-fetch`/`-time`/`-git`) carry equally unbounded `mcp>=` constraints and import-crash identically under 2.0.0 (reproduced in clean venvs).

Durable options (tracked in #6108, deliberately not decided here):
1. uvx builder support for dependency constraints (e.g. `uv tool install --with/--constraints`),
2. a hermetic in-repo uvx fixture package with bounded deps (local-path build),
3. upstream PRs bounding `mcp<2` in the affected packages.

Unskip when any of those lands.

Refs #6108

🤖 Generated with [Claude Code](https://claude.com/claude-code)