### PR TITLE
Pin mcp-server-time e2e image by digest

### DIFF
--- a/test/e2e/images/images.go
+++ b/test/e2e/images/images.go
@@ -117,6 +117,33 @@ const (
 	// Provides ~64 PagerDuty incident management tools (incidents, services, schedules, etc.).
 	PagerDutyMCPServerImage = pagerdutyMCPServerImageURL + ":" + pagerdutyMCPServerImageTag
 
+	timeMCPServerImageURL = "ghcr.io/stacklok/dockyard/uvx/mcp-server-time"
+	timeMCPServerImageTag = "2026.7.10"
+	// timeMCPServerImageDigest pins the 2026-07-27 build of tag 2026.7.10.
+	//
+	// Same failure mode as idaProMCPServerImageDigest above, different symptom:
+	// the tag is mutable, dockyard rebuilds it and resolves Python dependencies
+	// fresh, and the 2026-07-31 rebuild picked up the mcp Python SDK 2.0.0
+	// released 2026-07-28. mcp-server-time imports McpError from
+	// mcp.shared.exceptions, which 2.x moved, so the container now exits on
+	// startup with "ImportError: cannot import name 'McpError' from
+	// 'mcp.shared.exceptions'". The proxy suites then fail with
+	// "timeout waiting for MCP server to be ready".
+	//
+	// Pin the last build that resolved a 1.x mcp until upstream caps the
+	// constraint or adopts the 2.x API. Verified by driving both builds over
+	// stdio: the pinned digest answers initialize, tag 2026.7.10 does not.
+	timeMCPServerImageDigest = "sha256:5cca77dec3fefbacad35e3008ab1660f8725ef246213afb24231504fc73c999d"
+	// TimeMCPServerImage is the stdio backend used by the proxy e2e suites
+	// (proxy_stdio_test.go, stdio_proxy_over_streamable_http_mcp_server_test.go).
+	// Provides get_current_time / convert_time.
+	//
+	// These suites reference this constant rather than the "time" registry entry
+	// so a mutable upstream tag cannot break CI: the registry resolves "time" to
+	// the moving :2026.7.10 tag, which is currently broken. Registry-name
+	// resolution itself is still covered by the suites that run "osv".
+	TimeMCPServerImage = timeMCPServerImageURL + ":" + timeMCPServerImageTag + "@" + timeMCPServerImageDigest
+
 	redisImageURL = "redis"
 	redisImageTag = "7-alpine"
 	// RedisImage is used for Redis-backed session storage in scaling tests.

--- a/test/e2e/proxy_stdio_test.go
+++ b/test/e2e/proxy_stdio_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/transport/types"
 	"github.com/stacklok/toolhive/test/e2e"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 const (
@@ -183,7 +184,7 @@ var _ = Describe("Proxy Stdio E2E", Label("proxy", "stdio", "e2e"), Serial, func
 		BeforeEach(func() {
 			transportType = types.TransportTypeStdio
 			proxyMode = "sse"
-			mcpServerName = "time"
+			mcpServerName = images.TimeMCPServerImage
 		})
 		It("should proxy MCP requests successfully", func() {
 			By("Getting time server URL")
@@ -234,7 +235,7 @@ var _ = Describe("Proxy Stdio E2E", Label("proxy", "stdio", "e2e"), Serial, func
 		BeforeEach(func() {
 			transportType = types.TransportTypeStdio
 			proxyMode = "streamable-http"
-			mcpServerName = "time"
+			mcpServerName = images.TimeMCPServerImage
 		})
 		It("should proxy MCP requests successfully", func() {
 			By("Getting time server URL")

--- a/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
+++ b/test/e2e/stdio_proxy_over_streamable_http_mcp_server_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/stacklok/toolhive/test/e2e"
+	"github.com/stacklok/toolhive/test/e2e/images"
 )
 
 var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http", "e2e"), Serial, func() {
@@ -44,8 +45,9 @@ var _ = Describe("TimeStreamableHttpMcpServer", Label("proxy", "streamable-http"
 			By("Starting the time MCP server with streamable-http proxy")
 			e2e.NewTHVCommand(config, "run",
 				"--name", serverName,
+				"--transport", "stdio",
 				"--proxy-mode", "streamable-http",
-				"time").ExpectSuccess()
+				images.TimeMCPServerImage).ExpectSuccess()
 
 			By("Waiting for the server to be running")
 			err := e2e.WaitForMCPServer(config, serverName, 60*time.Second)


### PR DESCRIPTION
## Summary

`E2E Tests Core (proxy)` is failing on every PR in the repo with `timeout waiting for MCP server to be ready`. Three specs fail: `TimeStreamableHttpMcpServer`, and both `Proxy Stdio E2E` proxy modes.

Same root cause as #6159, a different image. Tag `2026.7.10` of `mcp-server-time` is mutable; dockyard rebuilds it and resolves Python dependencies fresh each time. The 2026-07-31 rebuild picked up the **mcp Python SDK 2.0.0** released 2026-07-28. `mcp-server-time` imports `McpError` from `mcp.shared.exceptions`, which 2.x moved, so the container now exits on startup:

```
ImportError: cannot import name 'McpError' from 'mcp.shared.exceptions'
```

The server never becomes ready, and the proxy suites time out waiting for it.

- **Pin `mcp-server-time` to the last build that resolved a 1.x mcp** (`sha256:5cca77de…`, the 2026-07-27 build of the same tag).
- **Point the two affected suites at the pinned constant** rather than the `"time"` registry entry. The registry resolves `"time"` to the moving `:2026.7.10` tag and is not fixable from this repo, so referencing it leaves CI hostage to an upstream rebuild.
- `stdio_proxy_over_streamable_http_mcp_server_test.go` gains an explicit `--transport stdio`, which the registry entry previously supplied.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)

Ran both affected suites locally against a locally-built `thv`:

| | unpinned (`"time"`) | pinned digest |
|---|---|---|
| `TimeStreamableHttpMcpServer` | **FAIL** — `timeout waiting for MCP server to be ready` | **pass** (43s) |
| `Proxy Stdio E2E` (both modes) | — | **pass** (87s) |

The unpinned run reproduces the CI error exactly, at the same assertion (`stdio_proxy_over_streamable_http_mcp_server_test.go:60`).

Also confirmed the two builds differ by driving each directly over stdio with an `initialize` request: the pinned digest returns a result, tag `2026.7.10` exits with the `ImportError` above.

`task lint-fix` is clean on the changed files; the one remaining finding (`cmd/thv/app/upgrade.go` gosec G115) is pre-existing and untouched.

## Does this introduce a user-facing change?

No. Test-only.

## Special notes for reviewers

**This is repo-wide, not specific to any PR.** Confirmed by re-running an unrelated PR's previously-green E2E job: same code, 14 hours later, same failure. Unrelated open PRs (#6157, #6150) show the identical `35 Passed | 3 Failed`. The last green proxy runs were 2026-07-30 ~14:25.

**Coverage tradeoff.** These two suites no longer exercise registry-name resolution for `"time"`. That path is still covered by the sibling cases in `proxy_stdio_test.go` that run `"osv"`, so nothing is lost overall — and the alternative is CI that any upstream rebuild can break.

**Second mutable-tag breakage in two days.** #6159 pinned `ida-pro-mcp` for the same reason. Both are dockyard `uvx` images with unbounded `mcp>=` constraints meeting the 2.0.0 release. A sweep pinning the remaining dockyard `uvx` images by digest — or capping the constraint upstream — would stop this recurring; `pagerduty-mcp` is already safe because it caps `mcp[cli]~=1.8`.

Generated with [Claude Code](https://claude.com/claude-code)
