### PR TITLE
Block upgrades that change the signer identity

### DIFF
--- a/cmd/thv/app/skill_upgrade.go
+++ b/cmd/thv/app/skill_upgrade.go
@@ -13,13 +13,14 @@ import (
 )
 
 var (
-	skillUpgradeProjectRoot    string
-	skillUpgradeClientsRaw     string
-	skillUpgradePreview        bool
-	skillUpgradeFailOnChanges  bool
-	skillUpgradeAllowRefChange bool
-	skillUpgradeYes            bool
-	skillUpgradeFormat         string
+	skillUpgradeProjectRoot       string
+	skillUpgradeClientsRaw        string
+	skillUpgradePreview           bool
+	skillUpgradeFailOnChanges     bool
+	skillUpgradeAllowRefChange    bool
+	skillUpgradeAllowSignerChange bool
+	skillUpgradeYes               bool
+	skillUpgradeFormat            string
 )
 
 var skillUpgradeCmd = &cobra.Command{
@@ -59,6 +60,8 @@ func init() {
 		"Report what would change without persisting anything (OCI sources are still fetched to compare digests)")
 	skillUpgradeCmd.Flags().BoolVar(&skillUpgradeFailOnChanges, "fail-on-changes", false,
 		"Report what would change without installing anything; a CI freshness gate")
+	skillUpgradeCmd.Flags().BoolVar(&skillUpgradeAllowSignerChange, "allow-signer-change", false,
+		"Permit upgrading to an artifact signed by a different identity; the new identity replaces the recorded one")
 	skillUpgradeCmd.Flags().BoolVar(&skillUpgradeAllowRefChange, "allow-ref-change", false,
 		"Permit the resolved reference itself to change during upgrade")
 	skillUpgradeCmd.Flags().BoolVar(&skillUpgradeYes, "yes", false,
@@ -88,12 +91,13 @@ func skillUpgradeCmdFunc(cmd *cobra.Command, args []string) error {
 
 	c := newSkillClient(cmd.Context())
 	result, err := c.Upgrade(cmd.Context(), skills.UpgradeOptions{
-		ProjectRoot:    projectRoot,
-		Names:          args,
-		Clients:        parseSkillInstallClients(skillUpgradeClientsRaw),
-		Preview:        skillUpgradePreview,
-		FailOnChanges:  skillUpgradeFailOnChanges,
-		AllowRefChange: skillUpgradeAllowRefChange,
+		ProjectRoot:       projectRoot,
+		Names:             args,
+		Clients:           parseSkillInstallClients(skillUpgradeClientsRaw),
+		Preview:           skillUpgradePreview,
+		FailOnChanges:     skillUpgradeFailOnChanges,
+		AllowRefChange:    skillUpgradeAllowRefChange,
+		AllowSignerChange: skillUpgradeAllowSignerChange,
 	})
 	if err != nil {
 		return formatSkillError("upgrade skills", err)
@@ -113,21 +117,36 @@ func skillUpgradeCmdFunc(cmd *cobra.Command, args []string) error {
 // (exit 2). A ref-change block maps to a policy rejection (exit 4) only
 // when the run wasn't a preview/gate evaluation — during those nothing was
 // actually blocked, only reported.
-func upgradeExitError(result *skills.UpgradeResult, preview, failOnChanges bool) error {
-	var failed, refBlocked, wouldChange int
+// upgradeTally counts the exit-code-relevant outcome classes.
+type upgradeTally struct {
+	failed, refBlocked, signerBlocked, wouldChange int
+}
+
+func tallyUpgradeOutcomes(result *skills.UpgradeResult) upgradeTally {
+	var t upgradeTally
 	for _, o := range result.Outcomes {
 		switch o.Status {
 		case skills.UpgradeStatusFailed:
-			failed++
+			t.failed++
 		case skills.UpgradeStatusRefChangeBlocked:
-			refBlocked++
-			wouldChange++
+			t.refBlocked++
+			t.wouldChange++
+		case skills.UpgradeStatusSignerChangeBlocked:
+			t.signerBlocked++
+			t.wouldChange++
 		case skills.UpgradeStatusUpgraded:
-			wouldChange++
+			t.wouldChange++
 		case skills.UpgradeStatusUpToDate, skills.UpgradeStatusNotUpgradable:
 			// No exit-code impact.
 		}
 	}
+	return t
+}
+
+func upgradeExitError(result *skills.UpgradeResult, preview, failOnChanges bool) error {
+	tally := tallyUpgradeOutcomes(result)
+	failed, refBlocked, signerBlocked, wouldChange :=
+		tally.failed, tally.refBlocked, tally.signerBlocked, tally.wouldChange
 	if failed > 0 {
 		return withExitCode(fmt.Errorf("upgrade failed for %d skill(s)", failed), ExitCodePartialFailure)
 	}
@@ -135,6 +154,12 @@ func upgradeExitError(result *skills.UpgradeResult, preview, failOnChanges bool)
 		return withExitCode(
 			fmt.Errorf("%d skill(s) would change; the lock file is stale", wouldChange),
 			ExitCodeCheckFailure,
+		)
+	}
+	if !preview && !failOnChanges && signerBlocked > 0 {
+		return withExitCode(
+			fmt.Errorf("%d skill(s) blocked by a signer change; use --allow-signer-change", signerBlocked),
+			ExitCodePolicyRejection,
 		)
 	}
 	if !preview && !failOnChanges && refBlocked > 0 {
@@ -177,6 +202,12 @@ func printUpgradeResult(result *skills.UpgradeResult, format string, planOnly bo
 			fmt.Printf("%s: not upgradable (pinned to an immutable reference)\n", o.Name)
 		case skills.UpgradeStatusRefChangeBlocked:
 			fmt.Printf("%s: reference change blocked (would move to %s; use --allow-ref-change)\n", o.Name, o.NewResolvedReference)
+		case skills.UpgradeStatusSignerChangeBlocked:
+			newSigner := o.NewSignerIdentity
+			if newSigner == "" {
+				newSigner = "unsigned"
+			}
+			fmt.Printf("%s: signer change blocked (candidate is %s; use --allow-signer-change)\n", o.Name, newSigner)
 		case skills.UpgradeStatusFailed:
 			fmt.Printf("%s: failed [%s]: %s\n", o.Name, o.Reason, o.Error)
 		}

--- a/cmd/thv/app/skill_upgrade_test.go
+++ b/cmd/thv/app/skill_upgrade_test.go
@@ -43,6 +43,23 @@ func TestUpgradeExitError(t *testing.T) {
 			wantCode: ExitCodePolicyRejection,
 		},
 		{
+			name:     "signer change blocked is a policy rejection",
+			outcomes: []skills.UpgradeOutcome{{Name: "a", Status: skills.UpgradeStatusSignerChangeBlocked}},
+			wantCode: ExitCodePolicyRejection,
+		},
+		{
+			name:     "signer change blocked in preview is informational",
+			outcomes: []skills.UpgradeOutcome{{Name: "a", Status: skills.UpgradeStatusSignerChangeBlocked}},
+			preview:  true,
+			wantCode: 0,
+		},
+		{
+			name:          "signer change blocked counts as would-change under fail-on-changes",
+			outcomes:      []skills.UpgradeOutcome{{Name: "a", Status: skills.UpgradeStatusSignerChangeBlocked}},
+			failOnChanges: true,
+			wantCode:      ExitCodeCheckFailure,
+		},
+		{
 			name:     "ref change blocked during preview is not a policy rejection",
 			outcomes: []skills.UpgradeOutcome{{Name: "a", Status: skills.UpgradeStatusRefChangeBlocked}},
 			preview:  true,

--- a/docs/cli/thv_skill_upgrade.md
+++ b/docs/cli/thv_skill_upgrade.md
@@ -41,6 +41,7 @@ thv skill upgrade [skill-name...] [flags]
 
 ```
       --allow-ref-change      Permit the resolved reference itself to change during upgrade
+      --allow-signer-change   Permit upgrading to an artifact signed by a different identity; the new identity replaces the recorded one
       --clients string        Comma-separated target client apps (e.g. claude-code,opencode), or "all" for every available client
       --fail-on-changes       Report what would change without installing anything; a CI freshness gate
       --format string         Output format (json, text) (default "text")

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1907,6 +1907,10 @@ const docTemplate = `{
                         "description": "NewResolvedReference is the new resolvedReference when it changed.",
                         "type": "string"
                     },
+                    "new_signer_identity": {
+                        "description": "NewSignerIdentity is the candidate's signer identity when it differs\nfrom the recorded one (empty when the candidate is unsigned).",
+                        "type": "string"
+                    },
                     "old_digest": {
                         "description": "OldDigest is the digest pinned in the lock file before this operation.",
                         "type": "string"
@@ -1940,6 +1944,7 @@ const docTemplate = `{
                     "up-to-date",
                     "not-upgradable",
                     "ref-change-blocked",
+                    "signer-change-blocked",
                     "failed"
                 ],
                 "type": "string",
@@ -1948,6 +1953,7 @@ const docTemplate = `{
                     "UpgradeStatusUpToDate",
                     "UpgradeStatusNotUpgradable",
                     "UpgradeStatusRefChangeBlocked",
+                    "UpgradeStatusSignerChangeBlocked",
                     "UpgradeStatusFailed"
                 ]
             },
@@ -3805,6 +3811,10 @@ const docTemplate = `{
                 "properties": {
                     "allow_ref_change": {
                         "description": "AllowRefChange permits resolvedReference changes during upgrade",
+                        "type": "boolean"
+                    },
+                    "allow_signer_change": {
+                        "description": "AllowSignerChange permits upgrading to an artifact signed by a\ndifferent identity than the recorded one",
                         "type": "boolean"
                     },
                     "clients": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1900,6 +1900,10 @@
                         "description": "NewResolvedReference is the new resolvedReference when it changed.",
                         "type": "string"
                     },
+                    "new_signer_identity": {
+                        "description": "NewSignerIdentity is the candidate's signer identity when it differs\nfrom the recorded one (empty when the candidate is unsigned).",
+                        "type": "string"
+                    },
                     "old_digest": {
                         "description": "OldDigest is the digest pinned in the lock file before this operation.",
                         "type": "string"
@@ -1933,6 +1937,7 @@
                     "up-to-date",
                     "not-upgradable",
                     "ref-change-blocked",
+                    "signer-change-blocked",
                     "failed"
                 ],
                 "type": "string",
@@ -1941,6 +1946,7 @@
                     "UpgradeStatusUpToDate",
                     "UpgradeStatusNotUpgradable",
                     "UpgradeStatusRefChangeBlocked",
+                    "UpgradeStatusSignerChangeBlocked",
                     "UpgradeStatusFailed"
                 ]
             },
@@ -3798,6 +3804,10 @@
                 "properties": {
                     "allow_ref_change": {
                         "description": "AllowRefChange permits resolvedReference changes during upgrade",
+                        "type": "boolean"
+                    },
+                    "allow_signer_change": {
+                        "description": "AllowSignerChange permits upgrading to an artifact signed by a\ndifferent identity than the recorded one",
                         "type": "boolean"
                     },
                     "clients": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1875,6 +1875,11 @@ components:
         new_resolved_reference:
           description: NewResolvedReference is the new resolvedReference when it changed.
           type: string
+        new_signer_identity:
+          description: |-
+            NewSignerIdentity is the candidate's signer identity when it differs
+            from the recorded one (empty when the candidate is unsigned).
+          type: string
         old_digest:
           description: OldDigest is the digest pinned in the lock file before this
             operation.
@@ -1900,6 +1905,7 @@ components:
       - up-to-date
       - not-upgradable
       - ref-change-blocked
+      - signer-change-blocked
       - failed
       type: string
       x-enum-varnames:
@@ -1907,6 +1913,7 @@ components:
       - UpgradeStatusUpToDate
       - UpgradeStatusNotUpgradable
       - UpgradeStatusRefChangeBlocked
+      - UpgradeStatusSignerChangeBlocked
       - UpgradeStatusFailed
     github_com_stacklok_toolhive_pkg_skills.ValidationResult:
       properties:
@@ -3370,6 +3377,11 @@ components:
       properties:
         allow_ref_change:
           description: AllowRefChange permits resolvedReference changes during upgrade
+          type: boolean
+        allow_signer_change:
+          description: |-
+            AllowSignerChange permits upgrading to an artifact signed by a
+            different identity than the recorded one
           type: boolean
         clients:
           description: |-

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -452,12 +452,13 @@ func (s *SkillsRoutes) upgradeSkills(w http.ResponseWriter, r *http.Request) err
 	}
 
 	result, err := s.lockService.Upgrade(r.Context(), skills.UpgradeOptions{
-		ProjectRoot:    req.ProjectRoot,
-		Names:          req.Names,
-		Preview:        req.Preview,
-		FailOnChanges:  req.FailOnChanges,
-		AllowRefChange: req.AllowRefChange,
-		Clients:        req.Clients,
+		ProjectRoot:       req.ProjectRoot,
+		Names:             req.Names,
+		Preview:           req.Preview,
+		FailOnChanges:     req.FailOnChanges,
+		AllowRefChange:    req.AllowRefChange,
+		AllowSignerChange: req.AllowSignerChange,
+		Clients:           req.Clients,
 	})
 	if err != nil {
 		return err

--- a/pkg/api/v1/skills_types.go
+++ b/pkg/api/v1/skills_types.go
@@ -107,6 +107,9 @@ type upgradeSkillsRequest struct {
 	FailOnChanges bool `json:"fail_on_changes,omitempty"`
 	// AllowRefChange permits resolvedReference changes during upgrade
 	AllowRefChange bool `json:"allow_ref_change,omitempty"`
+	// AllowSignerChange permits upgrading to an artifact signed by a
+	// different identity than the recorded one
+	AllowSignerChange bool `json:"allow_signer_change,omitempty"`
 	// Clients lists target client identifiers. Empty means every
 	// skill-supporting client detected on this host.
 	Clients []string `json:"clients,omitempty"`

--- a/pkg/skills/client/client.go
+++ b/pkg/skills/client/client.go
@@ -291,12 +291,13 @@ func (c *Client) Sync(ctx context.Context, opts skills.SyncOptions) (*skills.Syn
 // where available.
 func (c *Client) Upgrade(ctx context.Context, opts skills.UpgradeOptions) (*skills.UpgradeResult, error) {
 	body := upgradeRequest{
-		ProjectRoot:    opts.ProjectRoot,
-		Names:          opts.Names,
-		Preview:        opts.Preview,
-		FailOnChanges:  opts.FailOnChanges,
-		AllowRefChange: opts.AllowRefChange,
-		Clients:        opts.Clients,
+		ProjectRoot:       opts.ProjectRoot,
+		Names:             opts.Names,
+		Preview:           opts.Preview,
+		FailOnChanges:     opts.FailOnChanges,
+		AllowRefChange:    opts.AllowRefChange,
+		AllowSignerChange: opts.AllowSignerChange,
+		Clients:           opts.Clients,
 	}
 
 	var result skills.UpgradeResult

--- a/pkg/skills/client/dto.go
+++ b/pkg/skills/client/dto.go
@@ -56,10 +56,12 @@ type syncRequest struct {
 }
 
 type upgradeRequest struct {
-	ProjectRoot    string   `json:"project_root"`
-	Names          []string `json:"names,omitempty"`
-	Preview        bool     `json:"preview,omitempty"`
-	FailOnChanges  bool     `json:"fail_on_changes,omitempty"`
-	AllowRefChange bool     `json:"allow_ref_change,omitempty"`
-	Clients        []string `json:"clients,omitempty"`
+	ProjectRoot string   `json:"project_root"`
+	Names       []string `json:"names,omitempty"`
+	// AllowSignerChange mirrors skills.UpgradeOptions.AllowSignerChange.
+	AllowSignerChange bool     `json:"allow_signer_change,omitempty"`
+	Preview           bool     `json:"preview,omitempty"`
+	FailOnChanges     bool     `json:"fail_on_changes,omitempty"`
+	AllowRefChange    bool     `json:"allow_ref_change,omitempty"`
+	Clients           []string `json:"clients,omitempty"`
 }

--- a/pkg/skills/options.go
+++ b/pkg/skills/options.go
@@ -76,6 +76,11 @@ type InstallOptions struct {
 	// normal "same digest means content is already correct" fast path must
 	// not apply. Internal use only — NOT exposed via HTTP API.
 	SyncRestore bool `json:"-"`
+	// AllowSignerChange lets install-time verification re-record the
+	// observed identity instead of enforcing the lock file's recorded one.
+	// Internal use only — set by upgrade when its signer-change guard was
+	// explicitly overridden.
+	AllowSignerChange bool `json:"-"`
 	// Unsigned records the trust decision that this install proceeded
 	// without a verified signature (via AllowUnsigned). Set internally by
 	// install-time verification; recorded as `unsigned: true` in the lock
@@ -311,6 +316,10 @@ type UpgradeOptions struct {
 	FailOnChanges bool `json:"fail_on_changes,omitempty"`
 	// AllowRefChange permits resolvedReference changes during upgrade.
 	AllowRefChange bool `json:"allow_ref_change,omitempty"`
+	// AllowSignerChange permits upgrading to an artifact signed by a
+	// different identity than the one recorded in the lock file; the new
+	// identity is recorded in its place.
+	AllowSignerChange bool `json:"allow_signer_change,omitempty"`
 	// Clients lists target clients (e.g., "claude-code"). Empty means every
 	// skill-supporting client detected on this host.
 	Clients []string `json:"clients,omitempty"`
@@ -329,6 +338,10 @@ const (
 	UpgradeStatusNotUpgradable UpgradeStatus = "not-upgradable"
 	// UpgradeStatusRefChangeBlocked indicates re-resolution changed resolvedReference.
 	UpgradeStatusRefChangeBlocked UpgradeStatus = "ref-change-blocked"
+	// UpgradeStatusSignerChangeBlocked indicates the candidate artifact is
+	// signed by a different identity (or unsigned) versus the identity the
+	// lock file records.
+	UpgradeStatusSignerChangeBlocked UpgradeStatus = "signer-change-blocked"
 	// UpgradeStatusFailed indicates the upgrade attempt failed.
 	UpgradeStatusFailed UpgradeStatus = "failed"
 )
@@ -346,6 +359,9 @@ type UpgradeOutcome struct {
 	NewDigest string `json:"new_digest,omitempty"`
 	// NewResolvedReference is the new resolvedReference when it changed.
 	NewResolvedReference string `json:"new_resolved_reference,omitempty"`
+	// NewSignerIdentity is the candidate's signer identity when it differs
+	// from the recorded one (empty when the candidate is unsigned).
+	NewSignerIdentity string `json:"new_signer_identity,omitempty"`
 	// Reason is a typed failure reason when Status is UpgradeStatusFailed.
 	Reason FailureReason `json:"reason,omitempty"`
 	// Error is a human-readable description of the failure, set only when Status is UpgradeStatusFailed.

--- a/pkg/skills/skillsvc/upgrade.go
+++ b/pkg/skills/skillsvc/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	nameref "github.com/google/go-containerregistry/pkg/name"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/skills"
 	"github.com/stacklok/toolhive/pkg/skills/gitresolver"
 	"github.com/stacklok/toolhive/pkg/skills/lockfile"
+	"github.com/stacklok/toolhive/pkg/skills/verifier"
 )
 
 // var _ ensures *service continues to satisfy the full lock service surface
@@ -146,6 +148,18 @@ func (s *service) planUpgrade(ctx context.Context, opts skills.UpgradeOptions, e
 		outcome.NewResolvedReference = newRef
 	}
 
+	// Signer-change guard: when the entry records a signer identity, the
+	// candidate must verify with the same one before the upgrade is even
+	// planned. Verification happens here (plan-only modes stay
+	// install-free) with a nil expected identity so a differing signer is
+	// reported as a change rather than a bare failure; blocked plans carry
+	// no pinnedRef, exactly like ref changes.
+	if entry.Provenance != nil && !opts.AllowSignerChange {
+		if blocked := s.guardSignerChange(ctx, entry, newRef, newDigest, &outcome); blocked {
+			return upgradePlan{entry: entry, outcome: outcome}
+		}
+	}
+
 	pinnedRef, err := buildPinnedReference(lockfile.Entry{ResolvedReference: newRef, Digest: newDigest})
 	if err != nil {
 		outcome.Status = skills.UpgradeStatusFailed
@@ -156,6 +170,60 @@ func (s *service) planUpgrade(ctx context.Context, opts skills.UpgradeOptions, e
 
 	outcome.Status = skills.UpgradeStatusUpgraded
 	return upgradePlan{entry: entry, outcome: outcome, pinnedRef: pinnedRef, resolvedRef: newRef}
+}
+
+// guardSignerChange probes the candidate artifact's signer identity and
+// fills outcome when the upgrade must not proceed: the candidate is signed
+// by a different identity (or unsigned) versus the recorded provenance, or
+// its signature cannot be verified at all. Returns true when blocked.
+func (s *service) guardSignerChange(
+	ctx context.Context,
+	entry lockfile.Entry,
+	newRef, newDigest string,
+	outcome *skills.UpgradeOutcome,
+) bool {
+	probe, probeErr := s.probeCandidateSigner(ctx, newRef, newDigest)
+	switch {
+	case probeErr != nil && errors.Is(probeErr, verifier.ErrUnsigned):
+		outcome.Status = skills.UpgradeStatusSignerChangeBlocked
+		return true
+	case probeErr != nil:
+		outcome.Status = skills.UpgradeStatusFailed
+		outcome.Reason = classifySignatureError(probeErr)
+		if outcome.Reason == "" {
+			outcome.Reason = skills.FailureReasonUnknown
+		}
+		outcome.Error = probeErr.Error()
+		return true
+	case probe.SignerIdentity != entry.Provenance.SignerIdentity ||
+		probe.CertIssuer != entry.Provenance.CertIssuer:
+		outcome.Status = skills.UpgradeStatusSignerChangeBlocked
+		outcome.NewSignerIdentity = probe.SignerIdentity
+		return true
+	}
+	return false
+}
+
+// probeCandidateSigner verifies the candidate artifact chain-of-trust-only
+// (nil expected identity) and returns the observed identity. Git candidates
+// are re-resolved at the pinned commit to obtain the signature material.
+func (s *service) probeCandidateSigner(ctx context.Context, newRef, newDigest string) (*verifier.Result, error) {
+	if strings.Contains(newDigest, ":") {
+		return s.artifactVerifier().VerifyOCI(ctx, newRef, newDigest, nil)
+	}
+	pinned, err := buildPinnedReference(lockfile.Entry{ResolvedReference: newRef, Digest: newDigest})
+	if err != nil {
+		return nil, err
+	}
+	gitRef, err := gitresolver.ParseGitReference(pinned)
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := s.gitResolver.Resolve(ctx, gitRef)
+	if err != nil {
+		return nil, err
+	}
+	return s.artifactVerifier().VerifyGit(ctx, resolved.CommitPayload, []byte(resolved.CommitSignature), nil)
 }
 
 // applyUpgrade installs plan's pinned content when the plan calls for it.
@@ -179,6 +247,7 @@ func (s *service) applyUpgrade(ctx context.Context, opts skills.UpgradeOptions, 
 		Clients:               clients,
 		LockSource:            plan.entry.Source,
 		LockResolvedReference: plan.resolvedRef,
+		AllowSignerChange:     opts.AllowSignerChange,
 	}); err != nil {
 		outcome := plan.outcome
 		outcome.Status = skills.UpgradeStatusFailed

--- a/pkg/skills/skillsvc/upgrade_verify_test.go
+++ b/pkg/skills/skillsvc/upgrade_verify_test.go
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skillsvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/skills"
+	"github.com/stacklok/toolhive/pkg/skills/lockfile"
+	"github.com/stacklok/toolhive/pkg/skills/verifier"
+	verifiermocks "github.com/stacklok/toolhive/pkg/skills/verifier/mocks"
+)
+
+// otherSignerResult is a verification result from a different identity than
+// signedResult's.
+func otherSignerResult() *verifier.Result {
+	r := signedResult()
+	r.SignerIdentity = "/.github/workflows/other.yml"
+	return r
+}
+
+// signerChangeFixture installs a signed skill, then republishes newer
+// content at the same source and returns a service whose verifier reports
+// the candidate as signed by candidate() (or unsigned when candidate
+// returns nil, err).
+func signerChangeFixture(
+	t *testing.T,
+	candidate func() (*verifier.Result, error),
+) (skills.SkillService, string) {
+	t.Helper()
+	gr, fx := newGitResolverMock(t)
+	fx.register("guarded-skill", gitSkill("guarded-skill"))
+
+	installs := 0
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ any, _, _ []byte, expected *lockfile.Provenance) (*verifier.Result, error) {
+			installs++
+			if installs == 1 {
+				return signedResult(), nil // initial install (TOFU)
+			}
+			result, err := candidate()
+			if err != nil {
+				return nil, err
+			}
+			if expected != nil && expected.SignerIdentity != result.SignerIdentity {
+				return nil, verifier.ErrSignerMismatch
+			}
+			return result, nil
+		})
+	mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(nil)
+
+	svc, projectRoot := newLockTestService(t, gr, WithVerifier(mv))
+	ref, _ := gitRef("guarded-skill")
+	_, err := svc.Install(t.Context(), skills.InstallOptions{
+		Name: ref, Scope: skills.ScopeProject, ProjectRoot: projectRoot, Clients: []string{"claude-code"},
+	})
+	require.NoError(t, err)
+
+	// Republish newer content at the same source so an upgrade is planned.
+	fx.register("guarded-skill", gitSkillVersion("guarded-skill"))
+	return svc, projectRoot
+}
+
+//nolint:paralleltest // uses t.Setenv via newLockTestService, incompatible with t.Parallel
+func TestUpgrade_SignerChangeBlocked(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return otherSignerResult(), nil
+	})
+
+	result, err := svc.(*service).Upgrade(t.Context(), skills.UpgradeOptions{ProjectRoot: projectRoot}) //nolint:forcetypeassert
+	require.NoError(t, err)
+	require.Len(t, result.Outcomes, 1)
+	assert.Equal(t, skills.UpgradeStatusSignerChangeBlocked, result.Outcomes[0].Status)
+	assert.Equal(t, "/.github/workflows/other.yml", result.Outcomes[0].NewSignerIdentity)
+
+	// Nothing installed, lock unchanged.
+	lf := readLockfile(t, projectRoot)
+	entry, ok := lf.Get("guarded-skill")
+	require.True(t, ok)
+	require.NotNil(t, entry.Provenance)
+	assert.Equal(t, testSignerIdentity, entry.Provenance.SignerIdentity)
+}
+
+//nolint:paralleltest // uses t.Setenv via newLockTestService, incompatible with t.Parallel
+func TestUpgrade_UnsignedCandidateBlockedAgainstSignedEntry(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return nil, verifier.ErrUnsigned
+	})
+
+	result, err := svc.(*service).Upgrade(t.Context(), skills.UpgradeOptions{ProjectRoot: projectRoot}) //nolint:forcetypeassert
+	require.NoError(t, err)
+	require.Len(t, result.Outcomes, 1)
+	assert.Equal(t, skills.UpgradeStatusSignerChangeBlocked, result.Outcomes[0].Status)
+	assert.Empty(t, result.Outcomes[0].NewSignerIdentity, "an unsigned candidate has no identity to report")
+}
+
+//nolint:paralleltest // uses t.Setenv via newLockTestService, incompatible with t.Parallel
+func TestUpgrade_AllowSignerChangeRecordsNewIdentity(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return otherSignerResult(), nil
+	})
+
+	result, err := svc.(*service).Upgrade(t.Context(), //nolint:forcetypeassert
+		skills.UpgradeOptions{ProjectRoot: projectRoot, AllowSignerChange: true})
+	require.NoError(t, err)
+	require.Len(t, result.Outcomes, 1)
+	assert.Equal(t, skills.UpgradeStatusUpgraded, result.Outcomes[0].Status)
+
+	lf := readLockfile(t, projectRoot)
+	entry, ok := lf.Get("guarded-skill")
+	require.True(t, ok)
+	require.NotNil(t, entry.Provenance)
+	assert.Equal(t, "/.github/workflows/other.yml", entry.Provenance.SignerIdentity,
+		"the explicit override must re-record the new identity")
+}
+
+//nolint:paralleltest // uses t.Setenv via newLockTestService, incompatible with t.Parallel
+func TestUpgrade_SignerChangePreviewParity(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return otherSignerResult(), nil
+	})
+
+	result, err := svc.(*service).Upgrade(t.Context(), //nolint:forcetypeassert
+		skills.UpgradeOptions{ProjectRoot: projectRoot, Preview: true})
+	require.NoError(t, err)
+	require.Len(t, result.Outcomes, 1)
+	assert.Equal(t, skills.UpgradeStatusSignerChangeBlocked, result.Outcomes[0].Status,
+		"preview must report the same signer-change block as apply")
+
+	// Preview installed nothing and rewrote nothing.
+	lf := readLockfile(t, projectRoot)
+	entry, ok := lf.Get("guarded-skill")
+	require.True(t, ok)
+	assert.Equal(t, testSignerIdentity, entry.Provenance.SignerIdentity)
+}

--- a/pkg/skills/skillsvc/verify.go
+++ b/pkg/skills/skillsvc/verify.go
@@ -67,6 +67,11 @@ func (s *service) verifyOCIInstall(
 	if err != nil {
 		return nil, err
 	}
+	if opts.AllowSignerChange {
+		// The signer-change guard was explicitly overridden: verify the
+		// chain of trust only and re-record whatever identity is observed.
+		expected, expectUnsigned = nil, false
+	}
 	if expectUnsigned {
 		return unsignedLockedDecision(opts, skillName)
 	}
@@ -96,6 +101,9 @@ func (s *service) verifyGitInstall(
 	expected, expectUnsigned, err := expectedLockTrust(opts.ProjectRoot, skillName)
 	if err != nil {
 		return nil, err
+	}
+	if opts.AllowSignerChange {
+		expected, expectUnsigned = nil, false
 	}
 	if expectUnsigned {
 		return unsignedLockedDecision(opts, skillName)


### PR DESCRIPTION
> [!NOTE]
> **Stack 2 of RFC THV-0080** (tracking issue #5899) — part of stack #6128: #6091 ← #6121 ← #6129 ← #6131 ← this.

## Summary

An upgrade re-resolves a mutable source — exactly the moment a compromised or transferred publisher could slip a differently-signed artifact into the pinned trust chain. This PR closes that gap:

- **Plan-time signer probe**: when a lock entry records a signer identity, `planUpgrade` verifies the candidate artifact (chain-of-trust only, no install — preview stays install-free) and compares the observed identity against the recorded one. OCI candidates verify directly; git candidates are re-resolved at the pinned commit for their signature material.
- **`signer-change-blocked` status**: a differing identity — or an unsigned candidate against a signed entry — blocks the plan with no pinned reference, mirroring `ref-change-blocked` exactly: preview reports it, `--fail-on-changes` counts it as a change (exit 2), and a plain upgrade exits with the policy-rejection code (exit 4) pointing at the escape hatch. The blocked outcome carries `new_signer_identity` so the user sees who signed the candidate.
- **`--allow-signer-change`** (CLI, client, API): the explicit override verifies the candidate chain-of-trust-only and **re-records the new identity** in the lock entry — a deliberate, diff-visible trust rotation rather than a silent one. This is also the recovery path the install-time signer-mismatch error now points at.
- Entries without recorded provenance (unsigned/legacy) are unaffected — no probe, no behavior change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test improvements
- [ ] CI/CD or build system changes

## Test plan

- [x] Unit tests pass locally
- [x] Linting passes (`task lint-fix`, 0 issues)
- [x] New unit tests: signer-change blocked with the new identity reported and the lock untouched; unsigned candidate blocked against a signed entry; `--allow-signer-change` upgrades and re-records the new identity; preview parity (same block reported, nothing installed or rewritten); exit-code matrix rows (policy rejection, preview-informational, fail-on-changes interaction).
- [x] `task docs` regenerated (new flag + API field).

## Does this introduce a user-facing change?

Yes, behind the experimental gate: `thv skill upgrade` refuses to move a skill to an artifact signed by a different identity (or unsigned) unless `--allow-signer-change` is passed.

Generated with [Claude Code](https://claude.com/claude-code)