### PR TITLE
Pin ida-pro-mcp e2e image by digest

### DIFF
--- a/.github/workflows/test-e2e-lifecycle.yml
+++ b/.github/workflows/test-e2e-lifecycle.yml
@@ -8,6 +8,11 @@ on:
       - 'cmd/thv-operator/**'
       - 'pkg/**'
       - 'test/e2e/thv-operator/**'
+      # This job is the only one that runs the Ginkgo suite under
+      # test/e2e/thv-operator, and that suite sources every backend container
+      # image from test/e2e/images. A change there alters what these tests
+      # actually deploy, so it has to trigger them.
+      - 'test/e2e/images/**'
       - '.github/workflows/test-e2e-lifecycle.yml'
 
 permissions:

--- a/examples/operator/virtual-mcps/vmcp_optimizer_quickstart.yaml
+++ b/examples/operator/virtual-mcps/vmcp_optimizer_quickstart.yaml
@@ -288,6 +288,9 @@ spec:
 
 ---
 # Step 2j: MCPServer backend - ida-pro-mcp (IDA Pro reverse engineering)
+# The 1.4.0 tag is mutable and its latest rebuild resolves mcp Python SDK 2.0.0,
+# which dropped mcp.server.fastmcp and makes the container crashloop. Pinned to
+# the last build that resolved mcp 1.x. See test/e2e/images/images.go.
 apiVersion: toolhive.stacklok.dev/v1beta1
 kind: MCPServer
 metadata:
@@ -296,7 +299,7 @@ metadata:
 spec:
   groupRef:
     name: optimizer-services
-  image: ghcr.io/stacklok/dockyard/uvx/ida-pro-mcp:1.4.0
+  image: ghcr.io/stacklok/dockyard/uvx/ida-pro-mcp:1.4.0@sha256:5a596d965fe05052d615a41152213f93ebc72bf46b07304718de948833d73c70
   transport: stdio
   proxyPort: 8080
   resources:

--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -92,9 +92,24 @@ const (
 
 	idaProMCPServerImageURL = "ghcr.io/stacklok/dockyard/uvx/ida-pro-mcp"
 	idaProMCPServerImageTag = "1.4.0"
+	// idaProMCPServerImageDigest pins the 2026-07-27 build of tag 1.4.0.
+	//
+	// The tag is mutable: dockyard periodically rebuilds it and resolves Python
+	// dependencies fresh each time. ida-pro-mcp 1.4.0 declares an unbounded
+	// "mcp>=1.16.0" and imports mcp.server.fastmcp, which was removed in the
+	// mcp Python SDK 2.0.0 (released 2026-07-28). The 2026-07-31 rebuild picked
+	// up mcp 2.0.0, so the container now crashloops on startup with
+	// "ModuleNotFoundError: No module named 'mcp.server.fastmcp'".
+	//
+	// 1.4.0 is the newest ida-pro-mcp release on PyPI, so there is nothing to
+	// bump to. Pin the last build that resolved a 1.x mcp (1.28.1) until
+	// upstream caps the constraint or adopts the 2.x API. Every other backend
+	// in the optimizer test is unaffected -- pagerduty-mcp, the only other
+	// dockyard uvx image, caps "mcp[cli]~=1.8".
+	idaProMCPServerImageDigest = "sha256:5a596d965fe05052d615a41152213f93ebc72bf46b07304718de948833d73c70"
 	// IDAProMCPServerImage is used for testing multi-backend optimizer scenarios.
 	// Provides ~47 IDA Pro reverse engineering tools (decompile, disassemble, rename, etc.).
-	IDAProMCPServerImage = idaProMCPServerImageURL + ":" + idaProMCPServerImageTag
+	IDAProMCPServerImage = idaProMCPServerImageURL + ":" + idaProMCPServerImageTag + "@" + idaProMCPServerImageDigest
 
 	pagerdutyMCPServerImageURL = "ghcr.io/stacklok/dockyard/uvx/pagerduty-mcp"
 	pagerdutyMCPServerImageTag = "0.12.0"


### PR DESCRIPTION
## Summary

`E2E Test Lifecycle` is currently failing on every PR, on all three kind versions, regardless of the diff. The `ida-pro-mcp` backend in the optimizer multi-backend spec crashloops on startup:

```
File ".../site-packages/ida_pro_mcp/server.py", line 11, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

One unhealthy backend out of eleven makes the vMCP report `Ready: False` (`Some backends are unhealthy`), so the spec times out after 300s in `BeforeAll`. The optimizer path itself is fine: `EmbeddingServerReady` is `True` and the other ten backends reach `Ready`.

The cause is upstream drift in a mutable tag:

- `ida-pro-mcp` 1.4.0 declares an unbounded `mcp>=1.16.0` and imports `mcp.server.fastmcp`.
- The `mcp` Python SDK removed that module in 2.0.0, uploaded to PyPI on 2026-07-28.
- Dockyard rebuilt `ghcr.io/stacklok/dockyard/uvx/ida-pro-mcp:1.4.0` on 2026-07-31 and resolved `mcp` 2.0.0. The previous build, 2026-07-27, has `mcp` 1.28.1 and works.

1.4.0 is the newest `ida-pro-mcp` release on PyPI, so there is no version to bump to. This pins the last build that resolved a 1.x `mcp`, which makes the reference immutable and the spec independent of future rebuilds.

- Pin `IDAProMCPServerImage` to `1.4.0@sha256:5a596d96...` in `test/e2e/images/images.go`, with a comment recording why.
- Apply the same pin to the quickstart example, which the spec mirrors.
- Add `test/e2e/images/**` to the `E2E Tests Lifecycle` trigger filter. See below.

## The trigger gap, found while verifying this PR

The first push here went green on all 45 checks without ever running the test it fixes.

`E2E Tests Lifecycle` is the only job that runs the Ginkgo suite under `test/e2e/thv-operator`, which is where the optimizer multi-backend spec lives. (`Operator CI / E2E Tests Operator` looks like it would cover it, but it only runs the chainsaw suites under `test/e2e/chainsaw/operator`.) Its `paths` filter listed `test/e2e/thv-operator/**` but not `test/e2e/images/**`, even though that package supplies every backend image the suite deploys.

So a change to a test backend image could not trigger the tests that consume it. That is also why the original breakage looked like it came from unrelated PRs: the drift landed in an image, and nothing tied that to the suite.

Adding the path fixes it. Since the workflow file is itself in the filter, the second commit triggers the suite and verifies the pin on this PR.

## Type of change

- [x] Bug fix

## Test plan

- [x] E2E tests (`task test-e2e`)
- [x] Manual testing (describe below)

**E2E:** `E2E Test Lifecycle` now runs on this PR across all three kind versions, which is the suite that was failing. This is the actual verification of the fix, and it was only possible after the trigger-filter commit.

**Manual:** verified against `linux/amd64`, the arch CI runs, by pulling the per-arch manifest inside each index:

- Current `1.4.0` (`sha256:05691124`, built 2026-07-31): `mcp` 2.0.0 installed, `ida-pro-mcp` exits with the `ModuleNotFoundError` above. Failure reproduced.
- Pinned digest (`sha256:5a596d96`, built 2026-07-27): `mcp` 1.28.1 installed. Full stdio MCP handshake succeeds, `initialize` returns `serverInfo` `ida-pro-mcp`, and `tools/list` returns 48 tools.

Also confirmed the reference form is supported: `MCPServerSpec.Image` carries no pattern validation, `pkg/runner/retriever` already branches on `nameref.Digest`, and `repo:tag@digest` resolves through the registry.

## Changes

| File | Change |
|------|--------|
| `test/e2e/images/images.go` | Pin `IDAProMCPServerImage` to the 2026-07-27 digest of tag 1.4.0 |
| `examples/operator/virtual-mcps/vmcp_optimizer_quickstart.yaml` | Same pin for the `ida-pro-mcp` backend |
| `.github/workflows/test-e2e-lifecycle.yml` | Trigger the suite on `test/e2e/images/**` changes |

## Does this introduce a user-facing change?

No. Test fixtures, a CI trigger filter, and an example manifest.

## Special notes for reviewers

The two approvals landed on the first commit, before the trigger-filter change. Worth a second look at `.github/workflows/test-e2e-lifecycle.yml` specifically.

This is distinct from #6026. That issue is the nondeterministic search-quality ranking assertion in the same spec file; this is a deterministic `BeforeAll` timeout from an unhealthy backend. Fixing this does not close that one.

Two follow-ups I did not fold in, to keep the scope contained:

- `test/e2e/images/images.go` is not covered by any Renovate manager, despite the package doc saying it enables automated updates. That is why the tag drifted unnoticed in the first place.
- Four other entries ride mutable tags and can break the same way at any time: `mcp/puppeteer:latest`, `mcp/memory:latest`, `mcp/everything:latest`, `text-embeddings-inference:cpu-latest`.

The pin should be revisited once upstream `ida-pro-mcp` either caps its `mcp` constraint or adopts the 2.x API. `pagerduty-mcp`, the only other dockyard uvx image in the spec, caps `mcp[cli]~=1.8` and is not exposed.

Generated with [Claude Code](https://claude.com/claude-code)