### PR TITLE
Wire tool_keywords into the BM25 search arm

### DIFF
--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
@@ -176,30 +176,40 @@ func (s sqliteToolStore) generateEmbeddings(ctx context.Context, tools []server.
 	return blobs, nil
 }
 
-// Search finds tools matching the query string using FTS5 full-text search
-// and optional semantic search when an embedding client is configured.
+// Search finds tools matching q using FTS5 full-text search and optional
+// semantic search when an embedding client is configured. The lexical arm
+// prefers q.Keywords, falling back to q.Description when Keywords is empty;
+// the semantic arm always embeds q.Description.
 // The allowedTools parameter limits results to only tools with names in the given set.
 // If allowedTools is empty, no results are returned (empty = no access).
 // Returns matches ranked by relevance.
-func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools []string) ([]mcp.Tool, error) {
+func (s sqliteToolStore) Search(ctx context.Context, q types.SearchQuery, allowedTools []string) ([]mcp.Tool, error) {
 	if len(allowedTools) == 0 {
 		slog.Debug("search skipped, no allowed tools")
 		return nil, nil
 	}
 
-	ftsExpr := sanitizeFTS5Query(query)
+	// The lexical arm prefers explicit keywords and falls back to the words of
+	// the description, either when no keywords were supplied or when every
+	// keyword was dropped as too common to discriminate. The semantic arm
+	// always embeds the description.
+	ftsExpr := sanitizeFTS5Terms(q.Keywords)
+	if ftsExpr == "" {
+		ftsExpr = sanitizeFTS5Terms(strings.Fields(q.Description))
+	}
 
 	// FTS5-only path (no embedding client)
 	if s.embeddingClient == nil {
 		if ftsExpr == "" {
-			slog.Debug("search skipped, empty FTS5 expression", "query", query)
+			slog.Debug("search skipped, empty FTS5 expression", "query", q.Description, "keywords", q.Keywords)
 			return nil, nil
 		}
 		results, err := s.searchFTS5(ctx, ftsExpr, allowedTools, s.maxToolsToReturn)
 		if err != nil {
 			return nil, err
 		}
-		slog.Debug("search completed (FTS5-only)", "query", query, "results", len(results), "matched_tools", matchNames(results))
+		slog.Debug("search completed (FTS5-only)",
+			"query", q.Description, "keywords", q.Keywords, "results", len(results), "matched_tools", matchNames(results))
 		return results, nil
 	}
 
@@ -221,7 +231,7 @@ func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools 
 	if semanticLimit > 0 {
 		g.Go(func() error {
 			var err error
-			semanticResults, err = s.searchSemantic(gCtx, query, allowedTools, semanticLimit)
+			semanticResults, err = s.searchSemantic(gCtx, q.Description, allowedTools, semanticLimit)
 			return err
 		})
 	}
@@ -233,7 +243,8 @@ func (s sqliteToolStore) Search(ctx context.Context, query string, allowedTools 
 	merged := mergeResults(ftsResults, semanticResults, s.maxToolsToReturn)
 
 	slog.Debug("search completed (hybrid)",
-		"query", query,
+		"query", q.Description,
+		"keywords", q.Keywords,
 		"fts5_results", len(ftsResults),
 		"semantic_results", len(semanticResults),
 		"merged_results", len(merged),
@@ -263,7 +274,7 @@ func (s sqliteToolStore) Close() error {
 // it has high cosine similarity, because the semantic query runs separately
 // and will surface it.
 //
-// The ftsExpr is produced by sanitizeFTS5Query and is always passed as a
+// The ftsExpr is produced by sanitizeFTS5Terms and is always passed as a
 // parameterized ? value, never interpolated into SQL.
 func (s sqliteToolStore) searchFTS5(
 	ctx context.Context, ftsExpr string, allowedTools []string, limit int,
@@ -458,8 +469,12 @@ func matchNames(matches []mcp.Tool) []string {
 }
 
 // problematicWords contains words that FTS5 interprets as operators or that
-// are too common in tool metadata to be useful search terms. This set aligns
-// with Python mcp_optimizer's DEFAULT_FTS_PROBLEMATIC_WORDS.
+// are too common in tool metadata to be useful search terms.
+//
+// sanitizeFTS5Terms drops them. The alternative, falling back to a phrase
+// search over the whole query when one of these appears, demands exact token
+// adjacency and so reliably matches nothing; dropping the noise word and
+// OR-joining the rest avoids the result flood without going empty-handed.
 var problematicWords = map[string]struct{}{
 	"name": {}, "description": {}, "schema": {}, "input": {},
 	"output": {}, "type": {}, "properties": {}, "required": {},
@@ -469,13 +484,16 @@ var problematicWords = map[string]struct{}{
 	"index": {}, "key": {}, "primary": {},
 }
 
-// sanitizeFTS5Query prepares a user query string for use with FTS5 MATCH.
+// sanitizeFTS5Terms builds an FTS5 MATCH expression from a list of search terms.
+//
+// Each entry is split on whitespace (a single term may arrive multi-word), words
+// in problematicWords are dropped, the remainder is deduplicated case-insensitively,
+// and what is left is OR-joined. Returns "" when no usable term remains, letting
+// the caller fall back to another source of terms.
 //
 // The returned string is designed to be passed as a single ? parameter to
-// QueryContext. It cannot cause SQL injection because it is always bound via ?.
-//
-// FTS5 MATCH requires a single string operand containing the full query
-// expression (e.g., "read" OR "write"). Individual terms cannot be separate
+// QueryContext. FTS5 MATCH requires a single string operand containing the full
+// query expression (e.g., "read" OR "write"). Individual terms cannot be separate
 // ? SQL parameters because the OR/AND operators are part of the FTS5 query
 // language, not SQL.
 // See: https://sqlite.org/fts5.html#full_text_query_syntax
@@ -484,32 +502,24 @@ var problematicWords = map[string]struct{}{
 //   - SQL injection is prevented because the expression is always bound via ?.
 //   - FTS5 operator injection is prevented by double-quoting each term and
 //     escaping embedded double-quotes (standard FTS5 escaping).
-func sanitizeFTS5Query(query string) string {
-	words := strings.Fields(strings.TrimSpace(query))
-	if len(words) == 0 {
-		return ""
-	}
-
-	hasProblematic := false
-	for _, word := range words {
-		if _, ok := problematicWords[strings.ToLower(word)]; ok {
-			hasProblematic = true
-			break
+func sanitizeFTS5Terms(terms []string) string {
+	seen := make(map[string]struct{}, len(terms))
+	var quoted []string
+	for _, term := range terms {
+		for _, word := range strings.Fields(term) {
+			lower := strings.ToLower(word)
+			if _, ok := problematicWords[lower]; ok {
+				continue
+			}
+			if _, ok := seen[lower]; ok {
+				continue
+			}
+			seen[lower] = struct{}{}
+			escaped := strings.ReplaceAll(word, `"`, `""`)
+			quoted = append(quoted, `"`+escaped+`"`)
 		}
 	}
 
-	// Single word or any problematic word present: use phrase search
-	if len(words) == 1 || hasProblematic {
-		escaped := strings.ReplaceAll(strings.Join(words, " "), `"`, `""`)
-		return `"` + escaped + `"`
-	}
-
-	// Multi-word with no problematic words: join with OR
-	quoted := make([]string, len(words))
-	for i, word := range words {
-		escaped := strings.ReplaceAll(word, `"`, `""`)
-		quoted[i] = `"` + escaped + `"`
-	}
 	return strings.Join(quoted, " OR ")
 }
 

--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_bench_test.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_bench_test.go
@@ -56,7 +56,7 @@ func BenchmarkSearch_FTS5Only_1000Tools(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for b.Loop() {
-		_, _ = store.Search(ctx, "task operation", names)
+		_, _ = store.Search(ctx, types.SearchQuery{Description: "task operation"}, names)
 	}
 }
 
@@ -86,7 +86,7 @@ func BenchmarkSearch_Hybrid_1000Tools(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for b.Loop() {
-		_, _ = store.Search(ctx, "task operation", names)
+		_, _ = store.Search(ctx, types.SearchQuery{Description: "task operation"}, names)
 	}
 }
 

--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
@@ -6,6 +6,7 @@ package toolstore
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -113,7 +114,7 @@ func TestSQLiteToolStore_UpsertTools(t *testing.T) {
 			}
 			require.NoError(t, store.UpsertTools(ctx, tc.upsert))
 
-			results, err := store.Search(ctx, tc.searchQuery, tc.allowedTools)
+			results, err := store.Search(ctx, types.SearchQuery{Description: tc.searchQuery}, tc.allowedTools)
 			require.NoError(t, err)
 			require.Len(t, results, tc.wantLen)
 			if tc.wantDesc != "" && len(results) > 0 {
@@ -149,6 +150,7 @@ func TestSQLiteToolStore_Search(t *testing.T) {
 		name         string
 		tools        []server.ServerTool
 		query        string
+		keywords     []string
 		allowedTools []string
 		wantNames    []string
 		wantNonEmpty bool // just assert results are non-empty (when exact names vary)
@@ -241,6 +243,39 @@ func TestSQLiteToolStore_Search(t *testing.T) {
 			allowedTools: []string{"generic_tool", "search_tool"},
 			wantNonEmpty: true,
 		},
+		{
+			name: "keywords surface a tool the description alone misses",
+			tools: makeTools(
+				mcp.NewTool("run_query", mcp.WithDescription("Executes arbitrary commands against a Postgres datastore")),
+			),
+			query:        "do something with data",
+			keywords:     []string{"postgres"},
+			allowedTools: []string{"run_query"},
+			wantNames:    []string{"run_query"},
+		},
+		{
+			// Negative twin of the case above. Without it, that case would keep
+			// passing if keywords were ignored but the description happened to
+			// start matching (say, if "data" left problematicWords).
+			name: "same description without keywords finds nothing",
+			tools: makeTools(
+				mcp.NewTool("run_query", mcp.WithDescription("Executes arbitrary commands against a Postgres datastore")),
+			),
+			query:        "do something with data",
+			keywords:     nil,
+			allowedTools: []string{"run_query"},
+			wantNames:    nil,
+		},
+		{
+			name: "keywords all problematic falls back to description",
+			tools: makeTools(
+				mcp.NewTool("read_file", mcp.WithDescription("Read a file from disk")),
+			),
+			query:        "read disk",
+			keywords:     []string{"table", "schema"},
+			allowedTools: []string{"read_file"},
+			wantNames:    []string{"read_file"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -251,7 +286,7 @@ func TestSQLiteToolStore_Search(t *testing.T) {
 
 			require.NoError(t, store.UpsertTools(ctx, tc.tools))
 
-			results, err := store.Search(ctx, tc.query, tc.allowedTools)
+			results, err := store.Search(ctx, types.SearchQuery{Description: tc.query, Keywords: tc.keywords}, tc.allowedTools)
 			require.NoError(t, err)
 
 			if tc.wantNonEmpty {
@@ -307,7 +342,7 @@ func TestSQLiteToolStore_Search_ResultsCapped(t *testing.T) {
 			)
 			require.NoError(t, store.UpsertTools(ctx, tools))
 
-			results, err := store.Search(ctx, "file", toolNames(tools))
+			results, err := store.Search(ctx, types.SearchQuery{Description: "file"}, toolNames(tools))
 			require.NoError(t, err)
 			require.LessOrEqual(t, len(results), tc.wantMax,
 				"results should be capped at %d", tc.wantMax)
@@ -372,7 +407,7 @@ func TestSQLiteToolStore_Concurrent(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			// Pass a known tool name so we don't hit the empty-allowedTools shortcut
-			_, err := store.Search(ctx, "tool", []string{"tool_0"})
+			_, err := store.Search(ctx, types.SearchQuery{Description: "tool"}, []string{"tool_0"})
 			if err != nil {
 				t.Errorf("concurrent search failed for goroutine %d: %v", idx, err)
 			}
@@ -415,10 +450,82 @@ func TestSQLiteToolStore_HybridSearch(t *testing.T) {
 	require.NoError(t, store.UpsertTools(ctx, tools))
 
 	// Hybrid search should return results from both FTS5 and semantic
-	results, err := store.Search(ctx, "file", toolNames(tools))
+	results, err := store.Search(ctx, types.SearchQuery{Description: "file"}, toolNames(tools))
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
 	require.LessOrEqual(t, len(results), DefaultMaxToolsToReturn)
+}
+
+// TestSQLiteToolStore_SemanticArmEmbedsDescriptionOnly pins half of the hybrid
+// design: whatever the keywords are, the semantic arm embeds Description and
+// nothing else. A regression that embedded the keywords, or a concatenation of
+// both fields, would go unnoticed through result assertions alone, because the
+// merged set can look identical either way.
+//
+// The other half, keywords driving the lexical arm, is covered by the
+// "keywords surface a tool the description alone misses" case in
+// TestSQLiteToolStore_Search, which runs FTS5-only so the semantic arm cannot
+// mask the result.
+func TestSQLiteToolStore_SemanticArmEmbedsDescriptionOnly(t *testing.T) {
+	t.Parallel()
+	client := newFakeEmbeddingClient(384)
+	store := newTestStore(t, client, nil)
+	ctx := context.Background()
+
+	tools := makeTools(
+		mcp.NewTool("run_query", mcp.WithDescription("Executes arbitrary commands against a Postgres datastore")),
+		mcp.NewTool("send_email", mcp.WithDescription("Send an email message")),
+	)
+	require.NoError(t, store.UpsertTools(ctx, tools))
+
+	_, err := store.Search(ctx, types.SearchQuery{
+		Description: "do something with data",
+		Keywords:    []string{"postgres", "sql"},
+	}, toolNames(tools))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"do something with data"}, client.embeddedTexts(),
+		"semantic arm must embed Description verbatim, never the keywords")
+}
+
+// TestSQLiteToolStore_KeywordsOnly covers a SearchQuery with no description.
+// FindTool rejects that upstream, but the store is a separate unit.
+func TestSQLiteToolStore_KeywordsOnly(t *testing.T) {
+	t.Parallel()
+
+	tools := makeTools(
+		mcp.NewTool("github_create_issue", mcp.WithDescription("Create a GitHub issue")),
+		mcp.NewTool("slack_send_message", mcp.WithDescription("Send a Slack message")),
+	)
+
+	t.Run("keywords alone drive the lexical arm", func(t *testing.T) {
+		t.Parallel()
+		// FTS5-only, so the semantic arm cannot supply the match.
+		store := newTestStore(t, nil, nil)
+		ctx := context.Background()
+		require.NoError(t, store.UpsertTools(ctx, tools))
+
+		results, err := store.Search(ctx, types.SearchQuery{
+			Keywords: []string{"github"},
+		}, toolNames(tools))
+		require.NoError(t, err)
+		require.Equal(t, []string{"github_create_issue"}, matchNames(results))
+	})
+
+	t.Run("hybrid tolerates an empty description", func(t *testing.T) {
+		t.Parallel()
+		client := newFakeEmbeddingClient(384)
+		store := newTestStore(t, client, nil)
+		ctx := context.Background()
+		require.NoError(t, store.UpsertTools(ctx, tools))
+
+		_, err := store.Search(ctx, types.SearchQuery{
+			Keywords: []string{"github"},
+		}, toolNames(tools))
+		require.NoError(t, err)
+		// The semantic arm still runs and embeds the empty description.
+		require.Equal(t, []string{""}, client.embeddedTexts())
+	})
 }
 
 func TestSQLiteToolStore_ConcurrentSemantic(t *testing.T) {
@@ -440,7 +547,7 @@ func TestSQLiteToolStore_ConcurrentSemantic(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			_, err := store.Search(ctx, "file", toolNames(tools))
+			_, err := store.Search(ctx, types.SearchQuery{Description: "file"}, toolNames(tools))
 			if err != nil {
 				t.Errorf("concurrent semantic search failed for goroutine %d: %v", idx, err)
 			}
@@ -460,41 +567,55 @@ func TestSQLiteToolStore_EmbeddingRoundTrip(t *testing.T) {
 	require.Equal(t, original, decoded)
 }
 
-func TestSanitizeFTS5Query(t *testing.T) {
+// TestSanitizeFTS5Terms covers both callers of the sanitizer: an explicit
+// keyword list, and the words of a description. Both converge on the same
+// function, so a single-element slice containing spaces exercises the same
+// whitespace split that strings.Fields(description) produces.
+func TestSanitizeFTS5Terms(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		input    string
+		name     string
+		terms    []string
 		wantExpr string
 	}{
-		{input: "simple", wantExpr: `"simple"`},
-		{input: "two words", wantExpr: `"two" OR "words"`},
-		{input: "hello world foo", wantExpr: `"hello" OR "world" OR "foo"`},
-		{input: "", wantExpr: ""},
-		{input: "   ", wantExpr: ""},
+		{name: "single term", terms: []string{"simple"}, wantExpr: `"simple"`},
+		{name: "two terms", terms: []string{"two", "words"}, wantExpr: `"two" OR "words"`},
+		{name: "three terms", terms: []string{"hello", "world", "foo"}, wantExpr: `"hello" OR "world" OR "foo"`},
+		{name: "nil list", terms: nil, wantExpr: ""},
+		{name: "whitespace-only entry", terms: []string{"   "}, wantExpr: ""},
+		{name: "empty string entry", terms: []string{""}, wantExpr: ""},
 
-		// Special chars are NOT stripped (unlike previous behavior)
-		{input: "key:value", wantExpr: `"key:value"`},
-		{input: `"quoted"`, wantExpr: `"""quoted"""`},
-		{input: "read*", wantExpr: `"read*"`},
-		{input: "***", wantExpr: `"***"`},
-		{input: "read + file", wantExpr: `"read" OR "+" OR "file"`},
+		// Special chars are NOT stripped; quoting makes them inert to FTS5.
+		{name: "colon", terms: []string{"key:value"}, wantExpr: `"key:value"`},
+		{name: "embedded quotes", terms: []string{`"quoted"`}, wantExpr: `"""quoted"""`},
+		{name: "trailing star", terms: []string{"read*"}, wantExpr: `"read*"`},
+		{name: "all stars", terms: []string{"***"}, wantExpr: `"***"`},
+		{name: "plus operator", terms: []string{"read", "+", "file"}, wantExpr: `"read" OR "+" OR "file"`},
 
-		// Problematic words trigger phrase search
-		{input: "name value", wantExpr: `"name value"`},
-		{input: "search description fast", wantExpr: `"search description fast"`},
-		{input: "read tool write", wantExpr: `"read tool write"`},
-		{input: "schema definition", wantExpr: `"schema definition"`},
+		// Problematic words are dropped, not phrase-searched. A phrase search
+		// would demand exact adjacency and reliably match nothing.
+		{name: "problematic word dropped", terms: []string{"name", "lookup"}, wantExpr: `"lookup"`},
+		{name: "problematic word in middle", terms: []string{"search", "description", "fast"}, wantExpr: `"search" OR "fast"`},
+		{name: "problematic word leaves two", terms: []string{"read", "tool", "write"}, wantExpr: `"read" OR "write"`},
+		{name: "problematic word leaves one", terms: []string{"schema", "definition"}, wantExpr: `"definition"`},
+		{name: "all problematic", terms: []string{"table", "schema"}, wantExpr: ""},
+		{name: "mixed problematic and valid", terms: []string{"table", "postgres"}, wantExpr: `"postgres"`},
 
-		// Non-problematic multi-word queries use OR
-		{input: "read write", wantExpr: `"read" OR "write"`},
-		{input: "github slack", wantExpr: `"github" OR "slack"`},
+		// A single entry containing spaces splits, matching the description path.
+		{name: "multi-word entry splits", terms: []string{"list issues"}, wantExpr: `"list" OR "issues"`},
+		{name: "multi-word entry drops problematic", terms: []string{"name lookup"}, wantExpr: `"lookup"`},
+		{name: "every word problematic yields empty", terms: []string{"name value"}, wantExpr: ""},
+
+		{name: "duplicates deduped", terms: []string{"github", "github"}, wantExpr: `"github"`},
+		{name: "dedup is case-insensitive", terms: []string{"GitHub", "github"}, wantExpr: `"GitHub"`},
+		{name: "escapes embedded quote", terms: []string{`db"name`}, wantExpr: `"db""name"`},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotExpr := sanitizeFTS5Query(tt.input)
+			gotExpr := sanitizeFTS5Terms(tt.terms)
 			require.Equal(t, tt.wantExpr, gotExpr)
 		})
 	}
@@ -713,14 +834,45 @@ func TestSQLiteToolStore_SemanticDistanceThreshold(t *testing.T) {
 // import cycles.
 type fakeEmbeddingClient struct {
 	dim int
+
+	// mu guards embedded, which Search writes from an errgroup goroutine.
+	mu sync.Mutex
+	// embedded records every text passed to Embed, so tests can assert which
+	// SearchQuery field reaches the semantic arm.
+	embedded []string
 }
 
 func newFakeEmbeddingClient(dim int) *fakeEmbeddingClient {
 	return &fakeEmbeddingClient{dim: dim}
 }
 
+// embeddedTexts returns the texts passed to Embed so far. EmbedBatch, used on
+// the write path by UpsertTools, is deliberately not recorded.
+func (f *fakeEmbeddingClient) embeddedTexts() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.embedded)
+}
+
 func (f *fakeEmbeddingClient) Embed(_ context.Context, text string) ([]float32, error) {
-	// Simple deterministic hash: use string bytes as seed
+	f.mu.Lock()
+	f.embedded = append(f.embedded, text)
+	f.mu.Unlock()
+
+	return f.embedVector(text), nil
+}
+
+func (f *fakeEmbeddingClient) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	result := make([][]float32, len(texts))
+	for i, text := range texts {
+		result[i] = f.embedVector(text)
+	}
+	return result, nil
+}
+
+// embedVector produces the deterministic vector without recording the text,
+// keeping embeddedTexts limited to the read path.
+func (f *fakeEmbeddingClient) embedVector(text string) []float32 {
 	vec := make([]float32, f.dim)
 	for i := range vec {
 		// Use text bytes to generate deterministic values
@@ -730,19 +882,7 @@ func (f *fakeEmbeddingClient) Embed(_ context.Context, text string) ([]float32, 
 		}
 		vec[i] = float32(b)/128.0 - 1.0 + float32(i)*0.001
 	}
-	return vec, nil
-}
-
-func (f *fakeEmbeddingClient) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
-	result := make([][]float32, len(texts))
-	for i, text := range texts {
-		vec, err := f.Embed(ctx, text)
-		if err != nil {
-			return nil, err
-		}
-		result[i] = vec
-	}
-	return result, nil
+	return vec
 }
 
 func (*fakeEmbeddingClient) Close() error { return nil }

--- a/pkg/vmcp/optimizer/internal/types/mocks/mock_types.go
+++ b/pkg/vmcp/optimizer/internal/types/mocks/mock_types.go
@@ -15,6 +15,7 @@ import (
 
 	mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
 	server "github.com/stacklok/toolhive-core/mcpcompat/server"
+	types "github.com/stacklok/toolhive/pkg/vmcp/optimizer/internal/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -57,18 +58,18 @@ func (mr *MockToolStoreMockRecorder) Close() *gomock.Call {
 }
 
 // Search mocks base method.
-func (m *MockToolStore) Search(ctx context.Context, query string, allowedTools []string) ([]mcp.Tool, error) {
+func (m *MockToolStore) Search(ctx context.Context, q types.SearchQuery, allowedTools []string) ([]mcp.Tool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", ctx, query, allowedTools)
+	ret := m.ctrl.Call(m, "Search", ctx, q, allowedTools)
 	ret0, _ := ret[0].([]mcp.Tool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Search indicates an expected call of Search.
-func (mr *MockToolStoreMockRecorder) Search(ctx, query, allowedTools any) *gomock.Call {
+func (mr *MockToolStoreMockRecorder) Search(ctx, q, allowedTools any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockToolStore)(nil).Search), ctx, query, allowedTools)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockToolStore)(nil).Search), ctx, q, allowedTools)
 }
 
 // UpsertTools mocks base method.

--- a/pkg/vmcp/optimizer/internal/types/types.go
+++ b/pkg/vmcp/optimizer/internal/types/types.go
@@ -14,6 +14,19 @@ import (
 	"github.com/stacklok/toolhive-core/mcpcompat/server"
 )
 
+// SearchQuery describes a tool search request.
+//
+// The two fields feed different arms of hybrid search: Description is embedded
+// for semantic matching, Keywords build the FTS5/BM25 expression. When Keywords
+// is empty the lexical arm falls back to Description.
+type SearchQuery struct {
+	// Description is a natural language description of the desired capability.
+	Description string
+
+	// Keywords are optional discrete terms for the keyword-search arm.
+	Keywords []string
+}
+
 // ToolStore defines the interface for storing and searching tools.
 // Implementations may use in-memory maps, SQLite FTS5, or other backends.
 //
@@ -24,12 +37,14 @@ type ToolStore interface {
 	// Tools are identified by name; duplicate names are overwritten.
 	UpsertTools(ctx context.Context, tools []server.ServerTool) error
 
-	// Search finds tools matching the query string.
+	// Search finds tools matching q. Description is embedded for semantic
+	// matching; Keywords build the FTS5/BM25 expression, falling back to
+	// Description when empty.
 	// The allowedTools parameter limits results to only tools with names in the given set.
 	// If allowedTools is empty, no results are returned (empty = no access).
 	// Returns matches ranked by relevance. The returned mcp.Tool values contain
 	// only Name and Description; the caller is responsible for enriching with schemas.
-	Search(ctx context.Context, query string, allowedTools []string) ([]mcp.Tool, error)
+	Search(ctx context.Context, q SearchQuery, allowedTools []string) ([]mcp.Tool, error)
 
 	// Close releases any resources held by the store (e.g., database connections).
 	// For in-memory stores this is a no-op.

--- a/pkg/vmcp/optimizer/optimizer.go
+++ b/pkg/vmcp/optimizer/optimizer.go
@@ -201,7 +201,7 @@ type FindToolInput struct {
 
 	// ToolKeywords is an optional list of keywords to narrow the search.
 	//nolint:lll // Long description tag provides essential context for LLM tool usage.
-	ToolKeywords []string `json:"tool_keywords,omitempty" description:"Optional keywords for BM25 text search to narrow results (e.g. ['list', 'issues', 'github'] or ['SQL', 'query', 'postgres']). Combined with tool_description for hybrid search."`
+	ToolKeywords []string `json:"tool_keywords,omitempty" description:"Optional keywords driving the BM25 keyword-search arm (e.g. ['list', 'issues', 'github'] or ['SQL', 'query', 'postgres']). Semantic matching always uses tool_description, so provide a complete description even when supplying keywords."`
 }
 
 // FindToolOutput contains the results of a tool search.
@@ -336,7 +336,10 @@ func (d *toolOptimizer) FindTool(ctx context.Context, input FindToolInput) (*Fin
 		return nil, fmt.Errorf("tool_description is required")
 	}
 
-	matches, err := d.store.Search(ctx, input.ToolDescription, d.toolNames)
+	matches, err := d.store.Search(ctx, types.SearchQuery{
+		Description: input.ToolDescription,
+		Keywords:    input.ToolKeywords,
+	}, d.toolNames)
 	if err != nil {
 		return nil, fmt.Errorf("tool search failed: %w", err)
 	}

--- a/pkg/vmcp/optimizer/optimizer_test.go
+++ b/pkg/vmcp/optimizer/optimizer_test.go
@@ -437,11 +437,11 @@ func newMockStoreWithSubstringSearch(ctrl *gomock.Controller) *mocks.MockToolSto
 	).AnyTimes()
 
 	store.EXPECT().Search(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, query string, allowedTools []string) ([]mcp.Tool, error) {
+		func(_ context.Context, q types.SearchQuery, allowedTools []string) ([]mcp.Tool, error) {
 			if len(allowedTools) == 0 {
 				return nil, nil
 			}
-			searchTerm := strings.ToLower(query)
+			searchTerm := strings.ToLower(q.Description)
 			allowedSet := make(map[string]struct{}, len(allowedTools))
 			for _, name := range allowedTools {
 				allowedSet[name] = struct{}{}
@@ -483,8 +483,8 @@ func TestOptimizer_SearchDelegation(t *testing.T) {
 	}
 
 	store.EXPECT().UpsertTools(gomock.Any(), gomock.Any()).Return(nil)
-	store.EXPECT().Search(gomock.Any(), "query", gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ string, allowedTools []string) ([]mcp.Tool, error) {
+	store.EXPECT().Search(gomock.Any(), types.SearchQuery{Description: "query"}, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.SearchQuery, allowedTools []string) ([]mcp.Tool, error) {
 			require.ElementsMatch(t, []string{"tool_a", "tool_b"}, allowedTools)
 			return []mcp.Tool{
 				{Name: "tool_a", Description: "Tool A"},
@@ -686,6 +686,35 @@ func TestOptimizer_FindTool(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestOptimizer_FindToolPassesKeywords is the regression guard for the bug
+// where ToolKeywords was decoded off the wire, logged, and then dropped
+// instead of reaching the store's Search call.
+func TestOptimizer_FindToolPassesKeywords(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	store := mocks.NewMockToolStore(ctrl)
+
+	tools := []server.ServerTool{
+		{Tool: mcp.Tool{Name: "tool_a", Description: "Tool A"}},
+	}
+
+	store.EXPECT().UpsertTools(gomock.Any(), gomock.Any()).Return(nil)
+	store.EXPECT().Search(gomock.Any(), types.SearchQuery{
+		Description: "query",
+		Keywords:    []string{"list", "issues", "github"},
+	}, gomock.Any()).Return(nil, nil)
+
+	opt, err := newToolOptimizer(context.Background(), store, tokencounter.NewJSONByteCounter(), tools)
+	require.NoError(t, err)
+
+	_, err = opt.FindTool(context.Background(), FindToolInput{
+		ToolDescription: "query",
+		ToolKeywords:    []string{"list", "issues", "github"},
+	})
+	require.NoError(t, err)
 }
 
 func TestOptimizerFactoryWithStore(t *testing.T) {

--- a/pkg/vmcp/schema/reflect_test.go
+++ b/pkg/vmcp/schema/reflect_test.go
@@ -25,7 +25,7 @@ func TestGenerateSchema_FindToolInput(t *testing.T) {
 			"tool_keywords": map[string]any{
 				"type":        "array",
 				"items":       map[string]any{"type": "string"},
-				"description": "Optional keywords for BM25 text search to narrow results (e.g. ['list', 'issues', 'github'] or ['SQL', 'query', 'postgres']). Combined with tool_description for hybrid search.",
+				"description": "Optional keywords driving the BM25 keyword-search arm (e.g. ['list', 'issues', 'github'] or ['SQL', 'query', 'postgres']). Semantic matching always uses tool_description, so provide a complete description even when supplying keywords.",
 			},
 		},
 		"required": []string{"tool_description"},


### PR DESCRIPTION
## Summary

- `find_tool` advertises a `tool_keywords` input to the model, but the field was decoded off the wire, logged once, and dropped. `ToolStore.Search` took a single query string, so `tool_description` fed both the semantic arm (`Embed`) and the lexical arm (`sanitizeFTS5Query`), and there was nowhere to put keywords. The schema's claim that keywords are "combined with tool_description for hybrid search" was false.
- Two costs: models paid tokens for a field that did nothing, and a model trusting the schema could write a short, vague `tool_description` on the assumption that `tool_keywords` carried the lexical precision. That degrades the only arm running in FTS5-only mode (`--optimizer` without embeddings).
- `ToolStore.Search` now takes a `types.SearchQuery{Description, Keywords}`. Keywords build the FTS5 expression, the description is embedded for semantic matching, and the lexical arm falls back to the description when no usable keyword remains.
- Collapsed the two FTS5 sanitizers into one `sanitizeFTS5Terms` and dropped the phrase-search fallback. See "Special notes" below.
- Updated the `tool_keywords` schema description so the model knows semantic matching uses `tool_description` only, and keeps writing a complete one.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Full suite passes. Two failures remain in `pkg/plugins/pluginsvc` and `pkg/desktop`; both are pre-existing on `main` and neither package has the changed packages anywhere in its dependency graph, including test deps. Lint is clean apart from a pre-existing `G115` in `cmd/thv/app/upgrade.go`.

Each new test was validated as a real guard by reintroducing the bug and confirming a failure:

| Mutation | Caught by |
|---|---|
| Keywords ignored (the original bug) | `TestSQLiteToolStore_Search/keywords_surface_a_tool_the_description_alone_misses`, `TestSQLiteToolStore_KeywordsOnly/keywords_alone_drive_the_lexical_arm` |
| Semantic arm embeds keywords instead of the description | `TestSQLiteToolStore_SemanticArmEmbedsDescriptionOnly`, `TestSQLiteToolStore_KeywordsOnly/hybrid_tolerates_an_empty_description` |

That exercise changed the tests. A first attempt asserted `Contains(results, "run_query")` in hybrid mode and survived both mutations, because the semantic arm returns that tool on its own. The lexical assertions now run against FTS5-only stores where the semantic arm cannot mask the result.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `internal/types/types.go` | Add `SearchQuery`; widen `ToolStore.Search` |
| `internal/toolstore/sqlite_store.go` | Replace both sanitizers with `sanitizeFTS5Terms`; rework `Search` to split the arms |
| `optimizer.go` | Pass keywords into `Search`; update the schema tag |
| `internal/types/mocks/mock_types.go` | Regenerated via `task gen` |

## Does this introduce a user-facing change?

Yes. `tool_keywords` on `find_tool` now affects results instead of being ignored, and its schema description changed. Separately, a `tool_description` containing a common word (`name`, `data`, `table`, ...) now returns results where it previously returned none.

## Special notes for reviewers

**The sanitizer collapse is a second logical change.** It could be split out if you'd prefer. `sanitizeFTS5Query` used to fall back to a phrase search whenever the query contained a word from `problematicWords`. A phrase search demands exact token adjacency, so it reliably matched nothing: the new `"do something with data"` test case returns zero results from the description arm for exactly this reason. Dropping the noise word and OR-joining the rest avoids the result flood the fallback was guarding against without going empty-handed. Four `TestSanitizeFTS5Query` expectations flip as a result, all toward returning results instead of none.

**Fallback is keyed on the sanitized result, not on `len(Keywords)`.** All-noise keywords like `["table","schema"]` fall through to the description rather than blanking the lexical arm.

**`fakeEmbeddingClient` now records texts passed to `Embed`,** behind a mutex since `Search` calls it from an errgroup goroutine. `EmbedBatch`, the write path, is deliberately not recorded so `embeddedTexts()` reflects queries only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)