### PR TITLE
Refresh the cached MCP parse after webhook mutation

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -31,6 +31,8 @@ Two webhook types are supported:
 1. **Mutating webhooks**: Transform the parsed MCP request before later policy evaluation.
 2. **Validating webhooks**: Approve or deny the request after mutation has completed.
 
+A mutating webhook therefore steers what authorization (and audit, telemetry, and usage metrics) evaluates, including the feature/operation mapping used to pick a Cedar policy. This is intended: an operator who configures a mutating webhook — including a fail-open one — is deliberately giving it influence over policy input, not introducing an accident.
+
 When configured together, the effective order is:
 
 1. Audit (wraps everything below, so webhook denials are audited)
@@ -57,6 +59,11 @@ Example config files:
 
 - [`docs/examples/webhooks.yaml`](examples/webhooks.yaml)
 - [`docs/examples/webhooks.json`](examples/webhooks.json)
+
+### Known limitations
+
+- **Stale Modern headers.** A mutating webhook patches only the JSON body, so after it renames a tool the `Mcp-Method`/`Mcp-Name` headers forwarded to the backend still describe the original name. `ValidateHeaderConsistency` (`pkg/mcp/revision.go:512`) requires the header and body to agree and returns a `RequestHeaderMismatchError` (`CodeHeaderMismatch`) if they don't, but today that check is only wired into vMCP (`pkg/vmcp/server/classification.go:72`), which never runs the mutating webhook — so nothing in ToolHive catches this yet. A spec-conformant Modern (2026-07-28) backend will reject the mismatched request itself, so this fails closed rather than silently mis-authorizing. Practical guidance: a mutating webhook must not rename tools on the Modern path.
+- **Controls outside the parser see the pre-mutation request.** The tool-call filter (`pkg/mcp/tool_filter.go`) reads the raw request body directly, and the rate limiter runs before the mutating webhook in the chain (see the ordering rules below) — both decide against the request as received, not as mutated. A mutating webhook can therefore rename a call into a tool that `--tools` filtering excluded, and the rate limiter debits the bucket for the requested tool rather than the executed one. This is a known gap, not a regression: the tool filter's position ahead of the MCP parser is deliberate (it needs the raw request), as already noted in the ordering rules below.
 
 ## Architecture Diagram
 
@@ -1048,11 +1055,14 @@ The middleware chain execution order is critical and controlled by the order in 
 5. **Tool Filter Middleware** (if enabled) - Filters available tools in list responses
 6. **Tool Call Filter Middleware** (if enabled) - Filters tool call requests
 7. **MCP Parser Middleware** (always present) - Parses JSON-RPC MCP requests
-8. **Usage Metrics Middleware** (if enabled) - Tracks tool call counts
-9. **Telemetry Middleware** (if enabled) - OpenTelemetry instrumentation
-10. **Authorization Middleware** (if enabled) - Cedar policy evaluation
-11. **Header Forward Middleware** (if configured for remote servers) - Injects custom headers
-12. **Recovery Middleware** (always present) - Catches panics
+8. **Rate Limit Middleware** (if configured) - Enforces per-identity/tool limits using the parsed request
+9. **Mutating Webhook Middleware** (if configured) - Patches the parsed MCP request and republishes the parse
+10. **Validating Webhook Middleware** (if configured) - Approves or denies the (possibly mutated) request
+11. **Usage Metrics Middleware** (if enabled) - Tracks tool call counts
+12. **Telemetry Middleware** (if enabled) - OpenTelemetry instrumentation
+13. **Authorization Middleware** (if enabled) - Cedar policy evaluation
+14. **Header Forward Middleware** (if configured for remote servers) - Injects custom headers
+15. **Recovery Middleware** (always present) - Catches panics
 
 **Important Ordering Rules**:
 - Audit wraps the whole chain (directly inside the body-size limit): every request that passes the size cap produces an audit event no matter which middleware rejects it. It does not need to run inside auth or the parser — those publish the identity and parsed MCP data back to it via `auth.IdentityHolder` and `mcp.ParsedRequestHolder`.
@@ -1062,9 +1072,12 @@ The middleware chain execution order is critical and controlled by the order in 
 - Token Exchange must come after Upstream Swap if both are used (can further transform the upstream IdP token)
 - Tool filters should come before MCP Parser to operate on raw requests
 - MCP Parser must come before Authorization (provides structured MCP data)
+- Mutating webhooks must come before Validating webhooks and before Authorization, so policy evaluation sees the patched request
+- Middleware that rewrites the request body must republish the parsed request via `mcp.RepublishParsedMCPRequest` and refresh `r.ContentLength` — `ParsingMiddleware` deliberately parses only once, so every later consumer (authorization, audit, telemetry, usage metrics) reads the cached parse rather than re-reading the body
 - Header Forward executes close to the backend handler (innermost position)
 - Recovery is always last in config, making it the innermost wrapper (the chain wraps in reverse config order, so the first entry is the outermost and runs first)
 - Body-size limit and Origin validation stay OUTSIDE audit: oversized bodies must be rejected before audit buffers request data, and origin validation is a pre-auth DNS-rebind guard. Their rejections (413/403) are the only ones not audited.
+- The list above (steps 1-15) describes the operator/proxyrunner path (`PopulateMiddlewareConfigs` in `pkg/runner/middleware.go`). The CLI flag path (`WithMiddlewareFromFlags` in `pkg/runner/config_builder.go`) has no rate limiting at all, and orders Usage Metrics before the webhooks rather than after (see the comment at `pkg/runner/config_builder.go:700`) — both paths still run Mutating before Validating webhooks and both before Authorization.
 
 ### Custom Authorization Policies
 

--- a/pkg/mcp/parser.go
+++ b/pkg/mcp/parser.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -139,6 +140,46 @@ func ParsingMiddleware(next http.Handler) http.Handler {
 		// Call the next handler
 		next.ServeHTTP(w, r)
 	})
+}
+
+// RepublishParsedMCPRequest refreshes the cached parse after middleware has
+// rewritten the request body, returning the request to pass downstream.
+// ParsingMiddleware deliberately parses only once, so any middleware that
+// replaces r.Body MUST call this or downstream consumers (authorization,
+// audit, telemetry) will decide on the bytes that arrived rather than the
+// bytes the backend executes.
+//
+// On error, the returned request is nil and must not be passed downstream:
+// the caller is responsible for terminating the request (e.g. writing an
+// error response) instead of proceeding with a stale or absent parse.
+//
+// This only refreshes consumers that read the parse from the request context or
+// from a ParsedRequestHolder. Middleware that inspects the raw body from OUTSIDE
+// ParsingMiddleware — the tool-call filter and the rate limiter — has already
+// decided against the pre-rewrite body and is not corrected by republishing.
+//
+// The caller must also refresh r.ContentLength when it replaces r.Body, or the
+// reverse proxy will reject the forwarded request.
+func RepublishParsedMCPRequest(r *http.Request, body []byte) (*http.Request, error) {
+	// Batch-reject before parsing, using the same guard ParsingMiddleware uses,
+	// so a mutation can never smuggle a batch past authz/audit by rewriting a
+	// single request into an array (see IsBatchRequest's doc comment).
+	if IsBatchRequest(body) {
+		return nil, &BatchUnsupportedError{}
+	}
+
+	parsed := parseMCPRequest(body)
+	if parsed == nil {
+		return nil, errors.New("republished body is not a valid JSON-RPC request")
+	}
+	parsed.MCPMethodHeader = r.Header.Get("Mcp-Method")
+	parsed.MCPNameHeader = r.Header.Get("Mcp-Name")
+
+	if holder, ok := ParsedRequestHolderFromContext(r.Context()); ok {
+		holder.Parsed = parsed
+	}
+
+	return r.WithContext(context.WithValue(r.Context(), MCPRequestContextKey, parsed)), nil
 }
 
 // parsedRequestHolderContextKey is the context key for ParsedRequestHolder.

--- a/pkg/mcp/parser_test.go
+++ b/pkg/mcp/parser_test.go
@@ -1871,3 +1871,142 @@ func TestParsingMiddlewareIntegration(t *testing.T) {
 		})
 	}
 }
+
+func TestRepublishParsedMCPRequest(t *testing.T) {
+	t.Parallel()
+
+	oldBody := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"old-tool","arguments":{"a":1}}}`
+	newBody := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"new-tool","arguments":{"b":2}}}`
+
+	tests := []struct {
+		name          string
+		body          []byte
+		expectErr     bool
+		expectBatch   bool
+		expectNilReq  bool
+		checkResponse func(t *testing.T, req *http.Request, err error)
+	}{
+		{
+			name: "happy re-parse reflects new body",
+			body: []byte(newBody),
+			checkResponse: func(t *testing.T, req *http.Request, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				parsed := GetParsedMCPRequest(req.Context())
+				require.NotNil(t, parsed)
+				assert.Equal(t, "tools/call", parsed.Method)
+				assert.Equal(t, "new-tool", parsed.ResourceID)
+				assert.Equal(t, map[string]interface{}{"b": float64(2)}, parsed.Arguments)
+				assert.NotNil(t, parsed.Params)
+				assert.Equal(t, int64(2), parsed.ID)
+				assert.False(t, parsed.IsBatch)
+			},
+		},
+		{
+			name:        "batch body rejected before parsing",
+			body:        []byte(`[{"jsonrpc":"2.0","method":"tools/call","id":1}]`),
+			expectErr:   true,
+			expectBatch: true,
+		},
+		{
+			name:        "whitespace-prefixed batch still detected",
+			body:        []byte(" \t[{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":1}]"),
+			expectErr:   true,
+			expectBatch: true,
+		},
+		{
+			name:      "valid JSON that is not a request",
+			body:      []byte(`{"jsonrpc":"2.0","result":{}}`),
+			expectErr: true,
+		},
+		{
+			name:      "empty object is not a request",
+			body:      []byte(`{}`),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/messages", bytes.NewBufferString(oldBody))
+			req.Header.Set("Content-Type", "application/json")
+			var capturedOldCtx context.Context
+			testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				capturedOldCtx = r.Context()
+			})
+			ParsingMiddleware(testHandler).ServeHTTP(httptest.NewRecorder(), req)
+			require.NotNil(t, GetParsedMCPRequest(capturedOldCtx), "precondition: old body must have parsed")
+			req = req.WithContext(capturedOldCtx)
+
+			republished, err := RepublishParsedMCPRequest(req, tt.body)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, republished)
+				if tt.expectBatch {
+					var batchErr *BatchUnsupportedError
+					assert.ErrorAs(t, err, &batchErr)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, republished)
+			if tt.checkResponse != nil {
+				tt.checkResponse(t, republished, err)
+			}
+
+			// The original request's context must still yield the OLD parse:
+			// RepublishParsedMCPRequest must not mutate the caller's request.
+			oldParsed := GetParsedMCPRequest(req.Context())
+			require.NotNil(t, oldParsed)
+			assert.Equal(t, "old-tool", oldParsed.ResourceID)
+		})
+	}
+}
+
+func TestRepublishParsedMCPRequestHeaders(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/messages", bytes.NewBufferString(""))
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", "some-tool")
+
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"weather"}}`)
+	republished, err := RepublishParsedMCPRequest(req, body)
+	require.NoError(t, err)
+
+	parsed := GetParsedMCPRequest(republished.Context())
+	require.NotNil(t, parsed)
+	assert.Equal(t, "tools/call", parsed.MCPMethodHeader)
+	assert.Equal(t, "some-tool", parsed.MCPNameHeader)
+}
+
+func TestRepublishParsedMCPRequestHolder(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"weather"}}`)
+
+	t.Run("holder present is refreshed", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/messages", bytes.NewBufferString(""))
+		holder := &ParsedRequestHolder{}
+		req = req.WithContext(WithParsedRequestHolder(req.Context(), holder))
+
+		republished, err := RepublishParsedMCPRequest(req, body)
+		require.NoError(t, err)
+		require.NotNil(t, republished)
+		require.NotNil(t, holder.Parsed)
+		assert.Equal(t, "weather", holder.Parsed.ResourceID)
+	})
+
+	t.Run("holder absent does not panic", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/messages", bytes.NewBufferString(""))
+
+		republished, err := RepublishParsedMCPRequest(req, body)
+		require.NoError(t, err)
+		require.NotNil(t, republished)
+	})
+}

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -699,8 +699,11 @@ func WithMiddlewareFromFlags(
 		//
 		// NOTE: addCoreMiddlewares also injects usage metrics before webhook insertion here,
 		// which differs slightly from PopulateMiddlewareConfigs where usage metrics is added
-		// after webhooks. This is currently benign because usage metrics does not depend on
-		// webhook state, and the broader ordering TODO remains to unify these paths.
+		// after webhooks. Since mutating webhooks republish the parsed request
+		// (mcp.RepublishParsedMCPRequest), the two paths now disagree when a webhook rewrites
+		// the JSON-RPC method: this path counts the method as received, the operator path counts
+		// the method as mutated. Only tool-call counts are affected, and only for a webhook that
+		// patches "method" itself. The broader ordering TODO remains to unify these paths.
 
 		// Add Mutating webhooks before Validating webhooks
 		var err error

--- a/pkg/webhook/mutating/middleware.go
+++ b/pkg/webhook/mutating/middleware.go
@@ -129,8 +129,30 @@ func createMutatingHandler(executors []clientExecutor, serverName, transport str
 				return
 			}
 
+			// A mutating webhook rewrote the body, so the parse cached by ParsingMiddleware
+			// now describes a request the backend will not execute. Refresh it before any
+			// downstream consumer (authorization, audit, telemetry) reads it.
+			if !bytes.Equal(bodyBytes, mutatedBody) {
+				republished, err := mcp.RepublishParsedMCPRequest(r, mutatedBody)
+				if err != nil {
+					var batchErr *mcp.BatchUnsupportedError
+					if errors.As(err, &batchErr) {
+						mcp.WriteBatchUnsupportedError(w)
+						return
+					}
+					slog.Error("Mutating webhook produced an unparseable MCP request", "error", err)
+					sendErrorResponse(w, http.StatusInternalServerError, "Webhook produced an invalid MCP request", parsedMCP.ID)
+					return
+				}
+				r = republished
+			}
+
 			// Replace the request body with the (potentially mutated) MCP body for downstream handlers.
+			// ContentLength must be updated alongside it: a patch almost always changes the body
+			// length, and the reverse proxy rejects a forwarded request whose declared length
+			// disagrees with the body it can actually read.
 			r.Body = io.NopCloser(bytes.NewBuffer(mutatedBody))
+			r.ContentLength = int64(len(mutatedBody))
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/pkg/webhook/mutating/middleware.go
+++ b/pkg/webhook/mutating/middleware.go
@@ -140,7 +140,7 @@ func createMutatingHandler(executors []clientExecutor, serverName, transport str
 						mcp.WriteBatchUnsupportedError(w)
 						return
 					}
-					slog.Error("Mutating webhook produced an unparseable MCP request", "error", err)
+					slog.Error("Mutating webhook produced an unparsable MCP request", "error", err)
 					sendErrorResponse(w, http.StatusInternalServerError, "Webhook produced an invalid MCP request", parsedMCP.ID)
 					return
 				}

--- a/pkg/webhook/mutating/middleware_test.go
+++ b/pkg/webhook/mutating/middleware_test.go
@@ -58,6 +58,17 @@ func makeMCPRequest(tb testing.TB, body []byte) *http.Request {
 	return req
 }
 
+// newUnparsedMCPRequest builds a POST request with a JSON body and no parsed
+// request in its context, so mcp.ParsingMiddleware will actually parse it
+// (see shouldParseMCPRequest) rather than short-circuiting on an existing parse.
+func newUnparsedMCPRequest(tb testing.TB, body []byte) *http.Request {
+	tb.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.168.1.1:1234"
+	return req
+}
+
 //nolint:paralleltest // Shares mock server state
 func TestMutatingMiddleware_AllowedWithPatch(t *testing.T) {
 	const reqBody = `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"db","arguments":{"query":"SELECT *"}}}`
@@ -401,6 +412,210 @@ func TestMutatingMiddleware_ChainedMutations(t *testing.T) {
 	assert.Equal(t, "alice", args["user"], "user from webhook 1 should be present")
 	assert.Equal(t, "engineering", args["dept"], "dept from webhook 2 should be present")
 	assert.Equal(t, "SELECT *", args["query"], "original query should be preserved")
+}
+
+// renameToolReqBody and renameToolPatch model a mutating webhook that renames
+// the called tool. Shared by the tests that pin the tool-rename invariant from
+// both the authz (context) and audit (holder) observation points.
+const renameToolReqBody = `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"read_file","arguments":{"path":"/etc/passwd"}}}`
+
+var renameToolPatch = []JSONPatchOp{
+	{Op: "replace", Path: "/mcp_request/params/name", Value: json.RawMessage(`"delete_file"`)},
+}
+
+// newMutatingWebhookServer starts a fake mutating webhook that always allows
+// the request and returns the given JSON Patch. Callers must not mutate patch
+// afterwards: it's read by the handler on every request, including from
+// parallel tests that share a patch value.
+func newMutatingWebhookServer(t *testing.T, patch []JSONPatchOp) *httptest.Server {
+	t.Helper()
+	patchJSON, err := json.Marshal(patch)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req webhook.Request
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		resp := webhook.MutatingResponse{
+			Response:  webhook.Response{Version: webhook.APIVersion, UID: req.UID, Allowed: true},
+			PatchType: patchTypeJSONPatch,
+			Patch:     patchJSON,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestMutatingMiddleware_ParsedRequestReflectsRenamedTool pins the invariant
+// that authorization (which reads mcp.GetParsedMCPRequest) depends on: the
+// cached parse in the request context must always describe the SAME tool
+// name that ends up in the body the backend receives, even after a mutating
+// webhook renames the tool. The chain here uses the real mcp.ParsingMiddleware
+// (not a hand-built ParsedMCPRequest) so the cached parse is produced exactly
+// as it is in production.
+func TestMutatingMiddleware_ParsedRequestReflectsRenamedTool(t *testing.T) {
+	t.Parallel()
+
+	server := newMutatingWebhookServer(t, renameToolPatch)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{makeConfig(server.URL, webhook.FailurePolicyFail)}), "srv", "stdio")
+
+	var nextCalled bool
+	handler := mcp.ParsingMiddleware(mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		parsed := mcp.GetParsedMCPRequest(r.Context())
+		require.NotNil(t, parsed)
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.EqualValues(t, len(bodyBytes), r.ContentLength, "ContentLength must match the mutated body actually readable from r.Body")
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(bodyBytes, &body))
+		params := body["params"].(map[string]interface{})
+
+		assert.Equal(t, "delete_file", parsed.ResourceID, "cached parse must reflect the renamed tool")
+		assert.Equal(t, params["name"], parsed.ResourceID, "cached parse and mutated body must agree on the tool name")
+	})))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, newUnparsedMCPRequest(t, []byte(renameToolReqBody)))
+
+	require.True(t, nextCalled, "next must be called for the request to be observed")
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+// TestMutatingMiddleware_ParsedRequestReflectsPatchedArgument pins the same
+// invariant as the tool-rename case but for an argument value: a webhook that
+// replaces an existing argument (not one that merely adds a new field) must be
+// reflected in the cached parse's Arguments, since authorization/audit read
+// Arguments from the parse rather than re-reading the body.
+func TestMutatingMiddleware_ParsedRequestReflectsPatchedArgument(t *testing.T) {
+	t.Parallel()
+
+	const reqBody = `{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"db","arguments":{"query":"SELECT *"}}}`
+	patch := []JSONPatchOp{
+		{Op: "replace", Path: "/mcp_request/params/arguments/query", Value: json.RawMessage(`"DROP TABLE users"`)},
+	}
+
+	server := newMutatingWebhookServer(t, patch)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{makeConfig(server.URL, webhook.FailurePolicyFail)}), "srv", "stdio")
+
+	var nextCalled bool
+	handler := mcp.ParsingMiddleware(mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		parsed := mcp.GetParsedMCPRequest(r.Context())
+		require.NotNil(t, parsed)
+		assert.Equal(t, "DROP TABLE users", parsed.Arguments["query"], "cached parse must reflect the patched argument")
+	})))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, newUnparsedMCPRequest(t, []byte(reqBody)))
+
+	require.True(t, nextCalled, "next must be called for the request to be observed")
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+// TestMutatingMiddleware_HolderReflectsMutatedResourceID pins the invariant
+// that audit (pkg/audit/auditor.go) depends on: it wraps the chain, injects an
+// mcp.ParsedRequestHolder before calling in, and reads the holder after
+// ServeHTTP returns. That holder must reflect the SAME mutated tool name that
+// ends up in the body the backend receives, not the pre-mutation name the
+// parser first observed.
+func TestMutatingMiddleware_HolderReflectsMutatedResourceID(t *testing.T) {
+	t.Parallel()
+
+	server := newMutatingWebhookServer(t, renameToolPatch)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{makeConfig(server.URL, webhook.FailurePolicyFail)}), "srv", "stdio")
+	handler := mcp.ParsingMiddleware(mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})))
+
+	holder := &mcp.ParsedRequestHolder{}
+	req := newUnparsedMCPRequest(t, []byte(renameToolReqBody))
+	req = req.WithContext(mcp.WithParsedRequestHolder(req.Context(), holder))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, holder.Parsed, "audit holder must be filled by the parser")
+	assert.Equal(t, "delete_file", holder.Parsed.ResourceID, "audit holder must reflect the mutated tool name")
+}
+
+// TestMutatingMiddleware_PatchRemovesMethod_ReturnsConformantError pins the
+// republish failure path: a webhook patch can produce a body that is valid
+// JSON but no longer a JSON-RPC request (e.g. the "method" field is removed).
+// RepublishParsedMCPRequest fails to parse it, so the middleware must fail
+// closed with a 500 and a conformant JSON-RPC error, never reaching next.
+func TestMutatingMiddleware_PatchRemovesMethod_ReturnsConformantError(t *testing.T) {
+	t.Parallel()
+
+	patch := []JSONPatchOp{
+		{Op: "remove", Path: "/mcp_request/method"},
+	}
+	server := newMutatingWebhookServer(t, patch)
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{makeConfig(server.URL, webhook.FailurePolicyFail)}), "srv", "stdio")
+
+	var nextCalled bool
+	handler := mcp.ParsingMiddleware(mw(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		nextCalled = true
+	})))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, newUnparsedMCPRequest(t, []byte(renameToolReqBody)))
+
+	assert.False(t, nextCalled, "next must not be called when the mutated body fails to re-parse")
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &decoded))
+	assert.Equal(t, "2.0", decoded["jsonrpc"])
+	assert.Equal(t, float64(1), decoded["id"])
+	errObj, ok := decoded["error"].(map[string]interface{})
+	require.True(t, ok, "response must contain a JSON-RPC error object")
+	assert.NotEmpty(t, errObj["message"])
+	_, hasResult := decoded["result"]
+	assert.False(t, hasResult, "error response must not contain a result key")
+}
+
+// TestMutatingMiddleware_NoMutation_ParseUnchangedAndNextCalled pins the
+// bytes.Equal guard: when a webhook allows the request without a patch, the
+// body handed to RepublishParsedMCPRequest would be byte-identical to what
+// ParsingMiddleware already parsed, so no republish should happen, and next
+// must still be called with the original, correct parse intact.
+func TestMutatingMiddleware_NoMutation_ParseUnchangedAndNextCalled(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := webhook.MutatingResponse{
+			Response: webhook.Response{Version: webhook.APIVersion, UID: "uid", Allowed: true},
+			// No patch: the body is unchanged.
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(server.Close)
+
+	mw := createMutatingHandler(makeExecutors(t, []webhook.Config{makeConfig(server.URL, webhook.FailurePolicyFail)}), "srv", "stdio")
+
+	var nextCalled bool
+	handler := mcp.ParsingMiddleware(mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		parsed := mcp.GetParsedMCPRequest(r.Context())
+		require.NotNil(t, parsed)
+		assert.Equal(t, "read_file", parsed.ResourceID, "parse must reflect the original, unmutated tool name")
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.EqualValues(t, len(bodyBytes), r.ContentLength, "ContentLength must match the unchanged body on the no-mutation path")
+	})))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, newUnparsedMCPRequest(t, []byte(renameToolReqBody)))
+
+	assert.True(t, nextCalled, "next must be called on the no-mutation path")
+	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestMutatingMiddleware_SkipNonMCPRequests(t *testing.T) {


### PR DESCRIPTION
## Summary

- When a mutating webhook and authorization are both configured, ToolHive authorized the
  **pre-mutation** MCP request while the backend executed the **post-mutation** body.
  `ParsingMiddleware` parses the body once and publishes the parse into the request context and
  into a `ParsedRequestHolder`, then refuses to parse again. The mutating webhook replaced
  `r.Body` but passed the request through unchanged, so Cedar evaluated policy against the tool
  name and arguments that arrived, not the ones that ran. `docs/middleware.md:31` documented the
  opposite behavior.
- The audit half shipped in the **default** configuration: the event type and `target.name` are
  not gated on `includeRequestData`, so the audit trail named a request that never executed.
  Telemetry and usage metrics drifted the same way.
- Republish the parse at the mutation site when the body actually changed. One change corrects
  every consumer that reads the cached parse, rather than patching four of them. The re-parse
  routes through the same `IsBatchRequest` guard as `ParsingMiddleware`, so a patched body still
  cannot smuggle a JSON-RPC batch past controls that inspect one request per call. An unparseable
  result fails closed instead of reaching the backend.
- Also refresh `r.ContentLength` alongside `r.Body`. A patch almost always changes the body
  length, and the reverse proxy rejects a forwarded request whose declared length disagrees with
  its readable body. This was a pre-existing bug at the same lines.

Fixes #6133

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Unit tests were run per-package with the Taskfile's flags
(`go test -ldflags=-extldflags=-Wl,-w -race`) rather than as a full `task test` sweep, across
`pkg/mcp`, `pkg/webhook/...`, `pkg/authz/...`, `pkg/audit`, `pkg/runner/...`, `pkg/telemetry/...`,
`pkg/usagemetrics` and `pkg/ratelimit/...` — 18 packages green from a cleared test cache, plus
`go build ./...`. `task lint-fix` has **not** been run; relying on CI for that.

The three regression tests were written first and confirmed failing against unmodified code, each
on a value-mismatch assertion showing the pre-mutation value (`read_file`, `SELECT *`), not on a
compile error or panic.

## Changes

| File | Change |
|------|--------|
| `pkg/mcp/parser.go` | Adds `RepublishParsedMCPRequest`: batch-guards, re-parses, re-attaches the Modern header fields, refreshes both the context value and the holder. |
| `pkg/mcp/parser_test.go` | Table-driven coverage: happy re-parse, header re-attach, holder present/absent, batch (incl. whitespace-prefixed), unparseable bodies, no mutation of the caller's request. |
| `pkg/webhook/mutating/middleware.go` | Calls the helper when the body changed; refreshes `ContentLength`; batch errors reuse `WriteBatchUnsupportedError`, others reuse `sendErrorResponse`. |
| `pkg/webhook/mutating/middleware_test.go` | Five tests: tool rename, argument rewrite, holder refresh (the audit half), method removed → conformant 500, and the no-mutation path. |
| `pkg/runner/config_builder.go` | Comment only. Its claim that the usage-metrics ordering split was "benign because usage metrics does not depend on webhook state" is falsified by this change. |
| `docs/middleware.md` | Reconciles two contradictory ordering lists, records the republish contract as a decision, documents two gaps this does not close. |

## Does this introduce a user-facing change?

Yes. With a mutating webhook and authorization both configured, Cedar policy is now evaluated
against the mutated request rather than the request as received, and audit events, spans and
metrics name the tool that actually executed. Operators whose policies were written against
un-normalized values — and were passing only because policy never saw the webhook's rewrite —
may see decisions change. That is the documented contract (`docs/middleware.md:31`) taking effect.

## Special notes for reviewers

**Why `bytes.Equal` gates the republish.** Only republishing when the body changed bounds the
change to the mutation case. Without it, every no-patch and fail-open path would newly re-parse,
and five existing fail-open tests pass a body of `{"jsonrpc":"2.0","id":1}` that has no `method`
and so is not a parseable JSON-RPC request — they would start returning 500. The guard is the
correct answer rather than a workaround: in production an unmutated body provably parsed already,
because this middleware returns early when no parse exists.

**Two gaps this deliberately does not close**, both documented rather than fixed:
1. After a webhook renames a tool, the `Mcp-Method`/`Mcp-Name` headers forwarded to the backend
   still describe the original name, since a webhook patches only the JSON body.
   `ValidateHeaderConsistency` is enforced only in vMCP today, which never wires this middleware,
   so nothing here catches it — but a conformant Modern backend rejects the mismatch, so it fails
   closed. Re-rendering headers means fabricating client-supplied values with sentinel encoding,
   which is a separate decision.
2. The tool-call filter and rate limiter run **outside** `ParsingMiddleware` and so still decide
   against the request as received. Republishing cannot reach them. Filed separately as #6134.

**Coupling with #5800.** That PR moves telemetry from after the webhook layers to immediately
after the parser, which would put telemetry outside the mutation and make it read the pre-mutation
parse again — it has no `ParsedRequestHolder`, and a derived context only flows downstream, so
republishing cannot reach it there. Whichever lands second needs to reconcile. If this merges
first, #5800 should update the ordering list and limitations bullet in `docs/middleware.md`, the
inline comment at the republish site, and the `RepublishParsedMCPRequest` doc comment, which names
the rate limiter as an uncorrected consumer. I have commented on #5800 with the details. There is
no textual conflict in either direction.

**Latent, not fixed here.** This makes the holder a *fresher* copy than the context value, where
previously both were equally stale. `pkg/audit/auditor.go` reads context-then-holder. Audit is
outermost in every wired chain, so its own context never holds a parse and it always falls through
to the fresh holder — the precedence would only matter if the parser ran outside audit while a
mutating webhook ran inside, which no current chain does. Left alone as out of scope.

Generated with [Claude Code](https://claude.com/claude-code)
