### PR TITLE
Extract workflow audit event prologue

### DIFF
--- a/pkg/audit/workflow_auditor.go
+++ b/pkg/audit/workflow_auditor.go
@@ -48,6 +48,18 @@ func NewWorkflowAuditor(config *Config) (*WorkflowAuditor, error) {
 	}, nil
 }
 
+func (w *WorkflowAuditor) newEvent(ctx context.Context, eventType string, outcome string) *AuditEvent {
+	event := NewAuditEvent(
+		eventType,
+		w.extractSource(ctx),
+		outcome,
+		w.extractSubjects(ctx),
+		w.component,
+	)
+	w.attachDelegation(ctx, event)
+	return event
+}
+
 // LogWorkflowStarted logs the start of workflow execution.
 func (w *WorkflowAuditor) LogWorkflowStarted(
 	ctx context.Context,
@@ -60,17 +72,7 @@ func (w *WorkflowAuditor) LogWorkflowStarted(
 		return
 	}
 
-	source := w.extractSource(ctx)
-	subjects := w.extractSubjects(ctx)
-
-	event := NewAuditEvent(
-		EventTypeWorkflowStarted,
-		source,
-		OutcomeSuccess,
-		subjects,
-		w.component,
-	)
-	w.attachDelegation(ctx, event)
+	event := w.newEvent(ctx, EventTypeWorkflowStarted, OutcomeSuccess)
 
 	target := map[string]string{
 		TargetKeyWorkflowID:   workflowID,
@@ -112,17 +114,7 @@ func (w *WorkflowAuditor) LogWorkflowCompleted(
 		return
 	}
 
-	source := w.extractSource(ctx)
-	subjects := w.extractSubjects(ctx)
-
-	event := NewAuditEvent(
-		EventTypeWorkflowCompleted,
-		source,
-		OutcomeSuccess,
-		subjects,
-		w.component,
-	)
-	w.attachDelegation(ctx, event)
+	event := w.newEvent(ctx, EventTypeWorkflowCompleted, OutcomeSuccess)
 
 	target := map[string]string{
 		TargetKeyWorkflowID:   workflowID,
@@ -165,17 +157,7 @@ func (w *WorkflowAuditor) LogWorkflowFailed(
 		return
 	}
 
-	source := w.extractSource(ctx)
-	subjects := w.extractSubjects(ctx)
-
-	event := NewAuditEvent(
-		EventTypeWorkflowFailed,
-		source,
-		OutcomeFailure,
-		subjects,
-		w.component,
-	)
-	w.attachDelegation(ctx, event)
+	event := w.newEvent(ctx, EventTypeWorkflowFailed, OutcomeFailure)
 
 	target := map[string]string{
 		TargetKeyWorkflowID:   workflowID,
@@ -205,17 +187,7 @@ func (w *WorkflowAuditor) LogWorkflowTimedOut(
 		return
 	}
 
-	source := w.extractSource(ctx)
-	subjects := w.extractSubjects(ctx)
-
-	event := NewAuditEvent(
-		EventTypeWorkflowTimedOut,
-		source,
-		OutcomeFailure,
-		subjects,
-		w.component,
-	)
-	w.attachDelegation(ctx, event)
+	event := w.newEvent(ctx, EventTypeWorkflowTimedOut, OutcomeFailure)
 
 	target := map[string]string{
 		TargetKeyWorkflowID:   workflowID,
@@ -245,17 +217,7 @@ func (w *WorkflowAuditor) LogStepStarted(
 		return
 	}
 
-	source := w.extractSource(ctx)
-	subjects := w.extractSubjects(ctx)
-
-	event := NewAuditEvent(
-		EventTypeWorkflowStepStarted,
-		source,
-		OutcomeSuccess,
-		subjects,
-		w.component,
-	)
-	w.attachDelegation(ctx, event)
+	event := w.newEvent(ctx, EventTypeWorkflowStepStarted, OutcomeSuccess)
 
 	target := map[string]string{
 		TargetKeyWorkflowID: workflowID,
@@ -283,17 +245,7 @@ func (w *WorkflowAuditor) LogStepCompleted(
 		return
 	}
 
-	source := w.extractSource(ctx)
-	subjects := w.extractSubjects(ctx)
-
-	event := NewAuditEvent(
-		EventTypeWorkflowStepCompleted,
-		source,
-		OutcomeSuccess,
-		subjects,
-		w.component,
-	)
-	w.attachDelegation(ctx, event)
+	event := w.newEvent(ctx, EventTypeWorkflowStepCompleted, OutcomeSuccess)
 
 	target := map[string]string{
 		TargetKeyWorkflowID: workflowID,
@@ -323,17 +275,7 @@ func (w *WorkflowAuditor) LogStepFailed(
 		return
 	}
 
-	source := w.extractSource(ctx)
-	subjects := w.extractSubjects(ctx)
-
-	event := NewAuditEvent(
-		EventTypeWorkflowStepFailed,
-		source,
-		OutcomeFailure,
-		subjects,
-		w.component,
-	)
-	w.attachDelegation(ctx, event)
+	event := w.newEvent(ctx, EventTypeWorkflowStepFailed, OutcomeFailure)
 
 	target := map[string]string{
 		TargetKeyWorkflowID: workflowID,
@@ -361,17 +303,7 @@ func (w *WorkflowAuditor) LogStepSkipped(
 		return
 	}
 
-	source := w.extractSource(ctx)
-	subjects := w.extractSubjects(ctx)
-
-	event := NewAuditEvent(
-		EventTypeWorkflowStepSkipped,
-		source,
-		OutcomeSuccess,
-		subjects,
-		w.component,
-	)
-	w.attachDelegation(ctx, event)
+	event := w.newEvent(ctx, EventTypeWorkflowStepSkipped, OutcomeSuccess)
 
 	target := map[string]string{
 		TargetKeyWorkflowID: workflowID,

--- a/pkg/audit/workflow_auditor_test.go
+++ b/pkg/audit/workflow_auditor_test.go
@@ -595,7 +595,7 @@ func TestWorkflowAuditor_ExtractSubjects(t *testing.T) {
 	}
 }
 
-func TestWorkflowAuditor_DelegationChain(t *testing.T) {
+func TestWorkflowAuditor_NewEvent(t *testing.T) {
 	t.Parallel()
 
 	delegatedChain := coreaudit.ParseDelegationChain(
@@ -617,124 +617,54 @@ func TestWorkflowAuditor_DelegationChain(t *testing.T) {
 		},
 	}
 
-	// attachDelegation is hand-repeated in every Log* method, so each call site is pinned individually.
-	logMethods := []struct {
-		name    string
-		logFunc func(a *WorkflowAuditor, ctx context.Context)
-	}{
-		{
-			name: "LogWorkflowStarted",
-			logFunc: func(a *WorkflowAuditor, ctx context.Context) {
-				a.LogWorkflowStarted(ctx, "wf-1", "wf", nil, time.Second)
-			},
-		},
-		{
-			name: "LogWorkflowCompleted",
-			logFunc: func(a *WorkflowAuditor, ctx context.Context) {
-				a.LogWorkflowCompleted(ctx, "wf-1", "wf", time.Second, 1, nil)
-			},
-		},
-		{
-			name: "LogWorkflowFailed",
-			logFunc: func(a *WorkflowAuditor, ctx context.Context) {
-				a.LogWorkflowFailed(ctx, "wf-1", "wf", time.Second, 1, errors.New("failed"))
-			},
-		},
-		{
-			name: "LogWorkflowTimedOut",
-			logFunc: func(a *WorkflowAuditor, ctx context.Context) {
-				a.LogWorkflowTimedOut(ctx, "wf-1", "wf", time.Second, 1)
-			},
-		},
-		{
-			name: "LogStepStarted",
-			logFunc: func(a *WorkflowAuditor, ctx context.Context) {
-				a.LogStepStarted(ctx, "wf-1", "step-1", "tool", "some-tool")
-			},
-		},
-		{
-			name: "LogStepCompleted",
-			logFunc: func(a *WorkflowAuditor, ctx context.Context) {
-				a.LogStepCompleted(ctx, "wf-1", "step-1", time.Second, 0)
-			},
-		},
-		{
-			name: "LogStepFailed",
-			logFunc: func(a *WorkflowAuditor, ctx context.Context) {
-				a.LogStepFailed(ctx, "wf-1", "step-1", time.Second, 0, errors.New("failed"))
-			},
-		},
-		{
-			name: "LogStepSkipped",
-			logFunc: func(a *WorkflowAuditor, ctx context.Context) {
-				a.LogStepSkipped(ctx, "wf-1", "step-1", "condition")
-			},
-		},
-	}
+	t.Run("adds source subjects and delegation", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range logMethods {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			auditor, writer := createTestAuditor(t, DefaultConfig())
+		auditor, _ := createTestAuditor(t, DefaultConfig())
+		ctx := auth.WithIdentity(context.Background(), delegatedIdentity)
 
-			ctx := auth.WithIdentity(context.Background(), delegatedIdentity)
-			tt.logFunc(auditor, ctx)
+		event := auditor.newEvent(ctx, EventTypeWorkflowStarted, OutcomeSuccess)
 
-			require.NotEmpty(t, writer.logs, "expected log entry")
-			entry := parseLogEntry(t, writer.getLastLog())
-
-			chain, ok := entry["delegation"].(map[string]any)
-			require.True(t, ok, "delegation should be present in the log output")
-			assert.Equal(t, false, chain["truncated"])
-			hops, ok := chain["chain"].([]any)
-			require.True(t, ok)
-			require.Len(t, hops, 2)
-			first, ok := hops[0].(map[string]any)
-			require.True(t, ok)
-			assert.Equal(t, "agent-1", first["sub"])
-			second, ok := hops[1].(map[string]any)
-			require.True(t, ok)
-			assert.Equal(t, "agent-2", second["sub"])
-		})
-	}
+		assert.Equal(t, EventTypeWorkflowStarted, event.Type)
+		assert.Equal(t, OutcomeSuccess, event.Outcome)
+		assert.Equal(t, "vmcp-composer", event.Component)
+		assert.Equal(t, SourceTypeLocal, event.Source.Type)
+		assert.Equal(t, "vmcp-composer", event.Source.Value)
+		assert.Equal(t, "Delegated User", event.Subjects[SubjectKeyUser])
+		require.NotNil(t, event.DelegationChain)
+		assert.False(t, event.DelegationChain.Truncated)
+		require.Len(t, event.DelegationChain.Chain, 2)
+		assert.Equal(t, "agent-1", event.DelegationChain.Chain[0].Subject)
+		assert.Equal(t, "agent-2", event.DelegationChain.Chain[1].Subject)
+	})
 
 	t.Run("no identity omits delegation chain", func(t *testing.T) {
 		t.Parallel()
-		auditor, writer := createTestAuditor(t, DefaultConfig())
 
-		auditor.LogWorkflowStarted(context.Background(), "wf-1", "wf", nil, time.Second)
+		auditor, _ := createTestAuditor(t, DefaultConfig())
 
-		require.NotEmpty(t, writer.logs, "expected log entry")
-		entry := parseLogEntry(t, writer.getLastLog())
+		event := auditor.newEvent(context.Background(), EventTypeWorkflowStarted, OutcomeSuccess)
 
-		_, exists := entry["delegation"]
-		assert.False(t, exists, "delegation should be omitted without an identity")
+		assert.Nil(t, event.DelegationChain)
+		assert.Equal(t, "anonymous", event.Subjects[SubjectKeyUser])
 	})
 
 	t.Run("configured max depth truncates chain", func(t *testing.T) {
 		t.Parallel()
+
 		maxDepth := 1
-		auditor, writer := createTestAuditor(t, &Config{MaxDelegationDepth: &maxDepth})
-
+		auditor, _ := createTestAuditor(t, &Config{MaxDelegationDepth: &maxDepth})
 		ctx := auth.WithIdentity(context.Background(), delegatedIdentity)
-		auditor.LogWorkflowStarted(ctx, "wf-1", "wf", nil, time.Second)
 
-		require.NotEmpty(t, writer.logs, "expected log entry")
-		entry := parseLogEntry(t, writer.getLastLog())
+		event := auditor.newEvent(ctx, EventTypeWorkflowStarted, OutcomeSuccess)
 
-		chain, ok := entry["delegation"].(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, true, chain["truncated"])
-		hops, ok := chain["chain"].([]any)
-		require.True(t, ok)
-		require.Len(t, hops, 1)
-		first, ok := hops[0].(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, "agent-1", first["sub"])
-		assert.Equal(t, float64(1), chain["omitted"])
+		require.NotNil(t, event.DelegationChain)
+		assert.True(t, event.DelegationChain.Truncated)
+		require.Len(t, event.DelegationChain.Chain, 1)
+		assert.Equal(t, "agent-1", event.DelegationChain.Chain[0].Subject)
+		assert.Equal(t, 1, event.DelegationChain.Omitted)
 	})
 }
-
 func TestWorkflowAuditor_ExtractSource(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Workflow audit logging repeated the same event prologue in all eight `Log*` methods, which made future cross-cutting additions easy to miss at individual call sites.
- Extract the shared source/subject/event/delegation setup into a private `newEvent` helper and route each workflow/step log method through it.
- Collapse the delegation-chain test from eight call-site checks to focused helper coverage for delegated, anonymous, and truncated-chain cases.

Fixes #6095

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual testing:

- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./pkg/audit`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test -race ./pkg/audit`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./pkg/vmcp/composer`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH task lint`
- `git diff --check`

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

No. This is an internal workflow-auditor refactor with no intended log schema or behavior change.
