### PR TITLE
Reallocate rate-limit error code to 429

### DIFF
--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -514,14 +514,18 @@ sessionless by design and store nothing, a coexistence asserted end-to-end by
 limiting does not gate Modern either: the limiter is a core decorator
 (`pkg/vmcp/ratelimit`), so both eras meter the same `CallTool` seam, and the
 Modern dispatcher preserves the limiter's coded error on the wire — a real
-JSON-RPC error object, `-32029` with `data.retryAfterSeconds`
+JSON-RPC error object, `429` with `data.retryAfterSeconds`
 (`writeModernCodedError`, at HTTP 200 because go-sdk rejects a non-200
-response before decoding the body, so on a 429 the error object — and its
-`retryAfterSeconds` — would be discarded unread) — where the Legacy SDK seam
-can only smuggle the same code and data into an `IsError` tool result's
-`structuredContent` (`conversion.ErrorToToolResult`). Note that `-32029` sits
-inside the draft spec's reserved band (`-32020`..`-32099`, reserved for
-spec-defined codes); reallocating it is tracked in #6101.
+response before decoding the body, so on an HTTP 429 the error object — and
+its `retryAfterSeconds` — would be discarded unread) — where the Legacy SDK
+seam can only smuggle the same code and data into an `IsError` tool result's
+`structuredContent` (`conversion.ErrorToToolResult`). The code `429` mirrors
+HTTP Too Many Requests (the same pattern as the `403` denial code) and sits
+outside the JSON-RPC reserved range (`-32768`..`-32000`), making it
+conformant under both MCP 2026-07-28 — which reserves `-32020`..`-32099`
+exclusively for spec-defined codes — and 2025-11-25 and earlier, which
+inherit plain JSON-RPC 2.0. It replaced `-32029`, which sat inside the
+reserved band (#6101).
 
 "Does not gate Modern" is not "costs the same", though. The limiter wraps only
 the `CallTool` seam, so the list verbs and `server/discover` are unmetered on

--- a/pkg/ratelimit/errors.go
+++ b/pkg/ratelimit/errors.go
@@ -11,13 +11,17 @@ import (
 )
 
 const (
-	// CodeRateLimited is the JSON-RPC error code for rate-limited requests.
-	// It was chosen (RFC THV-0057) when -32000..-32099 was uniformly
-	// implementation-defined, but the draft MCP spec now reserves
-	// -32020..-32099 exclusively for spec-defined codes, which this is not.
-	// The value is retained for wire compatibility; reallocation outside
-	// -32768..-32000 is tracked in #6101.
-	CodeRateLimited int64 = -32029
+	// CodeRateLimited is the JSON-RPC error code for rate-limited requests,
+	// mirroring HTTP 429 (Too Many Requests) the same way mcp.JSONRPCCodeDenied
+	// mirrors 403. It sits outside the JSON-RPC reserved range
+	// (-32768..-32000) so a single value is conformant on every MCP revision:
+	// 2026-07-28 reserves -32020..-32099 exclusively for spec-defined codes
+	// and directs application codes outside the reserved range, while
+	// 2025-11-25 and earlier inherit plain JSON-RPC 2.0, which leaves the
+	// space outside that range application-defined. Replaces -32029, chosen
+	// by RFC THV-0057 when -32000..-32099 was uniformly implementation-defined
+	// — a premise the 2026-07-28 partition invalidated (#6101).
+	CodeRateLimited int64 = 429
 
 	// MessageRateLimited is the error message for rate-limited requests.
 	MessageRateLimited = "Rate limit exceeded"

--- a/pkg/ratelimit/middleware.go
+++ b/pkg/ratelimit/middleware.go
@@ -186,7 +186,7 @@ func rateLimitedBody(requestID any, retryAfter time.Duration) []byte {
 	data, err := json.Marshal(resp)
 	if err != nil {
 		return []byte(fmt.Sprintf(
-			`{"jsonrpc":"2.0","error":{"code":-32029,"message":"Rate limit exceeded","data":{"retryAfterSeconds":%.0f}}}`,
+			`{"jsonrpc":"2.0","error":{"code":429,"message":"Rate limit exceeded","data":{"retryAfterSeconds":%.0f}}}`,
 			retrySeconds,
 		))
 	}

--- a/pkg/ratelimit/middleware_test.go
+++ b/pkg/ratelimit/middleware_test.go
@@ -108,7 +108,7 @@ func TestRateLimitHandler_ToolCallRejected(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(body, &resp))
 	errObj := resp["error"].(map[string]any)
-	assert.Equal(t, float64(-32029), errObj["code"])
+	assert.Equal(t, float64(429), errObj["code"])
 	assert.Equal(t, "Rate limit exceeded", errObj["message"])
 	data := errObj["data"].(map[string]any)
 	assert.Equal(t, float64(5), data["retryAfterSeconds"])
@@ -201,7 +201,7 @@ func TestRateLimitedBody(t *testing.T) {
 func TestRateLimitedBodyMarshalFallback(t *testing.T) {
 	t.Parallel()
 
-	const want = `{"jsonrpc":"2.0","error":{"code":-32029,"message":"Rate limit exceeded","data":{"retryAfterSeconds":5}}}`
+	const want = `{"jsonrpc":"2.0","error":{"code":429,"message":"Rate limit exceeded","data":{"retryAfterSeconds":5}}}`
 	got := rateLimitedBody(make(chan int), 5*time.Second)
 	assert.Equal(t, want, string(got))
 	assert.NotContains(t, string(got), `"id"`)

--- a/pkg/vmcp/server/modern_dispatch.go
+++ b/pkg/vmcp/server/modern_dispatch.go
@@ -624,7 +624,7 @@ func writeModernMissingCapability(w http.ResponseWriter, id any, capName string)
 // error.
 //
 // A domain error that carries its own stable JSON-RPC code and data
-// (mcpparser.CodedError — e.g. the rate limiter's -32029 with
+// (mcpparser.CodedError — e.g. the rate limiter's 429 with
 // data.retryAfterSeconds) is written with that code rather than laundered
 // into -32603. This is the Modern counterpart of the SDK path's
 // conversion.ErrorToToolResult, whose CodedError branch preserves the same

--- a/pkg/vmcp/server/modern_dispatch_test.go
+++ b/pkg/vmcp/server/modern_dispatch_test.go
@@ -724,7 +724,7 @@ func TestDispatchModern_AuthzGate(t *testing.T) {
 
 // TestDispatchModern_CodedErrorPreservesCodeAndData pins the CodedError branch
 // of writeModernDispatchError: a domain error carrying its own stable JSON-RPC
-// code and data (here the rate limiter's -32029 with data.retryAfterSeconds)
+// code and data (here the rate limiter's 429 with data.retryAfterSeconds)
 // must reach the Modern client with that code and data intact, not be
 // laundered into an opaque -32603 — parity with the SDK path, where
 // conversion.ErrorToToolResult preserves the same code/data in

--- a/pkg/vmcp/server/modern_envelope.go
+++ b/pkg/vmcp/server/modern_envelope.go
@@ -604,15 +604,12 @@ func writeModernError(w http.ResponseWriter, id any, code int, msg string) {
 // Status is HTTP 200 deliberately: go-sdk's streamable client
 // (v1.7.0-pre.3) rejects a non-200 POST response in checkResponse BEFORE
 // decoding its body, so on any 4xx the JSON-RPC error object below —
-// including data.retryAfterSeconds on the rate limiter's -32029 — would be
+// including data.retryAfterSeconds on the rate limiter's 429 — would be
 // discarded unread. 200 is the only status on which the client surfaces the
 // coded error to the caller. The request was accepted and processed; the
 // failure is an application-level JSON-RPC error riding the transport.
 // (writeModernMissingCapability in modern_dispatch.go documents a related
-// but distinct 200-over-4xx deviation for -32021.) Separately, -32029 sits
-// in the -32020..-32099 band the draft MCP spec reserves exclusively for
-// spec-defined codes; it predates that partition and its reallocation is
-// tracked in #6101.
+// but distinct 200-over-4xx deviation for -32021.)
 //
 // id follows writeModernError: absent (via transportsession.HasJSONRPCID) is
 // encoded by omitting the "id" key, never as null.

--- a/test/e2e/mcp_raw_client_test.go
+++ b/test/e2e/mcp_raw_client_test.go
@@ -395,7 +395,7 @@ func TestRawClientSSEResponse(t *testing.T) {
 		// split across them must still parse.
 		server := newSSEServer(t, "event: message\n"+
 			`data: {"jsonrpc":"2.0","id":3,`+"\n"+
-			`data:  "error":{"code":-32029,"message":"Rate limit exceeded"}}`+"\n\n")
+			`data:  "error":{"code":429,"message":"Rate limit exceeded"}}`+"\n\n")
 
 		req, err := NewLegacyRequest("tools/call", map[string]any{"name": "echo"})
 		require.NoError(t, err)
@@ -403,7 +403,7 @@ func TestRawClientSSEResponse(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, resp.Error)
-		require.EqualValues(t, -32029, resp.Error.Code)
+		require.EqualValues(t, 429, resp.Error.Code)
 		require.Equal(t, "Rate limit exceeded", resp.Error.Message)
 	})
 

--- a/test/e2e/thv-operator/acceptance_tests/ratelimit_test.go
+++ b/test/e2e/thv-operator/acceptance_tests/ratelimit_test.go
@@ -122,13 +122,13 @@ var _ = Describe("MCPServer Rate Limiting", Ordered, func() {
 			Expect(status).To(Equal(http.StatusTooManyRequests),
 				"4th request should be rate limited, body: %s", string(body))
 
-			By("Verifying JSON-RPC error code -32029")
+			By("Verifying JSON-RPC error code 429")
 			var resp map[string]any
 			Expect(json.Unmarshal(body, &resp)).To(Succeed())
 
 			errObj, ok := resp["error"].(map[string]any)
 			Expect(ok).To(BeTrue(), "response should have error object")
-			Expect(errObj["code"]).To(BeEquivalentTo(-32029))
+			Expect(errObj["code"]).To(BeEquivalentTo(429))
 			Expect(errObj["message"]).To(Equal("Rate limit exceeded"))
 
 			data, ok := errObj["data"].(map[string]any)
@@ -314,13 +314,13 @@ var _ = Describe("MCPServer Rate Limiting", Ordered, func() {
 			By("Verifying Retry-After header is present (AC12)")
 			Expect(retryAfter).ToNot(BeEmpty(), "Retry-After header should be set on 429 response")
 
-			By("Verifying JSON-RPC error code -32029 with retryAfterSeconds")
+			By("Verifying JSON-RPC error code 429 with retryAfterSeconds")
 			var resp map[string]any
 			Expect(json.Unmarshal(body, &resp)).To(Succeed())
 
 			errObj, ok := resp["error"].(map[string]any)
 			Expect(ok).To(BeTrue(), "response should have error object")
-			Expect(errObj["code"]).To(BeEquivalentTo(-32029))
+			Expect(errObj["code"]).To(BeEquivalentTo(429))
 
 			data, ok := errObj["data"].(map[string]any)
 			Expect(ok).To(BeTrue(), "error should have data object")

--- a/test/e2e/thv-operator/virtualmcp/virtualmcp_rate_limiting_test.go
+++ b/test/e2e/thv-operator/virtualmcp/virtualmcp_rate_limiting_test.go
@@ -226,7 +226,7 @@ var _ = ginkgo.Describe("VirtualMCPServer Rate Limiting", ginkgo.Ordered, func()
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring(ratelimit.MessageRateLimited))
 
 		// Pin the full Modern envelope with an era-pinned raw request (the
-		// #6051 convention): RFC THV-0057's -32029 with data.retryAfterSeconds
+		// #6051 convention): the rate limiter's 429 with data.retryAfterSeconds
 		// must survive the Modern dispatch path, which the go-sdk client above
 		// can only surface as an error string.
 		ginkgo.By("Verifying the Modern rate-limit error envelope")


### PR DESCRIPTION
## Summary

The MCP **2026-07-28 revision published today** and partitions the JSON-RPC implementation-defined server-error range ([Error Codes](https://modelcontextprotocol.io/specification/2026-07-28/basic#error-codes), verified live): `-32020..-32099` is reserved exclusively for spec-defined codes (only `-32020` HeaderMismatch, `-32021` MissingRequiredClientCapability, `-32022` UnsupportedProtocolVersion are defined), and implementations MUST NOT emit undefined codes from that band. ToolHive's `CodeRateLimited = -32029` is therefore non-conformant; it was chosen (RFC THV-0057) when `-32000..-32099` was uniformly implementation-defined.

The reallocation keeps ToolHive conformant with **both eras with a single code and no version branching**:

- **2026-07-28**: new application codes SHOULD be allocated outside the JSON-RPC reserved range (`-32768..-32000`) — `429` complies.
- **2025-11-25 and earlier**: these revisions inherit plain JSON-RPC 2.0, which leaves everything outside `-32768..-32000` application-defined — `429` is equally legal, and no earlier revision ever defined a rate-limit code, so old-era clients have no spec-based expectation of `-32029`. (Version branching would also be impossible in the HTTP middleware, which runs before protocol parsing.)

What changed:

- `CodeRateLimited` is now `429`, mirroring HTTP Too Many Requests — the same pattern as the existing `JSONRPCCodeDenied = 403` (`pkg/mcp/errors.go`), which is positive-code precedent already shipped in production. `data.retryAfterSeconds` is unchanged (error `data` "MAY include a data member with additional information of any type" in every revision).
- Updated the hardcoded fallback body in the ratelimit middleware, comments on the vMCP Modern dispatch/envelope path, the pinned wire values in unit/e2e tests, and the vMCP architecture doc's rate-limit gate section.

Also audited every other custom code ToolHive emits against the new partition: `-32001` (SessionNotFound) and the streamable proxy's `-32000` fallback sit in `-32000..-32019`, which 2026-07-28 explicitly grandfathers as legacy — and both are legacy-transport-only paths (the new revision removes sessions entirely), so they are conformant as-is. `-32020/-32021/-32022` are used with their spec meanings.

Closes #6101

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`) — `pkg/ratelimit` and `pkg/vmcp/server` pass; the only failures are two pre-existing `pkg/api` tests requiring a container runtime unavailable in the sandbox
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`) — 0 issues

## Does this introduce a user-facing change?

Yes. The JSON-RPC error code for rate-limited requests changes from `-32029` to `429` on every surface that carries it: the HTTP 429 response body from the ratelimit middleware, the vMCP Modern dispatch path's JSON-RPC error object, and the Legacy path's `IsError` tool-result `structuredContent`. Clients pattern-matching `-32029` must switch to `429`; `data.retryAfterSeconds` and the `Retry-After` header are unchanged.

## Special notes for reviewers

- RFC THV-0057 cites the now-invalidated "implementation-defined code in the -32000 to -32099 range" premise; it lives outside this repo, so it needs a follow-up edit there to record the `429` allocation.
- Follow-up (cosmetic, separate PR): `pkg/mcp/revision.go` comments still say "draft MCP spec" throughout — the revision shipped today as `2026-07-28`, and the wording could be updated.

Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1kKpsGZTfSgKBi8GdTZXR