### PR TITLE
Await manager shutdown before stopping envtest

### DIFF
--- a/cmd/thv-operator/test-integration/testutil/envtest.go
+++ b/cmd/thv-operator/test-integration/testutil/envtest.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -33,9 +34,19 @@ import (
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 )
 
-// gracefulShutdownDelay gives a running manager a moment to stop cleanly after
-// the suite context is cancelled, before the envtest control plane is torn down.
-const gracefulShutdownDelay = 100 * time.Millisecond
+const (
+	// managerGracefulShutdownTimeout bounds how long the manager waits for its
+	// runnables (controllers and the informer cache) to return once the suite
+	// context is cancelled. It is deliberately well under envtest's 20s
+	// ControlPlaneStopTimeout so a wedged runnable surfaces as a manager
+	// shutdown timeout rather than as a kube-apiserver teardown failure.
+	managerGracefulShutdownTimeout = 10 * time.Second
+
+	// managerStopTimeout bounds how long Stop waits for Manager.Start to return.
+	// It allows a little slack over managerGracefulShutdownTimeout so the
+	// manager's own bounded shutdown always wins the race.
+	managerStopTimeout = 15 * time.Second
+)
 
 // SuiteOptions configures the envtest bootstrap performed by StartSuite. Add
 // fields only as concrete suites require them.
@@ -64,6 +75,10 @@ type SuiteEnv struct {
 
 	testEnv *envtest.Environment
 	cancel  context.CancelFunc
+	// managerDone is closed when the goroutine started by StartManager returns,
+	// i.e. once Manager.Start has fully shut down every runnable. It stays nil
+	// until StartManager is called.
+	managerDone chan struct{}
 }
 
 // StartSuite bootstraps a full operator integration suite: it starts an envtest
@@ -104,6 +119,9 @@ func StartSuite(opts SuiteOptions) *SuiteEnv {
 			BindAddress: "0", // Disable metrics server for tests to avoid port conflicts
 		},
 		HealthProbeBindAddress: "0", // Disable health probe for tests
+		// Keep the manager's own shutdown bounded so Stop never waits on it
+		// longer than envtest is willing to wait for the control plane.
+		GracefulShutdownTimeout: ptr.To(managerGracefulShutdownTimeout),
 	})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -162,21 +180,40 @@ func (e *SuiteEnv) StartManager() {
 	if e.Manager == nil {
 		return
 	}
+	e.managerDone = make(chan struct{})
 	go func() {
 		defer GinkgoRecover()
+		// Closing before GinkgoRecover runs (deferred functions are LIFO) means
+		// Stop is released even if the manager fails.
+		defer close(e.managerDone)
 		Expect(e.Manager.Start(e.Ctx)).To(Succeed(), "failed to run manager")
 	}()
 }
 
-// Stop cancels the suite context and tears down the envtest control plane. When
-// a manager is running it first waits a short grace period so the manager can
-// shut down cleanly before the API server goes away.
+// Stop cancels the suite context and tears down the envtest control plane.
+//
+// When a manager is running it waits for Manager.Start to return before
+// stopping the control plane. That wait is load-bearing, not politeness: the
+// manager's informers hold long-running watch requests against kube-apiserver,
+// and kube-apiserver's graceful shutdown blocks on draining them. Signalling
+// the API server to stop while watches are still open makes it miss envtest's
+// 20s ControlPlaneStopTimeout, which surfaces as a flaky
+// "timeout waiting for process kube-apiserver to stop" failure in AfterSuite.
+// The suites with fewer specs than Ginkgo procs (MCPTelemetryConfig, MCPGroup)
+// hit it most often: their idle procs cancel the suite context moments after
+// the informers established their watches.
 func (e *SuiteEnv) Stop() {
 	By("tearing down the test environment")
 	e.cancel()
-	if e.Manager != nil {
-		// Give the manager some time to shut down gracefully.
-		time.Sleep(gracefulShutdownDelay)
+	if e.managerDone != nil {
+		select {
+		case <-e.managerDone:
+		case <-time.After(managerStopTimeout):
+			// Fall through to the control plane teardown anyway: reporting the
+			// apiserver timeout on top of this would only obscure the real
+			// problem, which is a runnable that refused to stop.
+			AddReportEntry("manager did not shut down within " + managerStopTimeout.String())
+		}
 	}
 	Expect(e.testEnv.Stop()).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
## Summary

- `Operator CI / Operator Tests Integration` has a flaky `AfterSuite` failure: `timeout waiting for process kube-apiserver to stop`. It accounts for **32 of the last 51 failures** of that job, all in `mcp-telemetry-config` (27) and `mcp-group` (5).
- Root cause: `SuiteEnv.Stop` cancelled the suite context, slept 100ms, then tore down the envtest control plane. 100ms is not enough for the controller manager to finish, so its informers still held long-running watch requests when kube-apiserver got SIGTERM. kube-apiserver's graceful shutdown blocks draining those requests, overruns envtest's 20s `ControlPlaneStopTimeout`, and fails the suite. The CI logs show it directly: reflectors log `Failed to watch ... connection refused` *during* teardown, so the manager was demonstrably still running after the API server closed its listener.
- Why only those two suites: they are the only ones with fewer specs than Ginkgo procs (5 specs, 7 procs in CI). `BeforeSuite` runs on *every* proc, so the idle procs boot a control plane and cancel the context moments after the informers established their watches — the worst case for the race.
- Fix: wait for `Manager.Start` to return before stopping the control plane, instead of guessing at a delay. controller-runtime's `Informers.Start` blocks on `waitGroup.Wait()` until every informer has stopped, so that return is a real guarantee the watch connections are closed.
- Also bound the manager's own `GracefulShutdownTimeout` (10s) and the wait (15s) safely under envtest's 20s stop timeout, so a genuinely wedged runnable is reported as a manager shutdown problem rather than mis-attributed to apiserver teardown.

All 11 operator integration suites share this helper, so no per-suite changes are needed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Reproduced the flake locally first, then verified the fix:

| | Result |
|---|---|
| Baseline, `ginkgo -p --repeat=6 mcp-telemetry-config` | Flaked on attempt 2 — identical `20.121s` / same error as CI |
| Baseline, second `--repeat` run | Flaked again |
| Fix, 10 consecutive `mcp-telemetry-config` runs | 10/10 pass |
| Fix, soak: 15 rounds × (`mcp-telemetry-config` + `mcp-group`) | 30/30 suite runs pass, 0 timeouts, 11m34s |
| Fix, full `ginkgo -p ./cmd/thv-operator/test-integration/...` (11 suites) | Pass, 5m19s |

Roughly 40 clean runs of the previously-flaky suites, against a baseline that failed twice in ~17.

`task lint-fix` reports one pre-existing failure unrelated to this change (`cmd/thv/app/upgrade.go:204`, gosec G115); confirmed present on the base commit by re-running with the change stashed.

## Does this introduce a user-facing change?

No. Test infrastructure only.

## Special notes for reviewers

Two deliberate omissions, both open to a different call:

- **The idle-proc waste is untouched.** `mcp-telemetry-config` and `mcp-group` each boot 7 control planes for 5 specs and spend ~38s almost entirely on control-plane startup, because the suites use `BeforeSuite` (per-proc) rather than `SynchronizedBeforeSuite`. That inefficiency is what makes this race so easy to hit, but fixing it means sharing one API server across procs and namespace-isolating the specs — worth a follow-up PR, and not needed to stop the flake.
- **No tracking issue exists** for this flake; I searched and found nothing matching, hence no `Fixes #`.

The `AddReportEntry` in the timeout branch is intentional: if the manager ever does hang, teardown still proceeds and the report names the real cause instead of surfacing a second, misleading apiserver timeout.

Generated with [Claude Code](https://claude.com/claude-code)
