### PR TITLE
Expire the refuted-Modern-hint memory after a TTL

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -64,6 +64,14 @@ const (
 	// Note: This limit is enforced per HTTP response, not per MCP request.
 	// A tools/list response with 1000 tools would be limited to 100MB total.
 	maxResponseSize = 100 * 1024 * 1024 // 100 MB
+
+	// defaultRefutationTTL is the default lifetime of a modernHintRefuted
+	// entry. Chosen to be long enough that a persistently hint-lying backend
+	// (#6154) pays a negligible probe cost (one server/discover per backend
+	// per 5 minutes, only when calls are flowing), and short enough that a
+	// backend redeployed genuinely Modern self-heals its reported revision
+	// within minutes rather than never.
+	defaultRefutationTTL = 5 * time.Minute
 )
 
 // Option configures an httpBackendClient.
@@ -106,6 +114,18 @@ type Option func(*httpBackendClient)
 func WithDialControl(control func(network, address string, c syscall.RawConn) error) Option {
 	return func(h *httpBackendClient) {
 		h.dialControl = control
+	}
+}
+
+// WithRefutationTTL overrides how long a refuted Modern-handshake hint
+// suppresses the confirming server/discover probe in legacyInit. Zero or
+// negative restores the default. Production callers should not set this; it
+// exists so tests can shrink the window.
+func WithRefutationTTL(d time.Duration) Option {
+	return func(h *httpBackendClient) {
+		if d > 0 {
+			h.refutationTTL = d
+		}
 	}
 }
 
@@ -177,11 +197,18 @@ type httpBackendClient struct {
 	// the refutation stops legacyInit re-probing on every subsequent call for a
 	// backend already known to lie.
 	//
-	// NOTE: never evicted, bounded by backend count like revisions. A backend
-	// that genuinely becomes Modern later is still corrected through the other
-	// paths -- probeRevision runs whenever the cache is absent, and dispatch
-	// reclassifies on a revision mismatch.
-	modernHintRefuted sync.Map // map[string]struct{}
+	// The refutation EXPIRES after refutationTTL: a permanently refuted flag
+	// would pin a redeemed backend (one that lied once but was later redeployed
+	// genuinely Modern) to Legacy forever, because legacyInit skips the
+	// confirming probe while the flag stands. With the TTL, a persistent liar
+	// pays one confirming probe per window instead of per call, and a redeemed
+	// backend self-heals within one window.
+	modernHintRefuted sync.Map // map[string]time.Time (refuted-at)
+
+	// refutationTTL bounds how long a modernHintRefuted entry suppresses the
+	// confirming probe in legacyInit. Defaults to defaultRefutationTTL;
+	// configurable via WithRefutationTTL (tests).
+	refutationTTL time.Duration
 }
 
 // NewHTTPBackendClient creates a new HTTP-based backend client.
@@ -204,6 +231,7 @@ func NewHTTPBackendClient(registry vmcpauth.OutgoingAuthRegistry, opts ...Option
 	c := &httpBackendClient{
 		registry:        registry,
 		secretsProvider: secrets.NewEnvironmentProvider(),
+		refutationTTL:   defaultRefutationTTL,
 	}
 	for _, o := range opts {
 		o(c)
@@ -1503,7 +1531,9 @@ var errLegacyInitFailed = errors.New("legacy initialize step failed")
 // hint must win a confirming probe first; probeRevision caches whatever it
 // finds, so a genuinely Modern backend still self-heals in one extra round
 // trip. A refuted hint is remembered (modernHintRefuted) so the confirming
-// probe runs once per backend rather than on every call.
+// probe runs at most once per refutationTTL window per backend rather than on
+// every call — and a redeemed backend (refuted once, later genuinely Modern)
+// self-heals within one window instead of never.
 func (h *httpBackendClient) legacyInit(
 	ctx context.Context, c *client.Client, target *vmcp.BackendTarget,
 ) (*mcp.ServerCapabilities, error) {
@@ -1521,7 +1551,7 @@ func (h *httpBackendClient) legacyInit(
 	case !isCached:
 		h.setRevision(backendID, mcpparser.RevisionModern)
 	case cached == mcpparser.RevisionLegacy:
-		if _, refuted := h.modernHintRefuted.Load(backendID); refuted {
+		if h.hintRefuted(backendID) {
 			break
 		}
 		// probeRevision caches its own verdict, so a confirmation needs no
@@ -1529,10 +1559,26 @@ func (h *httpBackendClient) legacyInit(
 		if probed, perr := h.probeRevision(ctx, target); perr == nil && probed != mcpparser.RevisionModern {
 			slog.DebugContext(ctx, "legacy handshake negotiated Modern but discover disagrees; keeping Legacy",
 				"backend", backendID, "negotiated", negotiatedVersion)
-			h.modernHintRefuted.Store(backendID, struct{}{})
+			h.modernHintRefuted.Store(backendID, time.Now())
 		}
 	}
 	return caps, nil
+}
+
+// hintRefuted reports whether backendID's Modern-handshake hint is currently
+// refuted: a refutation was recorded and has not yet aged past refutationTTL.
+// An expired entry is deleted so the map stays bounded by live backends.
+func (h *httpBackendClient) hintRefuted(backendID string) bool {
+	v, ok := h.modernHintRefuted.Load(backendID)
+	if !ok {
+		return false
+	}
+	refutedAt, ok := v.(time.Time)
+	if !ok || time.Since(refutedAt) > h.refutationTTL {
+		h.modernHintRefuted.Delete(backendID)
+		return false
+	}
+	return true
 }
 
 // dispatch resolves the backend's MCP revision (cache hit, else probeRevision)

--- a/pkg/vmcp/client/revision_realbackend_test.go
+++ b/pkg/vmcp/client/revision_realbackend_test.go
@@ -15,7 +15,9 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,6 +26,9 @@ import (
 	mcpserver "github.com/stacklok/toolhive-core/mcpcompat/server"
 	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	vmcpauth "github.com/stacklok/toolhive/pkg/vmcp/auth"
+	"github.com/stacklok/toolhive/pkg/vmcp/auth/strategies"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 )
 
 // newRealEchoServer stands up a real go-sdk v1.7-backed streamable-HTTP MCP
@@ -313,4 +318,96 @@ func TestLegacyInit_DoesNotPromoteOnHandshakeHintAlone(t *testing.T) {
 		assert.Equal(t, mcpparser.RevisionLegacy, rev,
 			"cached revision must stay Legacy after call %d; flipping to Modern is the #6154 oscillation", i)
 	}
+}
+
+// TestLegacyInit_RefutedHintExpires covers #5992: a backend that lied once
+// (Modern on the Legacy initialize, Legacy-shaped discover) is recorded in
+// modernHintRefuted so the confirming probe does not run on every call. That
+// memory must NOT be permanent: if the backend is later redeployed genuinely
+// Modern (hint and discover now agree), the refutation expires after
+// refutationTTL and the next call's confirming probe flips the cache.
+//
+// The redeeming server flips its discover answer mid-test: Legacy-shaped until
+// redeemed.Store(true), then a valid Modern envelope.
+func TestLegacyInit_RefutedHintExpires(t *testing.T) {
+	t.Parallel()
+
+	var redeemed atomic.Bool
+	backend := newRealEchoServer(t, true, nil) // stateless => negotiates 2026-07-28
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+	rp := httputil.NewSingleHostReverseProxy(backendURL)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		require.NoError(t, readErr)
+		r.Body = io.NopCloser(bytes.NewReader(body))
+
+		if !bytes.Contains(body, []byte(`"server/discover"`)) {
+			rp.ServeHTTP(w, r)
+			return
+		}
+		if redeemed.Load() {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(discoverEnvelope(t, r))
+			return
+		}
+
+		var req struct {
+			ID json.RawMessage `json:"id"`
+		}
+		_ = json.Unmarshal(body, &req)
+		id := req.ID
+		if len(id) == 0 {
+			id = json.RawMessage(`null`)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{`+
+			`"capabilities":{"tools":{}},`+
+			`"supportedVersions":["2026-07-28","2025-11-25"],`+
+			`"serverInfo":{"name":"hint-liar","version":"1.0.0"}}}`, id)
+	}))
+	t.Cleanup(ts.Close)
+
+	reg := vmcpauth.NewDefaultOutgoingAuthRegistry()
+	require.NoError(t, reg.RegisterStrategy(authtypes.StrategyTypeUnauthenticated, &strategies.UnauthenticatedStrategy{}))
+	c, err := NewHTTPBackendClient(reg, WithRefutationTTL(50*time.Millisecond))
+	require.NoError(t, err)
+	h := c.(*httpBackendClient)
+
+	target := &vmcp.BackendTarget{
+		WorkloadID:    "b",
+		BaseURL:       ts.URL + "/mcp",
+		TransportType: "streamable-http",
+	}
+
+	// Phase 1: the backend lies. The refutation is recorded and the cache
+	// stays Legacy (#6154 behavior is preserved within the window).
+	_, err = h.ListCapabilities(context.Background(), target)
+	require.NoError(t, err)
+	rev, ok := h.cachedRevision(target.WorkloadID)
+	require.True(t, ok)
+	require.Equal(t, mcpparser.RevisionLegacy, rev)
+	_, refuted := h.modernHintRefuted.Load(target.WorkloadID)
+	require.True(t, refuted, "the refutation should be recorded after the confirming probe disagrees")
+
+	// Phase 2: the backend is "redeployed" genuinely Modern. Within the TTL
+	// the refutation still suppresses the confirming probe...
+	_, err = h.ListCapabilities(context.Background(), target)
+	require.NoError(t, err)
+	rev, _ = h.cachedRevision(target.WorkloadID)
+	require.Equal(t, mcpparser.RevisionLegacy, rev,
+		"within the TTL the refutation still suppresses re-probing")
+
+	// Phase 3: ...but once the window lapses the next call re-probes and the
+	// cache self-heals to Modern.
+	redeemed.Store(true)
+	time.Sleep(2 * 50 * time.Millisecond)
+
+	_, err = h.ListCapabilities(context.Background(), target)
+	require.NoError(t, err)
+	rev, ok = h.cachedRevision(target.WorkloadID)
+	require.True(t, ok)
+	assert.Equal(t, mcpparser.RevisionModern, rev,
+		"after the refutation expires, a redeemed backend must self-heal to Modern")
 }


### PR DESCRIPTION
## Summary

Implements #5992 option 1 (the recommendation from my analysis comment).

The `modernHintRefuted` flag (added for #6154) stops `legacyInit` re-probing `server/discover` on every call for a backend whose Legacy-handshake version hint was contradicted by an authoritative discover probe. It was **never evicted**: a backend that lied once (hint Modern, discover Legacy — e.g. github-mcp-server v1.6.0) and was later redeployed *genuinely* Modern stayed pinned Legacy forever, because the flag suppresses exactly the confirming probe that would flip the cache. Wire behavior stayed correct (the SDK negotiates Modern transparently on the Legacy path), but `CachedRevision` — which feeds the health monitor's revision read-model and CRD status — reported Legacy indefinitely, and every call paid the heavier handshake.

The fix stores the refuted-at timestamp and expires entries after a TTL (default 5m, overridable via `WithRefutationTTL` for tests):

- A persistent liar pays one confirming probe per window instead of per call — the #6154 anti-oscillation behavior is unchanged within the window (the existing hint-liar test passes unmodified).
- A redeemed backend self-heals its cached (and status-reported) revision within one window.

Closes #5992

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — new `TestLegacyInit_RefutedHintExpires` (liar redeployed genuinely Modern: stays Legacy within the TTL, self-heals to Modern after); `TestLegacyInit_DoesNotPromoteOnHandshakeHintAlone` (#6154 pin) unchanged and green; full `pkg/vmcp/client`, `pkg/vmcp/server`, `pkg/vmcp/session`, `pkg/vmcp/health` suites green
- [x] Linting (`task lint-fix`)

## Does this introduce a user-facing change?

Yes — a vMCP backend that is redeployed from a "hint-lying" Legacy server to a genuinely Modern (2026-07-28) server now has its reported MCP revision correct itself within ~5 minutes instead of staying Legacy until the vMCP pod restarts. No operator action needed.
