### PR TITLE
Pin optimizer store connection to keep schema alive

### DIFF
--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store.go
@@ -50,7 +50,13 @@ var schemaSQL string
 // and optional vector embedding-based semantic search.
 // It satisfies the types.ToolStore interface.
 type sqliteToolStore struct {
-	db                        *sql.DB
+	db *sql.DB
+
+	// pinnedConn is a single connection held open for the lifetime of the store.
+	// It is never used to run queries; it exists only to keep the in-memory
+	// database alive. See newSQLiteToolStore for why.
+	pinnedConn *sql.Conn
+
 	embeddingClient           types.EmbeddingClient // nil = FTS5-only
 	maxToolsToReturn          int
 	hybridSemanticRatio       float64
@@ -77,8 +83,28 @@ func newSQLiteToolStore(
 		return sqliteToolStore{}, fmt.Errorf("failed to open sqlite database: %w", err)
 	}
 
+	// Pin one connection for the store's lifetime. A mode=memory database exists
+	// only while at least one connection to it is open, and the schema is applied
+	// once here and never re-applied, so if the pool ever drains to zero the
+	// database and its schema are gone and every later query fails with
+	// "no such table: llm_capabilities" until the process restarts (issue #5889).
+	//
+	// The pool does drain in practice: cancelling a request while a query is in
+	// flight makes the driver interrupt the connection and then report it
+	// unusable (modernc.org/sqlite conn.IsValid), so database/sql discards it
+	// instead of returning it to the pool. One disconnecting client is enough.
+	// Pinning a connection puts a floor of one under the pool, so the database
+	// outlives any such churn. Acquiring the pin before applying the schema also
+	// ensures the schema is written into the instance the pin holds open.
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		_ = db.Close()
+		return sqliteToolStore{}, fmt.Errorf("failed to pin sqlite connection: %w", err)
+	}
+
 	// Execute schema
-	if _, err := db.Exec(schemaSQL); err != nil {
+	if _, err := conn.ExecContext(context.Background(), schemaSQL); err != nil {
+		_ = conn.Close()
 		_ = db.Close()
 		return sqliteToolStore{}, fmt.Errorf("failed to initialize schema: %w", err)
 	}
@@ -100,6 +126,7 @@ func newSQLiteToolStore(
 
 	store := sqliteToolStore{
 		db:                        db,
+		pinnedConn:                conn,
 		embeddingClient:           embeddingClient,
 		maxToolsToReturn:          maxTools,
 		hybridSemanticRatio:       hybridRatio,
@@ -117,7 +144,16 @@ func newSQLiteToolStore(
 }
 
 // UpsertTools adds or updates tools in the store.
+// Embeddings are generated before the transaction opens. generateEmbeddings makes
+// a network call to the embedding service, so opening the transaction first held a
+// write transaction — and its pooled connection — for the length of an HTTP
+// round-trip, blocking other writers for no benefit.
 func (s sqliteToolStore) UpsertTools(ctx context.Context, tools []server.ServerTool) (retErr error) {
+	embBlobs, err := s.generateEmbeddings(ctx, tools)
+	if err != nil {
+		return err
+	}
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -127,11 +163,6 @@ func (s sqliteToolStore) UpsertTools(ctx context.Context, tools []server.ServerT
 			_ = tx.Rollback()
 		}
 	}()
-
-	embBlobs, err := s.generateEmbeddings(ctx, tools)
-	if err != nil {
-		return err
-	}
 
 	stmt, err := tx.PrepareContext(ctx, "INSERT OR REPLACE INTO llm_capabilities (name, description, embedding) VALUES (?, ?, ?)")
 	if err != nil {
@@ -260,8 +291,17 @@ func (s sqliteToolStore) Close() error {
 	if s.embeddingClient != nil {
 		embErr = s.embeddingClient.Close()
 	}
+	// Release the pin before closing the pool: db.Close waits for checked-out
+	// connections to be returned. ErrConnDone is expected on a repeated Close,
+	// which the ToolStore contract requires to be safe.
+	var connErr error
+	if s.pinnedConn != nil {
+		if err := s.pinnedConn.Close(); err != nil && !errors.Is(err, sql.ErrConnDone) {
+			connErr = err
+		}
+	}
 	dbErr := s.db.Close()
-	return errors.Join(embErr, dbErr)
+	return errors.Join(embErr, connErr, dbErr)
 }
 
 // searchFTS5 performs a full-text search using FTS5 MATCH with BM25 ranking.

--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -827,6 +828,74 @@ func TestSQLiteToolStore_SemanticDistanceThreshold(t *testing.T) {
 	// With such a tight threshold, very few (if any) results should pass
 	require.Less(t, len(results), len(tools),
 		"tight threshold should filter out some results")
+}
+
+// TestSQLiteToolStore_SchemaSurvivesPoolDrain is a regression test for #5889.
+//
+// A mode=memory SQLite database only exists while some connection to it is open.
+// The schema is written once at construction and never re-applied, so if the
+// connection pool ever empties the database — and its schema — is discarded and
+// every later query fails with "no such table: llm_capabilities" for the life of
+// the process. Setting MaxIdleConns to zero makes the pool release every
+// connection it is handed back, simulating that drain deterministically.
+func TestSQLiteToolStore_SchemaSurvivesPoolDrain(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t, nil, nil)
+	ctx := context.Background()
+
+	tools := makeTools(mcp.NewTool("read_file", mcp.WithDescription("Read a file from disk")))
+	require.NoError(t, store.UpsertTools(ctx, tools))
+
+	// Every connection returned to the pool from here on is closed outright.
+	store.db.SetMaxIdleConns(0)
+	results, err := store.Search(ctx, types.SearchQuery{Description: "file"}, []string{"read_file"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	// Only the pinned connection should remain; the database must have survived.
+	require.LessOrEqual(t, store.db.Stats().OpenConnections, 1, "pool should have drained to the pin")
+
+	require.NoError(t, store.UpsertTools(ctx, tools))
+	results, err = store.Search(ctx, types.SearchQuery{Description: "file"}, []string{"read_file"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+}
+
+// TestSQLiteToolStore_SurvivesCancelledQuery is a regression test for the
+// production trigger behind #5889.
+//
+// When a caller's context is cancelled while a query is executing, the SQLite
+// driver interrupts the connection and then reports it unusable, so the pool
+// discards rather than reuses it. Any MCP client that disconnects mid-find_tool
+// therefore destroyed the last pooled connection — and with it the in-memory
+// database — leaving every later request to fail permanently. The store must
+// stay usable after such a cancellation.
+func TestSQLiteToolStore_SurvivesCancelledQuery(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t, nil, nil)
+	ctx := context.Background()
+
+	tools := makeTools(mcp.NewTool("read_file", mcp.WithDescription("Read a file from disk")))
+	require.NoError(t, store.UpsertTools(ctx, tools))
+
+	// A query long enough to still be running when its context expires.
+	cancelCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+	var n int
+	err := store.db.QueryRowContext(cancelCtx,
+		`WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c WHERE x < 90000000) SELECT count(*) FROM c`,
+	).Scan(&n)
+	require.Error(t, err, "query should be interrupted by context expiry")
+
+	// The interrupted connection is discarded asynchronously; wait for the pool
+	// to settle before asserting the database survived.
+	require.Eventually(t, func() bool {
+		return store.db.Stats().OpenConnections <= 1
+	}, 5*time.Second, 10*time.Millisecond, "interrupted connection should be discarded")
+
+	results, searchErr := store.Search(ctx, types.SearchQuery{Description: "file"}, []string{"read_file"})
+	require.NoError(t, searchErr)
+	require.Len(t, results, 1)
 }
 
 // newFakeEmbeddingClient is a test helper that creates a deterministic embedding client.

--- a/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
+++ b/pkg/vmcp/optimizer/internal/toolstore/sqlite_store_test.go
@@ -853,7 +853,7 @@ func TestSQLiteToolStore_SchemaSurvivesPoolDrain(t *testing.T) {
 	require.Len(t, results, 1)
 
 	// Only the pinned connection should remain; the database must have survived.
-	require.LessOrEqual(t, store.db.Stats().OpenConnections, 1, "pool should have drained to the pin")
+	require.Equal(t, 1, store.db.Stats().OpenConnections, "pool should have drained to the pin")
 
 	require.NoError(t, store.UpsertTools(ctx, tools))
 	results, err = store.Search(ctx, types.SearchQuery{Description: "file"}, []string{"read_file"})
@@ -885,13 +885,17 @@ func TestSQLiteToolStore_SurvivesCancelledQuery(t *testing.T) {
 	err := store.db.QueryRowContext(cancelCtx,
 		`WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c WHERE x < 90000000) SELECT count(*) FROM c`,
 	).Scan(&n)
-	require.Error(t, err, "query should be interrupted by context expiry")
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"query must fail from context expiry, not some other query error, "+
+			"or the test would not be exercising the interrupt path")
 
-	// The interrupted connection is discarded asynchronously; wait for the pool
-	// to settle before asserting the database survived.
+	// The interrupted connection is discarded asynchronously. Waiting for the
+	// count to fall back to exactly one — the pin — proves it was discarded
+	// rather than returned to the pool, which is the condition that used to
+	// destroy the database.
 	require.Eventually(t, func() bool {
-		return store.db.Stats().OpenConnections <= 1
-	}, 5*time.Second, 10*time.Millisecond, "interrupted connection should be discarded")
+		return store.db.Stats().OpenConnections == 1
+	}, 5*time.Second, 10*time.Millisecond, "interrupted connection should be discarded, leaving only the pin")
 
 	results, searchErr := store.Search(ctx, types.SearchQuery{Description: "file"}, []string{"read_file"})
 	require.NoError(t, searchErr)


### PR DESCRIPTION
## Summary

**Why:** The vMCP tool optimizer keeps its search index in a SQLite database held entirely in process memory (`file:memdb?mode=memory&cache=shared`). Such a database exists only while at least one connection to it is open, and the schema is applied exactly once at store construction and never re-applied. If the connection pool ever drains to zero, the database and its schema evaporate and **every subsequent request fails with `no such table: llm_capabilities` for the remaining life of the process** — while `/health` and `/readyz` stay green throughout, so nothing surfaces it. The reporter in #5889 lost a gateway for ~14 hours this way; only deleting the pod recovered it.

The pool does drain in practice. Cancelling a request while a query is in flight makes the SQLite driver interrupt the connection and then report it unusable (`modernc.org/sqlite` `conn.IsValid`), so `database/sql` discards it rather than returning it to the pool. **One MCP client disconnecting mid-`find_tool` is enough** to destroy the last pooled connection and take the optimizer out permanently.

**What changed:**

- Hold one connection open for the lifetime of the store, so the pool can never empty and the database always survives. The pin is acquired before the schema is applied, so the schema is written into the same database instance the pin holds open, and released in `Close()` before the pool is closed.
- Generate embeddings *before* opening the write transaction, instead of holding a transaction (and its connection) open across an HTTP round-trip to the embedding service for no benefit.

**Note on the issue's diagnosis:** the reporter hypothesised that the schema is created lazily on first upsert and that a failed embedding call therefore prevents it from ever being created. That isn't what happens — the schema is already created eagerly at construction. The reported symptom is real, but the cause is the pool drain above. The embedding outage in their report is correlated (a failing backend drives error paths and client cancellations) rather than causal, so a schema-creation or upsert-retry fix would not have addressed it.

Fixes #5889

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Two regression tests, both of which **fail on `main` with the exact error string from the issue** (`no such table: llm_capabilities_fts`) and pass with the fix:

- `TestSQLiteToolStore_SchemaSurvivesPoolDrain` — sets `MaxIdleConns(0)` so the pool releases every connection handed back, deterministically simulating the drain.
- `TestSQLiteToolStore_SurvivesCancelledQuery` — reproduces the production trigger: a query interrupted by context expiry, after which the store must still serve searches.

Also ran the optimizer package with `-race -count=3` (clean) and the full `./pkg/vmcp/...` suite. `task lint` reports only 4 findings, all pre-existing on a clean tree in unrelated files.

Manual verification of the mechanism: instrumented `db.Stats()` around an interrupted query on unpatched code and observed `OpenConnections` drop from 1 to 0, with the next query returning `no such table: llm_capabilities` — confirming the diagnosis empirically rather than by inspection.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes — for deployments with the optimizer enabled, a transient fault or a client disconnecting mid-request no longer leaves the optimizer permanently broken until the pod is restarted. No configuration change is required, and there is no schema, migration, or persisted-data impact: this store is ephemeral by design and is rebuilt from live backend tools.

## Special notes for reviewers

- **The store is ephemeral.** No on-disk file, no persistence, no migration concern. The `llm_capabilities` schema itself is unchanged.
- **Why pinning rather than pool tuning.** `SetMaxIdleConns`/`SetConnMaxLifetime` set a ceiling, not a floor, and an interrupted connection is discarded regardless of idle settings. A private (non-shared) in-memory DB is also not a fix — each new connection would get its own empty database.
- **Known gap, deliberately out of scope.** During this class of failure `/health` and `/readyz` remain green; readiness has no notion of optimizer health. After this fix such failures are transient rather than permanent, but the observability gap remains and is separate work.
- Related to #5847 (same optimizer/Serve path, but about re-embedding cost rather than this failure).

<details>
<summary>Approved implementation plan</summary>

Approved scope investigation, with the "belt-and-braces schema re-apply/retry" option explicitly declined as out of scope:

1. **Pin the database's lifetime.** At construction, after applying the schema, acquire one dedicated connection and hold it for the store's lifetime, releasing it in `Close()`. Pool tuning alone is not sufficient — idle count is a ceiling, not a floor, and a discarded connection is dropped regardless. A private in-memory DB doesn't help either, since each new connection would get its own empty database.
2. **Stop holding a transaction open across the embedding network call.** Generate embeddings before `BeginTx`.
3. **Regression test** reproducing connection loss and asserting a later search still succeeds.

Estimated at ~20–30 lines of production change in a single file plus tests; one focused PR, no staging.

**Deviation from the plan, and why:** the plan's stated *trigger* for the pool drain was that `database/sql` discards a connection whose transaction context was cancelled. While implementing, I tested that hypothesis directly and **disproved it** — `Tx.awaitDone` sets `keepConnOnRollback`, so a cancelled transaction returns its connection to the pool intact. The real trigger, confirmed empirically, is that cancelling *any* query mid-flight causes the driver to interrupt the connection, after which the pool discards it. The approved fix (pinning) is unchanged and is still correct — it defends against pool drain from any cause. Only the regression test and the explanatory comments were adjusted to describe the real mechanism instead of the hypothesised one. Change 2 is retained as approved; it is a genuine improvement (not holding a write transaction across an HTTP round-trip) but is no longer load-bearing for the bug.

</details>
