### PR TITLE
Close workflow audit log writers

### DIFF
--- a/pkg/audit/auditor.go
+++ b/pkg/audit/auditor.go
@@ -107,7 +107,15 @@ func NewAuditorWithTransport(config *Config, transportType string) (*Auditor, er
 // Close closes the underlying log writer if it implements io.Closer.
 // This should be called when the auditor is no longer needed to properly release resources.
 func (a *Auditor) Close() error {
-	if closer, ok := a.logWriter.(io.Closer); ok {
+	return closeLogWriter(a.logWriter)
+}
+
+func closeLogWriter(logWriter io.Writer) error {
+	if logWriter == os.Stdout || logWriter == os.Stderr {
+		return nil
+	}
+
+	if closer, ok := logWriter.(io.Closer); ok {
 		return closer.Close()
 	}
 	return nil

--- a/pkg/audit/auditor.go
+++ b/pkg/audit/auditor.go
@@ -88,7 +88,15 @@ func NewAuditorWithTransport(config *Config, transportType string) (*Auditor, er
 // Close closes the underlying log writer if it implements io.Closer.
 // This should be called when the auditor is no longer needed to properly release resources.
 func (a *Auditor) Close() error {
-	if closer, ok := a.logWriter.(io.Closer); ok {
+	return closeLogWriter(a.logWriter)
+}
+
+func closeLogWriter(logWriter io.Writer) error {
+	if logWriter == os.Stdout || logWriter == os.Stderr {
+		return nil
+	}
+
+	if closer, ok := logWriter.(io.Closer); ok {
 		return closer.Close()
 	}
 	return nil

--- a/pkg/audit/auditor_test.go
+++ b/pkg/audit/auditor_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +33,16 @@ func TestNewAuditor(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, auditor)
 	assert.Equal(t, config, auditor.config)
+}
+
+func TestAuditor_CloseDoesNotCloseStdout(t *testing.T) {
+	t.Parallel()
+
+	auditor := &Auditor{logWriter: os.Stdout}
+
+	require.NoError(t, auditor.Close())
+	_, err := os.Stdout.Write(nil)
+	require.NoError(t, err, "Close() must not close os.Stdout")
 }
 
 func TestAuditorMiddlewareDisabled(t *testing.T) {

--- a/pkg/audit/workflow_auditor.go
+++ b/pkg/audit/workflow_auditor.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"time"
 
@@ -21,6 +22,7 @@ type WorkflowAuditor struct {
 	auditLogger *slog.Logger
 	config      *Config
 	component   string
+	logWriter   io.Writer
 }
 
 // NewWorkflowAuditor creates a new workflow auditor.
@@ -45,7 +47,14 @@ func NewWorkflowAuditor(config *Config) (*WorkflowAuditor, error) {
 		auditLogger: NewAuditLogger(logWriter),
 		config:      config,
 		component:   component,
+		logWriter:   logWriter,
 	}, nil
+}
+
+// Close closes the underlying log writer if it owns a closeable resource.
+// This should be called when the workflow auditor is no longer needed.
+func (w *WorkflowAuditor) Close() error {
+	return closeLogWriter(w.logWriter)
 }
 
 // LogWorkflowStarted logs the start of workflow execution.

--- a/pkg/audit/workflow_auditor_test.go
+++ b/pkg/audit/workflow_auditor_test.go
@@ -24,9 +24,23 @@ type testLogWriter struct {
 	logs []string
 }
 
+type closeTrackingWriter struct {
+	closed   bool
+	closeErr error
+}
+
 func (w *testLogWriter) Write(p []byte) (n int, err error) {
 	w.logs = append(w.logs, string(p))
 	return len(p), nil
+}
+
+func (*closeTrackingWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func (w *closeTrackingWriter) Close() error {
+	w.closed = true
+	return w.closeErr
 }
 
 func (w *testLogWriter) getLastLog() string {
@@ -53,6 +67,7 @@ func createTestAuditor(t *testing.T, config *Config) (*WorkflowAuditor, *testLog
 		auditLogger: NewAuditLogger(writer),
 		config:      config,
 		component:   "vmcp-composer",
+		logWriter:   writer,
 	}
 
 	return auditor, writer
@@ -121,6 +136,48 @@ func TestNewWorkflowAuditor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWorkflowAuditor_Close(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closes retained file writer", func(t *testing.T) {
+		t.Parallel()
+
+		logFilePath := t.TempDir() + "/workflow-audit.log"
+		auditor, err := NewWorkflowAuditor(&Config{LogFile: logFilePath})
+		require.NoError(t, err)
+
+		_, ok := auditor.logWriter.(interface{ Close() error })
+		require.True(t, ok, "file-backed workflow auditor should retain a closeable writer")
+
+		require.NoError(t, auditor.Close())
+	})
+
+	t.Run("does not close stdout", func(t *testing.T) {
+		t.Parallel()
+
+		auditor, err := NewWorkflowAuditor(&Config{})
+		require.NoError(t, err)
+
+		require.NoError(t, auditor.Close())
+		_, err = os.Stdout.Write(nil)
+		require.NoError(t, err, "Close() must not close os.Stdout")
+		assert.Same(t, os.Stdout, auditor.logWriter)
+	})
+
+	t.Run("propagates close errors", func(t *testing.T) {
+		t.Parallel()
+
+		closeErr := errors.New("close failed")
+		writer := &closeTrackingWriter{closeErr: closeErr}
+		auditor := &WorkflowAuditor{logWriter: writer}
+
+		err := auditor.Close()
+
+		require.ErrorIs(t, err, closeErr)
+		assert.True(t, writer.closed)
+	})
 }
 
 func TestWorkflowAuditor_LogWorkflowStarted(t *testing.T) {

--- a/pkg/audit/workflow_auditor_test.go
+++ b/pkg/audit/workflow_auditor_test.go
@@ -23,9 +23,23 @@ type testLogWriter struct {
 	logs []string
 }
 
+type closeTrackingWriter struct {
+	closed   bool
+	closeErr error
+}
+
 func (w *testLogWriter) Write(p []byte) (n int, err error) {
 	w.logs = append(w.logs, string(p))
 	return len(p), nil
+}
+
+func (*closeTrackingWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func (w *closeTrackingWriter) Close() error {
+	w.closed = true
+	return w.closeErr
 }
 
 func (w *testLogWriter) getLastLog() string {
@@ -52,6 +66,7 @@ func createTestAuditor(t *testing.T, config *Config) (*WorkflowAuditor, *testLog
 		auditLogger: NewAuditLogger(writer),
 		config:      config,
 		component:   "vmcp-composer",
+		logWriter:   writer,
 	}
 
 	return auditor, writer
@@ -120,6 +135,54 @@ func TestNewWorkflowAuditor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWorkflowAuditor_Close(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closes retained file writer", func(t *testing.T) {
+		t.Parallel()
+
+		logFilePath := t.TempDir() + "/workflow-audit.log"
+		auditor, err := NewWorkflowAuditor(&Config{LogFile: logFilePath})
+		require.NoError(t, err)
+
+		_, ok := auditor.logWriter.(interface{ Close() error })
+		require.True(t, ok, "file-backed workflow auditor should retain a closeable writer")
+
+		require.NoError(t, auditor.Close())
+	})
+
+	t.Run("does not close stdout", func(t *testing.T) {
+		t.Parallel()
+
+		auditor, err := NewWorkflowAuditor(&Config{})
+		require.NoError(t, err)
+
+		require.NoError(t, auditor.Close())
+		assert.Same(t, os.Stdout, auditor.logWriter)
+	})
+
+	t.Run("propagates close errors", func(t *testing.T) {
+		t.Parallel()
+
+		closeErr := errors.New("close failed")
+		writer := &closeTrackingWriter{closeErr: closeErr}
+		auditor := &WorkflowAuditor{logWriter: writer}
+
+		err := auditor.Close()
+
+		require.ErrorIs(t, err, closeErr)
+		assert.True(t, writer.closed)
+	})
+}
+
+func TestAuditor_CloseDoesNotCloseStdout(t *testing.T) {
+	t.Parallel()
+
+	auditor := &Auditor{logWriter: os.Stdout}
+
+	require.NoError(t, auditor.Close())
 }
 
 func TestWorkflowAuditor_LogWorkflowStarted(t *testing.T) {

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -71,6 +71,10 @@ type coreVMCP struct {
 	// by advertised tool name.
 	workflowDefs map[string]*composer.WorkflowDefinition
 
+	// workflowAuditor owns the optional workflow audit log writer and is closed
+	// with the core. Nil when workflow audit logging is disabled.
+	workflowAuditor *audit.WorkflowAuditor
+
 	// composerFactory builds a per-call composite-tool engine bound to a routing
 	// table, generalizing server.New's sessionComposerFactory (server.go:393).
 	composerFactory func(sessionRT *vmcp.RoutingTable, sessionTools []vmcp.Tool) composer.Composer
@@ -138,6 +142,14 @@ func New(cfg *Config) (VMCP, error) {
 		}
 		slog.Info("workflow audit logging enabled")
 	}
+	closeWorkflowAuditor := func() {
+		if workflowAuditor == nil {
+			return
+		}
+		if err := workflowAuditor.Close(); err != nil {
+			slog.Warn("failed to close workflow auditor", "error", err)
+		}
+	}
 
 	// The elicitation handler depends only on the domain-typed ElicitationRequester
 	// (#5436); no mcp-go types cross this boundary (vmcp anti-pattern #5).
@@ -168,6 +180,7 @@ func New(cfg *Config) (VMCP, error) {
 	instruments, err := newWorkflowInstruments(cfg.TelemetryProvider)
 	if err != nil {
 		stopStore()
+		closeWorkflowAuditor()
 		return nil, fmt.Errorf("failed to create workflow telemetry instruments: %w", err)
 	}
 
@@ -195,6 +208,7 @@ func New(cfg *Config) (VMCP, error) {
 	workflowDefs, err := validateWorkflowDefs(validationEngine, cfg.WorkflowDefs)
 	if err != nil {
 		stopStore()
+		closeWorkflowAuditor()
 		return nil, fmt.Errorf("workflow validation failed: %w", err)
 	}
 
@@ -206,6 +220,7 @@ func New(cfg *Config) (VMCP, error) {
 	healthMonitor, healthProvider, err := buildHealthMonitor(cfg)
 	if err != nil {
 		stopStore()
+		closeWorkflowAuditor()
 		return nil, err
 	}
 
@@ -217,6 +232,7 @@ func New(cfg *Config) (VMCP, error) {
 		healthMonitor:   healthMonitor,
 		admission:       admission,
 		workflowDefs:    workflowDefs,
+		workflowAuditor: workflowAuditor,
 		composerFactory: composerFactory,
 		stopStore:       stopStore,
 	}, nil
@@ -543,6 +559,11 @@ func (c *coreVMCP) InvalidateCapabilityCache() {
 func (c *coreVMCP) Close() error {
 	c.closeOnce.Do(func() {
 		c.stopStore()
+		if c.workflowAuditor != nil {
+			if err := c.workflowAuditor.Close(); err != nil {
+				slog.Warn("failed to close workflow auditor", "error", err)
+			}
+		}
 		if c.healthMonitor != nil {
 			if err := c.healthMonitor.Stop(); err != nil {
 				slog.Warn("failed to stop health monitor", "error", err)

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -85,6 +86,7 @@ type coreVMCP struct {
 	stopStore func()
 
 	closeOnce sync.Once
+	closeErr  error
 }
 
 var _ VMCP = (*coreVMCP)(nil)
@@ -142,13 +144,15 @@ func New(cfg *Config) (VMCP, error) {
 		}
 		slog.Info("workflow audit logging enabled")
 	}
-	closeWorkflowAuditor := func() {
+	closeWorkflowAuditor := func() error {
 		if workflowAuditor == nil {
-			return
+			return nil
 		}
 		if err := workflowAuditor.Close(); err != nil {
 			slog.Warn("failed to close workflow auditor", "error", err)
+			return err
 		}
+		return nil
 	}
 
 	// The elicitation handler depends only on the domain-typed ElicitationRequester
@@ -180,8 +184,11 @@ func New(cfg *Config) (VMCP, error) {
 	instruments, err := newWorkflowInstruments(cfg.TelemetryProvider)
 	if err != nil {
 		stopStore()
-		closeWorkflowAuditor()
-		return nil, fmt.Errorf("failed to create workflow telemetry instruments: %w", err)
+		cleanupErr := closeWorkflowAuditor()
+		return nil, errors.Join(
+			fmt.Errorf("failed to create workflow telemetry instruments: %w", err),
+			cleanupErr,
+		)
 	}
 
 	// composerFactory builds a composite-tool engine bound to a specific routing
@@ -208,8 +215,8 @@ func New(cfg *Config) (VMCP, error) {
 	workflowDefs, err := validateWorkflowDefs(validationEngine, cfg.WorkflowDefs)
 	if err != nil {
 		stopStore()
-		closeWorkflowAuditor()
-		return nil, fmt.Errorf("workflow validation failed: %w", err)
+		cleanupErr := closeWorkflowAuditor()
+		return nil, errors.Join(fmt.Errorf("workflow validation failed: %w", err), cleanupErr)
 	}
 
 	// Build and start the backend health monitor (#5443 reversal: the core owns its
@@ -220,8 +227,8 @@ func New(cfg *Config) (VMCP, error) {
 	healthMonitor, healthProvider, err := buildHealthMonitor(cfg)
 	if err != nil {
 		stopStore()
-		closeWorkflowAuditor()
-		return nil, err
+		cleanupErr := closeWorkflowAuditor()
+		return nil, errors.Join(err, cleanupErr)
 	}
 
 	return &coreVMCP{
@@ -553,24 +560,32 @@ func (c *coreVMCP) InvalidateCapabilityCache() {
 	invalidator.InvalidateAll()
 }
 
-// Close stops the workflow state store's cleanup goroutine. It is idempotent:
-// the underlying Stop closes a channel that cannot be closed twice, so the work
-// is guarded by sync.Once and subsequent calls return nil.
+// Close stops the workflow state store's cleanup goroutine, closes the optional
+// workflow auditor, and stops the health monitor. It returns cleanup errors from
+// the first call, and is idempotent: the underlying cleanup work is guarded by
+// sync.Once and subsequent calls return nil.
 func (c *coreVMCP) Close() error {
+	ran := false
 	c.closeOnce.Do(func() {
+		ran = true
 		c.stopStore()
 		if c.workflowAuditor != nil {
 			if err := c.workflowAuditor.Close(); err != nil {
 				slog.Warn("failed to close workflow auditor", "error", err)
+				c.closeErr = errors.Join(c.closeErr, err)
 			}
 		}
 		if c.healthMonitor != nil {
 			if err := c.healthMonitor.Stop(); err != nil {
 				slog.Warn("failed to stop health monitor", "error", err)
+				c.closeErr = errors.Join(c.closeErr, err)
 			}
 		}
 	})
-	return nil
+	if !ran {
+		return nil
+	}
+	return c.closeErr
 }
 
 // aggregatedView health-filters the backend registry and aggregates capabilities

--- a/pkg/vmcp/core/core_vmcp_test.go
+++ b/pkg/vmcp/core/core_vmcp_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/stacklok/toolhive/pkg/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
@@ -59,6 +62,27 @@ func baseConfig(t *testing.T) (*Config, *coreMocks) {
 		BackendClient:   m.client,
 	}
 	return cfg, m
+}
+
+func requireNoOpenFDForPath(t *testing.T, path string) {
+	t.Helper()
+
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+	for _, entry := range entries {
+		target, err := os.Readlink(filepath.Join("/proc/self/fd", entry.Name()))
+		if err != nil {
+			continue
+		}
+		require.NotEqual(t, path, target, "audit log file descriptor must be closed")
+	}
+}
+
+func closeErrorPathAuditConfig(t *testing.T) (*audit.Config, string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "workflow-audit.log")
+	return &audit.Config{LogFile: path}, path
 }
 
 // testBackendID is the single backend ID used across these tests.
@@ -113,6 +137,84 @@ func TestNew_NilConfig(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, vmcp.ErrInvalidConfig)
 	assert.Nil(t, c)
+}
+
+func TestNew_CloseReleasesWorkflowAuditLogFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closes retained audit log file", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, _ := baseConfig(t)
+		cfg.AuditConfig, _ = closeErrorPathAuditConfig(t)
+
+		c, err := New(cfg)
+		require.NoError(t, err)
+		require.NoError(t, c.Close())
+
+		require.ErrorIs(t, c.(*coreVMCP).workflowAuditor.Close(), os.ErrClosed)
+	})
+
+	t.Run("logs close errors without failing Close", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, _ := baseConfig(t)
+		cfg.AuditConfig, _ = closeErrorPathAuditConfig(t)
+
+		c, err := New(cfg)
+		require.NoError(t, err)
+		core := c.(*coreVMCP)
+		require.NoError(t, core.workflowAuditor.Close())
+
+		require.NoError(t, c.Close())
+	})
+}
+
+func TestNew_ErrorPathsCloseWorkflowAuditLogFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *Config, *coreMocks)
+	}{
+		{
+			name: "workflow validation error",
+			mutate: func(_ *testing.T, cfg *Config, _ *coreMocks) {
+				cfg.WorkflowDefs = map[string]*composer.WorkflowDefinition{
+					"wf": {
+						Name: "wf",
+						Steps: []composer.WorkflowStep{
+							{ID: "s1", Type: composer.StepTypeTool, Tool: "be1.tool", DependsOn: []string{"s2"}},
+							{ID: "s2", Type: composer.StepTypeTool, Tool: "be1.tool", DependsOn: []string{"s1"}},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "health monitor creation error",
+			mutate: func(_ *testing.T, cfg *Config, mocks *coreMocks) {
+				mocks.reg.EXPECT().List(gomock.Any()).Return(nil)
+				cfg.HealthMonitorConfig = &health.MonitorConfig{}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, mocks := baseConfig(t)
+			var auditLogPath string
+			cfg.AuditConfig, auditLogPath = closeErrorPathAuditConfig(t)
+			tt.mutate(t, cfg, mocks)
+
+			c, err := New(cfg)
+
+			require.Error(t, err)
+			assert.Nil(t, c)
+			requireNoOpenFDForPath(t, auditLogPath)
+		})
+	}
 }
 
 func TestNew_ValidatesWorkflows(t *testing.T) {

--- a/pkg/vmcp/core/core_vmcp_test.go
+++ b/pkg/vmcp/core/core_vmcp_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -66,6 +67,10 @@ func baseConfig(t *testing.T) (*Config, *coreMocks) {
 
 func requireNoOpenFDForPath(t *testing.T, path string) {
 	t.Helper()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("/proc/self/fd is Linux-only; fd-release is covered on Linux CI")
+	}
 
 	entries, err := os.ReadDir("/proc/self/fd")
 	require.NoError(t, err)

--- a/pkg/vmcp/core/core_vmcp_test.go
+++ b/pkg/vmcp/core/core_vmcp_test.go
@@ -160,7 +160,7 @@ func TestNew_CloseReleasesWorkflowAuditLogFile(t *testing.T) {
 		require.ErrorIs(t, c.(*coreVMCP).workflowAuditor.Close(), os.ErrClosed)
 	})
 
-	t.Run("logs close errors without failing Close", func(t *testing.T) {
+	t.Run("returns first close error and keeps later Close idempotent", func(t *testing.T) {
 		t.Parallel()
 
 		cfg, _ := baseConfig(t)
@@ -171,6 +171,9 @@ func TestNew_CloseReleasesWorkflowAuditLogFile(t *testing.T) {
 		core := c.(*coreVMCP)
 		require.NoError(t, core.workflowAuditor.Close())
 
+		err = c.Close()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrClosed)
 		require.NoError(t, c.Close())
 	})
 }


### PR DESCRIPTION
## Summary

- Workflow audit logging can currently leak a file descriptor when `Config.LogFile` is set because `NewWorkflowAuditor` opens a log writer but the returned auditor does not retain or expose a way to close it.
- Retain the workflow auditor log writer, add `WorkflowAuditor.Close()`, and close the optional workflow auditor from `coreVMCP.Close()` and core construction error paths.
- Share close handling with the HTTP auditor and avoid closing `os.Stdout`/`os.Stderr` when audit logging uses default output.

Fixes #6094

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual testing:

- `PATH=/usr/local/go/bin:/root/go/bin:$PATH task lint`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test -race ./pkg/audit ./pkg/vmcp/core`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./pkg/vmcp/composer`

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/audit/auditor.go` | Reuse a shared close helper and avoid closing stdout/stderr. |
| `pkg/audit/workflow_auditor.go` | Retain the log writer and expose `Close()`. |
| `pkg/audit/workflow_auditor_test.go` | Cover file-backed close, stdout handling, and close error propagation. |
| `pkg/vmcp/core/core_vmcp.go` | Close workflow auditor resources during shutdown and constructor cleanup paths. |

## Does this introduce a user-facing change?

No. This releases an internal audit log file descriptor when the workflow auditor owner is closed.
