### PR TITLE
Move rate limit code out of reserved range

### DIFF
--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -514,14 +514,14 @@ sessionless by design and store nothing, a coexistence asserted end-to-end by
 limiting does not gate Modern either: the limiter is a core decorator
 (`pkg/vmcp/ratelimit`), so both eras meter the same `CallTool` seam, and the
 Modern dispatcher preserves the limiter's coded error on the wire — a real
-JSON-RPC error object, `-32029` with `data.retryAfterSeconds`
-(`writeModernCodedError`, at HTTP 200 because go-sdk rejects a non-200
-response before decoding the body, so on a 429 the error object — and its
-`retryAfterSeconds` — would be discarded unread) — where the Legacy SDK seam
-can only smuggle the same code and data into an `IsError` tool result's
-`structuredContent` (`conversion.ErrorToToolResult`). Note that `-32029` sits
-inside the draft spec's reserved band (`-32020`..`-32099`, reserved for
-spec-defined codes); reallocating it is tracked in #6101.
+JSON-RPC error object, application-defined `-32829` with
+`data.retryAfterSeconds` (`writeModernCodedError`, at HTTP 200 because go-sdk
+rejects a non-200 response before decoding the body, so on a 429 the error
+object — and its `retryAfterSeconds` — would be discarded unread) — where the
+Legacy SDK seam can only smuggle the same code and data into an `IsError` tool
+result's `structuredContent` (`conversion.ErrorToToolResult`). The code stays
+outside JSON-RPC's reserved range (`-32768`..`-32000`) and MCP's reserved
+sub-range (`-32020`..`-32099`).
 
 "Does not gate Modern" is not "costs the same", though. The limiter wraps only
 the `CallTool` seam, so the list verbs and `server/discover` are unmetered on

--- a/pkg/ratelimit/errors.go
+++ b/pkg/ratelimit/errors.go
@@ -12,12 +12,10 @@ import (
 
 const (
 	// CodeRateLimited is the JSON-RPC error code for rate-limited requests.
-	// It was chosen (RFC THV-0057) when -32000..-32099 was uniformly
-	// implementation-defined, but the draft MCP spec now reserves
-	// -32020..-32099 exclusively for spec-defined codes, which this is not.
-	// The value is retained for wire compatibility; reallocation outside
-	// -32768..-32000 is tracked in #6101.
-	CodeRateLimited int64 = -32029
+	// Keep this outside JSON-RPC's reserved range (-32768..-32000) and the
+	// draft MCP spec's reserved sub-range (-32020..-32099). MCP defines no
+	// rate-limit code, so ToolHive emits this as an application-defined error.
+	CodeRateLimited int64 = -32829
 
 	// MessageRateLimited is the error message for rate-limited requests.
 	MessageRateLimited = "Rate limit exceeded"

--- a/pkg/ratelimit/errors_test.go
+++ b/pkg/ratelimit/errors_test.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimitedErrorCodeIsApplicationDefined(t *testing.T) {
+	t.Parallel()
+
+	const (
+		jsonRPCReservedMin = -32768
+		jsonRPCReservedMax = -32000
+		mcpReservedMin     = -32099
+		mcpReservedMax     = -32020
+	)
+
+	assert.True(t,
+		CodeRateLimited < int64(jsonRPCReservedMin) || CodeRateLimited > int64(jsonRPCReservedMax),
+		"rate-limit code must stay outside the JSON-RPC reserved range",
+	)
+	assert.False(t,
+		CodeRateLimited >= int64(mcpReservedMin) && CodeRateLimited <= int64(mcpReservedMax),
+		"rate-limit code must stay outside the MCP reserved sub-range",
+	)
+
+	limited := &RateLimitedError{RetryAfter: 1500 * time.Millisecond}
+	assert.Equal(t, CodeRateLimited, limited.Code())
+	assert.Equal(t, map[string]any{"retryAfterSeconds": 2}, limited.Data())
+}

--- a/pkg/ratelimit/middleware.go
+++ b/pkg/ratelimit/middleware.go
@@ -186,7 +186,7 @@ func rateLimitedBody(requestID any, retryAfter time.Duration) []byte {
 	data, err := json.Marshal(resp)
 	if err != nil {
 		return []byte(fmt.Sprintf(
-			`{"jsonrpc":"2.0","error":{"code":-32029,"message":"Rate limit exceeded","data":{"retryAfterSeconds":%.0f}}}`,
+			`{"jsonrpc":"2.0","error":{"code":-32829,"message":"Rate limit exceeded","data":{"retryAfterSeconds":%.0f}}}`,
 			retrySeconds,
 		))
 	}

--- a/pkg/ratelimit/middleware_test.go
+++ b/pkg/ratelimit/middleware_test.go
@@ -108,7 +108,7 @@ func TestRateLimitHandler_ToolCallRejected(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(body, &resp))
 	errObj := resp["error"].(map[string]any)
-	assert.Equal(t, float64(-32029), errObj["code"])
+	assert.Equal(t, float64(-32829), errObj["code"])
 	assert.Equal(t, "Rate limit exceeded", errObj["message"])
 	data := errObj["data"].(map[string]any)
 	assert.Equal(t, float64(5), data["retryAfterSeconds"])
@@ -201,7 +201,7 @@ func TestRateLimitedBody(t *testing.T) {
 func TestRateLimitedBodyMarshalFallback(t *testing.T) {
 	t.Parallel()
 
-	const want = `{"jsonrpc":"2.0","error":{"code":-32029,"message":"Rate limit exceeded","data":{"retryAfterSeconds":5}}}`
+	const want = `{"jsonrpc":"2.0","error":{"code":-32829,"message":"Rate limit exceeded","data":{"retryAfterSeconds":5}}}`
 	got := rateLimitedBody(make(chan int), 5*time.Second)
 	assert.Equal(t, want, string(got))
 	assert.NotContains(t, string(got), `"id"`)

--- a/pkg/vmcp/server/modern_dispatch.go
+++ b/pkg/vmcp/server/modern_dispatch.go
@@ -624,7 +624,7 @@ func writeModernMissingCapability(w http.ResponseWriter, id any, capName string)
 // error.
 //
 // A domain error that carries its own stable JSON-RPC code and data
-// (mcpparser.CodedError — e.g. the rate limiter's -32029 with
+// (mcpparser.CodedError — e.g. the rate limiter's application-defined -32829 with
 // data.retryAfterSeconds) is written with that code rather than laundered
 // into -32603. This is the Modern counterpart of the SDK path's
 // conversion.ErrorToToolResult, whose CodedError branch preserves the same

--- a/pkg/vmcp/server/modern_dispatch_test.go
+++ b/pkg/vmcp/server/modern_dispatch_test.go
@@ -724,7 +724,7 @@ func TestDispatchModern_AuthzGate(t *testing.T) {
 
 // TestDispatchModern_CodedErrorPreservesCodeAndData pins the CodedError branch
 // of writeModernDispatchError: a domain error carrying its own stable JSON-RPC
-// code and data (here the rate limiter's -32029 with data.retryAfterSeconds)
+// code and data (here the rate limiter's application-defined -32829 with data.retryAfterSeconds)
 // must reach the Modern client with that code and data intact, not be
 // laundered into an opaque -32603 — parity with the SDK path, where
 // conversion.ErrorToToolResult preserves the same code/data in

--- a/pkg/vmcp/server/modern_envelope.go
+++ b/pkg/vmcp/server/modern_envelope.go
@@ -604,12 +604,12 @@ func writeModernError(w http.ResponseWriter, id any, code int, msg string) {
 // Status is HTTP 200 deliberately: go-sdk's streamable client
 // (v1.7.0-pre.3) rejects a non-200 POST response in checkResponse BEFORE
 // decoding its body, so on any 4xx the JSON-RPC error object below —
-// including data.retryAfterSeconds on the rate limiter's -32029 — would be
+// including data.retryAfterSeconds on the rate limiter's application-defined -32829 — would be
 // discarded unread. 200 is the only status on which the client surfaces the
 // coded error to the caller. The request was accepted and processed; the
 // failure is an application-level JSON-RPC error riding the transport.
 // (writeModernMissingCapability in modern_dispatch.go documents a related
-// but distinct 200-over-4xx deviation for -32021.) Separately, -32029 sits
+// but distinct 200-over-4xx deviation for -32021.) Separately, -32829 sits
 // in the -32020..-32099 band the draft MCP spec reserves exclusively for
 // spec-defined codes; it predates that partition and its reallocation is
 // tracked in #6101.

--- a/test/e2e/mcp_raw_client_test.go
+++ b/test/e2e/mcp_raw_client_test.go
@@ -395,7 +395,7 @@ func TestRawClientSSEResponse(t *testing.T) {
 		// split across them must still parse.
 		server := newSSEServer(t, "event: message\n"+
 			`data: {"jsonrpc":"2.0","id":3,`+"\n"+
-			`data:  "error":{"code":-32029,"message":"Rate limit exceeded"}}`+"\n\n")
+			`data:  "error":{"code":-32829,"message":"Rate limit exceeded"}}`+"\n\n")
 
 		req, err := NewLegacyRequest("tools/call", map[string]any{"name": "echo"})
 		require.NoError(t, err)
@@ -403,7 +403,7 @@ func TestRawClientSSEResponse(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, resp.Error)
-		require.EqualValues(t, -32029, resp.Error.Code)
+		require.EqualValues(t, -32829, resp.Error.Code)
 		require.Equal(t, "Rate limit exceeded", resp.Error.Message)
 	})
 

--- a/test/e2e/thv-operator/acceptance_tests/ratelimit_test.go
+++ b/test/e2e/thv-operator/acceptance_tests/ratelimit_test.go
@@ -122,13 +122,13 @@ var _ = Describe("MCPServer Rate Limiting", Ordered, func() {
 			Expect(status).To(Equal(http.StatusTooManyRequests),
 				"4th request should be rate limited, body: %s", string(body))
 
-			By("Verifying JSON-RPC error code -32029")
+			By("Verifying application-defined JSON-RPC error code -32829")
 			var resp map[string]any
 			Expect(json.Unmarshal(body, &resp)).To(Succeed())
 
 			errObj, ok := resp["error"].(map[string]any)
 			Expect(ok).To(BeTrue(), "response should have error object")
-			Expect(errObj["code"]).To(BeEquivalentTo(-32029))
+			Expect(errObj["code"]).To(BeEquivalentTo(-32829))
 			Expect(errObj["message"]).To(Equal("Rate limit exceeded"))
 
 			data, ok := errObj["data"].(map[string]any)
@@ -314,13 +314,13 @@ var _ = Describe("MCPServer Rate Limiting", Ordered, func() {
 			By("Verifying Retry-After header is present (AC12)")
 			Expect(retryAfter).ToNot(BeEmpty(), "Retry-After header should be set on 429 response")
 
-			By("Verifying JSON-RPC error code -32029 with retryAfterSeconds")
+			By("Verifying application-defined JSON-RPC error code -32829 with retryAfterSeconds")
 			var resp map[string]any
 			Expect(json.Unmarshal(body, &resp)).To(Succeed())
 
 			errObj, ok := resp["error"].(map[string]any)
 			Expect(ok).To(BeTrue(), "response should have error object")
-			Expect(errObj["code"]).To(BeEquivalentTo(-32029))
+			Expect(errObj["code"]).To(BeEquivalentTo(-32829))
 
 			data, ok := errObj["data"].(map[string]any)
 			Expect(ok).To(BeTrue(), "error should have data object")


### PR DESCRIPTION
## Summary

- ToolHive's rate-limit JSON-RPC error code used `-32029`, which now falls inside the draft MCP spec's reserved `-32020..-32099` band.
- Move `CodeRateLimited` to application-defined `-32829`, outside JSON-RPC's reserved range, while preserving the existing `data.retryAfterSeconds` payload.
- Update rate-limit, Modern-dispatch, e2e, and architecture references so the new wire code is covered consistently.

Fixes #6101

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual testing:

- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./pkg/ratelimit`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./pkg/ratelimit ./pkg/vmcp/server`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test -race ./pkg/ratelimit ./pkg/vmcp/server`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./test/e2e -run 'TestRawClientBuilders/parses_an_error_response_event'`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./test/e2e/thv-operator/acceptance_tests -run '^$'`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH task lint`
- `git diff --check`

Note: `task test` was also attempted, but the full non-e2e suite exceeded the local 10-minute tool timeout after starting `go test -race $(go list ./... | grep -v '/test/e2e' ...)`. The focused packages touched by this PR passed locally.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/ratelimit/*` | Reallocate `CodeRateLimited` to `-32829` and pin the reserved-range contract. |
| `pkg/vmcp/server/*` | Update Modern JSON-RPC dispatch comments/tests for the new rate-limit code. |
| `test/e2e/*` | Update rate-limit wire assertions to the application-defined code. |
| `docs/arch/10-virtual-mcp-architecture.md` | Document the conformant application-defined code. |

## Does this introduce a user-facing change?

Yes. Rate-limited JSON-RPC responses now use error code `-32829` instead of `-32029`. The message and `data.retryAfterSeconds` payload are unchanged.

## Special notes for reviewers

This is intentionally wire-visible. Existing clients that matched on `-32029` should update to `-32829`; clients matching on `data.retryAfterSeconds` or the message continue to work.
