### PR TITLE
Rename --uv-with to --build-with; reject constraints on unsupported ecosystems

### DIFF
--- a/cmd/thv/app/build.go
+++ b/cmd/thv/app/build.go
@@ -60,10 +60,10 @@ var buildFlags BuildFlags
 
 // BuildFlags holds the configuration for building MCP server containers
 type BuildFlags struct {
-	Tag    string
-	Output string
-	DryRun bool
-	UVWith []string
+	Tag       string
+	Output    string
+	DryRun    bool
+	BuildWith []string
 }
 
 func init() {
@@ -79,9 +79,10 @@ func AddBuildFlags(cmd *cobra.Command, config *BuildFlags) {
 		"(default builds an image instead of generating a Dockerfile)")
 	cmd.Flags().BoolVar(&config.DryRun, "dry-run", false, "Generate Dockerfile without building (stdout output unless -o is set) "+
 		"(default false)")
-	cmd.Flags().StringArrayVar(&config.UVWith, "uv-with", []string{},
-		"Additional PEP 508 requirement specifier passed to 'uv tool install --with' for uvx:// builds, "+
-			"e.g. --uv-with 'mcp<2' to constrain a transitive dependency (can be specified multiple times)")
+	cmd.Flags().StringArrayVar(&config.BuildWith, "build-with", []string{},
+		"Build-time dependency constraint for protocol scheme builds, interpreted per package ecosystem "+
+			"(uvx://: PEP 508 specifier passed to 'uv tool install --with', e.g. --build-with 'mcp<2'); "+
+			"errors on ecosystems without constraint support (can be specified multiple times)")
 }
 
 func buildCmdFunc(cmd *cobra.Command, args []string) error {
@@ -99,8 +100,8 @@ func buildCmdFunc(cmd *cobra.Command, args []string) error {
 
 	// Build runtime config override from flags (if any) and validate it early.
 	var runtimeOverride *templates.RuntimeConfig
-	if len(buildFlags.UVWith) > 0 {
-		runtimeOverride = &templates.RuntimeConfig{UVWith: buildFlags.UVWith}
+	if len(buildFlags.BuildWith) > 0 {
+		runtimeOverride = &templates.RuntimeConfig{BuildWith: buildFlags.BuildWith}
 		if err := runtimeOverride.Validate(); err != nil {
 			return fmt.Errorf("invalid runtime configuration: %w", err)
 		}

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -154,7 +154,7 @@ type RunFlags struct {
 	// Runtime configuration
 	RuntimeImage       string
 	RuntimeAddPackages []string
-	UVWith             []string
+	BuildWith          []string
 
 	// WebhookConfigs is a list of paths to webhook configuration files.
 	// Each file may define validating and/or mutating webhooks.
@@ -223,9 +223,10 @@ func AddRunFlags(cmd *cobra.Command, config *RunFlags) {
 		"Override the default base image for protocol schemes (e.g., golang:1.24-alpine, node:20-alpine, python:3.11-slim)")
 	cmd.Flags().StringArrayVar(&config.RuntimeAddPackages, "runtime-add-package", []string{},
 		"Add additional packages to install in the builder and runtime stages (can be repeated)")
-	cmd.Flags().StringArrayVar(&config.UVWith, "uv-with", []string{},
-		"Additional PEP 508 requirement specifier passed to 'uv tool install --with' for uvx:// builds, "+
-			"e.g. --uv-with 'mcp<2' to constrain a transitive dependency (can be specified multiple times)")
+	cmd.Flags().StringArrayVar(&config.BuildWith, "build-with", []string{},
+		"Build-time dependency constraint for protocol scheme builds, interpreted per package ecosystem "+
+			"(uvx://: PEP 508 specifier passed to 'uv tool install --with', e.g. --build-with 'mcp<2'); "+
+			"errors on ecosystems without constraint support (can be specified multiple times)")
 	cmd.Flags().StringVar(&config.VerifyImage, "image-verification", retriever.VerifyImageWarn,
 		fmt.Sprintf("Set image verification mode (%s, %s, %s)",
 			retriever.VerifyImageWarn, retriever.VerifyImageEnabled, retriever.VerifyImageDisabled))
@@ -499,11 +500,11 @@ func handleImageResolution(
 	// Validation here is intentionally duplicated with configureRuntimeOptions
 	// so that invalid input is caught early before registry lookups.
 	var runtimeOverride *templates.RuntimeConfig
-	if runFlags.RuntimeImage != "" || len(runFlags.RuntimeAddPackages) > 0 || len(runFlags.UVWith) > 0 {
+	if runFlags.RuntimeImage != "" || len(runFlags.RuntimeAddPackages) > 0 || len(runFlags.BuildWith) > 0 {
 		runtimeOverride = &templates.RuntimeConfig{
 			BuilderImage:       runFlags.RuntimeImage,
 			AdditionalPackages: runFlags.RuntimeAddPackages,
-			UVWith:             runFlags.UVWith,
+			BuildWith:          runFlags.BuildWith,
 		}
 		if err := runtimeOverride.Validate(); err != nil {
 			return "", nil, fmt.Errorf("invalid runtime configuration: %w", err)
@@ -635,14 +636,14 @@ func configureRemoteHeaderOptions(runFlags *RunFlags) ([]runner.RunConfigBuilder
 // It validates the configuration to prevent shell injection when values
 // are interpolated into Dockerfile templates.
 func configureRuntimeOptions(runFlags *RunFlags) ([]runner.RunConfigBuilderOption, error) {
-	if runFlags.RuntimeImage == "" && len(runFlags.RuntimeAddPackages) == 0 && len(runFlags.UVWith) == 0 {
+	if runFlags.RuntimeImage == "" && len(runFlags.RuntimeAddPackages) == 0 && len(runFlags.BuildWith) == 0 {
 		return nil, nil
 	}
 
 	runtimeConfig := &templates.RuntimeConfig{
 		BuilderImage:       runFlags.RuntimeImage,
 		AdditionalPackages: runFlags.RuntimeAddPackages,
-		UVWith:             runFlags.UVWith,
+		BuildWith:          runFlags.BuildWith,
 	}
 	if err := runtimeConfig.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid runtime configuration: %w", err)

--- a/docs/cli/thv_build.md
+++ b/docs/cli/thv_build.md
@@ -53,11 +53,11 @@ thv build [flags] PROTOCOL [-- ARGS...]
 ### Options
 
 ```
-      --dry-run               Generate Dockerfile without building (stdout output unless -o is set) (default false)
-  -h, --help                  help for build
-  -o, --output string         Write the Dockerfile to the specified file instead of building (default builds an image instead of generating a Dockerfile)
-  -t, --tag string            Name and optionally a tag in the 'name:tag' format for the built image (default generates a unique image name based on the package and transport type)
-      --uv-with stringArray   Additional PEP 508 requirement specifier passed to 'uv tool install --with' for uvx:// builds, e.g. --uv-with 'mcp<2' to constrain a transitive dependency (can be specified multiple times)
+      --build-with stringArray   Build-time dependency constraint for protocol scheme builds, interpreted per package ecosystem (uvx://: PEP 508 specifier passed to 'uv tool install --with', e.g. --build-with 'mcp<2'); errors on ecosystems without constraint support (can be specified multiple times)
+      --dry-run                  Generate Dockerfile without building (stdout output unless -o is set) (default false)
+  -h, --help                     help for build
+  -o, --output string            Write the Dockerfile to the specified file instead of building (default builds an image instead of generating a Dockerfile)
+  -t, --tag string               Name and optionally a tag in the 'name:tag' format for the built image (default generates a unique image name based on the package and transport type)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -115,6 +115,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --allowed-origins stringArray                 Exact-match allowlist for the HTTP Origin header (repeatable). Recommended when binding publicly; loopback binds derive a default allowlist automatically, non-loopback binds log a warning when no value is supplied. Example: https://my-mcp.example.com
       --audit-config string                         Path to the audit configuration file
       --authz-config string                         Path to the authorization configuration file
+      --build-with stringArray                      Build-time dependency constraint for protocol scheme builds, interpreted per package ecosystem (uvx://: PEP 508 specifier passed to 'uv tool install --with', e.g. --build-with 'mcp<2'); errors on ecosystems without constraint support (can be specified multiple times)
       --ca-cert string                              Path to a custom CA certificate file to use for container builds
       --enable-audit                                Enable audit logging with default configuration (default false)
       --endpoint-prefix string                      Path prefix to prepend to SSE endpoint URLs (e.g., /playwright)
@@ -197,7 +198,6 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
       --tools-override string                       Path to a JSON file containing overrides for MCP server tools names and descriptions
       --transport string                            Transport mode (sse, streamable-http or stdio)
       --trust-proxy-headers                         Trust X-Forwarded-* headers from reverse proxies (X-Forwarded-Proto, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Prefix) (default false)
-      --uv-with stringArray                         Additional PEP 508 requirement specifier passed to 'uv tool install --with' for uvx:// builds, e.g. --uv-with 'mcp<2' to constrain a transitive dependency (can be specified multiple times)
   -v, --volume stringArray                          Mount a volume into the container (format: host-path:container-path[:ro])
       --webhook-config stringArray                  Path to webhook configuration file (can be specified multiple times to merge configs)
 ```

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -4374,6 +4374,14 @@ const docTemplate = `{
                         "type": "array",
                         "uniqueItems": false
                     },
+                    "build_with": {
+                        "description": "BuildWith lists build-time dependency constraints, interpreted per\npackage ecosystem. For uvx:// builds these are PEP 508 requirement\nspecifiers passed to ` + "`" + `uv tool install --with` + "`" + `, used to constrain\ntransitive dependencies the package itself leaves unbounded\n(e.g. \"mcp\u003c2\"). Ecosystems without constraint support (npx://, go://)\nreject a non-empty BuildWith at build time.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
                     "builder_image": {
                         "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
                         "type": "string"
@@ -4384,14 +4392,6 @@ const docTemplate = `{
                         },
                         "description": "RuntimeEnv contains environment variables to inject into the Dockerfile's\nfinal runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),\nwhich only affects the builder stage, these variables are baked into the\nshipped image and are present in the running container's process\nenvironment at startup. Use this for values a packaged MCP server reads at\nprocess start (e.g. feature flags, cache backend selection), not for\nbuild-time package manager configuration.\nKeys must be uppercase with underscores, values are validated for safety.",
                         "type": "object"
-                    },
-                    "uv_with": {
-                        "description": "UVWith lists additional PEP 508 requirement specifiers passed to\n` + "`" + `uv tool install --with` + "`" + ` when building uvx:// packages. Use it to\nconstrain transitive dependencies that the package itself leaves\nunbounded (e.g. \"mcp\u003c2\"). Ignored by npx:// and go:// builds.",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -4367,6 +4367,14 @@
                         "type": "array",
                         "uniqueItems": false
                     },
+                    "build_with": {
+                        "description": "BuildWith lists build-time dependency constraints, interpreted per\npackage ecosystem. For uvx:// builds these are PEP 508 requirement\nspecifiers passed to `uv tool install --with`, used to constrain\ntransitive dependencies the package itself leaves unbounded\n(e.g. \"mcp\u003c2\"). Ecosystems without constraint support (npx://, go://)\nreject a non-empty BuildWith at build time.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
                     "builder_image": {
                         "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
                         "type": "string"
@@ -4377,14 +4385,6 @@
                         },
                         "description": "RuntimeEnv contains environment variables to inject into the Dockerfile's\nfinal runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),\nwhich only affects the builder stage, these variables are baked into the\nshipped image and are present in the running container's process\nenvironment at startup. Use this for values a packaged MCP server reads at\nprocess start (e.g. feature flags, cache backend selection), not for\nbuild-time package manager configuration.\nKeys must be uppercase with underscores, values are validated for safety.",
                         "type": "object"
-                    },
-                    "uv_with": {
-                        "description": "UVWith lists additional PEP 508 requirement specifiers passed to\n`uv tool install --with` when building uvx:// packages. Use it to\nconstrain transitive dependencies that the package itself leaves\nunbounded (e.g. \"mcp\u003c2\"). Ignored by npx:// and go:// builds.",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
                     }
                 },
                 "type": "object"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -3971,6 +3971,18 @@ components:
             type: string
           type: array
           uniqueItems: false
+        build_with:
+          description: |-
+            BuildWith lists build-time dependency constraints, interpreted per
+            package ecosystem. For uvx:// builds these are PEP 508 requirement
+            specifiers passed to `uv tool install --with`, used to constrain
+            transitive dependencies the package itself leaves unbounded
+            (e.g. "mcp<2"). Ecosystems without constraint support (npx://, go://)
+            reject a non-empty BuildWith at build time.
+          items:
+            type: string
+          type: array
+          uniqueItems: false
         builder_image:
           description: |-
             BuilderImage is the full image reference for the builder stage.
@@ -3990,16 +4002,6 @@ components:
             build-time package manager configuration.
             Keys must be uppercase with underscores, values are validated for safety.
           type: object
-        uv_with:
-          description: |-
-            UVWith lists additional PEP 508 requirement specifiers passed to
-            `uv tool install --with` when building uvx:// packages. Use it to
-            constrain transitive dependencies that the package itself leaves
-            unbounded (e.g. "mcp<2"). Ignored by npx:// and go:// builds.
-          items:
-            type: string
-          type: array
-          uniqueItems: false
       type: object
     tokenexchange.Config:
       description: TokenExchangeConfig contains token exchange configuration for external

--- a/pkg/container/templates/runtime_config.go
+++ b/pkg/container/templates/runtime_config.go
@@ -20,14 +20,14 @@ const maxPackageNameLength = 128
 // dots, underscores, plus signs, or hyphens.
 var packageNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+\-]*$`)
 
-// uvWithPattern matches a safe subset of PEP 508 requirement specifiers for
-// UVWith entries: a package name (optionally with extras) followed by version
+// buildWithPattern matches a safe subset of PEP 508 requirement specifiers for
+// BuildWith entries: a package name (optionally with extras) followed by version
 // specifiers, e.g. "mcp<2", "mcp>=1.27,<2", "pkg[extra]==1.2.*", "foo~=1.4".
 // The allowlist deliberately excludes quotes, backticks, dollar signs,
 // semicolons, parentheses, and backslashes: entries are interpolated into a
 // single-quoted shell word inside a Dockerfile RUN instruction, so anything
 // that could close the quote or expand in shell context is rejected.
-var uvWithPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+\[\],<>=!~* -]*$`)
+var buildWithPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+\[\],<>=!~* -]*$`)
 
 // envKeyPattern matches valid environment variable names for RuntimeEnv.
 // Must start with an uppercase letter, followed by uppercase letters, numbers, or underscores.
@@ -63,11 +63,13 @@ type RuntimeConfig struct {
 	// Examples for Debian: ["git", "build-essential"]
 	AdditionalPackages []string `json:"additional_packages,omitempty" yaml:"additional_packages,omitempty"`
 
-	// UVWith lists additional PEP 508 requirement specifiers passed to
-	// `uv tool install --with` when building uvx:// packages. Use it to
-	// constrain transitive dependencies that the package itself leaves
-	// unbounded (e.g. "mcp<2"). Ignored by npx:// and go:// builds.
-	UVWith []string `json:"uv_with,omitempty" yaml:"uv_with,omitempty"`
+	// BuildWith lists build-time dependency constraints, interpreted per
+	// package ecosystem. For uvx:// builds these are PEP 508 requirement
+	// specifiers passed to `uv tool install --with`, used to constrain
+	// transitive dependencies the package itself leaves unbounded
+	// (e.g. "mcp<2"). Ecosystems without constraint support (npx://, go://)
+	// reject a non-empty BuildWith at build time.
+	BuildWith []string `json:"build_with,omitempty" yaml:"build_with,omitempty"`
 
 	// RuntimeEnv contains environment variables to inject into the Dockerfile's
 	// final runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),
@@ -115,18 +117,18 @@ func (rc *RuntimeConfig) Validate() error {
 		}
 	}
 
-	// Validate each UVWith entry against a strict allowlist so specifiers
+	// Validate each BuildWith entry against a strict allowlist so specifiers
 	// cannot escape the single-quoted --with argument in the uvx Dockerfile.
-	for _, spec := range rc.UVWith {
+	for _, spec := range rc.BuildWith {
 		if len(spec) > maxPackageNameLength {
 			errs = append(errs, fmt.Errorf(
-				"uv_with specifier %q exceeds maximum length of %d characters",
+				"build_with specifier %q exceeds maximum length of %d characters",
 				spec, maxPackageNameLength,
 			))
-		} else if !uvWithPattern.MatchString(spec) {
+		} else if !buildWithPattern.MatchString(spec) {
 			errs = append(errs, fmt.Errorf(
-				"invalid uv_with specifier %q: must match %s",
-				spec, uvWithPattern.String(),
+				"invalid build_with specifier %q: must match %s",
+				spec, buildWithPattern.String(),
 			))
 		}
 	}

--- a/pkg/container/templates/runtime_config_test.go
+++ b/pkg/container/templates/runtime_config_test.go
@@ -458,7 +458,7 @@ func TestRuntimeConfigValidate_MultipleErrorsWithRuntimeEnv(t *testing.T) {
 	assert.Contains(t, err.Error(), "contains potentially dangerous characters")
 }
 
-func TestRuntimeConfigValidate_ValidUVWith(t *testing.T) {
+func TestRuntimeConfigValidate_ValidBuildWith(t *testing.T) {
 	t.Parallel()
 
 	valid := []string{
@@ -471,12 +471,12 @@ func TestRuntimeConfigValidate_ValidUVWith(t *testing.T) {
 		"pkg >= 1.0, < 3",
 	}
 	for _, spec := range valid {
-		rc := &RuntimeConfig{UVWith: []string{spec}}
+		rc := &RuntimeConfig{BuildWith: []string{spec}}
 		assert.NoError(t, rc.Validate(), "specifier %q should be valid", spec)
 	}
 }
 
-func TestRuntimeConfigValidate_InvalidUVWith(t *testing.T) {
+func TestRuntimeConfigValidate_InvalidBuildWith(t *testing.T) {
 	t.Parallel()
 
 	invalid := []string{
@@ -495,16 +495,16 @@ func TestRuntimeConfigValidate_InvalidUVWith(t *testing.T) {
 		"pkg; python_version<'3.8'", // env markers need quotes, deliberately unsupported
 	}
 	for _, spec := range invalid {
-		rc := &RuntimeConfig{UVWith: []string{spec}}
+		rc := &RuntimeConfig{BuildWith: []string{spec}}
 		assert.Error(t, rc.Validate(), "specifier %q should be rejected", spec)
 	}
 }
 
-func TestUVXTemplateRendersUVWith(t *testing.T) {
+func TestUVXTemplateRendersBuildWith(t *testing.T) {
 	t.Parallel()
 
 	rc := GetDefaultRuntimeConfig(TransportTypeUVX)
-	rc.UVWith = []string{"mcp<2", "other>=1,<4"}
+	rc.BuildWith = []string{"mcp<2", "other>=1,<4"}
 	data := TemplateData{
 		MCPPackage:    "arxiv-mcp-server",
 		RuntimeConfig: &rc,
@@ -512,10 +512,10 @@ func TestUVXTemplateRendersUVWith(t *testing.T) {
 	dockerfile, err := GetDockerfileTemplate(TransportTypeUVX, data)
 	require.NoError(t, err)
 	assert.Contains(t, dockerfile, `uv tool install --with 'mcp<2' --with 'other>=1,<4' "$package_spec"`,
-		"each UVWith specifier must be passed as a single-quoted --with argument")
+		"each BuildWith specifier must be passed as a single-quoted --with argument")
 }
 
-func TestUVXTemplateWithoutUVWithIsUnchanged(t *testing.T) {
+func TestUVXTemplateWithoutBuildWithIsUnchanged(t *testing.T) {
 	t.Parallel()
 
 	rc := GetDefaultRuntimeConfig(TransportTypeUVX)
@@ -526,6 +526,6 @@ func TestUVXTemplateWithoutUVWithIsUnchanged(t *testing.T) {
 	dockerfile, err := GetDockerfileTemplate(TransportTypeUVX, data)
 	require.NoError(t, err)
 	assert.Contains(t, dockerfile, `uv tool install "$package_spec"`,
-		"no --with arguments should appear when UVWith is empty")
+		"no --with arguments should appear when BuildWith is empty")
 	assert.NotContains(t, dockerfile, "--with")
 }

--- a/pkg/container/templates/uvx.tmpl
+++ b/pkg/container/templates/uvx.tmpl
@@ -77,7 +77,7 @@ ENV UV_TOOL_DIR=/opt/uv-tools \
 RUN package="{{.MCPPackage}}"; \
     # Replace @ with == for uv tool install (Python uses == for version pinning)
     package_spec=$(echo "$package" | sed 's/@/==/'); \
-    uv tool install {{range .RuntimeConfig.UVWith}}--with '{{.}}' {{end}}"$package_spec" && \
+    uv tool install {{range .RuntimeConfig.BuildWith}}--with '{{.}}' {{end}}"$package_spec" && \
     # List installed executables for debugging
     ls -la /opt/uv-tools/bin/
 {{end}}

--- a/pkg/runner/protocol.go
+++ b/pkg/runner/protocol.go
@@ -149,6 +149,15 @@ func createTemplateData(
 	}
 	templateData.RuntimeConfig = runtimeConfig
 
+	// Build-time dependency constraints are interpreted per package
+	// ecosystem; only the uvx builder currently supports them. Reject
+	// rather than silently ignore for the others.
+	if transportType != templates.TransportTypeUVX && len(runtimeConfig.BuildWith) > 0 {
+		return templateData, fmt.Errorf(
+			"--build-with is not supported for %s:// builds (only uvx://)", transportType,
+		)
+	}
+
 	return templateData, nil
 }
 
@@ -217,8 +226,8 @@ func mergeRuntimeConfig(transportType templates.TransportType, override *templat
 
 	merged.RuntimeEnv = mergeEnvMaps(defaults.RuntimeEnv, override.RuntimeEnv)
 
-	// UVWith has no defaults; the override's specifiers are used as-is.
-	merged.UVWith = override.UVWith
+	// BuildWith has no defaults; the override's specifiers are used as-is.
+	merged.BuildWith = override.BuildWith
 
 	return merged
 }

--- a/pkg/runner/protocol_test.go
+++ b/pkg/runner/protocol_test.go
@@ -720,19 +720,40 @@ func TestLoadRuntimeConfig_UsesOverrideBuilderImage(t *testing.T) {
 	assert.Equal(t, base.AdditionalPackages, got.AdditionalPackages)
 }
 
-func TestMergeRuntimeConfigCarriesUVWith(t *testing.T) {
+func TestMergeRuntimeConfigCarriesBuildWith(t *testing.T) {
 	t.Parallel()
 
 	got := mergeRuntimeConfig(templates.TransportTypeUVX, &templates.RuntimeConfig{
-		UVWith: []string{"mcp<2"},
+		BuildWith: []string{"mcp<2"},
 	})
-	if len(got.UVWith) != 1 || got.UVWith[0] != "mcp<2" {
-		t.Errorf("UVWith = %v, want [mcp<2]", got.UVWith)
+	if len(got.BuildWith) != 1 || got.BuildWith[0] != "mcp<2" {
+		t.Errorf("BuildWith = %v, want [mcp<2]", got.BuildWith)
 	}
 
 	// No override specifiers: merged config must not invent any.
 	got = mergeRuntimeConfig(templates.TransportTypeUVX, &templates.RuntimeConfig{})
-	if len(got.UVWith) != 0 {
-		t.Errorf("UVWith = %v, want empty", got.UVWith)
+	if len(got.BuildWith) != 0 {
+		t.Errorf("BuildWith = %v, want empty", got.BuildWith)
+	}
+}
+
+func TestCreateTemplateDataRejectsBuildWithForNonUVX(t *testing.T) {
+	t.Parallel()
+
+	for _, transport := range []templates.TransportType{
+		templates.TransportTypeNPX, templates.TransportTypeGO,
+	} {
+		_, err := createTemplateData(transport, "some-package", "", nil,
+			&templates.RuntimeConfig{BuildWith: []string{"mcp<2"}})
+		if err == nil {
+			t.Errorf("createTemplateData(%s) with BuildWith should error, got nil", transport)
+		}
+	}
+
+	// uvx accepts constraints.
+	_, err := createTemplateData(templates.TransportTypeUVX, "some-package", "", nil,
+		&templates.RuntimeConfig{BuildWith: []string{"mcp<2"}})
+	if err != nil {
+		t.Errorf("createTemplateData(uvx) with BuildWith should succeed, got %v", err)
 	}
 }

--- a/test/e2e/protocol_builds_e2e_test.go
+++ b/test/e2e/protocol_builds_e2e_test.go
@@ -207,15 +207,15 @@ var _ = Describe("Protocol Builds E2E", Label("mcp", "mcp-protocol", "protocols"
 
 			It("should build and start successfully and provide arxiv tools [Serial]", func() {
 				By("Starting the ArXiv MCP server using uvx:// protocol")
-				// --uv-with pins the transitive Python mcp SDK below 2.0:
+				// --build-with pins the transitive Python mcp SDK below 2.0:
 				// arxiv-mcp-server declares an unbounded mcp>=1.27.0 and
 				// import-crashes under the mcp 2.0.0 major (see #6108). The
-				// constraint also exercises the uvx builder's --uv-with
+				// constraint also exercises the uvx builder's --build-with
 				// plumbing end-to-end.
 				stdout, stderr := e2e.NewTHVCommand(config, "run",
 					"--name", serverName,
 					"--transport", "stdio",
-					"--uv-with", "mcp<2",
+					"--build-with", "mcp<2",
 					"uvx://arxiv-mcp-server").ExpectSuccess()
 
 				// The command should indicate success and show build process


### PR DESCRIPTION
Follow-up to #6111, while the flag is hours old and unreleased.

The build-time dependency-constraint concept is per-ecosystem, not uv-specific, so the flag becomes **`--build-with`** on `thv run` and `thv build`, documented as "interpreted per package ecosystem" — for `uvx://` that means PEP 508 specifiers passed to `uv tool install --with` (e.g. `--build-with 'mcp<2'`). Future ecosystems can map it to their native mechanism (npm `overrides`, Go module directives) if/when their builders can support it. `RuntimeConfig.UVWith` → `BuildWith` (wire tag `build_with`); swagger and CLI docs regenerated.

This also fixes a wart from #6111: a non-empty constraint list on `npx://` or `go://` builds was **silently ignored**. `createTemplateData` now rejects it with a clear error, so nobody is left believing an unsupported constraint applied — covered by a new test across both unsupported transports, plus the uvx acceptance case.

Lint clean, all touched package tests green, arxiv e2e updated to the new flag name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)