### PR TITLE
Skip logging/setLevel on a Modern-negotiated session

### DIFF
--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -1415,7 +1415,7 @@ func (h *httpBackendClient) legacyListCapabilities(
 	}()
 
 	// Initialize the client and get server capabilities
-	serverCaps, err := h.legacyInit(ctx, c, target)
+	serverCaps, _, err := h.legacyInit(ctx, c, target)
 	if err != nil {
 		return nil, err
 	}
@@ -1506,14 +1506,14 @@ var errLegacyInitFailed = errors.New("legacy initialize step failed")
 // probe runs once per backend rather than on every call.
 func (h *httpBackendClient) legacyInit(
 	ctx context.Context, c *client.Client, target *vmcp.BackendTarget,
-) (*mcp.ServerCapabilities, error) {
+) (*mcp.ServerCapabilities, string, error) {
 	backendID := target.WorkloadID
 	caps, negotiatedVersion, err := initializeClient(ctx, c)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errLegacyInitFailed, wrapBackendError(err, backendID, "initialize client"))
+		return nil, "", fmt.Errorf("%w: %w", errLegacyInitFailed, wrapBackendError(err, backendID, "initialize client"))
 	}
 	if negotiatedVersion != mcpparser.MCPVersionModern {
-		return caps, nil
+		return caps, negotiatedVersion, nil
 	}
 
 	cached, isCached := h.cachedRevision(backendID)
@@ -1532,7 +1532,7 @@ func (h *httpBackendClient) legacyInit(
 			h.modernHintRefuted.Store(backendID, struct{}{})
 		}
 	}
-	return caps, nil
+	return caps, negotiatedVersion, nil
 }
 
 // dispatch resolves the backend's MCP revision (cache hit, else probeRevision)
@@ -1754,7 +1754,7 @@ func (h *httpBackendClient) legacyCallTool(
 	}()
 
 	// Initialize the client and capture the backend's advertised capabilities.
-	serverCaps, err := h.legacyInit(ctx, c, target)
+	serverCaps, negotiatedVersion, err := h.legacyInit(ctx, c, target)
 	if err != nil {
 		return nil, err
 	}
@@ -1763,7 +1763,7 @@ func (h *httpBackendClient) legacyCallTool(
 	// level so the backend emits notifications/message during the call; the
 	// notification forwarder relays them to the downstream client. Best-effort:
 	// a failure here must not fail the tool call.
-	h.enableBackendLogging(ctx, c, serverCaps, target.WorkloadID)
+	h.enableBackendLogging(ctx, c, serverCaps, negotiatedVersion, target.WorkloadID)
 
 	// Call the tool using the original capability name from the backend's perspective.
 	// When conflict resolution renames tools (e.g., "fetch" → "fetch_fetch"),
@@ -1952,7 +1952,7 @@ func (h *httpBackendClient) legacyReadResource(
 	}()
 
 	// Initialize the client
-	if _, err := h.legacyInit(ctx, c, target); err != nil {
+	if _, _, err := h.legacyInit(ctx, c, target); err != nil {
 		return nil, err
 	}
 
@@ -2070,7 +2070,7 @@ func (h *httpBackendClient) legacyGetPrompt(
 	}()
 
 	// Initialize the client
-	if _, err := h.legacyInit(ctx, c, target); err != nil {
+	if _, _, err := h.legacyInit(ctx, c, target); err != nil {
 		return nil, err
 	}
 
@@ -2211,7 +2211,7 @@ func (h *httpBackendClient) legacyComplete(
 	}()
 
 	// Initialize the client and capture the backend's advertised capabilities.
-	serverCaps, err := h.legacyInit(ctx, c, target)
+	serverCaps, _, err := h.legacyInit(ctx, c, target)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vmcp/client/forwarding.go
+++ b/pkg/vmcp/client/forwarding.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stacklok/toolhive-core/mcpcompat/client"
 	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
 	"github.com/stacklok/toolhive/pkg/vmcp"
 	"github.com/stacklok/toolhive/pkg/vmcp/conversion"
 )
@@ -56,12 +57,33 @@ func (h *httpBackendClient) BindForwarders(
 // per-request io.modelcontextprotocol/logLevel _meta key, which modernCallTool
 // overlays onto the request it mints (see TestModernCallTool_LogLevelGating).
 func (h *httpBackendClient) enableBackendLogging(
-	ctx context.Context, c *client.Client, caps *mcp.ServerCapabilities, backendID string,
+	ctx context.Context, c *client.Client, caps *mcp.ServerCapabilities,
+	negotiatedVersion, backendID string,
 ) {
 	if h.forwarders.Load() == nil {
 		return
 	}
 	if caps == nil || caps.Logging == nil {
+		return
+	}
+	// The 2026-07-28 revision REMOVED logging/setLevel; the per-request
+	// io.modelcontextprotocol/logLevel _meta key replaces it (see
+	// mcpparser.MetaKeyLogLevel, which the Modern path already mints).
+	//
+	// A dual-era backend can negotiate 2026-07-28 over this Legacy handshake,
+	// and the session then MUST carry that version on every request. go-sdk
+	// still sends setLevel as a Legacy-shaped call, so the request arrives with
+	// a Modern protocol header and no Modern _meta -- a shape ToolHive's
+	// classifier rejects with -32020, deliberately and by a pinned contract
+	// (see TestIntegration_Modern_RealBackend_LoggingContract). go-sdk treats
+	// that rejection as fatal, closing the session and failing the tool call
+	// this logging was only meant to decorate.
+	//
+	// Calling an RPC the negotiated revision removed is the actual defect, so
+	// skip it. Backends that negotiate a Legacy version are unaffected.
+	if negotiatedVersion == mcpparser.MCPVersionModern {
+		slog.DebugContext(ctx, "skipping logging/setLevel: removed in the negotiated revision",
+			"backend", backendID, "negotiated", negotiatedVersion)
 		return
 	}
 	if err := c.SetLoggingLevel(ctx, mcp.LoggingLevelDebug); err != nil {

--- a/pkg/vmcp/client/reclassify_test.go
+++ b/pkg/vmcp/client/reclassify_test.go
@@ -355,7 +355,7 @@ func TestLegacyInit_SelfHealsRevisionCache(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
 
-	_, err = h.legacyInit(context.Background(), c, target)
+	_, _, err = h.legacyInit(context.Background(), c, target)
 	require.NoError(t, err, "the SDK client negotiates Modern transparently on the Legacy path")
 
 	rev, _ := h.cachedRevision(target.WorkloadID)

--- a/pkg/vmcp/client/revision_realbackend_test.go
+++ b/pkg/vmcp/client/revision_realbackend_test.go
@@ -33,10 +33,12 @@ import (
 // knob that determines whether the backend answers server/discover with
 // 2026-07-28 in supportedVersions (Modern) or negotiates it away (Legacy); see
 // TestProbeRevision_RealBackends.
-func newRealEchoServer(t *testing.T, stateless bool, onCallTool func(mcpmcp.CallToolRequest)) *httptest.Server {
+func newRealEchoServer(
+	t *testing.T, stateless bool, onCallTool func(mcpmcp.CallToolRequest), srvOpts ...mcpserver.ServerOption,
+) *httptest.Server {
 	t.Helper()
 
-	mcpSrv := mcpserver.NewMCPServer("real-backend", "1.0.0")
+	mcpSrv := mcpserver.NewMCPServer("real-backend", "1.0.0", srvOpts...)
 	mcpSrv.AddTool(
 		mcpmcp.NewTool("echo",
 			mcpmcp.WithDescription("Echoes the input back"),
@@ -236,6 +238,34 @@ func TestCallTool_MisCachedLegacy_ForwardingAgainstStatelessBackend(t *testing.T
 		"a successful mis-cached-Legacy call self-heals the cache to Modern")
 }
 
+// newRecordingEchoServer is a real go-sdk backend that advertises the logging
+// capability and reports every JSON-RPC method it receives.
+func newRecordingEchoServer(t *testing.T, onMethod func(method string)) *httptest.Server {
+	t.Helper()
+
+	backend := newRealEchoServer(t, false, nil, mcpserver.WithLogging())
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+	rp := httputil.NewSingleHostReverseProxy(backendURL)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		require.NoError(t, readErr)
+		r.Body = io.NopCloser(bytes.NewReader(body))
+
+		var probe struct {
+			Method string `json:"method"`
+		}
+		_ = json.Unmarshal(body, &probe)
+		if probe.Method != "" && onMethod != nil {
+			onMethod(probe.Method)
+		}
+		rp.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
 // newHintLyingServer emulates github-mcp-server v1.6.0's dual-era behaviour: a
 // backend that negotiates 2026-07-28 on the Legacy initialize handshake while
 // answering server/discover with a body that is NOT a valid Modern envelope
@@ -247,8 +277,18 @@ func TestCallTool_MisCachedLegacy_ForwardingAgainstStatelessBackend(t *testing.T
 // discover body that produces the mismatch.
 func newHintLyingServer(t *testing.T) *httptest.Server {
 	t.Helper()
+	return newHintLyingServerRecording(t, nil)
+}
 
-	backend := newRealEchoServer(t, true, nil) // stateless => negotiates 2026-07-28
+// newHintLyingServerRecording is newHintLyingServer with a hook invoked for
+// every JSON-RPC method the backend receives.
+func newHintLyingServerRecording(t *testing.T, onMethod func(method string)) *httptest.Server {
+	t.Helper()
+
+	// WithLogging so the backend advertises the logging capability: without it
+	// enableBackendLogging returns before ever reaching the version check, and
+	// a test asserting setLevel is not sent would pass vacuously.
+	backend := newRealEchoServer(t, true, nil, mcpserver.WithLogging()) // stateless => negotiates 2026-07-28
 	backendURL, err := url.Parse(backend.URL)
 	require.NoError(t, err)
 	rp := httputil.NewSingleHostReverseProxy(backendURL)
@@ -257,6 +297,16 @@ func newHintLyingServer(t *testing.T) *httptest.Server {
 		body, readErr := io.ReadAll(r.Body)
 		require.NoError(t, readErr)
 		r.Body = io.NopCloser(bytes.NewReader(body))
+
+		if onMethod != nil {
+			var probe struct {
+				Method string `json:"method"`
+			}
+			_ = json.Unmarshal(body, &probe)
+			if probe.Method != "" {
+				onMethod(probe.Method)
+			}
+		}
 
 		if !bytes.Contains(body, []byte(`"server/discover"`)) {
 			rp.ServeHTTP(w, r)
@@ -312,5 +362,80 @@ func TestLegacyInit_DoesNotPromoteOnHandshakeHintAlone(t *testing.T) {
 		require.True(t, ok, "revision should be cached after call %d", i)
 		assert.Equal(t, mcpparser.RevisionLegacy, rev,
 			"cached revision must stay Legacy after call %d; flipping to Modern is the #6154 oscillation", i)
+	}
+}
+
+// TestEnableBackendLogging_SkipsRemovedRPCOnModernSession pins the fix for
+// tool calls dying against a dual-era backend.
+//
+// A backend that negotiates 2026-07-28 over the LEGACY initialize handshake
+// leaves the session obliged to carry that version on every request. go-sdk
+// still sends logging/setLevel as a Legacy-shaped call, so it arrives with a
+// Modern protocol header and no Modern _meta -- a shape ToolHive's classifier
+// rejects with -32020 by a deliberate, pinned contract (see
+// TestIntegration_Modern_RealBackend_LoggingContract in pkg/vmcp/server).
+// go-sdk treats that rejection as fatal, so the session closes and the tool
+// call the logging was only meant to decorate dies with it.
+//
+// The RPC was removed in 2026-07-28, so issuing it on a session that
+// negotiated that revision is the defect. Legacy sessions must still get it.
+func TestEnableBackendLogging_SkipsRemovedRPCOnModernSession(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		negotiated       string
+		wantSetLevelSent bool
+	}{
+		{
+			name:             "modern negotiated: removed RPC is skipped",
+			negotiated:       mcpparser.MCPVersionModern,
+			wantSetLevelSent: false,
+		},
+		{
+			name:             "legacy negotiated: RPC is still sent",
+			negotiated:       mcpparser.MCPVersionLegacy,
+			wantSetLevelSent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mu sync.Mutex
+			var sawSetLevel bool
+			srv := newRecordingEchoServer(t, func(method string) {
+				if method == "logging/setLevel" {
+					mu.Lock()
+					sawSetLevel = true
+					mu.Unlock()
+				}
+			})
+
+			h := newProbeClient(t)
+			h.BindForwarders(&stubElicitationRequester{}, &stubSamplingRequester{}, stubClientNotifier{})
+			target := &vmcp.BackendTarget{
+				WorkloadID:    "b",
+				BaseURL:       srv.URL + "/mcp",
+				TransportType: "streamable-http",
+			}
+
+			c, err := h.clientFactory(context.Background(), target, true)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = c.Close() })
+
+			// The session must be live before SetLoggingLevel can reach the
+			// wire; an unconnected client fails inside the SDK instead.
+			_, _, err = h.legacyInit(context.Background(), c, target)
+			require.NoError(t, err)
+
+			caps := &mcpmcp.ServerCapabilities{Logging: &struct{}{}}
+			h.enableBackendLogging(context.Background(), c, caps, tt.negotiated, target.WorkloadID)
+
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Equal(t, tt.wantSetLevelSent, sawSetLevel)
+		})
 	}
 }


### PR DESCRIPTION
## Summary

vMCP tool calls against a dual-era stdio backend fail while the gateway reports healthy. Reproduced against `github-mcp-server` v1.6.0 over stdio:

```
backend unavailable: tool call failed on backend gh-c: connection closed:
  calling "tools/call": client is closing: sending "logging/setLevel":
  MCP-Protocol-Version header "2026-07-28" does not match _meta protocol version "": Bad Request
```

The chain:

1. `github-mcp-server` v1.6.0 negotiates `2026-07-28` over the **Legacy** `initialize` handshake, so the session must carry that version on every subsequent request.
2. `logging/setLevel` was **removed** in 2026-07-28 — the per-request `io.modelcontextprotocol/logLevel` `_meta` key replaces it, and the Modern path already mints it (`modern.go`).
3. go-sdk nonetheless sends `setLevel` as a Legacy-shaped call, so it arrives with a Modern protocol header and no Modern `_meta`.
4. The classifier rejects that shape with `-32020`, and go-sdk treats the rejection as **fatal** — the session closes and the tool call dies with it.

Skip the RPC when the negotiated version is Modern. Sessions that negotiate a Legacy version still get it. `legacyInit` now returns the negotiated version so the call site can decide; the four callers that do not need it discard it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (described below)

`TestEnableBackendLogging_SkipsRemovedRPCOnModernSession` is table-driven over both negotiated versions and asserts against a recording backend: Modern → not sent, Legacy → still sent. Verified to fail without the production change (`expected: false, actual: true` on the Modern case).

End-to-end A/B, real `tools/call` through a vMCP gateway to `github-mcp-server` v1.6.0 over stdio:

| | `tools/call` |
|---|---|
| `origin/main` | **fails** — `client is closing: sending "logging/setLevel"` |
| this branch | **succeeds** — returns the live GitHub payload |

Full `task test` run: only the 10 pre-existing `pkg/plugins/pluginsvc` failures, which reproduce identically on clean `origin/main`. `pkg/vmcp/server` — including `TestIntegration_Modern_RealBackend_LoggingContract` — is green.

## Does this introduce a user-facing change?

Yes. vMCP can call tools on dual-era stdio backends again, `github-mcp-server` v1.6.0 among them. Before this, such a gateway reported `Ready` with every health check passing and still failed every tool call.

## Special notes for reviewers

**Why not loosen the classifier.** My first attempt (#6184) classified `logging/setLevel` as Legacy-only. @jhrozek correctly caught that it breaks `TestIntegration_Modern_RealBackend_LoggingContract`, whose comment records a deliberate contract: go-sdk closed the upstream report **wont-fix-by-design**, so `-32020` is the standing answer for a caller using a removed RPC on a Modern session. That contract is right and this change leaves it intact. What it did not anticipate is the blast radius — its "worse than the failing upstream call" tradeoff assumed only the logging call fails, but the rejection closes the session and takes the tool call with it. Fixing the caller rather than the classifier resolves that without weakening the contract.

**Why this hid behind green health checks.** `enableBackendLogging` is called only from `legacyCallTool` — not from `ListCapabilities`, resources or prompts. Health checks and `tools/list` never send `setLevel`, so they stayed green while every tool call died. Worth knowing when reading vMCP health status: it does not exercise the tool-call path.

**Regression window.** The strict classifier shipped in v0.41.0 (#5839/#5884); v0.40.1's proxy answers the same request `{"result":{}}`. Verified by curling both builds directly.

Generated with [Claude Code](https://claude.com/claude-code)
