### PR TITLE
Avoid priority annexing unlisted tools

### DIFF
--- a/pkg/vmcp/aggregator/conflict_resolver_test.go
+++ b/pkg/vmcp/aggregator/conflict_resolver_test.go
@@ -208,6 +208,53 @@ func TestPriorityConflictResolver(t *testing.T) {
 			},
 		},
 		{
+			name:          "mixed listed and unlisted conflict uses prefix fallback",
+			priorityOrder: []string{"github"},
+			toolsByBackend: map[string][]vmcp.Tool{
+				"github": {
+					{Name: "deploy", Description: "GitHub deploy"},
+				},
+				"prod": {
+					{Name: "deploy", Description: "Production deploy"},
+				},
+			},
+			wantCount: 2,
+			wantWinners: map[string]string{
+				"github_deploy": "github",
+				"prod_deploy":   "prod",
+			},
+			wantStrategies: map[string]vmcp.ConflictResolutionStrategy{
+				"github_deploy": vmcp.ConflictStrategyPrefix,
+				"prod_deploy":   vmcp.ConflictStrategyPrefix,
+			},
+		},
+		{
+			name:          "three-way mixed listed and unlisted conflict uses prefix fallback",
+			priorityOrder: []string{"github", "staging"},
+			toolsByBackend: map[string][]vmcp.Tool{
+				"github": {
+					{Name: "deploy", Description: "GitHub deploy"},
+				},
+				"staging": {
+					{Name: "deploy", Description: "Staging deploy"},
+				},
+				"prod": {
+					{Name: "deploy", Description: "Production deploy"},
+				},
+			},
+			wantCount: 3,
+			wantWinners: map[string]string{
+				"github_deploy":  "github",
+				"staging_deploy": "staging",
+				"prod_deploy":    "prod",
+			},
+			wantStrategies: map[string]vmcp.ConflictResolutionStrategy{
+				"github_deploy":  vmcp.ConflictStrategyPrefix,
+				"staging_deploy": vmcp.ConflictStrategyPrefix,
+				"prod_deploy":    vmcp.ConflictStrategyPrefix,
+			},
+		},
+		{
 			name:          "empty priority order",
 			priorityOrder: []string{},
 			toolsByBackend: map[string][]vmcp.Tool{

--- a/pkg/vmcp/aggregator/conflict_resolver_test.go
+++ b/pkg/vmcp/aggregator/conflict_resolver_test.go
@@ -123,6 +123,7 @@ func TestPriorityConflictResolver(t *testing.T) {
 		wantCount      int
 		wantWinners    map[string]string                          // tool name -> expected backend ID
 		wantStrategies map[string]vmcp.ConflictResolutionStrategy // tool name -> expected strategy (optional)
+		wantMissing    []string                                   // tool names that must not be advertised
 		wantErr        bool
 	}{
 		{
@@ -182,7 +183,7 @@ func TestPriorityConflictResolver(t *testing.T) {
 			},
 		},
 		{
-			name:          "backends not in priority with conflict use prefix fallback",
+			name:          "unlisted backends with conflict are dropped",
 			priorityOrder: []string{"github"},
 			toolsByBackend: map[string][]vmcp.Tool{
 				"github": {
@@ -195,20 +196,13 @@ func TestPriorityConflictResolver(t *testing.T) {
 					{Name: "send_message", Description: "Teams message"},
 				},
 			},
-			wantCount: 3, // All tools included, conflicting ones prefixed
+			wantCount: 1, // Conflicting unrankable tools are dropped
 			wantWinners: map[string]string{
-				"create_issue":       "github", // In priority list
-				"slack_send_message": "slack",  // Not in priority, prefixed
-				"teams_send_message": "teams",  // Not in priority, prefixed
-			},
-			wantStrategies: map[string]vmcp.ConflictResolutionStrategy{
-				"create_issue":       vmcp.ConflictStrategyPriority, // Priority strategy used
-				"slack_send_message": vmcp.ConflictStrategyPrefix,   // Prefix fallback used
-				"teams_send_message": vmcp.ConflictStrategyPrefix,   // Prefix fallback used
+				"create_issue": "github", // In priority list, no conflict
 			},
 		},
 		{
-			name:          "mixed listed and unlisted conflict uses prefix fallback",
+			name:          "mixed listed and unlisted conflict drops all candidates",
 			priorityOrder: []string{"github"},
 			toolsByBackend: map[string][]vmcp.Tool{
 				"github": {
@@ -218,18 +212,12 @@ func TestPriorityConflictResolver(t *testing.T) {
 					{Name: "deploy", Description: "Production deploy"},
 				},
 			},
-			wantCount: 2,
-			wantWinners: map[string]string{
-				"github_deploy": "github",
-				"prod_deploy":   "prod",
-			},
-			wantStrategies: map[string]vmcp.ConflictResolutionStrategy{
-				"github_deploy": vmcp.ConflictStrategyPrefix,
-				"prod_deploy":   vmcp.ConflictStrategyPrefix,
-			},
+			wantCount:   0,
+			wantWinners: map[string]string{},
+			wantMissing: []string{"deploy", "github_deploy", "prod_deploy"},
 		},
 		{
-			name:          "three-way mixed listed and unlisted conflict uses prefix fallback",
+			name:          "three-way mixed conflict drops all candidates",
 			priorityOrder: []string{"github", "staging"},
 			toolsByBackend: map[string][]vmcp.Tool{
 				"github": {
@@ -242,17 +230,24 @@ func TestPriorityConflictResolver(t *testing.T) {
 					{Name: "deploy", Description: "Production deploy"},
 				},
 			},
-			wantCount: 3,
-			wantWinners: map[string]string{
-				"github_deploy":  "github",
-				"staging_deploy": "staging",
-				"prod_deploy":    "prod",
+			wantCount:   0,
+			wantWinners: map[string]string{},
+			wantMissing: []string{"deploy", "github_deploy", "staging_deploy", "prod_deploy"},
+		},
+		{
+			name:          "drop prevents forbid bypass via prefixed names",
+			priorityOrder: []string{"github"},
+			toolsByBackend: map[string][]vmcp.Tool{
+				"github": {
+					{Name: "deploy", Description: "GitHub deploy"},
+				},
+				"prod": {
+					{Name: "deploy", Description: "Production deploy"},
+				},
 			},
-			wantStrategies: map[string]vmcp.ConflictResolutionStrategy{
-				"github_deploy":  vmcp.ConflictStrategyPrefix,
-				"staging_deploy": vmcp.ConflictStrategyPrefix,
-				"prod_deploy":    vmcp.ConflictStrategyPrefix,
-			},
+			wantCount:   0,
+			wantWinners: map[string]string{},
+			wantMissing: []string{"deploy", "github_deploy", "prod_deploy"},
 		},
 		{
 			name:          "empty priority order",
@@ -312,6 +307,12 @@ func TestPriorityConflictResolver(t *testing.T) {
 					if tool.ConflictResolutionApplied != vmcp.ConflictStrategyPriority {
 						t.Errorf("tool %q has wrong strategy %q, want %q", toolName, tool.ConflictResolutionApplied, vmcp.ConflictStrategyPriority)
 					}
+				}
+			}
+
+			for _, toolName := range tt.wantMissing {
+				if _, exists := resolved[toolName]; exists {
+					t.Errorf("tool %q should have been dropped", toolName)
 				}
 			}
 		})

--- a/pkg/vmcp/aggregator/priority_resolver.go
+++ b/pkg/vmcp/aggregator/priority_resolver.go
@@ -12,11 +12,12 @@ import (
 )
 
 // PriorityConflictResolver implements priority-based conflict resolution.
-// The first backend in the priority order wins; conflicting tools from
-// lower-priority backends are dropped.
+// When every conflicting backend is listed in the priority order, the first
+// backend in that order wins and lower-priority tools are dropped.
 //
-// For backends not in the priority list, conflicts are resolved using
-// prefix strategy as a fallback (prevents data loss).
+// When any conflicting backend is absent from the priority list, all candidates
+// in that conflict use the prefix strategy as a fallback to prevent a listed
+// backend from annexing the bare tool name.
 type PriorityConflictResolver struct {
 	// PriorityOrder defines the priority of backends (first has highest priority).
 	PriorityOrder []string
@@ -82,35 +83,23 @@ func (r *PriorityConflictResolver) ResolveToolConflicts(
 			continue
 		}
 
-		// Conflict detected - choose the highest priority backend
-		winner := r.selectWinner(candidates)
-		if winner == nil {
-			// All candidates are from backends not in priority list
-			// Use prefix strategy as fallback to avoid data loss
+		if r.hasUnlistedCandidate(candidates) {
+			// A collision involving a backend outside priorityOrder cannot be safely
+			// rank-compared. Prefix every candidate instead of awarding the bare name
+			// to a listed backend, which could silently redirect name-only policies.
 			backendIDs := make([]string, len(candidates))
 			for i, c := range candidates {
 				backendIDs[i] = c.BackendID
 			}
-			slog.Debug("tool exists in backends not in priority order, using prefix fallback",
+			slog.Warn("tool conflict includes backend not in priority order, using prefix fallback",
 				"tool", toolName, "backends", backendIDs)
 
-			// Apply prefix strategy to these unmapped backends
-			for _, candidate := range candidates {
-				prefixedName := r.prefixResolver.applyPrefix(candidate.BackendID, toolName)
-				resolved[prefixedName] = &ResolvedTool{
-					ResolvedName:              prefixedName,
-					OriginalName:              toolName,
-					Description:               candidate.Tool.Description,
-					InputSchema:               candidate.Tool.InputSchema,
-					OutputSchema:              candidate.Tool.OutputSchema,
-					Annotations:               candidate.Tool.Annotations,
-					BackendID:                 candidate.BackendID,
-					ConflictResolutionApplied: vmcp.ConflictStrategyPrefix, // Fallback used prefix
-				}
-			}
+			r.addPrefixedCandidates(resolved, toolName, candidates)
 			continue
 		}
 
+		// Conflict detected among only listed backends; choose the highest priority backend.
+		winner := r.selectWinner(candidates)
 		resolved[toolName] = &ResolvedTool{
 			ResolvedName:              toolName,
 			OriginalName:              toolName,
@@ -142,8 +131,37 @@ func (r *PriorityConflictResolver) ResolveToolConflicts(
 	return resolved, nil
 }
 
+func (r *PriorityConflictResolver) hasUnlistedCandidate(candidates []toolWithBackend) bool {
+	for _, candidate := range candidates {
+		if _, exists := r.priorityMap[candidate.BackendID]; !exists {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *PriorityConflictResolver) addPrefixedCandidates(
+	resolved map[string]*ResolvedTool,
+	toolName string,
+	candidates []toolWithBackend,
+) {
+	for _, candidate := range candidates {
+		prefixedName := r.prefixResolver.applyPrefix(candidate.BackendID, toolName)
+		resolved[prefixedName] = &ResolvedTool{
+			ResolvedName:              prefixedName,
+			OriginalName:              toolName,
+			Description:               candidate.Tool.Description,
+			InputSchema:               candidate.Tool.InputSchema,
+			OutputSchema:              candidate.Tool.OutputSchema,
+			Annotations:               candidate.Tool.Annotations,
+			BackendID:                 candidate.BackendID,
+			ConflictResolutionApplied: vmcp.ConflictStrategyPrefix, // Fallback used prefix
+		}
+	}
+}
+
 // selectWinner chooses the tool from the highest-priority backend.
-// Returns nil if none of the candidates are in the priority list.
+// Callers should only pass candidates from backends that are in the priority list.
 func (r *PriorityConflictResolver) selectWinner(candidates []toolWithBackend) *toolWithBackend {
 	var winner *toolWithBackend
 	winnerPriority := -1

--- a/pkg/vmcp/aggregator/priority_resolver.go
+++ b/pkg/vmcp/aggregator/priority_resolver.go
@@ -16,17 +16,15 @@ import (
 // backend in that order wins and lower-priority tools are dropped.
 //
 // When any conflicting backend is absent from the priority list, all candidates
-// in that conflict use the prefix strategy as a fallback to prevent a listed
-// backend from annexing the bare tool name.
+// in that conflict are dropped because the conflict cannot be safely ranked.
+// Dropping preserves the fail-closed policy invariant: a renamed loser would be
+// advertised under a name that existing name-scoped forbid policies do not cover.
 type PriorityConflictResolver struct {
 	// PriorityOrder defines the priority of backends (first has highest priority).
 	PriorityOrder []string
 
 	// priorityMap is a map from backend ID to its priority index.
 	priorityMap map[string]int
-
-	// prefixResolver is used as fallback for backends not in priority list.
-	prefixResolver *PrefixConflictResolver
 }
 
 // NewPriorityConflictResolver creates a new priority-based conflict resolver.
@@ -45,9 +43,8 @@ func NewPriorityConflictResolver(priorityOrder []string) (*PriorityConflictResol
 	}
 
 	return &PriorityConflictResolver{
-		PriorityOrder:  priorityOrder,
-		priorityMap:    priorityMap,
-		prefixResolver: NewPrefixConflictResolver(defaultPrefixFormat), // Fallback for unmapped backends
+		PriorityOrder: priorityOrder,
+		priorityMap:   priorityMap,
 	}, nil
 }
 
@@ -85,16 +82,17 @@ func (r *PriorityConflictResolver) ResolveToolConflicts(
 
 		if r.hasUnlistedCandidate(candidates) {
 			// A collision involving a backend outside priorityOrder cannot be safely
-			// rank-compared. Prefix every candidate instead of awarding the bare name
-			// to a listed backend, which could silently redirect name-only policies.
+			// rank-compared. Drop every candidate instead of awarding the bare name
+			// to a listed backend or re-advertising losers under names outside
+			// existing name-scoped policies.
 			backendIDs := make([]string, len(candidates))
 			for i, c := range candidates {
 				backendIDs[i] = c.BackendID
 			}
-			slog.Warn("tool conflict includes backend not in priority order, using prefix fallback",
+			slog.Error("dropped tool conflict involving backend not in priority order",
 				"tool", toolName, "backends", backendIDs)
 
-			r.addPrefixedCandidates(resolved, toolName, candidates)
+			droppedTools += len(candidates)
 			continue
 		}
 
@@ -138,26 +136,6 @@ func (r *PriorityConflictResolver) hasUnlistedCandidate(candidates []toolWithBac
 		}
 	}
 	return false
-}
-
-func (r *PriorityConflictResolver) addPrefixedCandidates(
-	resolved map[string]*ResolvedTool,
-	toolName string,
-	candidates []toolWithBackend,
-) {
-	for _, candidate := range candidates {
-		prefixedName := r.prefixResolver.applyPrefix(candidate.BackendID, toolName)
-		resolved[prefixedName] = &ResolvedTool{
-			ResolvedName:              prefixedName,
-			OriginalName:              toolName,
-			Description:               candidate.Tool.Description,
-			InputSchema:               candidate.Tool.InputSchema,
-			OutputSchema:              candidate.Tool.OutputSchema,
-			Annotations:               candidate.Tool.Annotations,
-			BackendID:                 candidate.BackendID,
-			ConflictResolutionApplied: vmcp.ConflictStrategyPrefix, // Fallback used prefix
-		}
-	}
 }
 
 // selectWinner chooses the tool from the highest-priority backend.


### PR DESCRIPTION
## Summary

- The priority tool resolver could silently award a bare tool name to a listed backend when that name also came from a backend absent from `priorityOrder`.
- Because Cedar tool authorization is name-only today, that could redirect an existing `Tool::"name"` permit to a different backend's tool when a listed backend later introduced the same name.
- Treat any tool-name collision involving an unlisted backend as not safely rank-comparable: prefix every candidate instead of advertising a bare winner.
- Add a regression case covering a mixed listed/unlisted `deploy` conflict so both tools remain reachable as `github_deploy` and `prod_deploy`.

Fixes #6097

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manual testing:

- RED before fix: `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./pkg/vmcp/aggregator -run 'TestPriorityConflictResolver/mixed_listed_and_unlisted_conflict_uses_prefix_fallback'` failed with only one resolved tool and the unlisted backend dropped.
- GREEN after fix: `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./pkg/vmcp/aggregator -run TestPriorityConflictResolver`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test ./pkg/vmcp/aggregator`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH go test -race ./pkg/vmcp/aggregator -run TestPriorityConflictResolver`
- `PATH=/usr/local/go/bin:/root/go/bin:$PATH task lint`
- `git diff --check`

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes. Under the priority conflict strategy, a tool-name collision that includes any backend absent from `priorityOrder` now advertises the conflicting candidates with workload prefixes instead of selecting a bare-name winner.

## Special notes for reviewers

Conflicts where all candidates are listed in `priorityOrder` keep the existing priority-winner behavior. The prefix fallback is only for conflicts that include at least one unlisted backend, where no complete rank comparison exists. That fallback prefixes every candidate in the collision, so a listed backend's previously bare tool name can also be renamed when it collides with an unlisted backend.

Reviewer follow-up addressed:

- Added 3-way mixed listed/unlisted regression coverage.
- Updated stale priority resolver comments.
- Raised the prefix-fallback log from Debug to Warn.

