### PR TITLE
Add plugin registry catalog surface and name-based install

### DIFF
--- a/docs/arch/06-registry-system.md
+++ b/docs/arch/06-registry-system.md
@@ -973,6 +973,7 @@ re-sync, modify `configYAML` (or restart the registry API pod).
 - [Operator Architecture](09-operator-architecture.md) - MCPRegistry CRD
 - [RunConfig and Permissions](05-runconfig-and-permissions.md) - How registry metadata feeds a server's RunConfig
 - [Skills System](12-skills-system.md) - Skills discovery and distribution via registry
+- [Plugins System](14-plugins-system.md) - Plugins discovery and distribution via registry (analogue of skills)
 
 ### External Documentation
 - [ToolHive User Documentation](https://docs.stacklok.com/toolhive/) - User-facing guides

--- a/docs/arch/14-plugins-system.md
+++ b/docs/arch/14-plugins-system.md
@@ -46,7 +46,9 @@ different component subsets.
   + SQLite storage + migration 002.
 - **Phase 3** (this doc): install/list/info/uninstall + MaterializationAdapter
   (Claude Code + Codex) + groups integration.
-- **Phase 4** (planned, #5528): REST API + `thv ai-plugin` CLI + app wiring.
+- **Phase 4** (shipped, #5528): REST API + `thv ai-plugin` CLI + app wiring.
+- **Phase 5b** (shipped, #5529): registry-name install wired via `lazyPluginLookup`;
+  plain-name resolution through the registry lookup chain.
 
 ## Core Concepts
 
@@ -86,7 +88,8 @@ reporting which component types it deliberately dropped.
 
 OCI reference (`ghcr.io/org/plugin:v1`), git reference
 (`git://host/owner/repo[@ref][#subdir]`), or plain name (registry lookup —
-seam declared, wired in a later phase).
+wired via `lazyPluginLookup`; `thv ai-plugin install <plain-name>`
+resolves through the registry's `SearchPlugins` → first hit's OCI package).
 
 ### 2. Building
 
@@ -267,6 +270,8 @@ The OCI plugin layer (`ociplugins.Store`, `PluginPackager`, `RegistryClient`,
 | `pkg/plugins/pluginsvc/list.go` / `info.go` / `uninstall.go` | lifecycle methods |
 | `pkg/plugins/adapters/claudecode.go` | Claude Code adapter (FS + settings.json mutation) |
 | `pkg/plugins/adapters/codex.go` | Codex adapter (FS + TOML) |
+| `pkg/registry/api/plugins_client.go` | MCP v0.1 registry plugin search client |
+| `pkg/api/v1/registry_v01_plugins.go` | HTTP handler for plugin search endpoint |
 | `pkg/storage/sqlite/plugin_store.go` | SQLite store |
 | `pkg/groups/plugins.go` | group membership |
 | `pkg/client/plugins.go` | client metadata + path resolution |

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -3272,6 +3272,23 @@ const docTemplate = `{
                 },
                 "type": "object"
             },
+            "pkg_api_v1.pluginsV01Response": {
+                "description": "Paginated list of plugins from the registry",
+                "properties": {
+                    "metadata": {
+                        "$ref": "#/components/schemas/pkg_api_v1.paginationV01Metadata"
+                    },
+                    "plugins": {
+                        "description": "Plugins is the list of plugins on the current page",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.Plugin"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
             "pkg_api_v1.providerCapabilitiesResponse": {
                 "description": "Capabilities of the secrets provider",
                 "properties": {
@@ -4157,6 +4174,68 @@ const docTemplate = `{
                     "use_pkce": {
                         "description": "UsePKCE indicates whether to use PKCE for the OAuth flow\nDefaults to true for enhanced security",
                         "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.Plugin": {
+                "properties": {
+                    "_meta": {
+                        "additionalProperties": {},
+                        "description": "Meta is an opaque payload with extended meta data details of the plugin.",
+                        "type": "object"
+                    },
+                    "description": {
+                        "description": "Description is the description of the plugin.",
+                        "type": "string"
+                    },
+                    "icons": {
+                        "description": "Icons is the list of icons for the plugin.",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.SkillIcon"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "license": {
+                        "description": "License is the SPDX license identifier of the plugin.",
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "additionalProperties": {},
+                        "description": "Metadata is the official metadata of the plugin as reported in the\nplugin manifest file.",
+                        "type": "object"
+                    },
+                    "name": {
+                        "description": "Name is the name of the plugin.\nThe format is that of identifiers, e.g. \"my-plugin\".",
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "description": "Namespace is the namespace of the plugin.\nThe format is reverse-DNS, e.g. \"io.github.user\".",
+                        "type": "string"
+                    },
+                    "packages": {
+                        "description": "Packages is the list of packages for the plugin.",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.SkillPackage"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "repository": {
+                        "$ref": "#/components/schemas/registry.SkillRepository"
+                    },
+                    "status": {
+                        "description": "Status is the status of the plugin.\nCan be one of \"active\", \"deprecated\", or \"archived\".",
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "Title is the title of the plugin.\nThis is for human consumption, not an identifier.",
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "Version is the version of the plugin.\nAny non-empty string is valid, but ideally it should be either a\nsemantic version or a commit hash.",
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -9099,6 +9178,162 @@ const docTemplate = `{
                 "summary": "Get a registry server",
                 "tags": [
                     "registry-servers"
+                ]
+            }
+        },
+        "/registry/{registryName}/v0.1/x/dev.toolhive/plugins": {
+            "get": {
+                "description": "Get a paginated list of plugins from the registry. Supports optional full-text search and pagination.",
+                "parameters": [
+                    {
+                        "description": "Registry name (currently ignored, uses the default provider)",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Search filter — matches against plugin name, namespace, and description",
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Page number, 1-based (default: 1)",
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Items per page, max 200 (default: 50)",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.pluginsV01Response"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "List available registry plugins",
+                "tags": [
+                    "registry-plugins"
+                ]
+            }
+        },
+        "/registry/{registryName}/v0.1/x/dev.toolhive/plugins/{namespace}/{pluginName}": {
+            "get": {
+                "description": "Retrieve a single plugin by its namespace and name from the registry.",
+                "parameters": [
+                    {
+                        "description": "Registry name (currently ignored, uses the default provider)",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Plugin namespace in reverse-DNS format (e.g. io.github.stacklok)",
+                        "in": "path",
+                        "name": "namespace",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Plugin name",
+                        "in": "path",
+                        "name": "pluginName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/registry.Plugin"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Plugin not found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "Get a registry plugin",
+                "tags": [
+                    "registry-plugins"
                 ]
             }
         },

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -3265,6 +3265,23 @@
                 },
                 "type": "object"
             },
+            "pkg_api_v1.pluginsV01Response": {
+                "description": "Paginated list of plugins from the registry",
+                "properties": {
+                    "metadata": {
+                        "$ref": "#/components/schemas/pkg_api_v1.paginationV01Metadata"
+                    },
+                    "plugins": {
+                        "description": "Plugins is the list of plugins on the current page",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.Plugin"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
             "pkg_api_v1.providerCapabilitiesResponse": {
                 "description": "Capabilities of the secrets provider",
                 "properties": {
@@ -4150,6 +4167,68 @@
                     "use_pkce": {
                         "description": "UsePKCE indicates whether to use PKCE for the OAuth flow\nDefaults to true for enhanced security",
                         "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "registry.Plugin": {
+                "properties": {
+                    "_meta": {
+                        "additionalProperties": {},
+                        "description": "Meta is an opaque payload with extended meta data details of the plugin.",
+                        "type": "object"
+                    },
+                    "description": {
+                        "description": "Description is the description of the plugin.",
+                        "type": "string"
+                    },
+                    "icons": {
+                        "description": "Icons is the list of icons for the plugin.",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.SkillIcon"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "license": {
+                        "description": "License is the SPDX license identifier of the plugin.",
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "additionalProperties": {},
+                        "description": "Metadata is the official metadata of the plugin as reported in the\nplugin manifest file.",
+                        "type": "object"
+                    },
+                    "name": {
+                        "description": "Name is the name of the plugin.\nThe format is that of identifiers, e.g. \"my-plugin\".",
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "description": "Namespace is the namespace of the plugin.\nThe format is reverse-DNS, e.g. \"io.github.user\".",
+                        "type": "string"
+                    },
+                    "packages": {
+                        "description": "Packages is the list of packages for the plugin.",
+                        "items": {
+                            "$ref": "#/components/schemas/registry.SkillPackage"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "repository": {
+                        "$ref": "#/components/schemas/registry.SkillRepository"
+                    },
+                    "status": {
+                        "description": "Status is the status of the plugin.\nCan be one of \"active\", \"deprecated\", or \"archived\".",
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "Title is the title of the plugin.\nThis is for human consumption, not an identifier.",
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "Version is the version of the plugin.\nAny non-empty string is valid, but ideally it should be either a\nsemantic version or a commit hash.",
+                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -9092,6 +9171,162 @@
                 "summary": "Get a registry server",
                 "tags": [
                     "registry-servers"
+                ]
+            }
+        },
+        "/registry/{registryName}/v0.1/x/dev.toolhive/plugins": {
+            "get": {
+                "description": "Get a paginated list of plugins from the registry. Supports optional full-text search and pagination.",
+                "parameters": [
+                    {
+                        "description": "Registry name (currently ignored, uses the default provider)",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Search filter — matches against plugin name, namespace, and description",
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Page number, 1-based (default: 1)",
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Items per page, max 200 (default: 50)",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.pluginsV01Response"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "List available registry plugins",
+                "tags": [
+                    "registry-plugins"
+                ]
+            }
+        },
+        "/registry/{registryName}/v0.1/x/dev.toolhive/plugins/{namespace}/{pluginName}": {
+            "get": {
+                "description": "Retrieve a single plugin by its namespace and name from the registry.",
+                "parameters": [
+                    {
+                        "description": "Registry name (currently ignored, uses the default provider)",
+                        "in": "path",
+                        "name": "registryName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Plugin namespace in reverse-DNS format (e.g. io.github.stacklok)",
+                        "in": "path",
+                        "name": "namespace",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Plugin name",
+                        "in": "path",
+                        "name": "pluginName",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/registry.Plugin"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Plugin not found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/pkg_api_v1.registryErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Registry authentication required or upstream registry unavailable"
+                    }
+                },
+                "summary": "Get a registry plugin",
+                "tags": [
+                    "registry-plugins"
                 ]
             }
         },

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -2938,6 +2938,18 @@ components:
           type: array
           uniqueItems: false
       type: object
+    pkg_api_v1.pluginsV01Response:
+      description: Paginated list of plugins from the registry
+      properties:
+        metadata:
+          $ref: '#/components/schemas/pkg_api_v1.paginationV01Metadata'
+        plugins:
+          description: Plugins is the list of plugins on the current page
+          items:
+            $ref: '#/components/schemas/registry.Plugin'
+          type: array
+          uniqueItems: false
+      type: object
     pkg_api_v1.providerCapabilitiesResponse:
       description: Capabilities of the secrets provider
       properties:
@@ -3697,6 +3709,66 @@ components:
             UsePKCE indicates whether to use PKCE for the OAuth flow
             Defaults to true for enhanced security
           type: boolean
+      type: object
+    registry.Plugin:
+      properties:
+        _meta:
+          additionalProperties: {}
+          description: Meta is an opaque payload with extended meta data details of
+            the plugin.
+          type: object
+        description:
+          description: Description is the description of the plugin.
+          type: string
+        icons:
+          description: Icons is the list of icons for the plugin.
+          items:
+            $ref: '#/components/schemas/registry.SkillIcon'
+          type: array
+          uniqueItems: false
+        license:
+          description: License is the SPDX license identifier of the plugin.
+          type: string
+        metadata:
+          additionalProperties: {}
+          description: |-
+            Metadata is the official metadata of the plugin as reported in the
+            plugin manifest file.
+          type: object
+        name:
+          description: |-
+            Name is the name of the plugin.
+            The format is that of identifiers, e.g. "my-plugin".
+          type: string
+        namespace:
+          description: |-
+            Namespace is the namespace of the plugin.
+            The format is reverse-DNS, e.g. "io.github.user".
+          type: string
+        packages:
+          description: Packages is the list of packages for the plugin.
+          items:
+            $ref: '#/components/schemas/registry.SkillPackage'
+          type: array
+          uniqueItems: false
+        repository:
+          $ref: '#/components/schemas/registry.SkillRepository'
+        status:
+          description: |-
+            Status is the status of the plugin.
+            Can be one of "active", "deprecated", or "archived".
+          type: string
+        title:
+          description: |-
+            Title is the title of the plugin.
+            This is for human consumption, not an identifier.
+          type: string
+        version:
+          description: |-
+            Version is the version of the plugin.
+            Any non-empty string is valid, but ideally it should be either a
+            semantic version or a commit hash.
+          type: string
       type: object
     registry.Provenance:
       description: Provenance contains verification and signing metadata
@@ -7005,6 +7077,104 @@ paths:
       summary: Get a registry server
       tags:
       - registry-servers
+  /registry/{registryName}/v0.1/x/dev.toolhive/plugins:
+    get:
+      description: Get a paginated list of plugins from the registry. Supports optional
+        full-text search and pagination.
+      parameters:
+      - description: Registry name (currently ignored, uses the default provider)
+        in: path
+        name: registryName
+        required: true
+        schema:
+          type: string
+      - description: Search filter — matches against plugin name, namespace, and description
+        in: query
+        name: q
+        schema:
+          type: string
+      - description: 'Page number, 1-based (default: 1)'
+        in: query
+        name: page
+        schema:
+          type: integer
+      - description: 'Items per page, max 200 (default: 50)'
+        in: query
+        name: limit
+        schema:
+          type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.pluginsV01Response'
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Internal server error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Registry authentication required or upstream registry unavailable
+      summary: List available registry plugins
+      tags:
+      - registry-plugins
+  /registry/{registryName}/v0.1/x/dev.toolhive/plugins/{namespace}/{pluginName}:
+    get:
+      description: Retrieve a single plugin by its namespace and name from the registry.
+      parameters:
+      - description: Registry name (currently ignored, uses the default provider)
+        in: path
+        name: registryName
+        required: true
+        schema:
+          type: string
+      - description: Plugin namespace in reverse-DNS format (e.g. io.github.stacklok)
+        in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - description: Plugin name
+        in: path
+        name: pluginName
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/registry.Plugin'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Plugin not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Internal server error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pkg_api_v1.registryErrorResponse'
+          description: Registry authentication required or upstream registry unavailable
+      summary: Get a registry plugin
+      tags:
+      - registry-plugins
   /registry/{registryName}/v0.1/x/dev.toolhive/skills:
     get:
       description: Get a paginated list of skills from the registry. Supports optional

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -863,7 +863,10 @@ func (lazyPluginLookup) SearchPlugins(_ context.Context, query string) ([]plugin
 
 // pluginHitsFromRegistry adapts registry plugin search results to the
 // pluginsvc lookup shape. The OCI reference lives in SkillPackage.Identifier
-// on the wire; pluginsvc consumes it as PluginPackage.Reference.
+// on the wire; pluginsvc consumes it as PluginPackage.Reference. Namespace,
+// Version, and Digest are carried through so the install flow can disambiguate
+// by namespace, honor an explicit version request, and pin to a verified
+// digest.
 func pluginHitsFromRegistry(regPlugins []regtypes.Plugin) []pluginsvc.PluginSearchHit {
 	hits := make([]pluginsvc.PluginSearchHit, 0, len(regPlugins))
 	for i := range regPlugins {
@@ -873,10 +876,13 @@ func pluginHitsFromRegistry(regPlugins []regtypes.Plugin) []pluginsvc.PluginSear
 			pkgs = append(pkgs, pluginsvc.PluginPackage{
 				Reference: sp.Identifier,
 				Type:      sp.RegistryType,
+				Digest:    sp.Digest,
 			})
 		}
 		hits = append(hits, pluginsvc.PluginSearchHit{
 			Name:        p.Name,
+			Namespace:   p.Namespace,
+			Version:     p.Version,
 			Description: p.Description,
 			Packages:    pkgs,
 		})

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -391,6 +391,7 @@ func (b *ServerBuilder) createDefaultPluginManager() error {
 		pluginsvc.WithGroupManager(b.groupManager),
 		pluginsvc.WithMaterializers(materializers),
 		pluginsvc.WithClientManager(cm),
+		pluginsvc.WithPluginLookup(lazyPluginLookup{}),
 	}
 
 	b.pluginManager = pluginsvc.New(pluginOpts...)
@@ -841,6 +842,46 @@ func (lazySkillLookup) SearchSkills(query string) ([]regtypes.Skill, error) {
 		return nil, err
 	}
 	return provider.SearchSkills(query)
+}
+
+// lazyPluginLookup implements pluginsvc.PluginLookup by resolving the registry
+// provider on each call, mirroring lazySkillLookup. Registry config changes are
+// picked up without restarting the server.
+type lazyPluginLookup struct{}
+
+func (lazyPluginLookup) SearchPlugins(_ context.Context, query string) ([]pluginsvc.PluginSearchHit, error) {
+	provider, err := registry.GetDefaultProviderWithConfig(config.NewDefaultProvider())
+	if err != nil {
+		return nil, err
+	}
+	found, err := provider.SearchPlugins(query)
+	if err != nil {
+		return nil, err
+	}
+	return pluginHitsFromRegistry(found), nil
+}
+
+// pluginHitsFromRegistry adapts registry plugin search results to the
+// pluginsvc lookup shape. The OCI reference lives in SkillPackage.Identifier
+// on the wire; pluginsvc consumes it as PluginPackage.Reference.
+func pluginHitsFromRegistry(regPlugins []regtypes.Plugin) []pluginsvc.PluginSearchHit {
+	hits := make([]pluginsvc.PluginSearchHit, 0, len(regPlugins))
+	for i := range regPlugins {
+		p := &regPlugins[i]
+		pkgs := make([]pluginsvc.PluginPackage, 0, len(p.Packages))
+		for _, sp := range p.Packages {
+			pkgs = append(pkgs, pluginsvc.PluginPackage{
+				Reference: sp.Identifier,
+				Type:      sp.RegistryType,
+			})
+		}
+		hits = append(hits, pluginsvc.PluginSearchHit{
+			Name:        p.Name,
+			Description: p.Description,
+			Packages:    pkgs,
+		})
+	}
+	return hits
 }
 
 // clientPathAdapter adapts *client.ClientManager to the skills.PathResolver interface.

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -178,8 +178,8 @@ func TestNewServer_ReadTimeoutConfigured(t *testing.T) {
 func TestPluginHitsFromRegistry(t *testing.T) {
 	t.Parallel()
 
-	skillPkg := func(identifier, registryType string) regtypes.SkillPackage {
-		return regtypes.SkillPackage{Identifier: identifier, RegistryType: registryType}
+	skillPkg := func(identifier, registryType, digest string) regtypes.SkillPackage {
+		return regtypes.SkillPackage{Identifier: identifier, RegistryType: registryType, Digest: digest}
 	}
 
 	tests := []struct {
@@ -192,9 +192,11 @@ func TestPluginHitsFromRegistry(t *testing.T) {
 			input: []regtypes.Plugin{
 				{
 					Name:        "code-reviewer",
+					Namespace:   "io.github.user",
+					Version:     "1.0.0",
 					Description: "Reviews code for bugs",
 					Packages: []regtypes.SkillPackage{
-						skillPkg("ghcr.io/org/code-reviewer:v1", "oci"),
+						skillPkg("ghcr.io/org/code-reviewer:v1", "oci", "sha256:abc"),
 					},
 				},
 			},
@@ -202,10 +204,13 @@ func TestPluginHitsFromRegistry(t *testing.T) {
 				t.Helper()
 				require.Len(t, hits, 1)
 				assert.Equal(t, "code-reviewer", hits[0].Name)
+				assert.Equal(t, "io.github.user", hits[0].Namespace)
+				assert.Equal(t, "1.0.0", hits[0].Version)
 				assert.Equal(t, "Reviews code for bugs", hits[0].Description)
 				require.Len(t, hits[0].Packages, 1)
 				assert.Equal(t, "ghcr.io/org/code-reviewer:v1", hits[0].Packages[0].Reference)
 				assert.Equal(t, "oci", hits[0].Packages[0].Type)
+				assert.Equal(t, "sha256:abc", hits[0].Packages[0].Digest)
 			},
 		},
 		{
@@ -213,32 +218,40 @@ func TestPluginHitsFromRegistry(t *testing.T) {
 			input: []regtypes.Plugin{
 				{
 					Name:        "multi-pkg",
+					Namespace:   "io.github.acme",
+					Version:     "2.1.0",
 					Description: "Has multiple packages",
 					Packages: []regtypes.SkillPackage{
-						skillPkg("ghcr.io/org/multi:latest", "oci"),
-						skillPkg("https://github.com/org/repo.git", "git"),
+						skillPkg("ghcr.io/org/multi:latest", "oci", "sha256:def"),
+						skillPkg("https://github.com/org/repo.git", "git", ""),
 					},
 				},
 			},
 			assert: func(t *testing.T, hits []pluginsvc.PluginSearchHit) {
 				t.Helper()
 				require.Len(t, hits, 1)
+				assert.Equal(t, "io.github.acme", hits[0].Namespace)
+				assert.Equal(t, "2.1.0", hits[0].Version)
 				require.Len(t, hits[0].Packages, 2)
 				assert.Equal(t, "ghcr.io/org/multi:latest", hits[0].Packages[0].Reference)
 				assert.Equal(t, "oci", hits[0].Packages[0].Type)
+				assert.Equal(t, "sha256:def", hits[0].Packages[0].Digest)
 				assert.Equal(t, "https://github.com/org/repo.git", hits[0].Packages[1].Reference)
 				assert.Equal(t, "git", hits[0].Packages[1].Type)
+				assert.Empty(t, hits[0].Packages[1].Digest)
 			},
 		},
 		{
 			name: "plugin with zero packages",
 			input: []regtypes.Plugin{
-				{Name: "no-pkgs", Description: "No packages"},
+				{Name: "no-pkgs", Namespace: "io.github.bare", Version: "0.1.0", Description: "No packages"},
 			},
 			assert: func(t *testing.T, hits []pluginsvc.PluginSearchHit) {
 				t.Helper()
 				require.Len(t, hits, 1)
 				assert.Equal(t, "no-pkgs", hits[0].Name)
+				assert.Equal(t, "io.github.bare", hits[0].Namespace)
+				assert.Equal(t, "0.1.0", hits[0].Version)
 				assert.NotNil(t, hits[0].Packages)
 				assert.Empty(t, hits[0].Packages)
 			},

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -17,7 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	regtypes "github.com/stacklok/toolhive-core/registry/types"
 	pluginsmocks "github.com/stacklok/toolhive/pkg/plugins/mocks"
+	"github.com/stacklok/toolhive/pkg/plugins/pluginsvc"
 	skillsmocks "github.com/stacklok/toolhive/pkg/skills/mocks"
 )
 
@@ -171,4 +173,104 @@ func TestNewServer_ReadTimeoutConfigured(t *testing.T) {
 	require.NotNil(t, s.httpServer)
 	assert.Equal(t, readTimeout, s.httpServer.ReadTimeout)
 	assert.Zero(t, s.httpServer.WriteTimeout)
+}
+
+func TestPluginHitsFromRegistry(t *testing.T) {
+	t.Parallel()
+
+	skillPkg := func(identifier, registryType string) regtypes.SkillPackage {
+		return regtypes.SkillPackage{Identifier: identifier, RegistryType: registryType}
+	}
+
+	tests := []struct {
+		name   string
+		input  []regtypes.Plugin
+		assert func(t *testing.T, hits []pluginsvc.PluginSearchHit)
+	}{
+		{
+			name: "single plugin with one oci package",
+			input: []regtypes.Plugin{
+				{
+					Name:        "code-reviewer",
+					Description: "Reviews code for bugs",
+					Packages: []regtypes.SkillPackage{
+						skillPkg("ghcr.io/org/code-reviewer:v1", "oci"),
+					},
+				},
+			},
+			assert: func(t *testing.T, hits []pluginsvc.PluginSearchHit) {
+				t.Helper()
+				require.Len(t, hits, 1)
+				assert.Equal(t, "code-reviewer", hits[0].Name)
+				assert.Equal(t, "Reviews code for bugs", hits[0].Description)
+				require.Len(t, hits[0].Packages, 1)
+				assert.Equal(t, "ghcr.io/org/code-reviewer:v1", hits[0].Packages[0].Reference)
+				assert.Equal(t, "oci", hits[0].Packages[0].Type)
+			},
+		},
+		{
+			name: "multiple packages (oci + git)",
+			input: []regtypes.Plugin{
+				{
+					Name:        "multi-pkg",
+					Description: "Has multiple packages",
+					Packages: []regtypes.SkillPackage{
+						skillPkg("ghcr.io/org/multi:latest", "oci"),
+						skillPkg("https://github.com/org/repo.git", "git"),
+					},
+				},
+			},
+			assert: func(t *testing.T, hits []pluginsvc.PluginSearchHit) {
+				t.Helper()
+				require.Len(t, hits, 1)
+				require.Len(t, hits[0].Packages, 2)
+				assert.Equal(t, "ghcr.io/org/multi:latest", hits[0].Packages[0].Reference)
+				assert.Equal(t, "oci", hits[0].Packages[0].Type)
+				assert.Equal(t, "https://github.com/org/repo.git", hits[0].Packages[1].Reference)
+				assert.Equal(t, "git", hits[0].Packages[1].Type)
+			},
+		},
+		{
+			name: "plugin with zero packages",
+			input: []regtypes.Plugin{
+				{Name: "no-pkgs", Description: "No packages"},
+			},
+			assert: func(t *testing.T, hits []pluginsvc.PluginSearchHit) {
+				t.Helper()
+				require.Len(t, hits, 1)
+				assert.Equal(t, "no-pkgs", hits[0].Name)
+				assert.NotNil(t, hits[0].Packages)
+				assert.Empty(t, hits[0].Packages)
+			},
+		},
+		{
+			name:  "empty input returns non-nil empty slice",
+			input: []regtypes.Plugin{},
+			assert: func(t *testing.T, hits []pluginsvc.PluginSearchHit) {
+				t.Helper()
+				assert.NotNil(t, hits)
+				assert.Empty(t, hits)
+			},
+		},
+		{
+			name: "Description empty maps to empty string",
+			input: []regtypes.Plugin{
+				{Name: "bare-plugin"},
+			},
+			assert: func(t *testing.T, hits []pluginsvc.PluginSearchHit) {
+				t.Helper()
+				require.Len(t, hits, 1)
+				assert.Equal(t, "bare-plugin", hits[0].Name)
+				assert.Empty(t, hits[0].Description)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			hits := pluginHitsFromRegistry(tt.input)
+			tt.assert(t, hits)
+		})
+	}
 }

--- a/pkg/api/v1/registry_v01.go
+++ b/pkg/api/v1/registry_v01.go
@@ -32,6 +32,8 @@ func RegistryV01Router() http.Handler {
 		r.Get("/servers/{serverName}/versions/latest", getServerV01)
 		r.Get("/x/dev.toolhive/skills", listSkillsV01)
 		r.Get("/x/dev.toolhive/skills/{namespace}/{skillName}", getSkillV01)
+		r.Get("/x/dev.toolhive/plugins", listPluginsV01)
+		r.Get("/x/dev.toolhive/plugins/{namespace}/{pluginName}", getPluginV01)
 	})
 	return r
 }

--- a/pkg/api/v1/registry_v01_plugins.go
+++ b/pkg/api/v1/registry_v01_plugins.go
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	types "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/registry/api"
+)
+
+// listPluginsV01 handles GET /registry/{registryName}/v0.1/x/dev.toolhive/plugins
+//
+//	@Summary		List available registry plugins
+//	@Description	Get a paginated list of plugins from the registry. Supports optional full-text search and pagination.
+//	@Tags			registry-plugins
+//	@Produce		json
+//	@Param			registryName	path		string	true	"Registry name (currently ignored, uses the default provider)"
+//	@Param			q				query		string	false	"Search filter — matches against plugin name, namespace, and description"
+//	@Param			page			query		integer	false	"Page number, 1-based (default: 1)"
+//	@Param			limit			query		integer	false	"Items per page, max 200 (default: 50)"
+//	@Success		200				{object}	pluginsV01Response
+//	@Failure		500				{object}	registryErrorResponse	"Internal server error"
+//	@Failure		503				{object}	registryErrorResponse	"Registry authentication required or upstream registry unavailable"
+//	@Router			/registry/{registryName}/v0.1/x/dev.toolhive/plugins [get]
+func listPluginsV01(w http.ResponseWriter, r *http.Request) {
+	provider, ok := getRegistryProvider(w)
+	if !ok {
+		return
+	}
+
+	plugins, err := provider.ListAvailablePlugins()
+	if err != nil {
+		slog.Error("failed to list plugins", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "Failed to list plugins")
+		return
+	}
+	if plugins == nil {
+		plugins = []types.Plugin{}
+	}
+
+	// Apply search filter
+	if q := r.URL.Query().Get("q"); q != "" {
+		plugins = filterPluginsV01(plugins, q)
+	}
+
+	// Paginate
+	page, limit := parsePaginationV01(r)
+	total := len(plugins)
+	start, end := paginateSlice(total, page, limit)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(pluginsV01Response{
+		Plugins: plugins[start:end],
+		Metadata: paginationV01Metadata{
+			Total: total,
+			Page:  page,
+			Limit: limit,
+		},
+	}); err != nil {
+		slog.Error("failed to encode plugins response", "error", err)
+	}
+}
+
+// getPluginV01 handles GET /registry/{registryName}/v0.1/x/dev.toolhive/plugins/{namespace}/{pluginName}
+//
+//	@Summary		Get a registry plugin
+//	@Description	Retrieve a single plugin by its namespace and name from the registry.
+//	@Tags			registry-plugins
+//	@Produce		json
+//	@Param			registryName	path		string	true	"Registry name (currently ignored, uses the default provider)"
+//	@Param			namespace		path		string	true	"Plugin namespace in reverse-DNS format (e.g. io.github.stacklok)"
+//	@Param			pluginName		path		string	true	"Plugin name"
+//	@Success		200				{object}	types.Plugin
+//	@Failure		404				{object}	registryErrorResponse	"Plugin not found"
+//	@Failure		500				{object}	registryErrorResponse	"Internal server error"
+//	@Failure		503				{object}	registryErrorResponse	"Registry authentication required or upstream registry unavailable"
+//	@Router			/registry/{registryName}/v0.1/x/dev.toolhive/plugins/{namespace}/{pluginName} [get]
+func getPluginV01(w http.ResponseWriter, r *http.Request) {
+	namespace := chi.URLParam(r, "namespace")
+	pluginName := chi.URLParam(r, "pluginName")
+
+	provider, ok := getRegistryProvider(w)
+	if !ok {
+		return
+	}
+
+	plugin, err := provider.GetPlugin(namespace, pluginName)
+	if err != nil {
+		// Map upstream HTTP errors to appropriate responses
+		var httpErr *api.RegistryHTTPError
+		if errors.As(err, &httpErr) {
+			switch httpErr.StatusCode {
+			case http.StatusNotFound:
+				writeJSONError(w, http.StatusNotFound, "not_found", "Plugin not found")
+				return
+			case http.StatusUnauthorized, http.StatusForbidden:
+				writeRegistryAuthRequiredError(w)
+				return
+			}
+		}
+		slog.Error("failed to get plugin", "namespace", namespace, "name", pluginName, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "internal_error", "Failed to get plugin")
+		return
+	}
+	if plugin == nil {
+		writeJSONError(w, http.StatusNotFound, "not_found", "Plugin not found")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(plugin); err != nil {
+		slog.Error("failed to encode plugin response", "error", err)
+	}
+}
+
+func filterPluginsV01(plugins []types.Plugin, query string) []types.Plugin {
+	q := strings.ToLower(query)
+	result := make([]types.Plugin, 0)
+	for _, p := range plugins {
+		if strings.Contains(strings.ToLower(p.Name), q) ||
+			strings.Contains(strings.ToLower(p.Namespace), q) ||
+			strings.Contains(strings.ToLower(p.Description), q) {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// pluginsV01Response is the response body for the v0.1 plugins list endpoint.
+//
+//	@Description	Paginated list of plugins from the registry
+type pluginsV01Response struct {
+	// Plugins is the list of plugins on the current page
+	Plugins []types.Plugin `json:"plugins"`
+	// Metadata contains pagination information
+	Metadata paginationV01Metadata `json:"metadata"`
+}

--- a/pkg/api/v1/registry_v01_plugins.go
+++ b/pkg/api/v1/registry_v01_plugins.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	types "github.com/stacklok/toolhive-core/registry/types"
+	regpkg "github.com/stacklok/toolhive/pkg/registry"
 	"github.com/stacklok/toolhive/pkg/registry/api"
 )
 
@@ -84,13 +85,19 @@ func listPluginsV01(w http.ResponseWriter, r *http.Request) {
 //	@Failure		503				{object}	registryErrorResponse	"Registry authentication required or upstream registry unavailable"
 //	@Router			/registry/{registryName}/v0.1/x/dev.toolhive/plugins/{namespace}/{pluginName} [get]
 func getPluginV01(w http.ResponseWriter, r *http.Request) {
-	namespace := chi.URLParam(r, "namespace")
-	pluginName := chi.URLParam(r, "pluginName")
-
 	provider, ok := getRegistryProvider(w)
 	if !ok {
 		return
 	}
+	getPluginV01WithProvider(w, r, provider)
+}
+
+// getPluginV01WithProvider contains the Get-plugin logic against an explicit
+// provider, separated from getRegistryProvider so tests can inject a mock
+// provider without touching the process-wide singleton.
+func getPluginV01WithProvider(w http.ResponseWriter, r *http.Request, provider regpkg.Provider) {
+	namespace := chi.URLParam(r, "namespace")
+	pluginName := chi.URLParam(r, "pluginName")
 
 	plugin, err := provider.GetPlugin(namespace, pluginName)
 	if err != nil {

--- a/pkg/api/v1/registry_v01_plugins_test.go
+++ b/pkg/api/v1/registry_v01_plugins_test.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	types "github.com/stacklok/toolhive-core/registry/types"
+)
+
+func TestFilterPluginsV01(t *testing.T) {
+	t.Parallel()
+
+	plugins := []types.Plugin{
+		{Namespace: "stacklok", Name: "code-review", Description: "Reviews code for issues"},
+		{Namespace: "stacklok", Name: "commit", Description: "Creates git commits"},
+		{Namespace: "other", Name: "weather", Description: "Weather data"},
+	}
+
+	tests := []struct {
+		query     string
+		wantCount int
+	}{
+		{"code", 1},
+		{"CODE", 1},        // case-insensitive
+		{"Code-Review", 1}, // mixed case
+		{"stacklok", 2},
+		{"weather", 1},
+		{"commits", 1},
+		{"nonexistent", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			t.Parallel()
+			result := filterPluginsV01(plugins, tt.query)
+			assert.Len(t, result, tt.wantCount)
+		})
+	}
+}
+
+func TestFilterPluginsV01_EmptyResult_NotNull(t *testing.T) {
+	t.Parallel()
+
+	plugins := []types.Plugin{
+		{Namespace: "stacklok", Name: "test", Description: "A test plugin"},
+	}
+
+	result := filterPluginsV01(plugins, "nonexistent")
+	assert.NotNil(t, result, "Filter result should be empty slice, not nil")
+	assert.Empty(t, result)
+
+	// Verify JSON encoding produces [] not null
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(data))
+}
+
+func TestRegistryV01Router_ListPlugins(t *testing.T) {
+	t.Parallel()
+
+	handler := RegistryV01Router()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/default/v0.1/x/dev.toolhive/plugins")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var body pluginsV01Response
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	// Should return plugins from the embedded catalog (may be empty in test env)
+	assert.NotNil(t, body.Plugins)
+	assert.GreaterOrEqual(t, body.Metadata.Total, 0)
+}
+
+func TestRegistryV01Router_GetPlugin_NotFound(t *testing.T) {
+	t.Parallel()
+
+	handler := RegistryV01Router()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/default/v0.1/x/dev.toolhive/plugins/nonexistent/noplugin")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json",
+		"Error responses should be JSON")
+
+	var body registryErrorResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "not_found", body.Code)
+}
+
+func TestRegistryV01Router_ListPlugins_PaginationBeyondResults(t *testing.T) {
+	t.Parallel()
+
+	handler := RegistryV01Router()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/default/v0.1/x/dev.toolhive/plugins?page=999&limit=10")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body pluginsV01Response
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Empty(t, body.Plugins, "Page beyond results should return empty plugins")
+	assert.Equal(t, 999, body.Metadata.Page)
+	assert.GreaterOrEqual(t, body.Metadata.Total, 0)
+}

--- a/pkg/api/v1/registry_v01_plugins_test.go
+++ b/pkg/api/v1/registry_v01_plugins_test.go
@@ -9,10 +9,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	types "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/registry/api"
+	regmocks "github.com/stacklok/toolhive/pkg/registry/mocks"
 )
 
 func TestFilterPluginsV01(t *testing.T) {
@@ -122,4 +126,56 @@ func TestRegistryV01Router_ListPlugins_PaginationBeyondResults(t *testing.T) {
 	assert.Empty(t, body.Plugins, "Page beyond results should return empty plugins")
 	assert.Equal(t, 999, body.Metadata.Page)
 	assert.GreaterOrEqual(t, body.Metadata.Total, 0)
+}
+
+// TestRegistryV01Router_GetPlugin_RegistryAuthError confirms that an upstream
+// *api.RegistryHTTPError with a 401/403 status is mapped to the structured
+// registry_auth_required 503 response (writeRegistryAuthRequiredError), so
+// desktop clients can branch on the code. The skills handler has the same
+// mapping but lacks this test; plugins get explicit coverage here.
+//
+// The test wires getPluginV01WithProvider directly against a mock provider via
+// a dedicated chi route, avoiding the process-wide default provider singleton
+// so it stays deterministic and parallel-safe.
+func TestRegistryV01Router_GetPlugin_RegistryAuthError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"unauthorized maps to registry_auth_required", http.StatusUnauthorized},
+		{"forbidden maps to registry_auth_required", http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			provider := regmocks.NewMockProvider(ctrl)
+			provider.EXPECT().GetPlugin("io.test", "auth-plugin").
+				Return(nil, &api.RegistryHTTPError{StatusCode: tt.statusCode, URL: "https://registry.test/plugin"})
+
+			r := chi.NewRouter()
+			r.Get("/x/dev.toolhive/plugins/{namespace}/{pluginName}",
+				func(w http.ResponseWriter, req *http.Request) {
+					getPluginV01WithProvider(w, req, provider)
+				})
+			srv := httptest.NewServer(r)
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + "/x/dev.toolhive/plugins/io.test/auth-plugin")
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+			assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+			var body registryErrorResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			assert.Equal(t, RegistryAuthRequiredCode, body.Code)
+			assert.Contains(t, body.Message, "Registry authentication required")
+		})
+	}
 }

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -177,9 +177,9 @@ func isValidRegistryJSON(client *http.Client, url string) error {
 }
 
 // parseAndValidateUpstreamRegistry parses data as an UpstreamRegistry and
-// verifies that it contains at least one server or skill. If the data looks
-// like the legacy ToolHive registry format, returns an error containing the
-// migration hint message.
+// verifies that it contains at least one server, skill, or plugin. If the data
+// looks like the legacy ToolHive registry format, returns an error containing
+// the migration hint message.
 func parseAndValidateUpstreamRegistry(data []byte) error {
 	if legacyhint.Looks(data) {
 		return errors.New(legacyhint.MigrationMessage)
@@ -188,8 +188,8 @@ func parseAndValidateUpstreamRegistry(data []byte) error {
 	if err := json.Unmarshal(data, &upstream); err != nil {
 		return fmt.Errorf("invalid upstream registry format: %w", err)
 	}
-	if len(upstream.Data.Servers) == 0 && len(upstream.Data.Skills) == 0 {
-		return errors.New("upstream registry contains no servers or skills")
+	if len(upstream.Data.Servers) == 0 && len(upstream.Data.Skills) == 0 && len(upstream.Data.Plugins) == 0 {
+		return errors.New("upstream registry contains no servers, skills, or plugins")
 	}
 	return nil
 }

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -311,7 +311,7 @@ func TestValidateRegistryFileStructure_UpstreamFormat(t *testing.T) {
 				"data": {"servers": []}
 			}`,
 			expectError:    true,
-			errMsgContains: "no servers or skills",
+			errMsgContains: "no servers, skills, or plugins",
 		},
 		{
 			name: "legacy format with top-level servers returns migration hint",

--- a/pkg/plugins/pluginsvc/install.go
+++ b/pkg/plugins/pluginsvc/install.go
@@ -116,18 +116,48 @@ func (s *service) installByName(
 // installFromRegistryLookup resolves a plain plugin name via the registry
 // lookup and dispatches to the appropriate installer. When no lookup is
 // configured or it returns no hits, returns a 404 with an install hint.
+//
+// Resolution mirrors skillsvc.resolveFromRegistry exactly:
+//   - a lookup error is logged and treated as "not found" (fall back to the
+//     404 hint) rather than propagated, and
+//   - search hits are post-filtered for an exact, case-insensitive name match
+//     (PluginSearchHit carries Name only, so there is no namespace filter).
+//
+// Multiple exact matches are ambiguous and produce a 409 listing candidates.
+// Package selection mirrors skillsvc.resolveRegistryPackages: the first OCI
+// package (Type == "oci") is chosen; when none exists, a 422 is returned.
 func (s *service) installFromRegistryLookup(
 	ctx context.Context,
 	opts plugins.InstallOptions,
 	scope plugins.Scope,
 ) (*plugins.InstallResult, error) {
 	if s.pluginLookup != nil {
-		hits, err := s.pluginLookup.SearchPlugins(ctx, opts.Name)
+		// Use the last path segment as the search query (matching
+		// skillsvc.resolveFromRegistry's splitQualifiedName), since
+		// SearchPlugins matches on name substring.
+		_, searchName := splitQualifiedName(opts.Name)
+
+		hits, err := s.pluginLookup.SearchPlugins(ctx, searchName)
 		if err != nil {
-			return nil, fmt.Errorf("searching registry for plugin %q: %w", opts.Name, err)
+			slog.Warn("registry plugin lookup failed, falling back to not-found", "name", opts.Name, "error", err)
+			hits = nil
 		}
-		if len(hits) > 0 && len(hits[0].Packages) > 0 {
-			pkg := hits[0].Packages[0]
+
+		// Filter for exact match. Case-insensitive because registry data
+		// may not be normalized to lowercase even though local plugin names are.
+		var matches []PluginSearchHit
+		for _, hit := range hits {
+			if !strings.EqualFold(hit.Name, searchName) {
+				continue
+			}
+			matches = append(matches, hit)
+		}
+
+		if len(matches) == 1 {
+			pkg, pkgErr := selectOCIPluginPackage(opts.Name, matches[0].Packages)
+			if pkgErr != nil {
+				return nil, pkgErr
+			}
 			slog.Info("resolved plugin from registry", "name", opts.Name, "reference", pkg.Reference)
 			opts.Name = pkg.Reference
 			ref, _, parseErr := parseOCIReference(pkg.Reference)
@@ -143,6 +173,10 @@ func (s *service) installFromRegistryLookup(
 			}
 			return s.installAndRegister(ctx, result, opts.Group, result.Plugin.Metadata.Name, scope, opts.ProjectRoot)
 		}
+
+		if len(matches) > 1 {
+			return nil, ambiguousPluginNameError(opts.Name, matches)
+		}
 	}
 
 	return nil, httperr.WithCode(
@@ -151,6 +185,54 @@ func (s *service) installFromRegistryLookup(
 			opts.Name, opts.Name),
 		http.StatusNotFound,
 	)
+}
+
+// selectOCIPluginPackage selects the first OCI package from a registry entry's
+// package list. Mirror of skillsvc.resolveRegistryPackages' OCI branch: OCI
+// packages are preferred, and a missing OCI package yields a 422 error.
+func selectOCIPluginPackage(name string, packages []PluginPackage) (PluginPackage, error) {
+	for _, pkg := range packages {
+		if pkg.Type == "oci" && pkg.Reference != "" {
+			return pkg, nil
+		}
+	}
+	return PluginPackage{}, httperr.WithCode(
+		fmt.Errorf("plugin %q found in registry but has no installable OCI package", name),
+		http.StatusUnprocessableEntity,
+	)
+}
+
+// ambiguousPluginNameError builds a 409 error listing each ambiguous match,
+// capped at 5 candidates with an "and N more" suffix. Mirror of
+// skillsvc.resolveFromRegistry's ambiguity path.
+func ambiguousPluginNameError(name string, matches []PluginSearchHit) error {
+	const maxCandidates = 5
+	candidates := make([]string, 0, len(matches))
+	for _, m := range matches {
+		candidates = append(candidates, m.Name)
+	}
+	suffix := ""
+	if len(candidates) > maxCandidates {
+		suffix = fmt.Sprintf(" and %d more", len(candidates)-maxCandidates)
+		candidates = candidates[:maxCandidates]
+	}
+	return httperr.WithCode(
+		fmt.Errorf("ambiguous plugin name %q matches multiple registry entries: %s%s; install by full OCI reference instead",
+			name, strings.Join(candidates, ", "), suffix),
+		http.StatusConflict,
+	)
+}
+
+// splitQualifiedName splits "namespace/name" into (namespace, name). If the
+// input has no "/" it returns ("", name) unchanged. Plugin names validated by
+// ValidatePluginName never contain "/", so this is a structural mirror of
+// skillsvc.splitQualifiedName that is a no-op for valid plugin names.
+func splitQualifiedName(s string) (namespace, name string) {
+	idx := strings.LastIndex(s, "/")
+	if idx < 0 {
+		return "", s
+	}
+	return s[:idx], s[idx+1:]
 }
 
 // registerPluginInGroup adds the plugin to the requested group when a group

--- a/pkg/plugins/pluginsvc/install.go
+++ b/pkg/plugins/pluginsvc/install.go
@@ -123,6 +123,10 @@ func (s *service) installByName(
 //   - search hits are post-filtered for an exact, case-insensitive name match
 //     (PluginSearchHit carries Name only, so there is no namespace filter).
 //
+// When opts.Version is set, exact-name matches are further narrowed to those
+// whose Version equals opts.Version; no version match falls through to the 404
+// not-found path (which includes the requested version in the message).
+//
 // Multiple exact matches are ambiguous and produce a 409 listing candidates.
 // Package selection mirrors skillsvc.resolveRegistryPackages: the first OCI
 // package (Type == "oci") is chosen; when none exists, a 422 is returned.
@@ -153,25 +157,22 @@ func (s *service) installFromRegistryLookup(
 			matches = append(matches, hit)
 		}
 
+		// When a version was requested, narrow the exact-name matches to those
+		// whose Version equals opts.Version (string equality). A hit that does
+		// not carry a Version cannot satisfy a versioned request. No match
+		// falls through to the 404 not-found path below.
+		if opts.Version != "" {
+			var versioned []PluginSearchHit
+			for _, m := range matches {
+				if m.Version == opts.Version {
+					versioned = append(versioned, m)
+				}
+			}
+			matches = versioned
+		}
+
 		if len(matches) == 1 {
-			pkg, pkgErr := selectOCIPluginPackage(opts.Name, matches[0].Packages)
-			if pkgErr != nil {
-				return nil, pkgErr
-			}
-			slog.Info("resolved plugin from registry", "name", opts.Name, "reference", pkg.Reference)
-			opts.Name = pkg.Reference
-			ref, _, parseErr := parseOCIReference(pkg.Reference)
-			if parseErr != nil {
-				return nil, httperr.WithCode(
-					fmt.Errorf("registry returned invalid OCI reference %q: %w", pkg.Reference, parseErr),
-					http.StatusUnprocessableEntity,
-				)
-			}
-			result, ociErr := s.installFromOCI(ctx, opts, scope, ref)
-			if ociErr != nil {
-				return nil, ociErr
-			}
-			return s.installAndRegister(ctx, result, opts.Group, result.Plugin.Metadata.Name, scope, opts.ProjectRoot)
+			return s.installFromRegistryHit(ctx, opts, scope, matches[0])
 		}
 
 		if len(matches) > 1 {
@@ -179,12 +180,57 @@ func (s *service) installFromRegistryLookup(
 		}
 	}
 
+	if opts.Version != "" {
+		return nil, httperr.WithCode(
+			fmt.Errorf("plugin %q version %q not found in local store or registry;"+
+				" install by OCI reference:\n  thv ai-plugin install ghcr.io/<namespace>/%s:%s",
+				opts.Name, opts.Version, opts.Name, opts.Version),
+			http.StatusNotFound,
+		)
+	}
 	return nil, httperr.WithCode(
 		fmt.Errorf("plugin %q not found in local store or registry;"+
-			" install by OCI reference:\n  thv plugin install ghcr.io/<namespace>/%s:<version>",
+			" install by OCI reference:\n  thv ai-plugin install ghcr.io/<namespace>/%s:<version>",
 			opts.Name, opts.Name),
 		http.StatusNotFound,
 	)
+}
+
+// installFromRegistryHit selects the OCI package from a single resolved hit,
+// parses its reference, and dispatches to installFromOCI. It guards against a
+// malformed catalog package whose Reference is not structurally an OCI
+// reference (parseOCIReference returns (nil, false, nil) for such input),
+// which would otherwise nil-deref in validateOCIRegistryHost.
+func (s *service) installFromRegistryHit(
+	ctx context.Context,
+	opts plugins.InstallOptions,
+	scope plugins.Scope,
+	hit PluginSearchHit,
+) (*plugins.InstallResult, error) {
+	pkg, pkgErr := selectOCIPluginPackage(opts.Name, hit.Packages)
+	if pkgErr != nil {
+		return nil, pkgErr
+	}
+	slog.Info("resolved plugin from registry", "name", opts.Name, "reference", pkg.Reference)
+	opts.Name = pkg.Reference
+	ref, isOCIRef, parseErr := parseOCIReference(pkg.Reference)
+	if parseErr != nil {
+		return nil, httperr.WithCode(
+			fmt.Errorf("registry returned invalid OCI reference %q: %w", pkg.Reference, parseErr),
+			http.StatusUnprocessableEntity,
+		)
+	}
+	if !isOCIRef || ref == nil {
+		return nil, httperr.WithCode(
+			fmt.Errorf("registry returned invalid OCI reference %q", pkg.Reference),
+			http.StatusUnprocessableEntity,
+		)
+	}
+	result, ociErr := s.installFromOCI(ctx, opts, scope, ref)
+	if ociErr != nil {
+		return nil, ociErr
+	}
+	return s.installAndRegister(ctx, result, opts.Group, result.Plugin.Metadata.Name, scope, opts.ProjectRoot)
 }
 
 // selectOCIPluginPackage selects the first OCI package from a registry entry's

--- a/pkg/plugins/pluginsvc/install_registry_test.go
+++ b/pkg/plugins/pluginsvc/install_registry_test.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pluginsvc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive-core/httperr"
+	ociplugins "github.com/stacklok/toolhive-core/oci/plugins"
+	ocimocks "github.com/stacklok/toolhive-core/oci/plugins/mocks"
+	"github.com/stacklok/toolhive/pkg/plugins"
+	plugmocks "github.com/stacklok/toolhive/pkg/plugins/mocks"
+	"github.com/stacklok/toolhive/pkg/storage"
+	storemocks "github.com/stacklok/toolhive/pkg/storage/mocks"
+)
+
+// stubLookup is a test helper implementing PluginLookup with canned results.
+type stubLookup struct {
+	hits []PluginSearchHit
+	err  error
+}
+
+func (s *stubLookup) SearchPlugins(_ context.Context, _ string) ([]PluginSearchHit, error) {
+	return s.hits, s.err
+}
+
+func TestInstallRegistryResolution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolves plain name via lookup and installs from OCI", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociplugins.NewStore(tempDir(t))
+		require.NoError(t, err)
+		indexDigest := buildTestPlugin(t, ociStore, "my-plugin", "1.0.0")
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-plugin:v1").
+			Return(indexDigest, nil)
+
+		store := storemocks.NewMockPluginStore(ctrl)
+		adapter := plugmocks.NewMockMaterializationAdapter(ctrl)
+		store.EXPECT().Get(gomock.Any(), "my-plugin", plugins.ScopeUser, "").Return(plugins.InstalledPlugin{}, storage.ErrNotFound)
+		adapter.EXPECT().Materialize(gomock.Any(), gomock.Any()).Return(&plugins.MaterializeResult{}, nil)
+		store.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, p plugins.InstalledPlugin) error {
+				assert.Equal(t, "my-plugin", p.Metadata.Name)
+				assert.Equal(t, "1.0.0", p.Metadata.Version)
+				assert.Equal(t, "ghcr.io/org/my-plugin:v1", p.Reference)
+				return nil
+			})
+
+		lookup := &stubLookup{hits: []PluginSearchHit{
+			{
+				Name:        "my-plugin",
+				Description: "test plugin",
+				Packages:    []PluginPackage{{Reference: "ghcr.io/org/my-plugin:v1", Type: "oci"}},
+			},
+		}}
+
+		svc := newTestService(
+			WithStore(store),
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithMaterializers(map[string]plugins.MaterializationAdapter{"claude-code": adapter}),
+			WithPluginLookup(lookup),
+		)
+		result, err := svc.Install(t.Context(), plugins.InstallOptions{
+			Name:    "my-plugin",
+			Clients: []string{"claude-code"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "my-plugin", result.Plugin.Metadata.Name)
+		assert.Equal(t, "1.0.0", result.Plugin.Metadata.Version)
+		assert.Equal(t, "ghcr.io/org/my-plugin:v1", result.Plugin.Reference)
+	})
+
+	t.Run("lookup returns no hits returns 404", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		store := storemocks.NewMockPluginStore(ctrl)
+
+		lookup := &stubLookup{hits: nil}
+
+		svc := newTestService(
+			WithStore(store),
+			WithPluginLookup(lookup),
+		)
+		_, err := svc.Install(t.Context(), plugins.InstallOptions{Name: "nonexistent"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusNotFound, httperr.Code(err))
+		assert.Contains(t, err.Error(), "not found in local store or registry")
+	})
+
+	t.Run("lookup search error propagates", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		store := storemocks.NewMockPluginStore(ctrl)
+
+		lookup := &stubLookup{err: fmt.Errorf("registry timeout")}
+
+		svc := newTestService(
+			WithStore(store),
+			WithPluginLookup(lookup),
+		)
+		_, err := svc.Install(t.Context(), plugins.InstallOptions{Name: "some-plugin"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "registry timeout")
+	})
+}

--- a/pkg/plugins/pluginsvc/install_registry_test.go
+++ b/pkg/plugins/pluginsvc/install_registry_test.go
@@ -248,4 +248,129 @@ func TestInstallRegistryResolution(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, httperr.Code(err))
 		assert.Contains(t, err.Error(), "not found in local store or registry")
 	})
+
+	// Regression: a malformed catalog package typed "oci" but whose Reference
+	// has no '/', ':', or '@' must not reach installFromOCI with a nil ref.
+	// parseOCIReference returns (nil, false, nil) for such input; previously
+	// the isOCI bool was discarded and the nil ref caused a panic in
+	// validateOCIRegistryHost via ref.Context(). Must return 422 instead.
+	t.Run("malformed oci package reference returns 422 no panic", func(t *testing.T) {
+		t.Parallel()
+
+		lookup := &stubLookup{hits: []PluginSearchHit{
+			{
+				Name:    "my-plugin",
+				Version: "1.0.0",
+				Packages: []PluginPackage{
+					{Reference: "foo", Type: "oci"},
+				},
+			},
+		}}
+
+		svc := newTestService(
+			WithPluginLookup(lookup),
+		)
+		_, err := svc.Install(t.Context(), plugins.InstallOptions{Name: "my-plugin"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusUnprocessableEntity, httperr.Code(err))
+		assert.Contains(t, err.Error(), "invalid OCI reference")
+		assert.Contains(t, err.Error(), "foo")
+	})
+
+	// Regression: when opts.Version is set, only an exact-name hit whose
+	// Version matches is installed.
+	t.Run("version requested with matching hit version installs", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociplugins.NewStore(tempDir(t))
+		require.NoError(t, err)
+		indexDigest := buildTestPlugin(t, ociStore, "my-plugin", "1.0.0")
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-plugin:1.0.0").
+			Return(indexDigest, nil)
+
+		store := storemocks.NewMockPluginStore(ctrl)
+		adapter := plugmocks.NewMockMaterializationAdapter(ctrl)
+		store.EXPECT().Get(gomock.Any(), "my-plugin", plugins.ScopeUser, "").Return(plugins.InstalledPlugin{}, storage.ErrNotFound)
+		adapter.EXPECT().Materialize(gomock.Any(), gomock.Any()).Return(&plugins.MaterializeResult{}, nil)
+		store.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, p plugins.InstalledPlugin) error {
+				assert.Equal(t, "my-plugin", p.Metadata.Name)
+				assert.Equal(t, "ghcr.io/org/my-plugin:1.0.0", p.Reference)
+				return nil
+			})
+
+		lookup := &stubLookup{hits: []PluginSearchHit{
+			{
+				Name:    "my-plugin",
+				Version: "1.0.0",
+				Packages: []PluginPackage{
+					{Reference: "ghcr.io/org/my-plugin:1.0.0", Type: "oci"},
+				},
+			},
+		}}
+
+		svc := newTestService(
+			WithStore(store),
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithMaterializers(map[string]plugins.MaterializationAdapter{"claude-code": adapter}),
+			WithPluginLookup(lookup),
+		)
+		result, err := svc.Install(t.Context(), plugins.InstallOptions{
+			Name:    "my-plugin",
+			Version: "1.0.0",
+			Clients: []string{"claude-code"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "my-plugin", result.Plugin.Metadata.Name)
+		assert.Equal(t, "ghcr.io/org/my-plugin:1.0.0", result.Plugin.Reference)
+	})
+
+	// Regression: a version request with only non-matching hit versions must
+	// fall through to the 404 path, and the message must mention the version.
+	t.Run("version requested with non-matching hit version returns 404 mentioning version", func(t *testing.T) {
+		t.Parallel()
+
+		lookup := &stubLookup{hits: []PluginSearchHit{
+			{
+				Name:    "my-plugin",
+				Version: "2.0.0",
+				Packages: []PluginPackage{
+					{Reference: "ghcr.io/org/my-plugin:2.0.0", Type: "oci"},
+				},
+			},
+		}}
+
+		svc := newTestService(
+			WithPluginLookup(lookup),
+		)
+		_, err := svc.Install(t.Context(), plugins.InstallOptions{
+			Name:    "my-plugin",
+			Version: "1.0.0",
+		})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusNotFound, httperr.Code(err))
+		assert.Contains(t, err.Error(), "not found in local store or registry")
+		assert.Contains(t, err.Error(), "1.0.0", "404 message should mention the requested version")
+	})
+
+	// Regression: the install hint text uses the renamed command
+	// "thv ai-plugin install" (was "thv plugin install").
+	t.Run("not found hint text references thv ai-plugin install", func(t *testing.T) {
+		t.Parallel()
+
+		lookup := &stubLookup{hits: nil}
+
+		svc := newTestService(
+			WithPluginLookup(lookup),
+		)
+		_, err := svc.Install(t.Context(), plugins.InstallOptions{Name: "nonexistent"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusNotFound, httperr.Code(err))
+		assert.Contains(t, err.Error(), "thv ai-plugin install")
+		assert.NotContains(t, err.Error(), "thv plugin install")
+	})
 }

--- a/pkg/plugins/pluginsvc/install_registry_test.go
+++ b/pkg/plugins/pluginsvc/install_registry_test.go
@@ -84,6 +84,137 @@ func TestInstallRegistryResolution(t *testing.T) {
 		assert.Equal(t, "ghcr.io/org/my-plugin:v1", result.Plugin.Reference)
 	})
 
+	t.Run("exact name wins over substring matches", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociplugins.NewStore(tempDir(t))
+		require.NoError(t, err)
+		indexDigest := buildTestPlugin(t, ociStore, "my-plugin", "1.0.0")
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-plugin:v1").
+			Return(indexDigest, nil)
+
+		store := storemocks.NewMockPluginStore(ctrl)
+		adapter := plugmocks.NewMockMaterializationAdapter(ctrl)
+		store.EXPECT().Get(gomock.Any(), "my-plugin", plugins.ScopeUser, "").Return(plugins.InstalledPlugin{}, storage.ErrNotFound)
+		adapter.EXPECT().Materialize(gomock.Any(), gomock.Any()).Return(&plugins.MaterializeResult{}, nil)
+		store.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, p plugins.InstalledPlugin) error {
+				assert.Equal(t, "my-plugin", p.Metadata.Name)
+				return nil
+			})
+
+		// Search returns several substring hits, only one with an exact Name
+		// match. The exact match must be selected even though it is not first.
+		lookup := &stubLookup{hits: []PluginSearchHit{
+			{Name: "my-plugin-extra", Packages: []PluginPackage{{Reference: "ghcr.io/org/other:v1", Type: "oci"}}},
+			{Name: "my-plugin", Packages: []PluginPackage{{Reference: "ghcr.io/org/my-plugin:v1", Type: "oci"}}},
+			{Name: "my-plugin-tool", Packages: []PluginPackage{{Reference: "ghcr.io/org/other2:v1", Type: "oci"}}},
+		}}
+
+		svc := newTestService(
+			WithStore(store),
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithMaterializers(map[string]plugins.MaterializationAdapter{"claude-code": adapter}),
+			WithPluginLookup(lookup),
+		)
+		result, err := svc.Install(t.Context(), plugins.InstallOptions{
+			Name:    "my-plugin",
+			Clients: []string{"claude-code"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "my-plugin", result.Plugin.Metadata.Name)
+		assert.Equal(t, "ghcr.io/org/my-plugin:v1", result.Plugin.Reference)
+	})
+
+	t.Run("ambiguous exact matches return 409", func(t *testing.T) {
+		t.Parallel()
+
+		// Two hits with the exact same Name across namespaces — ambiguous.
+		lookup := &stubLookup{hits: []PluginSearchHit{
+			{Name: "my-plugin", Packages: []PluginPackage{{Reference: "ghcr.io/org1/my-plugin:v1", Type: "oci"}}},
+			{Name: "my-plugin", Packages: []PluginPackage{{Reference: "ghcr.io/org2/my-plugin:v1", Type: "oci"}}},
+		}}
+
+		svc := newTestService(
+			WithPluginLookup(lookup),
+		)
+		_, err := svc.Install(t.Context(), plugins.InstallOptions{Name: "my-plugin"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusConflict, httperr.Code(err))
+		assert.Contains(t, err.Error(), "ambiguous plugin name")
+		assert.Contains(t, err.Error(), "my-plugin")
+	})
+
+	t.Run("selects oci package over positional git package", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		ociStore, err := ociplugins.NewStore(tempDir(t))
+		require.NoError(t, err)
+		indexDigest := buildTestPlugin(t, ociStore, "my-plugin", "1.0.0")
+
+		reg := ocimocks.NewMockRegistryClient(ctrl)
+		// The OCI package is second in the list; the first is a git package.
+		// Selection must pick the OCI package, not Packages[0].
+		reg.EXPECT().Pull(gomock.Any(), ociStore, "ghcr.io/org/my-plugin:v1").
+			Return(indexDigest, nil)
+
+		store := storemocks.NewMockPluginStore(ctrl)
+		adapter := plugmocks.NewMockMaterializationAdapter(ctrl)
+		store.EXPECT().Get(gomock.Any(), "my-plugin", plugins.ScopeUser, "").Return(plugins.InstalledPlugin{}, storage.ErrNotFound)
+		adapter.EXPECT().Materialize(gomock.Any(), gomock.Any()).Return(&plugins.MaterializeResult{}, nil)
+		store.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, p plugins.InstalledPlugin) error {
+				assert.Equal(t, "ghcr.io/org/my-plugin:v1", p.Reference)
+				return nil
+			})
+
+		lookup := &stubLookup{hits: []PluginSearchHit{
+			{
+				Name: "my-plugin",
+				Packages: []PluginPackage{
+					{Reference: "https://github.com/org/repo", Type: "git"},
+					{Reference: "ghcr.io/org/my-plugin:v1", Type: "oci"},
+				},
+			},
+		}}
+
+		svc := newTestService(
+			WithStore(store),
+			WithOCIStore(ociStore),
+			WithRegistryClient(reg),
+			WithMaterializers(map[string]plugins.MaterializationAdapter{"claude-code": adapter}),
+			WithPluginLookup(lookup),
+		)
+		result, err := svc.Install(t.Context(), plugins.InstallOptions{
+			Name:    "my-plugin",
+			Clients: []string{"claude-code"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "ghcr.io/org/my-plugin:v1", result.Plugin.Reference)
+	})
+
+	t.Run("no oci package returns 422", func(t *testing.T) {
+		t.Parallel()
+
+		// Exact match but only a git package (plugins have no git install flow).
+		lookup := &stubLookup{hits: []PluginSearchHit{
+			{Name: "my-plugin", Packages: []PluginPackage{{Reference: "https://github.com/org/repo", Type: "git"}}},
+		}}
+
+		svc := newTestService(
+			WithPluginLookup(lookup),
+		)
+		_, err := svc.Install(t.Context(), plugins.InstallOptions{Name: "my-plugin"})
+		require.Error(t, err)
+		assert.Equal(t, http.StatusUnprocessableEntity, httperr.Code(err))
+		assert.Contains(t, err.Error(), "no installable OCI package")
+	})
+
 	t.Run("lookup returns no hits returns 404", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
@@ -102,20 +233,19 @@ func TestInstallRegistryResolution(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found in local store or registry")
 	})
 
-	t.Run("lookup search error propagates", func(t *testing.T) {
+	t.Run("lookup search error falls back to 404 not-found", func(t *testing.T) {
 		t.Parallel()
-		ctrl := gomock.NewController(t)
-
-		store := storemocks.NewMockPluginStore(ctrl)
 
 		lookup := &stubLookup{err: fmt.Errorf("registry timeout")}
 
 		svc := newTestService(
-			WithStore(store),
 			WithPluginLookup(lookup),
 		)
 		_, err := svc.Install(t.Context(), plugins.InstallOptions{Name: "some-plugin"})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "registry timeout")
+		// A lookup error is logged and treated as not-found (mirroring
+		// skillsvc.resolveFromRegistry), not propagated.
+		assert.Equal(t, http.StatusNotFound, httperr.Code(err))
+		assert.Contains(t, err.Error(), "not found in local store or registry")
 	})
 }

--- a/pkg/plugins/pluginsvc/service.go
+++ b/pkg/plugins/pluginsvc/service.go
@@ -92,6 +92,13 @@ func WithClientManager(cm *client.ClientManager) Option {
 type PluginSearchHit struct {
 	// Name is the plugin name (kebab-case).
 	Name string `json:"name"`
+	// Namespace is the registry namespace the hit was published under
+	// (reverse-DNS, e.g. "io.github.user"). Carried so callers can disambiguate
+	// same-named plugins across namespaces.
+	Namespace string `json:"namespace,omitempty"`
+	// Version is the plugin version string reported by the registry. Used by
+	// the install flow to honor an explicit --version request.
+	Version string `json:"version,omitempty"`
 	// Description is a human-readable description of the plugin.
 	Description string `json:"description,omitempty"`
 	// Packages lists the OCI packages that publish this plugin.
@@ -104,6 +111,10 @@ type PluginPackage struct {
 	Reference string `json:"reference"`
 	// Type is the package type (e.g. "oci").
 	Type string `json:"type,omitempty"`
+	// Digest is the OCI digest of the package artifact, when reported by the
+	// registry. Carried as part of the trust tuple (reference + digest) so
+	// callers can pin installs to a verified artifact.
+	Digest string `json:"digest,omitempty"`
 }
 
 // PluginLookup resolves a plain plugin name against a registry/index. This seam

--- a/pkg/registry/api/plugins_client.go
+++ b/pkg/registry/api/plugins_client.go
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	thvregistry "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/registry/auth"
+	"github.com/stacklok/toolhive/pkg/versions"
+)
+
+const pluginsBasePath = "/v0.1/x/dev.toolhive/plugins"
+
+// PluginsListOptions contains options for listing plugins.
+type PluginsListOptions struct {
+	// Search is an optional search query to filter plugins.
+	Search string
+	// Limit is the maximum number of plugins per page (default: 100).
+	Limit int
+	// Cursor is the pagination cursor for fetching the next page.
+	Cursor string
+}
+
+// PluginsListResult contains a page of plugins and pagination info.
+type PluginsListResult struct {
+	Plugins    []*thvregistry.Plugin
+	NextCursor string
+}
+
+// PluginsClient provides access to the ToolHive Plugins extension API.
+type PluginsClient interface {
+	// GetPlugin retrieves a plugin by namespace and name (latest version).
+	GetPlugin(ctx context.Context, namespace, name string) (*thvregistry.Plugin, error)
+	// GetPluginVersion retrieves a specific version of a plugin.
+	GetPluginVersion(ctx context.Context, namespace, name, version string) (*thvregistry.Plugin, error)
+	// ListPlugins retrieves plugins with optional filtering and pagination.
+	ListPlugins(ctx context.Context, opts *PluginsListOptions) (*PluginsListResult, error)
+	// SearchPlugins searches for plugins matching the query (single page, no auto-pagination).
+	SearchPlugins(ctx context.Context, query string) (*PluginsListResult, error)
+	// ListPluginVersions lists all versions of a specific plugin.
+	ListPluginVersions(ctx context.Context, namespace, name string) (*PluginsListResult, error)
+}
+
+// NewPluginsClient creates a new ToolHive Plugins extension API client.
+// If tokenSource is non-nil, the HTTP client transport will be wrapped to inject
+// Bearer tokens into all requests.
+func NewPluginsClient(baseURL string, allowPrivateIp bool, tokenSource auth.TokenSource) (PluginsClient, error) {
+	httpClient, err := buildHTTPClient(allowPrivateIp, tokenSource)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure base URL doesn't have trailing slash
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	return &mcpPluginsClient{
+		baseURL:    baseURL,
+		httpClient: httpClient,
+		userAgent:  versions.GetUserAgent(),
+	}, nil
+}
+
+// GetPlugin retrieves a plugin by namespace and name (latest version).
+func (c *mcpPluginsClient) GetPlugin(ctx context.Context, namespace, name string) (*thvregistry.Plugin, error) {
+	endpoint, err := url.JoinPath(c.baseURL, pluginsBasePath, url.PathEscape(namespace), url.PathEscape(name))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build plugins URL: %w", err)
+	}
+
+	var plugin thvregistry.Plugin
+	if err := c.doPluginsGet(ctx, endpoint, &plugin); err != nil {
+		return nil, err
+	}
+	return &plugin, nil
+}
+
+// GetPluginVersion retrieves a specific version of a plugin.
+func (c *mcpPluginsClient) GetPluginVersion(ctx context.Context, namespace, name, version string) (*thvregistry.Plugin, error) {
+	endpoint, err := url.JoinPath(c.baseURL, pluginsBasePath,
+		url.PathEscape(namespace), url.PathEscape(name),
+		"versions", url.PathEscape(version))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build plugins URL: %w", err)
+	}
+
+	var plugin thvregistry.Plugin
+	if err := c.doPluginsGet(ctx, endpoint, &plugin); err != nil {
+		return nil, err
+	}
+	return &plugin, nil
+}
+
+// ListPlugins retrieves plugins with optional filtering and pagination.
+// It auto-paginates through all available pages, concatenating results.
+func (c *mcpPluginsClient) ListPlugins(ctx context.Context, opts *PluginsListOptions) (*PluginsListResult, error) {
+	if opts == nil {
+		opts = &PluginsListOptions{}
+	}
+	if opts.Limit == 0 {
+		opts.Limit = 100
+	}
+
+	var allPlugins []*thvregistry.Plugin
+	cursor := opts.Cursor
+
+	// Pagination loop - continue until no more cursors
+	for {
+		page, nextCursor, err := c.fetchPluginsPage(ctx, cursor, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		allPlugins = append(allPlugins, page...)
+
+		// Check if we have more pages
+		if nextCursor == "" {
+			break
+		}
+
+		cursor = nextCursor
+
+		// Safety limit: prevent infinite loops
+		if len(allPlugins) > 10000 {
+			return nil, fmt.Errorf("exceeded maximum plugins limit (10000)")
+		}
+	}
+
+	return &PluginsListResult{
+		Plugins: allPlugins,
+	}, nil
+}
+
+// SearchPlugins searches for plugins matching the query.
+// Returns a single page of results (no auto-pagination).
+func (c *mcpPluginsClient) SearchPlugins(ctx context.Context, query string) (*PluginsListResult, error) {
+	basePath, err := url.JoinPath(c.baseURL, pluginsBasePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build plugins URL: %w", err)
+	}
+	params := url.Values{}
+	params.Add("search", query)
+
+	endpoint := basePath + "?" + params.Encode()
+
+	var listResp pluginsListResponse
+	if err := c.doPluginsGet(ctx, endpoint, &listResp); err != nil {
+		return nil, err
+	}
+
+	return &PluginsListResult{
+		Plugins:    listResp.Plugins,
+		NextCursor: listResp.Metadata.NextCursor,
+	}, nil
+}
+
+// ListPluginVersions lists all versions of a specific plugin.
+func (c *mcpPluginsClient) ListPluginVersions(ctx context.Context, namespace, name string) (*PluginsListResult, error) {
+	endpoint, err := url.JoinPath(c.baseURL, pluginsBasePath, url.PathEscape(namespace), url.PathEscape(name), "versions")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build plugins URL: %w", err)
+	}
+
+	var listResp pluginsListResponse
+	if err := c.doPluginsGet(ctx, endpoint, &listResp); err != nil {
+		return nil, err
+	}
+
+	return &PluginsListResult{
+		Plugins:    listResp.Plugins,
+		NextCursor: listResp.Metadata.NextCursor,
+	}, nil
+}
+
+// mcpPluginsClient implements the PluginsClient interface.
+type mcpPluginsClient struct {
+	baseURL    string
+	httpClient *http.Client
+	userAgent  string
+}
+
+// pluginsListResponse is the wire format for list/search responses.
+type pluginsListResponse struct {
+	Plugins  []*thvregistry.Plugin `json:"plugins"`
+	Metadata struct {
+		Count      int    `json:"count"`
+		NextCursor string `json:"nextCursor"`
+	} `json:"metadata"`
+}
+
+// doPluginsGet performs an HTTP GET request and decodes the JSON response into dest.
+func (c *mcpPluginsClient) doPluginsGet(ctx context.Context, endpoint string, dest any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL from configured registry
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			slog.Debug("failed to close response body", "error", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return newRegistryHTTPError(resp)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+	return nil
+}
+
+// fetchPluginsPage fetches a single page of plugins.
+func (c *mcpPluginsClient) fetchPluginsPage(
+	ctx context.Context, cursor string, opts *PluginsListOptions,
+) ([]*thvregistry.Plugin, string, error) {
+	params := url.Values{}
+	if cursor != "" {
+		params.Add("cursor", cursor)
+	}
+	if opts.Limit > 0 {
+		params.Add("limit", fmt.Sprintf("%d", opts.Limit))
+	}
+	if opts.Search != "" {
+		params.Add("search", opts.Search)
+	}
+
+	basePath, err := url.JoinPath(c.baseURL, pluginsBasePath)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to build plugins URL: %w", err)
+	}
+	endpoint := func() string {
+		if len(params) > 0 {
+			return basePath + "?" + params.Encode()
+		}
+		return basePath
+	}()
+
+	var listResp pluginsListResponse
+	if err := c.doPluginsGet(ctx, endpoint, &listResp); err != nil {
+		return nil, "", err
+	}
+
+	return listResp.Plugins, listResp.Metadata.NextCursor, nil
+}

--- a/pkg/registry/api/plugins_client.go
+++ b/pkg/registry/api/plugins_client.go
@@ -43,7 +43,7 @@ type PluginsClient interface {
 	GetPluginVersion(ctx context.Context, namespace, name, version string) (*thvregistry.Plugin, error)
 	// ListPlugins retrieves plugins with optional filtering and pagination.
 	ListPlugins(ctx context.Context, opts *PluginsListOptions) (*PluginsListResult, error)
-	// SearchPlugins searches for plugins matching the query (single page, no auto-pagination).
+	// SearchPlugins searches for plugins matching the query (auto-paginates).
 	SearchPlugins(ctx context.Context, query string) (*PluginsListResult, error)
 	// ListPluginVersions lists all versions of a specific plugin.
 	ListPluginVersions(ctx context.Context, namespace, name string) (*PluginsListResult, error)
@@ -139,25 +139,37 @@ func (c *mcpPluginsClient) ListPlugins(ctx context.Context, opts *PluginsListOpt
 }
 
 // SearchPlugins searches for plugins matching the query.
-// Returns a single page of results (no auto-pagination).
+// It auto-paginates through all available pages, concatenating results —
+// mirroring ListPlugins. This prevents wrong-publisher installs when
+// same-named plugins across namespaces span pages.
 func (c *mcpPluginsClient) SearchPlugins(ctx context.Context, query string) (*PluginsListResult, error) {
-	basePath, err := url.JoinPath(c.baseURL, pluginsBasePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build plugins URL: %w", err)
-	}
-	params := url.Values{}
-	params.Add("search", query)
+	opts := &PluginsListOptions{Search: query, Limit: 100}
 
-	endpoint := basePath + "?" + params.Encode()
+	var allPlugins []*thvregistry.Plugin
+	cursor := ""
 
-	var listResp pluginsListResponse
-	if err := c.doPluginsGet(ctx, endpoint, &listResp); err != nil {
-		return nil, err
+	for {
+		page, nextCursor, err := c.fetchPluginsPage(ctx, cursor, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		allPlugins = append(allPlugins, page...)
+
+		if nextCursor == "" {
+			break
+		}
+
+		cursor = nextCursor
+
+		// Safety limit: prevent infinite loops (mirrors ListPlugins).
+		if len(allPlugins) > 10000 {
+			return nil, fmt.Errorf("exceeded maximum plugins limit (10000)")
+		}
 	}
 
 	return &PluginsListResult{
-		Plugins:    listResp.Plugins,
-		NextCursor: listResp.Metadata.NextCursor,
+		Plugins: allPlugins,
 	}, nil
 }
 

--- a/pkg/registry/api/plugins_client_test.go
+++ b/pkg/registry/api/plugins_client_test.go
@@ -1,0 +1,571 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	thvregistry "github.com/stacklok/toolhive-core/registry/types"
+)
+
+func newTestPluginsClient(t *testing.T, server *httptest.Server) PluginsClient {
+	t.Helper()
+	client, err := NewPluginsClient(server.URL, true, nil)
+	require.NoError(t, err)
+	return client
+}
+
+func TestPluginsClient_GetPlugin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		namespace  string
+		pluginName string
+		handler    http.HandlerFunc
+		wantPlugin *thvregistry.Plugin
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			namespace:  "io.github.user",
+			pluginName: "my-plugin",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/v0.1/x/dev.toolhive/plugins/io.github.user/my-plugin", r.URL.Path)
+				require.Equal(t, http.MethodGet, r.Method)
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(thvregistry.Plugin{
+					Namespace:   "io.github.user",
+					Name:        "my-plugin",
+					Version:     "1.0.0",
+					Description: "A test plugin",
+				})
+				require.NoError(t, err)
+			},
+			wantPlugin: &thvregistry.Plugin{
+				Namespace:   "io.github.user",
+				Name:        "my-plugin",
+				Version:     "1.0.0",
+				Description: "A test plugin",
+			},
+		},
+		{
+			name:       "not found",
+			namespace:  "io.github.user",
+			pluginName: "nonexistent",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("plugin not found"))
+			},
+			wantErr: true,
+		},
+		{
+			name:       "server error",
+			namespace:  "io.github.user",
+			pluginName: "my-plugin",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("internal error"))
+			},
+			wantErr: true,
+		},
+		{
+			name:       "path escaping",
+			namespace:  "io.github.user/special",
+			pluginName: "my plugin",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				// Verify that the path components are properly escaped
+				require.Equal(t, "/v0.1/x/dev.toolhive/plugins/io.github.user%2Fspecial/my%20plugin", r.URL.RawPath)
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(thvregistry.Plugin{
+					Namespace: "io.github.user/special",
+					Name:      "my plugin",
+					Version:   "1.0.0",
+				})
+				require.NoError(t, err)
+			},
+			wantPlugin: &thvregistry.Plugin{
+				Namespace: "io.github.user/special",
+				Name:      "my plugin",
+				Version:   "1.0.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestPluginsClient(t, server)
+			plugin, err := client.GetPlugin(t.Context(), tt.namespace, tt.pluginName)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPlugin, plugin)
+		})
+	}
+}
+
+func TestPluginsClient_GetPluginVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		namespace  string
+		pluginName string
+		version    string
+		handler    http.HandlerFunc
+		wantPlugin *thvregistry.Plugin
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			namespace:  "io.github.user",
+			pluginName: "my-plugin",
+			version:    "2.0.0",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/v0.1/x/dev.toolhive/plugins/io.github.user/my-plugin/versions/2.0.0", r.URL.Path)
+				require.Equal(t, http.MethodGet, r.Method)
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(thvregistry.Plugin{
+					Namespace:   "io.github.user",
+					Name:        "my-plugin",
+					Version:     "2.0.0",
+					Description: "Version 2",
+				})
+				require.NoError(t, err)
+			},
+			wantPlugin: &thvregistry.Plugin{
+				Namespace:   "io.github.user",
+				Name:        "my-plugin",
+				Version:     "2.0.0",
+				Description: "Version 2",
+			},
+		},
+		{
+			name:       "version not found",
+			namespace:  "io.github.user",
+			pluginName: "my-plugin",
+			version:    "99.0.0",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("version not found"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestPluginsClient(t, server)
+			plugin, err := client.GetPluginVersion(t.Context(), tt.namespace, tt.pluginName, tt.version)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPlugin, plugin)
+		})
+	}
+}
+
+func TestPluginsClient_ListPlugins(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		opts        *PluginsListOptions
+		handler     http.HandlerFunc
+		wantCount   int
+		wantErr     bool
+		wantPlugins []*thvregistry.Plugin
+	}{
+		{
+			name: "single page",
+			opts: nil,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(pluginsListResponse{
+					Plugins: []*thvregistry.Plugin{
+						{Namespace: "io.github.a", Name: "plugin-1", Version: "1.0.0"},
+						{Namespace: "io.github.b", Name: "plugin-2", Version: "1.0.0"},
+					},
+					Metadata: struct {
+						Count      int    `json:"count"`
+						NextCursor string `json:"nextCursor"`
+					}{Count: 2, NextCursor: ""},
+				})
+				require.NoError(t, err)
+			},
+			wantCount: 2,
+			wantPlugins: []*thvregistry.Plugin{
+				{Namespace: "io.github.a", Name: "plugin-1", Version: "1.0.0"},
+				{Namespace: "io.github.b", Name: "plugin-2", Version: "1.0.0"},
+			},
+		},
+		{
+			name: "pagination across multiple pages",
+			opts: &PluginsListOptions{Limit: 1},
+			handler: func() http.HandlerFunc {
+				callCount := 0
+				return func(w http.ResponseWriter, r *http.Request) {
+					callCount++
+					w.Header().Set("Content-Type", "application/json")
+
+					cursor := r.URL.Query().Get("cursor")
+					var resp pluginsListResponse
+
+					switch {
+					case cursor == "" && callCount == 1:
+						resp = pluginsListResponse{
+							Plugins: []*thvregistry.Plugin{
+								{Namespace: "io.github.a", Name: "plugin-1", Version: "1.0.0"},
+							},
+							Metadata: struct {
+								Count      int    `json:"count"`
+								NextCursor string `json:"nextCursor"`
+							}{Count: 1, NextCursor: "page2"},
+						}
+					case cursor == "page2":
+						resp = pluginsListResponse{
+							Plugins: []*thvregistry.Plugin{
+								{Namespace: "io.github.b", Name: "plugin-2", Version: "1.0.0"},
+							},
+							Metadata: struct {
+								Count      int    `json:"count"`
+								NextCursor string `json:"nextCursor"`
+							}{Count: 1, NextCursor: ""},
+						}
+					default:
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+
+					err := json.NewEncoder(w).Encode(resp)
+					require.NoError(t, err)
+				}
+			}(),
+			wantCount: 2,
+			wantPlugins: []*thvregistry.Plugin{
+				{Namespace: "io.github.a", Name: "plugin-1", Version: "1.0.0"},
+				{Namespace: "io.github.b", Name: "plugin-2", Version: "1.0.0"},
+			},
+		},
+		{
+			name: "empty result",
+			opts: nil,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(pluginsListResponse{
+					Plugins: []*thvregistry.Plugin{},
+					Metadata: struct {
+						Count      int    `json:"count"`
+						NextCursor string `json:"nextCursor"`
+					}{Count: 0, NextCursor: ""},
+				})
+				require.NoError(t, err)
+			},
+			wantCount:   0,
+			wantPlugins: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestPluginsClient(t, server)
+			result, err := client.ListPlugins(t.Context(), tt.opts)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, result.Plugins, tt.wantCount)
+			if tt.wantPlugins != nil {
+				require.Equal(t, tt.wantPlugins, result.Plugins)
+			}
+		})
+	}
+}
+
+func TestPluginsClient_SearchPlugins(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		query     string
+		handler   http.HandlerFunc
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name:  "success with results",
+			query: "kubernetes",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "kubernetes", r.URL.Query().Get("search"))
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(pluginsListResponse{
+					Plugins: []*thvregistry.Plugin{
+						{Namespace: "io.github.user", Name: "k8s-plugin", Version: "1.0.0", Description: "Kubernetes plugin"},
+					},
+					Metadata: struct {
+						Count      int    `json:"count"`
+						NextCursor string `json:"nextCursor"`
+					}{Count: 1, NextCursor: ""},
+				})
+				require.NoError(t, err)
+			},
+			wantCount: 1,
+		},
+		{
+			name:  "empty result",
+			query: "nonexistent",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				err := json.NewEncoder(w).Encode(pluginsListResponse{
+					Plugins: []*thvregistry.Plugin{},
+					Metadata: struct {
+						Count      int    `json:"count"`
+						NextCursor string `json:"nextCursor"`
+					}{Count: 0, NextCursor: ""},
+				})
+				require.NoError(t, err)
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := newTestPluginsClient(t, server)
+			result, err := client.SearchPlugins(t.Context(), tt.query)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, result.Plugins, tt.wantCount)
+		})
+	}
+}
+
+func TestPluginsClient_ListPluginVersions(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v0.1/x/dev.toolhive/plugins/io.github.user/my-plugin/versions", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(pluginsListResponse{
+			Plugins: []*thvregistry.Plugin{
+				{Namespace: "io.github.user", Name: "my-plugin", Version: "1.0.0"},
+				{Namespace: "io.github.user", Name: "my-plugin", Version: "2.0.0"},
+				{Namespace: "io.github.user", Name: "my-plugin", Version: "3.0.0"},
+			},
+			Metadata: struct {
+				Count      int    `json:"count"`
+				NextCursor string `json:"nextCursor"`
+			}{Count: 3, NextCursor: ""},
+		})
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := newTestPluginsClient(t, server)
+	result, err := client.ListPluginVersions(t.Context(), "io.github.user", "my-plugin")
+	require.NoError(t, err)
+	require.Len(t, result.Plugins, 3)
+	require.Equal(t, "1.0.0", result.Plugins[0].Version)
+	require.Equal(t, "2.0.0", result.Plugins[1].Version)
+	require.Equal(t, "3.0.0", result.Plugins[2].Version)
+}
+
+func TestPluginsClient_ErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErrIs  error
+	}{
+		{
+			name:       "401 unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       "unauthorized",
+			wantErrIs:  ErrRegistryUnauthorized,
+		},
+		{
+			name:       "403 forbidden",
+			statusCode: http.StatusForbidden,
+			body:       "forbidden",
+			wantErrIs:  ErrRegistryUnauthorized,
+		},
+		{
+			name:       "404 not found",
+			statusCode: http.StatusNotFound,
+			body:       "not found",
+			wantErrIs:  nil,
+		},
+		{
+			name:       "500 server error does not unwrap to unauthorized",
+			statusCode: http.StatusInternalServerError,
+			body:       "internal server error",
+			wantErrIs:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := newTestPluginsClient(t, server)
+			_, err := client.GetPlugin(t.Context(), "io.github.user", "my-plugin")
+			require.Error(t, err)
+
+			var httpErr *RegistryHTTPError
+			require.True(t, errors.As(err, &httpErr), "expected *RegistryHTTPError, got %T", err)
+			require.Equal(t, tt.statusCode, httpErr.StatusCode)
+			require.Contains(t, httpErr.Body, tt.body)
+
+			if tt.wantErrIs != nil {
+				require.True(t, errors.Is(err, tt.wantErrIs),
+					"expected errors.Is(%v, %v) to be true", err, tt.wantErrIs)
+			} else {
+				require.False(t, errors.Is(err, ErrRegistryUnauthorized),
+					"expected errors.Is(%v, ErrRegistryUnauthorized) to be false", err)
+			}
+		})
+	}
+}
+
+func TestPluginsClient_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{invalid json`))
+	}))
+	defer server.Close()
+
+	client := newTestPluginsClient(t, server)
+	_, err := client.GetPlugin(t.Context(), "io.github.user", "my-plugin")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to decode response")
+}
+
+func TestPluginsClient_TrailingSlashInBaseURL(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The path should not have a double slash
+		require.NotContains(t, r.URL.Path, "//")
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(thvregistry.Plugin{
+			Namespace: "io.github.user",
+			Name:      "my-plugin",
+			Version:   "1.0.0",
+		})
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	// Create client with trailing slash
+	client, err := NewPluginsClient(server.URL+"/", true, nil)
+	require.NoError(t, err)
+
+	plugin, err := client.GetPlugin(t.Context(), "io.github.user", "my-plugin")
+	require.NoError(t, err)
+	require.Equal(t, "io.github.user", plugin.Namespace)
+}
+
+func TestPluginsClient_ListPluginsWithSearch(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "test-query", r.URL.Query().Get("search"))
+		require.Equal(t, "50", r.URL.Query().Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(pluginsListResponse{
+			Plugins: []*thvregistry.Plugin{
+				{Namespace: "io.github.user", Name: "test-plugin", Version: "1.0.0"},
+			},
+			Metadata: struct {
+				Count      int    `json:"count"`
+				NextCursor string `json:"nextCursor"`
+			}{Count: 1, NextCursor: ""},
+		})
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := newTestPluginsClient(t, server)
+	result, err := client.ListPlugins(t.Context(), &PluginsListOptions{
+		Search: "test-query",
+		Limit:  50,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Plugins, 1)
+	require.Equal(t, "test-plugin", result.Plugins[0].Name)
+}
+
+func TestPluginsClient_RegistryHTTPErrorUnwrap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErrIs  error
+	}{
+		{name: "401 wraps unauthorized", statusCode: http.StatusUnauthorized, wantErrIs: ErrRegistryUnauthorized},
+		{name: "403 wraps unauthorized", statusCode: http.StatusForbidden, wantErrIs: ErrRegistryUnauthorized},
+		{name: "404 unwraps to nil", statusCode: http.StatusNotFound, wantErrIs: nil},
+		{name: "500 unwraps to nil", statusCode: http.StatusInternalServerError, wantErrIs: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := &RegistryHTTPError{
+				StatusCode: tt.statusCode,
+				Body:       "test body",
+				URL:        "http://example.com/test",
+			}
+			require.Equal(t, tt.wantErrIs, err.Unwrap())
+			require.Contains(t, err.Error(), fmt.Sprintf("status %d", tt.statusCode))
+		})
+	}
+}

--- a/pkg/registry/api/plugins_client_test.go
+++ b/pkg/registry/api/plugins_client_test.go
@@ -376,6 +376,62 @@ func TestPluginsClient_SearchPlugins(t *testing.T) {
 	}
 }
 
+// TestPluginsClient_SearchPluginsPagination verifies that SearchPlugins
+// auto-paginates through all available pages, mirroring ListPlugins. Same-named
+// plugins across namespaces can span pages; a single-page search would miss the
+// later pages and enable wrong-publisher installs.
+func TestPluginsClient_SearchPluginsPagination(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "kube", r.URL.Query().Get("search"))
+		w.Header().Set("Content-Type", "application/json")
+
+		callCount++
+		cursor := r.URL.Query().Get("cursor")
+		var resp pluginsListResponse
+
+		switch {
+		case cursor == "" && callCount == 1:
+			resp = pluginsListResponse{
+				Plugins: []*thvregistry.Plugin{
+					{Namespace: "io.github.a", Name: "k8s-plugin", Version: "1.0.0"},
+				},
+				Metadata: struct {
+					Count      int    `json:"count"`
+					NextCursor string `json:"nextCursor"`
+				}{Count: 1, NextCursor: "page2"},
+			}
+		case cursor == "page2":
+			resp = pluginsListResponse{
+				Plugins: []*thvregistry.Plugin{
+					{Namespace: "io.github.b", Name: "k8s-plugin", Version: "2.0.0"},
+				},
+				Metadata: struct {
+					Count      int    `json:"count"`
+					NextCursor string `json:"nextCursor"`
+				}{Count: 1, NextCursor: ""},
+			}
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		err := json.NewEncoder(w).Encode(resp)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := newTestPluginsClient(t, server)
+	result, err := client.SearchPlugins(t.Context(), "kube")
+	require.NoError(t, err)
+	require.Len(t, result.Plugins, 2, "both pages should be concatenated")
+	require.Equal(t, "io.github.a", result.Plugins[0].Namespace)
+	require.Equal(t, "io.github.b", result.Plugins[1].Namespace)
+	require.Equal(t, 2, callCount, "both pages should have been fetched")
+}
+
 func TestPluginsClient_ListPluginVersions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/registry/convert_test.go
+++ b/pkg/registry/convert_test.go
@@ -332,7 +332,7 @@ func TestConvertJSON_OutputPassesSchemaValidation(t *testing.T) {
 func TestConvertJSON_RoundTripEmbeddedCatalog(t *testing.T) {
 	t.Parallel()
 
-	original, _, err := parseRegistryData(catalog.Upstream())
+	original, _, _, err := parseRegistryData(catalog.Upstream())
 	require.NoError(t, err)
 
 	roundTripped, err := converters.NewUpstreamRegistryFromToolhiveRegistry(original)

--- a/pkg/registry/mocks/mock_provider.go
+++ b/pkg/registry/mocks/mock_provider.go
@@ -40,6 +40,21 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
 }
 
+// GetPlugin mocks base method.
+func (m *MockProvider) GetPlugin(namespace, name string) (*registry.Plugin, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPlugin", namespace, name)
+	ret0, _ := ret[0].(*registry.Plugin)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPlugin indicates an expected call of GetPlugin.
+func (mr *MockProviderMockRecorder) GetPlugin(namespace, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlugin", reflect.TypeOf((*MockProvider)(nil).GetPlugin), namespace, name)
+}
+
 // GetRegistry mocks base method.
 func (m *MockProvider) GetRegistry() (*registry.Registry, error) {
 	m.ctrl.T.Helper()
@@ -85,6 +100,21 @@ func (mr *MockProviderMockRecorder) GetSkill(namespace, name any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSkill", reflect.TypeOf((*MockProvider)(nil).GetSkill), namespace, name)
 }
 
+// ListAvailablePlugins mocks base method.
+func (m *MockProvider) ListAvailablePlugins() ([]registry.Plugin, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAvailablePlugins")
+	ret0, _ := ret[0].([]registry.Plugin)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAvailablePlugins indicates an expected call of ListAvailablePlugins.
+func (mr *MockProviderMockRecorder) ListAvailablePlugins() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAvailablePlugins", reflect.TypeOf((*MockProvider)(nil).ListAvailablePlugins))
+}
+
 // ListAvailableSkills mocks base method.
 func (m *MockProvider) ListAvailableSkills() ([]registry.Skill, error) {
 	m.ctrl.T.Helper()
@@ -113,6 +143,21 @@ func (m *MockProvider) ListServers() ([]registry.ServerMetadata, error) {
 func (mr *MockProviderMockRecorder) ListServers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServers", reflect.TypeOf((*MockProvider)(nil).ListServers))
+}
+
+// SearchPlugins mocks base method.
+func (m *MockProvider) SearchPlugins(query string) ([]registry.Plugin, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchPlugins", query)
+	ret0, _ := ret[0].([]registry.Plugin)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchPlugins indicates an expected call of SearchPlugins.
+func (mr *MockProviderMockRecorder) SearchPlugins(query any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchPlugins", reflect.TypeOf((*MockProvider)(nil).SearchPlugins), query)
 }
 
 // SearchServers mocks base method.

--- a/pkg/registry/provider.go
+++ b/pkg/registry/provider.go
@@ -29,4 +29,13 @@ type Provider interface {
 
 	// SearchSkills searches for skills matching the query
 	SearchSkills(query string) ([]types.Skill, error)
+
+	// ListAvailablePlugins returns plugins discovered from the registry data
+	ListAvailablePlugins() ([]types.Plugin, error)
+
+	// GetPlugin returns a specific plugin by namespace and name
+	GetPlugin(namespace, name string) (*types.Plugin, error)
+
+	// SearchPlugins searches for plugins matching the query
+	SearchPlugins(query string) ([]types.Plugin, error)
 }

--- a/pkg/registry/provider_api.go
+++ b/pkg/registry/provider_api.go
@@ -26,6 +26,7 @@ type APIRegistryProvider struct {
 	client         api.Client
 	tokenSource    auth.TokenSource
 	skillsClient   api.SkillsClient
+	pluginsClient  api.PluginsClient
 }
 
 // NewAPIRegistryProvider creates a new API registry provider.
@@ -40,12 +41,16 @@ func NewAPIRegistryProvider(apiURL string, allowPrivateIp bool, tokenSource auth
 	// Create skills client (best-effort — skills API may not be available)
 	skillsClient, _ := api.NewSkillsClient(apiURL, allowPrivateIp, tokenSource)
 
+	// Create plugins client (best-effort — plugins API may not be available)
+	pluginsClient, _ := api.NewPluginsClient(apiURL, allowPrivateIp, tokenSource)
+
 	p := &APIRegistryProvider{
 		apiURL:         apiURL,
 		allowPrivateIp: allowPrivateIp,
 		client:         client,
 		tokenSource:    tokenSource,
 		skillsClient:   skillsClient,
+		pluginsClient:  pluginsClient,
 	}
 
 	// Initialize the base provider with the GetRegistry function
@@ -227,22 +232,54 @@ func (p *APIRegistryProvider) SearchSkills(query string) ([]types.Skill, error) 
 	return skills, nil
 }
 
-// ListAvailablePlugins returns nil until the PluginsClient is wired up.
-// TODO(5529): backed by PluginsClient in the next iteration.
-func (*APIRegistryProvider) ListAvailablePlugins() ([]types.Plugin, error) {
-	return nil, nil
+// ListAvailablePlugins returns all plugins from the API, with auto-pagination.
+func (p *APIRegistryProvider) ListAvailablePlugins() ([]types.Plugin, error) {
+	if p.pluginsClient == nil {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	result, err := p.pluginsClient.ListPlugins(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	plugins := make([]types.Plugin, 0, len(result.Plugins))
+	for _, pl := range result.Plugins {
+		if pl != nil {
+			plugins = append(plugins, *pl)
+		}
+	}
+	return plugins, nil
 }
 
-// GetPlugin returns nil until the PluginsClient is wired up.
-// TODO(5529): backed by PluginsClient in the next iteration.
-func (*APIRegistryProvider) GetPlugin(_, _ string) (*types.Plugin, error) {
-	return nil, nil
+// GetPlugin returns a specific plugin by namespace and name from the API.
+func (p *APIRegistryProvider) GetPlugin(namespace, name string) (*types.Plugin, error) {
+	if p.pluginsClient == nil {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return p.pluginsClient.GetPlugin(ctx, namespace, name)
 }
 
-// SearchPlugins returns nil until the PluginsClient is wired up.
-// TODO(5529): backed by PluginsClient in the next iteration.
-func (*APIRegistryProvider) SearchPlugins(_ string) ([]types.Plugin, error) {
-	return nil, nil
+// SearchPlugins searches for plugins matching the query via the API.
+func (p *APIRegistryProvider) SearchPlugins(query string) ([]types.Plugin, error) {
+	if p.pluginsClient == nil {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	result, err := p.pluginsClient.SearchPlugins(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	plugins := make([]types.Plugin, 0, len(result.Plugins))
+	for _, pl := range result.Plugins {
+		if pl != nil {
+			plugins = append(plugins, *pl)
+		}
+	}
+	return plugins, nil
 }
 
 // ConvertServerJSON converts an MCP Registry API ServerJSON to ToolHive ServerMetadata

--- a/pkg/registry/provider_api.go
+++ b/pkg/registry/provider_api.go
@@ -227,6 +227,24 @@ func (p *APIRegistryProvider) SearchSkills(query string) ([]types.Skill, error) 
 	return skills, nil
 }
 
+// ListAvailablePlugins returns nil until the PluginsClient is wired up.
+// TODO(5529): backed by PluginsClient in the next iteration.
+func (*APIRegistryProvider) ListAvailablePlugins() ([]types.Plugin, error) {
+	return nil, nil
+}
+
+// GetPlugin returns nil until the PluginsClient is wired up.
+// TODO(5529): backed by PluginsClient in the next iteration.
+func (*APIRegistryProvider) GetPlugin(_, _ string) (*types.Plugin, error) {
+	return nil, nil
+}
+
+// SearchPlugins returns nil until the PluginsClient is wired up.
+// TODO(5529): backed by PluginsClient in the next iteration.
+func (*APIRegistryProvider) SearchPlugins(_ string) ([]types.Plugin, error) {
+	return nil, nil
+}
+
 // ConvertServerJSON converts an MCP Registry API ServerJSON to ToolHive ServerMetadata
 // Uses converters from converters.go (same package)
 // Note: Only handles OCI packages and remote servers, skips npm/pypi by design

--- a/pkg/registry/provider_api_test.go
+++ b/pkg/registry/provider_api_test.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	thvregistry "github.com/stacklok/toolhive-core/registry/types"
+)
+
+// apiRegistryTestServer serves the MCP Registry API endpoints needed to exercise
+// APIRegistryProvider plugin methods. It serves the servers list (for the
+// constructor's validation probe) plus the ToolHive plugins extension endpoints.
+func apiRegistryTestServer(t *testing.T, plugins []*thvregistry.Plugin) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	// Servers list endpoint — required by the constructor's validation probe.
+	mux.HandleFunc("/v0.1/servers", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"servers":[],"metadata":{"next_cursor":""}}`))
+	})
+
+	// List plugins (auto-pagination) — required by ListAvailablePlugins.
+	mux.HandleFunc("/v0.1/x/dev.toolhive/plugins", func(w http.ResponseWriter, r *http.Request) {
+		// If there's a search query param, this is the SearchPlugins endpoint.
+		if r.URL.Query().Get("search") != "" {
+			searchHandler(w, r, plugins)
+			return
+		}
+		listHandler(w, r, plugins)
+	})
+
+	// Get plugin by namespace/name — required by GetPlugin.
+	mux.HandleFunc("/v0.1/x/dev.toolhive/plugins/", func(w http.ResponseWriter, _ *http.Request) {
+		// The path is /v0.1/x/dev.toolhive/plugins/{namespace}/{name}
+		// We serve a fixed plugin for any request (the handler extracts the
+		// namespace/name from the path but we just return the first plugin
+		// that matches, or 404).
+		w.Header().Set("Content-Type", "application/json")
+
+		// Simple match: if plugins has at least one, return the first one.
+		// The GetPlugin implementation extracts namespace/name from the
+		// path; we don't need to validate them here — we just need to
+		// return a valid plugin payload so the caller can assert it.
+		if len(plugins) > 0 {
+			require.NoError(t, json.NewEncoder(w).Encode(plugins[0]))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("plugin not found"))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func searchHandler(w http.ResponseWriter, _ *http.Request, plugins []*thvregistry.Plugin) {
+	w.Header().Set("Content-Type", "application/json")
+	payload := pluginsListPayload{Plugins: plugins}
+	payload.Metadata.Count = len(plugins)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func listHandler(w http.ResponseWriter, _ *http.Request, plugins []*thvregistry.Plugin) {
+	w.Header().Set("Content-Type", "application/json")
+	payload := pluginsListPayload{Plugins: plugins}
+	payload.Metadata.Count = len(plugins)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func TestAPIRegistryProvider_ListAvailablePlugins(t *testing.T) {
+	t.Parallel()
+
+	plugins := []*thvregistry.Plugin{
+		{
+			Namespace:   "io.github.stacklok",
+			Name:        "code-reviewer",
+			Description: "Reviews code for bugs",
+			Version:     "1.0.0",
+		},
+		{
+			Namespace:   "io.github.acme",
+			Name:        "doc-generator",
+			Description: "Generates documentation",
+			Version:     "0.2.0",
+		},
+	}
+
+	srv := apiRegistryTestServer(t, plugins)
+	provider, err := NewAPIRegistryProvider(srv.URL, true, nil)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	got, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "code-reviewer", got[0].Name)
+	assert.Equal(t, "io.github.stacklok", got[0].Namespace)
+	assert.Equal(t, "Reviews code for bugs", got[0].Description)
+	assert.Equal(t, "1.0.0", got[0].Version)
+
+	assert.Equal(t, "doc-generator", got[1].Name)
+	assert.Equal(t, "io.github.acme", got[1].Namespace)
+	assert.Equal(t, "0.2.0", got[1].Version)
+}
+
+func TestAPIRegistryProvider_GetPlugin(t *testing.T) {
+	t.Parallel()
+
+	plugins := []*thvregistry.Plugin{
+		{
+			Namespace:   "io.github.stacklok",
+			Name:        "code-reviewer",
+			Description: "Reviews code for bugs",
+			Version:     "1.0.0",
+		},
+	}
+
+	srv := apiRegistryTestServer(t, plugins)
+	provider, err := NewAPIRegistryProvider(srv.URL, true, nil)
+	require.NoError(t, err)
+
+	got, err := provider.GetPlugin("io.github.stacklok", "code-reviewer")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "code-reviewer", got.Name)
+	assert.Equal(t, "io.github.stacklok", got.Namespace)
+	assert.Equal(t, "1.0.0", got.Version)
+}
+
+func TestAPIRegistryProvider_SearchPlugins(t *testing.T) {
+	t.Parallel()
+
+	plugins := []*thvregistry.Plugin{
+		{
+			Namespace:   "io.github.stacklok",
+			Name:        "code-reviewer",
+			Description: "Reviews code for bugs",
+			Version:     "1.0.0",
+		},
+	}
+
+	srv := apiRegistryTestServer(t, plugins)
+	provider, err := NewAPIRegistryProvider(srv.URL, true, nil)
+	require.NoError(t, err)
+
+	got, err := provider.SearchPlugins("reviewer")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "code-reviewer", got[0].Name)
+	assert.Equal(t, "Reviews code for bugs", got[0].Description)
+}
+
+func TestAPIRegistryProvider_SearchPlugins_Empty(t *testing.T) {
+	t.Parallel()
+
+	srv := apiRegistryTestServer(t, nil)
+	provider, err := NewAPIRegistryProvider(srv.URL, true, nil)
+	require.NoError(t, err)
+
+	got, err := provider.SearchPlugins("nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestAPIRegistryProvider_PluginsNilClient(t *testing.T) {
+	t.Parallel()
+
+	// Construct an APIRegistryProvider with a nil pluginsClient (simulating
+	// the case where NewPluginsClient fails, e.g. due to HTTP transport setup).
+	// The constructor does best-effort plugin client creation, so a nil client
+	// is possible. The methods must return nil, nil rather than panicking.
+	p := &APIRegistryProvider{
+		pluginsClient: nil,
+	}
+
+	plugins, err := p.ListAvailablePlugins()
+	require.NoError(t, err)
+	assert.Nil(t, plugins)
+
+	got, err := p.GetPlugin("ns", "name")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	results, err := p.SearchPlugins("query")
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}

--- a/pkg/registry/provider_base.go
+++ b/pkg/registry/provider_base.go
@@ -136,6 +136,22 @@ func (*BaseProvider) SearchSkills(_ string) ([]types.Skill, error) {
 	return nil, nil
 }
 
+// ListAvailablePlugins returns an empty slice by default.
+// Providers that support plugins (local, remote) override this.
+func (*BaseProvider) ListAvailablePlugins() ([]types.Plugin, error) {
+	return nil, nil
+}
+
+// GetPlugin returns nil for providers that don't support plugins.
+func (*BaseProvider) GetPlugin(_, _ string) (*types.Plugin, error) {
+	return nil, nil
+}
+
+// SearchPlugins returns nil for providers that don't support plugins.
+func (*BaseProvider) SearchPlugins(_ string) ([]types.Plugin, error) {
+	return nil, nil
+}
+
 // matchesQuery checks if a server matches the search query
 func matchesQuery(name, description string, tags []string, query string) bool {
 	// Search in name

--- a/pkg/registry/provider_cached.go
+++ b/pkg/registry/provider_cached.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -155,8 +156,24 @@ func (p *CachedAPIRegistryProvider) refreshCache() (*types.Registry, error) {
 	return registry, nil
 }
 
-// ForceRefresh forces a cache refresh, ignoring TTL.
+// ForceRefresh forces a cache refresh, ignoring TTL. It also invalidates the
+// skills and plugins caches so the next ListAvailableSkills/ListAvailablePlugins
+// call re-fetches from the API rather than serving stale data until its own
+// TTL expires.
 func (p *CachedAPIRegistryProvider) ForceRefresh() error {
+	// Invalidate the skills and plugins caches so the next access refetches.
+	// Without this, ForceRefresh would only refresh the servers cache while
+	// skills/plugins kept serving stale data for up to cacheTTL after the
+	// refresh — a confusing inconsistency for callers who expect "force" to
+	// mean "everything is refreshed".
+	p.skillsMu.Lock()
+	p.skillsCacheSet = false
+	p.skillsMu.Unlock()
+
+	p.pluginsMu.Lock()
+	p.pluginsCacheSet = false
+	p.pluginsMu.Unlock()
+
 	_, err := p.refreshCache()
 	return err
 }
@@ -455,6 +472,16 @@ func (p *CachedAPIRegistryProvider) ListAvailableSkills() ([]types.Skill, error)
 
 // ListAvailablePlugins returns plugins from the registry API, with caching.
 // Creates a PluginsClient on demand and fetches all plugins with auto-pagination.
+//
+// Error semantics mirror refreshCache's contract for the servers cache:
+//   - authentication failures (401/403, surfaced as api.RegistryHTTPError that
+//     unwraps to api.ErrRegistryUnauthorized) are always propagated — stale
+//     cache must never mask a changed authentication state, or a revoked token
+//     would silently serve stale data and hide the need to re-auth;
+//   - other failures (network blip, 5xx) degrade gracefully to stale cache
+//     when one is present;
+//   - with no stale cache, the error is returned (never nil,nil), so the v0.1
+//     registry route surfaces a real failure instead of an empty 200.
 func (p *CachedAPIRegistryProvider) ListAvailablePlugins() ([]types.Plugin, error) {
 	// Check cache
 	p.pluginsMu.RLock()
@@ -468,7 +495,8 @@ func (p *CachedAPIRegistryProvider) ListAvailablePlugins() ([]types.Plugin, erro
 	// Fetch from API
 	pluginsClient, err := api.NewPluginsClient(p.apiURL, p.allowPrivateIp, p.tokenSource)
 	if err != nil {
-		// Return cached data if available
+		// Client construction is a local failure (bad URL / transport), not an
+		// auth-state change: fall back to stale cache when available.
 		p.pluginsMu.RLock()
 		defer p.pluginsMu.RUnlock()
 		if p.pluginsCacheSet {
@@ -483,13 +511,20 @@ func (p *CachedAPIRegistryProvider) ListAvailablePlugins() ([]types.Plugin, erro
 	// ListPlugins auto-paginates internally, returning all plugins in one call
 	result, err := pluginsClient.ListPlugins(ctx, nil)
 	if err != nil {
-		// Return cached data if available, otherwise nil (plugins are optional)
+		// Auth failures must propagate — never mask with stale cache.
+		var httpErr *api.RegistryHTTPError
+		if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
+			return nil, err
+		}
+		// Transient failures: degrade to stale cache if available.
 		p.pluginsMu.RLock()
 		defer p.pluginsMu.RUnlock()
 		if p.pluginsCacheSet {
 			return p.cachedPlugins, nil
 		}
-		return nil, nil
+		// No stale cache: surface the error rather than nil,nil so the
+		// v0.1 registry route does not answer 200 [] on a real failure.
+		return nil, err
 	}
 
 	allPlugins := make([]types.Plugin, 0, len(result.Plugins))

--- a/pkg/registry/provider_cached.go
+++ b/pkg/registry/provider_cached.go
@@ -46,6 +46,12 @@ type CachedAPIRegistryProvider struct {
 	skillsCacheSet bool
 	skillsTime     time.Time
 
+	// Plugins cache
+	pluginsMu       sync.RWMutex
+	cachedPlugins   []types.Plugin
+	pluginsCacheSet bool
+	pluginsTime     time.Time
+
 	// Cache configuration
 	cacheTTL      time.Duration
 	usePersistent bool
@@ -445,6 +451,62 @@ func (p *CachedAPIRegistryProvider) ListAvailableSkills() ([]types.Skill, error)
 	p.skillsMu.Unlock()
 
 	return allSkills, nil
+}
+
+// ListAvailablePlugins returns plugins from the registry API, with caching.
+// Creates a PluginsClient on demand and fetches all plugins with auto-pagination.
+func (p *CachedAPIRegistryProvider) ListAvailablePlugins() ([]types.Plugin, error) {
+	// Check cache
+	p.pluginsMu.RLock()
+	if p.pluginsCacheSet && time.Since(p.pluginsTime) < p.cacheTTL {
+		plugins := p.cachedPlugins
+		p.pluginsMu.RUnlock()
+		return plugins, nil
+	}
+	p.pluginsMu.RUnlock()
+
+	// Fetch from API
+	pluginsClient, err := api.NewPluginsClient(p.apiURL, p.allowPrivateIp, p.tokenSource)
+	if err != nil {
+		// Return cached data if available
+		p.pluginsMu.RLock()
+		defer p.pluginsMu.RUnlock()
+		if p.pluginsCacheSet {
+			return p.cachedPlugins, nil
+		}
+		return nil, fmt.Errorf("failed to create plugins client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// ListPlugins auto-paginates internally, returning all plugins in one call
+	result, err := pluginsClient.ListPlugins(ctx, nil)
+	if err != nil {
+		// Return cached data if available, otherwise nil (plugins are optional)
+		p.pluginsMu.RLock()
+		defer p.pluginsMu.RUnlock()
+		if p.pluginsCacheSet {
+			return p.cachedPlugins, nil
+		}
+		return nil, nil
+	}
+
+	allPlugins := make([]types.Plugin, 0, len(result.Plugins))
+	for _, pl := range result.Plugins {
+		if pl != nil {
+			allPlugins = append(allPlugins, *pl)
+		}
+	}
+
+	// Update cache
+	p.pluginsMu.Lock()
+	p.cachedPlugins = allPlugins
+	p.pluginsCacheSet = true
+	p.pluginsTime = time.Now()
+	p.pluginsMu.Unlock()
+
+	return allPlugins, nil
 }
 
 // ConvertServerJSON wraps ConvertServerJSON for cached provider

--- a/pkg/registry/provider_cached_plugins_errors_test.go
+++ b/pkg/registry/provider_cached_plugins_errors_test.go
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	thvregistry "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/registry/api"
+)
+
+// newPluginsStatusServer returns an httptest.Server whose plugins list endpoint
+// responds with statusCode when status.Load() is non-zero, and a normal page of
+// plugins otherwise. The servers list endpoint always answers an empty list so
+// the constructor's validation probe succeeds.
+func newPluginsStatusServer(t *testing.T, plugins []*thvregistry.Plugin, status *atomic.Int32) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var callCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v0.1/x/dev.toolhive/plugins", func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		if s := status.Load(); s != 0 {
+			w.WriteHeader(int(s))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		payload := pluginsListPayload{Plugins: plugins}
+		payload.Metadata.Count = len(plugins)
+		require.NoError(t, json.NewEncoder(w).Encode(payload))
+	})
+	mux.HandleFunc("/v0.1/servers", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"servers":[],"metadata":{"next_cursor":""}}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &callCount
+}
+
+// TestCachedProvider_PluginsAuthErrorWithWarmCache verifies that a 401 from the
+// registry is propagated even when a warm cache could otherwise mask it. A
+// revoked token must not silently serve stale data.
+func TestCachedProvider_PluginsAuthErrorWithWarmCache(t *testing.T) {
+	t.Parallel()
+
+	plugins := []*thvregistry.Plugin{
+		{Namespace: "io.github.stacklok", Name: "code-reviewer", Version: "1.0.0"},
+	}
+	var status atomic.Int32 // 0 = healthy
+	srv, callCount := newPluginsStatusServer(t, plugins, &status)
+
+	provider, err := NewCachedAPIRegistryProvider(srv.URL, true, false, nil)
+	require.NoError(t, err)
+
+	// Warm the cache.
+	got, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	firstCount := callCount.Load()
+
+	// Flip the registry to 401 and expire the cache.
+	status.Store(http.StatusUnauthorized)
+	provider.pluginsMu.Lock()
+	provider.pluginsTime = provider.pluginsTime.Add(-defaultCacheTTL - 1)
+	provider.pluginsMu.Unlock()
+
+	got2, err := provider.ListAvailablePlugins()
+	require.Error(t, err, "401 must propagate, not be masked by stale cache")
+	require.Nil(t, got2)
+	require.True(t,
+		errors.Is(err, api.ErrRegistryUnauthorized),
+		"expected errors.Is(err, ErrRegistryUnauthorized); got: %v", err)
+	require.Greater(t, callCount.Load(), firstCount, "expired cache should trigger a re-fetch attempt")
+}
+
+// TestCachedProvider_PluginsTransient500WithWarmCache verifies that a transient
+// 500 with a warm cache degrades to stale data (the auth path is the exception,
+// not the rule).
+func TestCachedProvider_PluginsTransient500WithWarmCache(t *testing.T) {
+	t.Parallel()
+
+	plugins := []*thvregistry.Plugin{
+		{Namespace: "io.github.stacklok", Name: "code-reviewer", Version: "1.0.0"},
+	}
+	var status atomic.Int32
+	srv, callCount := newPluginsStatusServer(t, plugins, &status)
+
+	provider, err := NewCachedAPIRegistryProvider(srv.URL, true, false, nil)
+	require.NoError(t, err)
+
+	// Warm the cache.
+	got, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	// Flip to 500 and expire the cache.
+	status.Store(http.StatusInternalServerError)
+	provider.pluginsMu.Lock()
+	provider.pluginsTime = provider.pluginsTime.Add(-defaultCacheTTL - 1)
+	provider.pluginsMu.Unlock()
+
+	got2, err := provider.ListAvailablePlugins()
+	require.NoError(t, err, "transient 500 with warm cache should serve stale data")
+	require.Len(t, got2, 1)
+	require.Equal(t, "code-reviewer", got2[0].Name)
+	_ = callCount // re-fetch attempt made (not asserting exact count here)
+}
+
+// TestCachedProvider_PluginsTransient500WithColdCache verifies that a transient
+// 500 with no cache returns the error rather than (nil, nil), so the v0.1
+// registry route does not answer 200 [] on a real failure.
+func TestCachedProvider_PluginsTransient500WithColdCache(t *testing.T) {
+	t.Parallel()
+
+	var status atomic.Int32
+	status.Store(http.StatusInternalServerError)
+	srv, _ := newPluginsStatusServer(t, nil, &status)
+
+	provider, err := NewCachedAPIRegistryProvider(srv.URL, true, false, nil)
+	require.NoError(t, err)
+
+	got, err := provider.ListAvailablePlugins()
+	require.Error(t, err, "transient 500 with cold cache must return the error, not nil,nil")
+	require.Nil(t, got)
+}
+
+// TestCachedProvider_ForceRefreshInvalidatesPluginsCache verifies that
+// ForceRefresh invalidates the plugins cache so the next ListAvailablePlugins
+// re-fetches from the API instead of serving the pre-refresh cached value.
+func TestCachedProvider_ForceRefreshInvalidatesPluginsCache(t *testing.T) {
+	t.Parallel()
+
+	plugins := []*thvregistry.Plugin{
+		{Namespace: "io.github.stacklok", Name: "code-reviewer", Version: "1.0.0"},
+	}
+	srv, callCount := newPluginsStatusServer(t, plugins, &atomic.Int32{})
+
+	provider, err := NewCachedAPIRegistryProvider(srv.URL, true, false, nil)
+	require.NoError(t, err)
+
+	// Prime the plugins cache.
+	got, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	afterFirst := callCount.Load()
+
+	// A second call within TTL must be served from cache (no re-fetch).
+	got2, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+	require.Equal(t, afterFirst, callCount.Load(), "second call should be served from cache")
+
+	// ForceRefresh must invalidate the plugins cache so the next call refetches.
+	require.NoError(t, provider.ForceRefresh())
+
+	got3, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, got3, 1)
+	require.Greater(t, callCount.Load(), afterFirst, "ForceRefresh should cause the next ListAvailablePlugins to refetch")
+}

--- a/pkg/registry/provider_cached_plugins_test.go
+++ b/pkg/registry/provider_cached_plugins_test.go
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	thvregistry "github.com/stacklok/toolhive-core/registry/types"
+)
+
+// pluginsListPayload is the wire format served by the test registry for the
+// plugins list endpoint. Field names mirror pluginsListResponse in
+// pkg/registry/api/plugins_client.go so the client decodes them cleanly.
+type pluginsListPayload struct {
+	Plugins  []*thvregistry.Plugin `json:"plugins"`
+	Metadata struct {
+		Count      int    `json:"count"`
+		NextCursor string `json:"nextCursor"`
+	} `json:"metadata"`
+}
+
+// newPluginsTestServer returns an httptest.Server that serves the plugins list
+// endpoint. The server endpoint is /v0.1/x/dev.toolhive/plugins. If fail is
+// non-nil and returns true, the server responds 500 to exercise stale-cache
+// fallback. callCount tracks how many times the list endpoint was hit.
+func newPluginsTestServer(t *testing.T, plugins []*thvregistry.Plugin, fail *atomic.Bool) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var callCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v0.1/x/dev.toolhive/plugins", func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		if fail != nil && fail.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		payload := pluginsListPayload{Plugins: plugins}
+		payload.Metadata.Count = len(plugins)
+		require.NoError(t, json.NewEncoder(w).Encode(payload))
+	})
+	// The constructor's validation probe hits the servers list endpoint; serve
+	// an empty server list so the probe succeeds and construction completes.
+	mux.HandleFunc("/v0.1/servers", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"servers":[],"metadata":{"next_cursor":""}}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &callCount
+}
+
+// TestCachedProvider_PluginsCacheHit verifies that a second ListAvailablePlugins
+// call within the TTL is served from cache without hitting the registry.
+func TestCachedProvider_PluginsCacheHit(t *testing.T) {
+	t.Parallel()
+
+	plugins := []*thvregistry.Plugin{
+		{Namespace: "io.github.stacklok", Name: "code-reviewer", Version: "1.0.0"},
+		{Namespace: "io.github.acme", Name: "doc-generator", Version: "0.2.0"},
+	}
+	srv, callCount := newPluginsTestServer(t, plugins, nil)
+
+	provider, err := NewCachedAPIRegistryProvider(srv.URL, true, false, nil)
+	require.NoError(t, err)
+
+	// First call: cache miss, fetches from API.
+	got, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, "code-reviewer", got[0].Name)
+	require.Equal(t, int32(1), callCount.Load())
+
+	// Second call: cache hit, must not hit the API again.
+	got2, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Equal(t, got, got2)
+	require.Equal(t, int32(1), callCount.Load(), "second call should be served from cache")
+}
+
+// TestCachedProvider_PluginsCacheMissFetch verifies that an empty cache
+// triggers a fetch from the registry API.
+func TestCachedProvider_PluginsCacheMissFetch(t *testing.T) {
+	t.Parallel()
+
+	plugins := []*thvregistry.Plugin{
+		{Namespace: "io.github.stacklok", Name: "linter", Version: "1.0.0"},
+	}
+	srv, callCount := newPluginsTestServer(t, plugins, nil)
+
+	provider, err := NewCachedAPIRegistryProvider(srv.URL, true, false, nil)
+	require.NoError(t, err)
+
+	got, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "linter", got[0].Name)
+	require.Equal(t, int32(1), callCount.Load())
+}
+
+// TestCachedProvider_PluginsStaleOnFailure verifies that when the registry
+// returns a transient error (500) on a cache miss, ListAvailablePlugins
+// returns nil (plugins are optional) rather than propagating the error —
+// mirroring the skills behavior in provider_cached.go.
+func TestCachedProvider_PluginsStaleOnFailure(t *testing.T) {
+	t.Parallel()
+
+	plugins := []*thvregistry.Plugin{
+		{Namespace: "io.github.stacklok", Name: "code-reviewer", Version: "1.0.0"},
+	}
+	var fail atomic.Bool
+	srv, callCount := newPluginsTestServer(t, plugins, &fail)
+
+	provider, err := NewCachedAPIRegistryProvider(srv.URL, true, false, nil)
+	require.NoError(t, err)
+
+	// First call: succeeds and populates the cache.
+	got, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	firstCount := callCount.Load()
+
+	// Force the registry to fail, then expire the cache so the next call must
+	// re-fetch. The stale cache should be served instead of the error.
+	fail.Store(true)
+	provider.pluginsMu.Lock()
+	provider.pluginsTime = provider.pluginsTime.Add(-defaultCacheTTL - 1)
+	provider.pluginsMu.Unlock()
+
+	got2, err := provider.ListAvailablePlugins()
+	require.NoError(t, err, "transient failure should return stale cache, not error")
+	require.Len(t, got2, 1, "stale cache should still hold the previously fetched plugin")
+	require.Equal(t, "code-reviewer", got2[0].Name)
+	require.Greater(t, callCount.Load(), firstCount, "expired cache should trigger a re-fetch attempt")
+}
+
+// TestCachedProvider_PluginsStaleOnFailureEmptyCache verifies that a transient
+// failure with NO cached data returns nil, nil (plugins are optional) rather
+// than an error — mirroring the skills fallback in provider_cached.go.
+func TestCachedProvider_PluginsStaleOnFailureEmptyCache(t *testing.T) {
+	t.Parallel()
+
+	var fail atomic.Bool
+	fail.Store(true)
+	srv, _ := newPluginsTestServer(t, nil, &fail)
+
+	provider, err := NewCachedAPIRegistryProvider(srv.URL, true, false, nil)
+	require.NoError(t, err)
+
+	got, err := provider.ListAvailablePlugins()
+	require.NoError(t, err, "transient failure with empty cache should return nil, nil")
+	require.Nil(t, got)
+}

--- a/pkg/registry/provider_cached_plugins_test.go
+++ b/pkg/registry/provider_cached_plugins_test.go
@@ -143,8 +143,8 @@ func TestCachedProvider_PluginsStaleOnFailure(t *testing.T) {
 }
 
 // TestCachedProvider_PluginsStaleOnFailureEmptyCache verifies that a transient
-// failure with NO cached data returns nil, nil (plugins are optional) rather
-// than an error — mirroring the skills fallback in provider_cached.go.
+// failure with NO cached data returns the error (not nil,nil) so the v0.1
+// registry route surfaces a real failure instead of an empty 200 [].
 func TestCachedProvider_PluginsStaleOnFailureEmptyCache(t *testing.T) {
 	t.Parallel()
 
@@ -156,6 +156,6 @@ func TestCachedProvider_PluginsStaleOnFailureEmptyCache(t *testing.T) {
 	require.NoError(t, err)
 
 	got, err := provider.ListAvailablePlugins()
-	require.NoError(t, err, "transient failure with empty cache should return nil, nil")
+	require.Error(t, err, "transient failure with empty cache should return the error, not nil,nil")
 	require.Nil(t, got)
 }

--- a/pkg/registry/provider_local.go
+++ b/pkg/registry/provider_local.go
@@ -16,9 +16,11 @@ import (
 // LocalRegistryProvider provides registry data from embedded JSON files or local files
 type LocalRegistryProvider struct {
 	*BaseProvider
-	filePath string
-	skillsMu sync.RWMutex
-	skills   []types.Skill
+	filePath  string
+	skillsMu  sync.RWMutex
+	skills    []types.Skill
+	pluginsMu sync.RWMutex
+	plugins   []types.Plugin
 }
 
 // NewLocalRegistryProvider creates a new local registry provider
@@ -52,11 +54,12 @@ func (p *LocalRegistryProvider) GetRegistry() (*types.Registry, error) {
 		data = catalog.Upstream()
 	}
 
-	registry, skills, err := parseRegistryData(data)
+	registry, skills, plugins, err := parseRegistryData(data)
 	if err != nil {
 		return nil, err
 	}
 	p.setSkills(skills)
+	p.setPlugins(plugins)
 
 	// Set name field on each server based on map key
 	for name, server := range registry.Servers {
@@ -86,6 +89,12 @@ func (p *LocalRegistryProvider) setSkills(skills []types.Skill) {
 	p.skillsMu.Lock()
 	defer p.skillsMu.Unlock()
 	p.skills = skills
+}
+
+func (p *LocalRegistryProvider) setPlugins(plugins []types.Plugin) {
+	p.pluginsMu.Lock()
+	defer p.pluginsMu.Unlock()
+	p.plugins = plugins
 }
 
 // ListAvailableSkills returns skills discovered from the upstream registry data.
@@ -135,6 +144,58 @@ func (p *LocalRegistryProvider) SearchSkills(query string) ([]types.Skill, error
 			strings.Contains(strings.ToLower(s.Description), query) ||
 			strings.Contains(strings.ToLower(s.Namespace), query) {
 			results = append(results, s)
+		}
+	}
+	return results, nil
+}
+
+// ListAvailablePlugins returns plugins discovered from the upstream registry data.
+// Triggers a registry load if plugins haven't been populated yet.
+func (p *LocalRegistryProvider) ListAvailablePlugins() ([]types.Plugin, error) {
+	p.pluginsMu.RLock()
+	plugins := p.plugins
+	p.pluginsMu.RUnlock()
+
+	if plugins == nil {
+		// Plugins are populated as a side effect of GetRegistry
+		if _, err := p.GetRegistry(); err != nil {
+			return nil, err
+		}
+		p.pluginsMu.RLock()
+		plugins = p.plugins
+		p.pluginsMu.RUnlock()
+	}
+
+	return plugins, nil
+}
+
+// GetPlugin returns a specific plugin by namespace and name.
+func (p *LocalRegistryProvider) GetPlugin(namespace, name string) (*types.Plugin, error) {
+	plugins, err := p.ListAvailablePlugins()
+	if err != nil {
+		return nil, err
+	}
+	for i := range plugins {
+		if plugins[i].Namespace == namespace && plugins[i].Name == name {
+			return &plugins[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// SearchPlugins searches for plugins matching the query in name, namespace, or description.
+func (p *LocalRegistryProvider) SearchPlugins(query string) ([]types.Plugin, error) {
+	plugins, err := p.ListAvailablePlugins()
+	if err != nil {
+		return nil, err
+	}
+	query = strings.ToLower(query)
+	var results []types.Plugin
+	for _, pl := range plugins {
+		if strings.Contains(strings.ToLower(pl.Name), query) ||
+			strings.Contains(strings.ToLower(pl.Description), query) ||
+			strings.Contains(strings.ToLower(pl.Namespace), query) {
+			results = append(results, pl)
 		}
 	}
 	return results, nil

--- a/pkg/registry/provider_plugins_test.go
+++ b/pkg/registry/provider_plugins_test.go
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upstreamRegistryWithPlugins is a minimal upstream-format registry payload
+// carrying a single server (so validateConnectivity accepts it for the remote
+// provider) plus two plugins used to exercise List/Get/Search on both the
+// local and remote providers.
+const upstreamRegistryWithPlugins = `{
+  "$schema": "https://example.com/schema.json",
+  "version": "1.0.0",
+  "meta": {"last_updated": "2025-01-01T00:00:00Z"},
+  "data": {
+    "servers": [
+      {
+        "name": "io.example.test-server",
+        "description": "Test server",
+        "packages": [
+          {
+            "registryType": "oci",
+            "identifier": "example/test-server:latest",
+            "transport": {"type": "stdio"}
+          }
+        ]
+      }
+    ],
+    "plugins": [
+      {
+        "namespace": "io.github.stacklok",
+        "name": "code-reviewer",
+        "description": "Reviews code for bugs",
+        "version": "1.0.0"
+      },
+      {
+        "namespace": "io.github.acme",
+        "name": "doc-generator",
+        "description": "Generates documentation",
+        "version": "0.2.0"
+      }
+    ]
+  }
+}`
+
+// pluginsOnlyRegistry is an upstream-format payload that carries plugins but
+// no servers or skills. The remote provider's validateConnectivity guard must
+// accept it (regression for the widened empty-data check).
+const pluginsOnlyRegistry = `{
+  "$schema": "https://example.com/schema.json",
+  "version": "1.0.0",
+  "meta": {"last_updated": "2025-01-01T00:00:00Z"},
+  "data": {
+    "servers": [],
+    "plugins": [
+      {
+        "namespace": "io.github.stacklok",
+        "name": "code-reviewer",
+        "description": "Reviews code for bugs",
+        "version": "1.0.0"
+      }
+    ]
+  }
+}`
+
+func TestParseRegistryData_Plugins(t *testing.T) {
+	t.Parallel()
+
+	_, _, plugins, err := parseRegistryData([]byte(upstreamRegistryWithPlugins))
+	require.NoError(t, err)
+	require.Len(t, plugins, 2)
+	assert.Equal(t, "io.github.stacklok", plugins[0].Namespace)
+	assert.Equal(t, "code-reviewer", plugins[0].Name)
+	assert.Equal(t, "Reviews code for bugs", plugins[0].Description)
+}
+
+func TestLocalRegistryProvider_Plugins(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	require.NoError(t, os.WriteFile(path, []byte(upstreamRegistryWithPlugins), 0o600))
+
+	provider := NewLocalRegistryProvider(path)
+
+	// ListAvailablePlugins yields the plugins from data.plugins.
+	plugins, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, plugins, 2)
+
+	// GetPlugin returns the matching plugin.
+	got, err := provider.GetPlugin("io.github.stacklok", "code-reviewer")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "code-reviewer", got.Name)
+	assert.Equal(t, "1.0.0", got.Version)
+
+	// GetPlugin returns nil for a missing plugin (no error).
+	missing, err := provider.GetPlugin("io.github.nope", "absent")
+	require.NoError(t, err)
+	assert.Nil(t, missing)
+
+	// SearchPlugins matches by name.
+	byName, err := provider.SearchPlugins("reviewer")
+	require.NoError(t, err)
+	require.Len(t, byName, 1)
+	assert.Equal(t, "code-reviewer", byName[0].Name)
+
+	// SearchPlugins matches by namespace.
+	byNs, err := provider.SearchPlugins("acme")
+	require.NoError(t, err)
+	require.Len(t, byNs, 1)
+	assert.Equal(t, "doc-generator", byNs[0].Name)
+
+	// SearchPlugins matches by description.
+	byDesc, err := provider.SearchPlugins("documentation")
+	require.NoError(t, err)
+	require.Len(t, byDesc, 1)
+	assert.Equal(t, "doc-generator", byDesc[0].Name)
+
+	// SearchPlugins returns nil for a non-matching query.
+	none, err := provider.SearchPlugins("non-existent-plugin")
+	require.NoError(t, err)
+	assert.Nil(t, none)
+}
+
+func TestRemoteRegistryProvider_Plugins(t *testing.T) {
+	t.Parallel()
+
+	server := createTestServer(upstreamRegistryWithPlugins, 200)
+	defer server.Close()
+
+	provider, err := NewRemoteRegistryProvider(server.URL, true)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	plugins, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, plugins, 2)
+
+	got, err := provider.GetPlugin("io.github.acme", "doc-generator")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "doc-generator", got.Name)
+
+	byName, err := provider.SearchPlugins("reviewer")
+	require.NoError(t, err)
+	require.Len(t, byName, 1)
+	assert.Equal(t, "code-reviewer", byName[0].Name)
+}
+
+// TestRemoteRegistryProvider_PluginsOnlyNotRejected confirms the widened
+// validateConnectivity guard accepts a plugins-only remote registry.
+func TestRemoteRegistryProvider_PluginsOnlyNotRejected(t *testing.T) {
+	t.Parallel()
+
+	server := createTestServer(pluginsOnlyRegistry, 200)
+	defer server.Close()
+
+	provider, err := NewRemoteRegistryProvider(server.URL, true)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	plugins, err := provider.ListAvailablePlugins()
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+	assert.Equal(t, "code-reviewer", plugins[0].Name)
+}
+
+// TestBaseProvider_PluginsNoOp confirms the BaseProvider no-op defaults return
+// nil, nil (providers that don't support plugins inherit these).
+func TestBaseProvider_PluginsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var p *BaseProvider
+	plugins, err := p.ListAvailablePlugins()
+	require.NoError(t, err)
+	assert.Nil(t, plugins)
+
+	got, err := p.GetPlugin("ns", "name")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	results, err := p.SearchPlugins("query")
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+// Compile-time assertions that the concrete providers satisfy the interface.
+var (
+	_ Provider = (*LocalRegistryProvider)(nil)
+	_ Provider = (*RemoteRegistryProvider)(nil)
+	_ Provider = (*APIRegistryProvider)(nil)
+	_ Provider = (*CachedAPIRegistryProvider)(nil)
+)

--- a/pkg/registry/provider_remote.go
+++ b/pkg/registry/provider_remote.go
@@ -25,6 +25,8 @@ type RemoteRegistryProvider struct {
 	allowPrivateIp bool
 	skillsMu       sync.RWMutex
 	skills         []types.Skill
+	pluginsMu      sync.RWMutex
+	plugins        []types.Plugin
 }
 
 // NewRemoteRegistryProvider creates a new remote registry provider.
@@ -89,8 +91,8 @@ func (p *RemoteRegistryProvider) validateConnectivity() error {
 	if err := json.Unmarshal(data, &upstream); err != nil {
 		return fmt.Errorf("registry returned invalid upstream JSON from %s: %w", p.registryURL, err)
 	}
-	if len(upstream.Data.Servers) == 0 && len(upstream.Data.Skills) == 0 {
-		return fmt.Errorf("registry at %s returned upstream format with no servers or skills", p.registryURL)
+	if len(upstream.Data.Servers) == 0 && len(upstream.Data.Skills) == 0 && len(upstream.Data.Plugins) == 0 {
+		return fmt.Errorf("registry at %s returned upstream format with no servers, skills, or plugins", p.registryURL)
 	}
 	return nil
 }
@@ -129,11 +131,12 @@ func (p *RemoteRegistryProvider) GetRegistry() (*types.Registry, error) {
 		return nil, fmt.Errorf("failed to read registry data from response body: %w", err)
 	}
 
-	registry, skills, err := parseRegistryData(data)
+	registry, skills, plugins, err := parseRegistryData(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse registry data from %s: %w", p.registryURL, err)
 	}
 	p.setSkills(skills)
+	p.setPlugins(plugins)
 
 	// Set name field on each server based on map key
 	for name, server := range registry.Servers {
@@ -211,8 +214,66 @@ func (p *RemoteRegistryProvider) SearchSkills(query string) ([]types.Skill, erro
 	return results, nil
 }
 
+// ListAvailablePlugins returns plugins discovered from the remote registry data.
+// Triggers a registry load if plugins haven't been populated yet.
+func (p *RemoteRegistryProvider) ListAvailablePlugins() ([]types.Plugin, error) {
+	p.pluginsMu.RLock()
+	plugins := p.plugins
+	p.pluginsMu.RUnlock()
+
+	if plugins == nil {
+		// Plugins are populated as a side effect of GetRegistry
+		if _, err := p.GetRegistry(); err != nil {
+			return nil, err
+		}
+		p.pluginsMu.RLock()
+		plugins = p.plugins
+		p.pluginsMu.RUnlock()
+	}
+
+	return plugins, nil
+}
+
+// GetPlugin returns a specific plugin by namespace and name.
+func (p *RemoteRegistryProvider) GetPlugin(namespace, name string) (*types.Plugin, error) {
+	plugins, err := p.ListAvailablePlugins()
+	if err != nil {
+		return nil, err
+	}
+	for i := range plugins {
+		if plugins[i].Namespace == namespace && plugins[i].Name == name {
+			return &plugins[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// SearchPlugins searches for plugins matching the query in name, namespace, or description.
+func (p *RemoteRegistryProvider) SearchPlugins(query string) ([]types.Plugin, error) {
+	plugins, err := p.ListAvailablePlugins()
+	if err != nil {
+		return nil, err
+	}
+	query = strings.ToLower(query)
+	var results []types.Plugin
+	for _, pl := range plugins {
+		if strings.Contains(strings.ToLower(pl.Name), query) ||
+			strings.Contains(strings.ToLower(pl.Description), query) ||
+			strings.Contains(strings.ToLower(pl.Namespace), query) {
+			results = append(results, pl)
+		}
+	}
+	return results, nil
+}
+
 func (p *RemoteRegistryProvider) setSkills(skills []types.Skill) {
 	p.skillsMu.Lock()
 	defer p.skillsMu.Unlock()
 	p.skills = skills
+}
+
+func (p *RemoteRegistryProvider) setPlugins(plugins []types.Plugin) {
+	p.pluginsMu.Lock()
+	defer p.pluginsMu.Unlock()
+	p.plugins = plugins
 }

--- a/pkg/registry/provider_test.go
+++ b/pkg/registry/provider_test.go
@@ -223,7 +223,7 @@ func TestRemoteRegistryProvider_ValidateConnectivity(t *testing.T) {
 			responseBody:   `{"$schema": "x", "version": "1.0", "meta": {}, "data": {"servers": []}}`,
 			responseStatus: 200,
 			expectError:    true,
-			errorContains:  "no servers or skills",
+			errorContains:  "no servers, skills, or plugins",
 		},
 		{
 			name:           "legacy format surfaces migration hint",

--- a/pkg/registry/schema_validation_test.go
+++ b/pkg/registry/schema_validation_test.go
@@ -27,7 +27,7 @@ func TestEmbeddedRegistrySchemaValidation(t *testing.T) {
 func TestValidateEmbeddedRegistryCanLoadData(t *testing.T) {
 	t.Parallel()
 
-	registry, skills, err := parseRegistryData(catalog.Upstream())
+	registry, skills, _, err := parseRegistryData(catalog.Upstream())
 	require.NoError(t, err, "Embedded upstream registry should parse successfully")
 
 	// Verify basic structure
@@ -45,7 +45,7 @@ func TestValidateEmbeddedRegistryCanLoadData(t *testing.T) {
 func TestUpstreamRegistryParsing(t *testing.T) {
 	t.Parallel()
 
-	registry, _, err := parseRegistryData(catalog.Upstream())
+	registry, _, _, err := parseRegistryData(catalog.Upstream())
 	require.NoError(t, err)
 
 	// Verify servers have names set (from conversion)
@@ -124,7 +124,7 @@ func TestParseRegistryData_LegacyFormatDetection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, _, err := parseRegistryData([]byte(tt.input))
+			_, _, _, err := parseRegistryData([]byte(tt.input))
 			if tt.wantLegacy {
 				require.Error(t, err)
 				assert.ErrorIs(t, err, errLegacyFormat)
@@ -142,7 +142,7 @@ func TestParseRegistryData_LegacyFormatDetection(t *testing.T) {
 func TestParseRegistryData_MalformedJSON(t *testing.T) {
 	t.Parallel()
 
-	_, _, err := parseRegistryData([]byte("not json"))
+	_, _, _, err := parseRegistryData([]byte("not json"))
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, errLegacyFormat)
 	assert.Contains(t, err.Error(), "failed to parse registry data")

--- a/pkg/registry/upstream_parser.go
+++ b/pkg/registry/upstream_parser.go
@@ -26,18 +26,19 @@ import (
 var errLegacyFormat = &LegacyFormatError{}
 
 // parseRegistryData parses raw JSON in the upstream MCP registry format and
-// converts it into the internal types.Registry plus any embedded skills.
+// converts it into the internal types.Registry plus any embedded skills and
+// plugins.
 //
 // Returns errLegacyFormat if the input looks like the legacy ToolHive registry
 // format.
-func parseRegistryData(data []byte) (*types.Registry, []types.Skill, error) {
+func parseRegistryData(data []byte) (*types.Registry, []types.Skill, []types.Plugin, error) {
 	if !legacyhint.IsUpstream(data) && legacyhint.Looks(data) {
-		return nil, nil, errLegacyFormat
+		return nil, nil, nil, errLegacyFormat
 	}
 
 	var upstream types.UpstreamRegistry
 	if err := json.Unmarshal(data, &upstream); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse registry data: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to parse registry data: %w", err)
 	}
 
 	// ConvertServersToMetadata expects []*v0.ServerJSON, but UpstreamData.Servers
@@ -49,7 +50,7 @@ func parseRegistryData(data []byte) (*types.Registry, []types.Skill, error) {
 
 	serverMetadata, err := ConvertServersToMetadata(serverPtrs)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to convert servers to metadata: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to convert servers to metadata: %w", err)
 	}
 
 	registry := &types.Registry{
@@ -72,5 +73,5 @@ func parseRegistryData(data []byte) (*types.Registry, []types.Skill, error) {
 		}
 	}
 
-	return registry, upstream.Data.Skills, nil
+	return registry, upstream.Data.Skills, upstream.Data.Plugins, nil
 }


### PR DESCRIPTION
## Summary

Phase 5b of the plugin lifecycle epic (#5525, RFC THV-0077). With Phases 0–4 and 5a merged, ToolHive can build/push/install plugins by OCI reference or git URL — but two catalog pieces were missing:

1. **No plugin surface on the registry `Provider` interface or catalog routes.** There was no way to browse or search plugins in a configured registry, and no client for the `/v0.1/x/dev.toolhive/plugins` extension API (mirroring skills).
2. **`PluginLookup` was dead code.** `pluginsvc.WithPluginLookup` was never wired in production, so `thv ai-plugin install <plain-name>` always 404ed with "not found in local store or registry" — only OCI/git installs worked.

What changed:

- **Provider plugin surface** — `ListAvailablePlugins`/`GetPlugin`/`SearchPlugins` on the `Provider` interface with `BaseProvider` no-op defaults; local/remote providers harvest plugins from the upstream payload (`parseRegistryData` now returns plugins as a third value); the remote connectivity guard accepts plugins-only registries.
- **`PluginsClient`** — port of `SkillsClient` for the `/v0.1/x/dev.toolhive/plugins` extension API (auto-pagination, auth error mapping), backing `APIRegistryProvider`; `CachedAPIRegistryProvider` adds a TTL cache with stale-on-transient-failure, mirroring skills.
- **Embedded catalog routes** — `GET /registry/{name}/v0.1/x/dev.toolhive/plugins[/{namespace}/{pluginName}]` on thv's own API server, with search filtering + pagination, templated on the skills routes.
- **Lookup wiring** — `lazyPluginLookup` (resolves the default provider per call so registry config changes are picked up without restart) + a `types.Plugin` → `pluginsvc.PluginSearchHit` adapter (`SkillPackage.Identifier` → `PluginPackage.Reference`), wired via `pluginsvc.WithPluginLookup` in `createDefaultPluginManager`. Registry-name install now resolves end-to-end.
- **Resolution hardening** (from review panel) — `installFromRegistryLookup` now mirrors the skills flow: warn-and-fall-back to 404 on registry errors, exact-name post-filtering with a 409 ambiguity error listing candidates, and selection of the `oci`-type package rather than the first positional one. `thv config set-registry` validation also accepts plugins-only registries.

Fixes #5529

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New coverage: `plugins_client_test.go` (httptest table tests incl. pagination + auth errors), `registry_v01_plugins_test.go` (routes, 404, pagination, 401/403 → `registry_auth_required`), `provider_plugins_test.go` (local/remote harvesting, plugins-only registry guard), `provider_cached_plugins_test.go` (cache hit/miss/stale), `install_registry_test.go` (registry-name resolution, 404 hint, exact-match, 409 ambiguity, oci-package selection).

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/registry/provider.go` | Plugin methods on `Provider` interface |
| `pkg/registry/provider_base.go` | No-op plugin defaults |
| `pkg/registry/upstream_parser.go` | `parseRegistryData` returns plugins (4-tuple) |
| `pkg/registry/provider_local.go`, `provider_remote.go` | Harvest plugins from upstream data; plugins-only connectivity guard |
| `pkg/registry/provider_api.go`, `provider_cached.go` | PluginsClient-backed methods; TTL cache with stale fallback |
| `pkg/registry/api/plugins_client.go` | New `PluginsClient` for the plugins extension API |
| `pkg/api/v1/registry_v01_plugins.go`, `registry_v01.go` | Catalog routes `/x/dev.toolhive/plugins[/{namespace}/{pluginName}]` |
| `pkg/api/server.go` | `lazyPluginLookup` + type adapter, wired into `createDefaultPluginManager` |
| `pkg/plugins/pluginsvc/install.go` | Exact-match/ambiguity/oci-package resolution hardening |
| `pkg/config/registry.go` | `set-registry` validation accepts plugins-only registries |
| `docs/arch/14-plugins-system.md`, `06-registry-system.md`, `docs/server/` | Phase 5b docs + regenerated swagger |
| `pkg/registry/mocks/mock_provider.go` | Regenerated |

## Does this introduce a user-facing change?

Yes. `thv ai-plugin install <plain-name>` now resolves the name against the configured registry (previously it always failed with a 404 hint unless given an OCI reference or git URL). The embedded registry API serves two new endpoints: `GET /registry/{name}/v0.1/x/dev.toolhive/plugins` (list, with `q` + pagination) and `GET .../plugins/{namespace}/{pluginName}`.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Architect-planned, 4 iterations (commit each), skills-mirroring throughout:

1. **Decision (no core change):** `types.Registry` gains no `Plugins` field — plugins are a parallel query surface on `Provider`. Local/remote providers harvest `upstream.Data.Plugins` (already present in toolhive-core v0.0.35) via the existing parser side-effect, exactly like skills; API/cached providers go through a new `PluginsClient`, matching `CachedAPIRegistryProvider.ListAvailableSkills`.
2. Iteration 1: parser 4-tuple + `Provider` interface methods + `BaseProvider` no-ops + local/remote provider plugin caches + connectivity guard + regenerated mocks.
3. Iteration 2: `PluginsClient` (port of `skills_client.go`) + `APIRegistryProvider` backing + `CachedAPIRegistryProvider` TTL cache with stale-on-transient-failure.
4. Iteration 3: embedded v0.1 catalog routes + swagger (`task docs`).
5. Iteration 4: `lazyPluginLookup` + `pluginHitsFromRegistry` (`Identifier`→`Reference`, `RegistryType`→`Type`) + `WithPluginLookup` wiring + registry-install resolution test + arch docs.

Review panel (spec/standards/domain) then produced two confirmed fixes, landed in the final commit: `set-registry` validation alignment, and install-resolution hardening (exact-match, 409 ambiguity, oci-package selection, error fallback) mirroring `skillsvc/registry.go`.

Out of scope: registry-server plugin catalog (#819), marketplace generate + signing (#5530), git-package plugin installs, plugin browsing CLI subcommands.
</details>

## Special notes for reviewers

- **The diff is large (~2.9k insertions) but ~1.9k is tests + generated swagger**; production code is ~700 lines, all near-verbatim ports of the skills analogues.
- **Deliberately mirrored, not fixed:** the `PluginsClient` sends `?search=`/`cursor` and expects `count`/`nextCursor` while thv's *embedded* v0.1 handler reads `?q=` and emits `total`/`page`/`limit` — this mismatch is copied from the skills client/handler pair. The client targets the registry-server API (which uses `search`/`cursor`/`count`/`nextCursor` — verified), not thv's embedded routes. Fixing the skills pair is cross-cutting and out of scope.
- `lazyPluginLookup.SearchPlugins` ignores the passed `ctx` (providers apply their own timeouts), mirroring `lazySkillLookup` whose interface takes no context.
- A plugin whose catalog entry has no `oci` package yields a 422 through the registry-name install path; git-package plugin install is follow-up work.

Generated with [Claude Code](https://claude.com/claude-code)