### PR TITLE
Reject tools/call for tools hidden from tools/list

### DIFF
--- a/pkg/vmcp/core/core_calls.go
+++ b/pkg/vmcp/core/core_calls.go
@@ -25,10 +25,12 @@ import (
 // from the same table. Returns vmcp.ErrNotFound for an unadvertised name and
 // vmcp.ErrAuthorizationFailed when admission denies identity the call.
 //
-// "Unadvertised" is enforced against the same view ListTools returns, NOT the
-// routing table — which intentionally holds more (see the advertised-view check
-// below). A tool hidden from tools/list is therefore not directly callable,
-// while composite workflow steps may still reach it.
+// "Unadvertised" here means the AGGREGATION view that ListTools filters — NOT
+// the routing table, which intentionally holds more (see the advertised-view
+// check below). Admission narrowing on top of that view is enforced separately,
+// by authorizeToolCall. So a tool hidden by excludeAllTools, per-workload
+// excludeAll, or filter is not directly callable, while composite workflow steps
+// may still reach it.
 //
 // args and meta are treated as read-only and copied before being forwarded
 // (go-style: copy before mutating caller input). The admission decision enforces
@@ -49,7 +51,18 @@ func (c *coreVMCP) CallTool(
 		return nil, err
 	}
 
-	if err := c.authorizeToolCall(ctx, identity, name, argsCopy, agg); err != nil {
+	// Resolve the advertised view ONCE and thread it through the three consumers
+	// below (admission, the not-found guard, the composite branch). Each of
+	// accessibleComposites and advertisedTools re-runs FilterWorkflowDefsForSession,
+	// ValidateNoToolConflicts and ConvertWorkflowDefsToTools, so computing them per
+	// consumer meant three passes and two concatenated-slice allocations per call.
+	// Sharing one result also removes any chance of the admission lookup and the
+	// guard below disagreeing about what is advertised.
+	composites := c.accessibleComposites(agg)
+	advertised := advertisedToolsWith(agg, composites)
+	tool := findAdvertisedTool(advertised, name)
+
+	if err := c.authorizeToolCall(ctx, identity, name, argsCopy, tool); err != nil {
 		return nil, err
 	}
 
@@ -67,13 +80,13 @@ func (c *coreVMCP) CallTool(
 	// denies must keep returning ErrAuthorizationFailed, never ErrNotFound, or the
 	// two errors together would let a caller probe which denied tools exist.
 	//
-	// advertisedTools includes accessible composites, so an advertised workflow
-	// still resolves here and falls through to the composite branch below. Note
-	// this also rejects RouteTool's "{workloadID}.{toolName}" alias
+	// advertised includes accessible composites, so an advertised workflow still
+	// resolves here and falls through to the composite branch below. Note this
+	// also rejects RouteTool's "{workloadID}.{toolName}" alias
 	// (router/session_router.go:105) for a direct call: an alias is never an
 	// advertised name. That alias exists for workflow step definitions and keeps
 	// working there, inside the composer.
-	if findAdvertisedTool(c.advertisedTools(agg), name) == nil {
+	if tool == nil {
 		return nil, fmt.Errorf("%w: tool %q", vmcp.ErrNotFound, name)
 	}
 
@@ -82,7 +95,7 @@ func (c *coreVMCP) CallTool(
 	// uses the same gate as ListTools (accessibleComposites), so advertised equals
 	// executed. A name that collides with a backend tool is NOT in the set and falls
 	// through to backend routing, matching the legacy decorator.
-	if def, ok := c.accessibleComposites(agg)[name]; ok {
+	if def, ok := composites[name]; ok {
 		engine := c.composerFactory(agg.RoutingTable, agg.Tools)
 		return executeComposite(ctx, engine, def, argsCopy)
 	}

--- a/pkg/vmcp/core/core_calls.go
+++ b/pkg/vmcp/core/core_calls.go
@@ -25,6 +25,11 @@ import (
 // from the same table. Returns vmcp.ErrNotFound for an unadvertised name and
 // vmcp.ErrAuthorizationFailed when admission denies identity the call.
 //
+// "Unadvertised" is enforced against the same view ListTools returns, NOT the
+// routing table — which intentionally holds more (see the advertised-view check
+// below). A tool hidden from tools/list is therefore not directly callable,
+// while composite workflow steps may still reach it.
+//
 // args and meta are treated as read-only and copied before being forwarded
 // (go-style: copy before mutating caller input). The admission decision enforces
 // the same policy ListTools filters on. identity is never logged. See ListTools
@@ -46,6 +51,30 @@ func (c *coreVMCP) CallTool(
 
 	if err := c.authorizeToolCall(ctx, identity, name, argsCopy, agg); err != nil {
 		return nil, err
+	}
+
+	// Hold the call to the ADVERTISED view, not the routing table. The routing
+	// table deliberately carries every backend tool — including those hidden from
+	// tools/list by excludeAllTools, per-workload excludeAll, or filter — so that
+	// composite-tool workflow STEPS can reach them (#3636,
+	// aggregator/default_aggregator.go:349). Workflow steps never come through
+	// here: a composite enters CallTool once under its own (advertised) name and
+	// its steps then run composer -> router.RouteTool -> backendClient.CallTool,
+	// bypassing this method. So narrowing to the advertised set closes direct
+	// invocation of a hidden tool without weakening #3636 at all.
+	//
+	// This is checked AFTER authorizeToolCall on purpose: a tool that admission
+	// denies must keep returning ErrAuthorizationFailed, never ErrNotFound, or the
+	// two errors together would let a caller probe which denied tools exist.
+	//
+	// advertisedTools includes accessible composites, so an advertised workflow
+	// still resolves here and falls through to the composite branch below. Note
+	// this also rejects RouteTool's "{workloadID}.{toolName}" alias
+	// (router/session_router.go:105) for a direct call: an alias is never an
+	// advertised name. That alias exists for workflow step definitions and keeps
+	// working there, inside the composer.
+	if findAdvertisedTool(c.advertisedTools(agg), name) == nil {
+		return nil, fmt.Errorf("%w: tool %q", vmcp.ErrNotFound, name)
 	}
 
 	// Composite tool: execute only when the workflow is actually advertised in the

--- a/pkg/vmcp/core/core_calls_test.go
+++ b/pkg/vmcp/core/core_calls_test.go
@@ -62,12 +62,54 @@ func TestCallTool_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, vmcp.ErrNotFound)
 }
 
+// TestCallTool_RejectsUnadvertisedRoutableTool is the hidden-tool regression
+// guard at the core boundary. The routing table intentionally holds EVERY backend
+// tool, including ones hidden from tools/list by excludeAllTools, per-workload
+// excludeAll, or filter, so that composite workflow steps can still reach them
+// (#3636, aggregator/default_aggregator.go:349). Before this guard, CallTool
+// resolved a name straight against that table, so a hidden tool was directly
+// callable by name — its ErrNotFound contract was documented but unenforced.
+//
+// The Times(0) on the backend client is the real security assertion: an
+// ErrNotFound alone would still pass if the call had already been forwarded to
+// the backend and only the response discarded.
+func TestCallTool_RejectsUnadvertisedRoutableTool(t *testing.T) {
+	t.Parallel()
+	cfg, m := baseConfig(t)
+
+	target := backendTarget()
+	expectAggregation(m, &aggregator.AggregatedCapabilities{
+		// "hidden" is routable but NOT advertised — exactly the shape excludeAll
+		// and filter produce.
+		Tools: []vmcp.Tool{backendTool("visible")},
+		RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{
+			"visible": target,
+			"hidden":  target,
+		}},
+	})
+
+	m.client.EXPECT().
+		CallTool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	c, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.CallTool(context.Background(), nil, "hidden", nil, nil)
+	assert.ErrorIs(t, err, vmcp.ErrNotFound,
+		"a routable-but-unadvertised tool must not be directly callable")
+}
+
 func TestCallTool_CopyBeforeMutate(t *testing.T) {
 	t.Parallel()
 	cfg, m := baseConfig(t)
 
 	target := backendTarget()
 	expectAggregation(m, &aggregator.AggregatedCapabilities{
+		// Advertised as well as routable: CallTool holds a direct call to the
+		// advertised view, so a routing-table-only entry would not reach the backend.
+		Tools:        []vmcp.Tool{backendTool("tool_a")},
 		RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"tool_a": target}},
 	})
 
@@ -242,31 +284,60 @@ func TestGetPrompt_NotFound(t *testing.T) {
 }
 
 // TestCallTool_ResolvesRenamedTool exercises the conflict-resolution name path:
-// the advertised name uses the dot convention ("be1.echo") while the routing
-// table is keyed by the prefixed resolved name ("be1_echo") whose target carries
-// a non-empty OriginalCapabilityName. The session router resolves it via
-// GetBackendCapabilityName, and the core forwards the advertised name to the
-// client (the client owns the translation to the backend's capability name).
+// the advertised and routing-table name is the prefixed resolved name
+// ("be1_echo") whose target carries a non-empty OriginalCapabilityName. The core
+// forwards the advertised name to the client, which owns the translation to the
+// backend's capability name ("echo").
+//
+// The second leg pins the narrowing this test used to contradict: RouteTool also
+// accepts the "{workloadID}.{toolName}" alias ("be1.echo",
+// router/session_router.go:105), but an alias is not an ADVERTISED name, so a
+// direct CallTool on it is ErrNotFound. The alias exists for composite workflow
+// step definitions and still resolves there, inside the composer — the step path
+// never enters CallTool (see TestCallTool_CompositeWorkflow, whose step targets
+// "be1.echo").
 func TestCallTool_ResolvesRenamedTool(t *testing.T) {
 	t.Parallel()
-	cfg, m := baseConfig(t)
 
 	target := &vmcp.BackendTarget{WorkloadID: "be1", OriginalCapabilityName: "echo", BaseURL: "http://be1:8080"}
-	expectAggregation(m, &aggregator.AggregatedCapabilities{
-		Tools:        []vmcp.Tool{{Name: "be1_echo", BackendID: "be1"}},
-		RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"be1_echo": target}},
+	caps := func() *aggregator.AggregatedCapabilities {
+		return &aggregator.AggregatedCapabilities{
+			Tools:        []vmcp.Tool{{Name: "be1_echo", BackendID: "be1"}},
+			RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{"be1_echo": target}},
+		}
+	}
+
+	t.Run("advertised resolved name routes to the backend", func(t *testing.T) {
+		t.Parallel()
+		cfg, m := baseConfig(t)
+		expectAggregation(m, caps())
+
+		m.client.EXPECT().
+			CallTool(gomock.Any(), target, "be1_echo", gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&vmcp.ToolCallResult{}, nil)
+
+		c, err := New(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = c.Close() })
+
+		_, err = c.CallTool(context.Background(), nil, "be1_echo", nil, nil)
+		require.NoError(t, err)
 	})
 
-	m.client.EXPECT().
-		CallTool(gomock.Any(), target, "be1.echo", gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&vmcp.ToolCallResult{}, nil)
+	t.Run("dot alias of an advertised tool is not directly callable", func(t *testing.T) {
+		t.Parallel()
+		cfg, m := baseConfig(t)
+		expectAggregation(m, caps())
 
-	c, err := New(cfg)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = c.Close() })
+		// No client EXPECT: the alias must be rejected before any backend call.
+		c, err := New(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = c.Close() })
 
-	_, err = c.CallTool(context.Background(), nil, "be1.echo", nil, nil)
-	require.NoError(t, err)
+		_, err = c.CallTool(context.Background(), nil, "be1.echo", nil, nil)
+		assert.ErrorIs(t, err, vmcp.ErrNotFound,
+			"the routing-table alias is not an advertised name, so a direct call must not resolve it")
+	})
 }
 
 // TestCompositeNameConflict_AdvertisedEqualsExecuted is the F1 parity guard: when a

--- a/pkg/vmcp/core/core_calls_test.go
+++ b/pkg/vmcp/core/core_calls_test.go
@@ -294,8 +294,10 @@ func TestGetPrompt_NotFound(t *testing.T) {
 // router/session_router.go:105), but an alias is not an ADVERTISED name, so a
 // direct CallTool on it is ErrNotFound. The alias exists for composite workflow
 // step definitions and still resolves there, inside the composer — the step path
-// never enters CallTool (see TestCallTool_CompositeWorkflow, whose step targets
-// "be1.echo").
+// never enters CallTool. Note that TestCallTool_CompositeWorkflow does NOT cover
+// the alias fallback: it registers "be1.echo" as an exact routing-table key, so
+// RouteTool's fast path answers and the fallback never runs. The third leg below
+// is what actually drives it.
 func TestCallTool_ResolvesRenamedTool(t *testing.T) {
 	t.Parallel()
 
@@ -337,6 +339,36 @@ func TestCallTool_ResolvesRenamedTool(t *testing.T) {
 		_, err = c.CallTool(context.Background(), nil, "be1.echo", nil, nil)
 		assert.ErrorIs(t, err, vmcp.ErrNotFound,
 			"the routing-table alias is not an advertised name, so a direct call must not resolve it")
+	})
+
+	// The guarantee the alias actually exists for, and the only test in the suite
+	// that drives RouteTool's dot-convention FALLBACK (session_router.go:110-118)
+	// rather than its exact-key fast path: a workflow step written "be1.echo"
+	// still resolves after conflict resolution rekeyed the table to "be1_echo".
+	// Without this leg, rejecting the alias for direct calls would leave the
+	// fallback with no coverage at all.
+	t.Run("composite step reaches the backend through the dot-alias fallback", func(t *testing.T) {
+		t.Parallel()
+		cfg, m := baseConfig(t)
+		cfg.WorkflowDefs = map[string]*composer.WorkflowDefinition{
+			"wf": {Name: "wf", Steps: []composer.WorkflowStep{
+				{ID: "s1", Type: composer.StepTypeTool, Tool: "be1.echo"},
+			}},
+		}
+		expectAggregation(m, caps())
+
+		// The step's "be1.echo" is NOT a routing-table key (the table holds only
+		// "be1_echo"), so reaching the backend here proves the fallback resolved it.
+		m.client.EXPECT().
+			CallTool(gomock.Any(), target, "be1.echo", gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&vmcp.ToolCallResult{StructuredContent: map[string]any{"ok": true}}, nil)
+
+		c, err := New(cfg)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = c.Close() })
+
+		_, err = c.CallTool(context.Background(), nil, "wf", nil, nil)
+		require.NoError(t, err)
 	})
 }
 

--- a/pkg/vmcp/core/core_checks.go
+++ b/pkg/vmcp/core/core_checks.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/vmcp"
-	"github.com/stacklok/toolhive/pkg/vmcp/aggregator"
 )
 
 // CheckToolCall runs the CallTool admission decision without invoking the tool.
@@ -35,7 +34,7 @@ func (c *coreVMCP) CheckToolCall(ctx context.Context, identity *auth.Identity, n
 		// it through existing mapping, rather than converting infra faults into 403s.
 		return err
 	}
-	return c.authorizeToolCall(ctx, identity, name, args, agg)
+	return c.authorizeToolCall(ctx, identity, name, args, findAdvertisedTool(c.advertisedTools(agg), name))
 }
 
 // CheckResourceRead runs the ReadResource admission decision without reading the
@@ -53,30 +52,29 @@ func (c *coreVMCP) CheckPromptGet(ctx context.Context, identity *auth.Identity, 
 }
 
 // authorizeToolCall runs the CALL-side admission decision for name with args,
-// sourcing the tool's annotations from the caller-supplied advertised view (agg)
-// so annotation-gated policies evaluate. It returns nil when allowed and an error
+// sourcing the tool's annotations from the caller-supplied advertised entry so
+// annotation-gated policies evaluate. It returns nil when allowed and an error
 // wrapping vmcp.ErrAuthorizationFailed on deny AND on an authorizer error (fail
 // closed), classified so the Serve adapter can distinguish it from a transport
 // failure via errors.Is — mirroring the live authorizeAndServe. The underlying
 // error is preserved in the chain for server-side diagnostics.
 //
 // This is the single source of truth for the tool-call decision: both CallTool
-// (before dispatch) and CheckToolCall (pre-flight) call it with the same agg, so
-// the two can never drift. args is treated as read-only.
+// (before dispatch) and CheckToolCall (pre-flight) resolve the tool the same way
+// (findAdvertisedTool over the advertised view) and hand it here, so the two
+// cannot drift. args is treated as read-only.
 //
-// A name absent from the advertised set carries no annotations, so an
-// annotation-gated decision evaluates with no hints (and may deny). In normal
-// operation the advertised set and the routing table are derived from the same
-// aggregation, so this only arises if they diverge. advertisedTools includes
-// composites, so their annotations are sourced too.
+// tool is nil when name is absent from the advertised set; the decision then runs
+// against a bare stub carrying only the name, so an annotation-gated policy
+// evaluates with no hints (and may deny). CallTool rejects an absent name outright
+// but only AFTER this call: the denial must win over not-found (see CallTool).
 func (c *coreVMCP) authorizeToolCall(
 	ctx context.Context,
 	identity *auth.Identity,
 	name string,
 	args map[string]any,
-	agg *aggregator.AggregatedCapabilities,
+	tool *vmcp.Tool,
 ) error {
-	tool := findAdvertisedTool(c.advertisedTools(agg), name)
 	if tool == nil {
 		tool = &vmcp.Tool{Name: name}
 	}

--- a/pkg/vmcp/core/core_checks_test.go
+++ b/pkg/vmcp/core/core_checks_test.go
@@ -109,6 +109,43 @@ func TestCheckResourceRead_AllowDenyFailClosed_NoAggregation(t *testing.T) {
 		vmcp.ErrAuthorizationFailed, "authorizer error must fail closed")
 }
 
+// TestCallTool_DenialPrecedesNotFound pins the ORDER of CallTool's two rejections.
+// A tool that is both hidden from tools/list and denied by policy must report the
+// DENIAL, not ErrNotFound: if the advertised-view check ran first, the pair of
+// answers would become an oracle — ErrNotFound for "hidden and denied" vs.
+// ErrAuthorizationFailed for "advertised but denied" would tell an unauthorized
+// caller which hidden tools exist.
+//
+// "hidden" is routable but unadvertised, and the authorizer denies it. The
+// advertised "visible" tool proves the same authorizer produces a denial (not a
+// not-found) for a name that IS in the view, so the two legs differ only in
+// advertising.
+func TestCallTool_DenialPrecedesNotFound(t *testing.T) {
+	t.Parallel()
+	_, m := baseConfig(t)
+
+	// Neither name is authorized: mockAuthorizer denies anything absent from results.
+	c := checkCore(m, newCedarAdmission(&mockAuthorizer{results: map[string]mockResult{}}))
+	target := backendTarget()
+	expectAggregationAnyTimes(m, &aggregator.AggregatedCapabilities{
+		Tools: []vmcp.Tool{backendTool("visible")},
+		RoutingTable: &vmcp.RoutingTable{Tools: map[string]*vmcp.BackendTarget{
+			"visible": target,
+			"hidden":  target,
+		}},
+	})
+
+	_, hiddenErr := c.CallTool(t.Context(), cedarIdentity(), "hidden", nil, nil)
+	assert.ErrorIs(t, hiddenErr, vmcp.ErrAuthorizationFailed,
+		"a denied tool must report the denial even when it is also unadvertised")
+	assert.NotErrorIs(t, hiddenErr, vmcp.ErrNotFound,
+		"reporting not-found for a denied hidden tool would leak which hidden tools exist")
+
+	_, visibleErr := c.CallTool(t.Context(), cedarIdentity(), "visible", nil, nil)
+	assert.ErrorIs(t, visibleErr, vmcp.ErrAuthorizationFailed,
+		"an advertised-but-denied tool must be indistinguishable from a hidden denied one")
+}
+
 func TestCheckPromptGet_AllowDenyFailClosed_NoAggregation(t *testing.T) {
 	t.Parallel()
 	_, m := baseConfig(t)

--- a/pkg/vmcp/core/core_vmcp.go
+++ b/pkg/vmcp/core/core_vmcp.go
@@ -633,7 +633,17 @@ func (c *coreVMCP) authorizedBackends(
 // may only SUBTRACT reachability ([VMCP] contract), so the core is the only layer
 // that can advertise them.
 func (c *coreVMCP) advertisedTools(agg *aggregator.AggregatedCapabilities) []vmcp.Tool {
-	defs := c.accessibleComposites(agg)
+	return advertisedToolsWith(agg, c.accessibleComposites(agg))
+}
+
+// advertisedToolsWith is advertisedTools against an ALREADY-RESOLVED composite set.
+// CallTool needs the same composites map for its own dispatch, and resolving it is
+// not free (FilterWorkflowDefsForSession + ValidateNoToolConflicts +
+// ConvertWorkflowDefsToTools), so it resolves once and passes the result here
+// rather than having this recompute it.
+func advertisedToolsWith(
+	agg *aggregator.AggregatedCapabilities, defs map[string]*composer.WorkflowDefinition,
+) []vmcp.Tool {
 	if len(defs) == 0 {
 		return agg.Tools
 	}

--- a/pkg/vmcp/server/hidden_tool_regression_test.go
+++ b/pkg/vmcp/server/hidden_tool_regression_test.go
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/composer"
+	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
+)
+
+// backendCallRecorder records the tool name of every call that reaches
+// BackendClient.CallTool. Asserting a name is ABSENT here is what proves the
+// request was rejected before dispatch: a JSON-RPC error alone would also be
+// produced if vMCP had forwarded the call to the backend and then discarded the
+// response.
+type backendCallRecorder struct {
+	mu    sync.Mutex
+	names []string
+}
+
+func (r *backendCallRecorder) record(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.names = append(r.names, name)
+}
+
+func (r *backendCallRecorder) got() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.names...)
+}
+
+// TestRegression_HiddenToolNotDirectlyCallable is the two-directional guard for
+// the tool-visibility invariant:
+//
+//	ADVERTISED == DIRECTLY CALLABLE, while the routing table stays deliberately
+//	WIDER so composite workflow steps can reach hidden tools.
+//
+// The aggregator puts EVERY backend tool in the routing table, including those
+// hidden from tools/list by excludeAllTools, per-workload excludeAll, or filter
+// (default_aggregator.go:349) — on purpose, so a composite tool can call a tool
+// its operator chose not to expose (#3636). core.CallTool used to resolve a
+// direct call against that same table, so a hidden tool was callable by name; on
+// the Modern (2026-07-28) path, where tools/call goes straight to core.CallTool,
+// that was reachable straight off the wire.
+//
+// BOTH directions are asserted because they must move in opposite directions, and
+// a single-direction test is exactly what let the bug ship:
+//
+//   - "hidden_tool is rejected AND never reaches the backend" fails if the
+//     advertised-view check in core.CallTool is reverted.
+//   - "a composite whose step targets hidden_tool still succeeds, and the backend
+//     DOES receive hidden_tool" fails if someone instead 'fixes' this by pruning
+//     hidden tools from the routing table — which would silently re-break #3636.
+//
+// Both eras are covered: Legacy is protected only by the SDK registering
+// advertised names on the session, so pinning it here keeps the two paths from
+// drifting apart again.
+func TestRegression_HiddenToolNotDirectlyCallable(t *testing.T) {
+	t.Parallel()
+
+	const (
+		visibleTool  = "visible_tool"
+		hiddenTool   = "hidden_tool"
+		compositeWF  = "wf_using_hidden"
+		schemaObject = "object"
+	)
+
+	// newFixture builds a server whose advertised set is {visible_tool} while the
+	// routing table also holds hidden_tool, plus one composite workflow whose only
+	// step targets the hidden tool. factory is the session factory: the Legacy leg
+	// needs one that stubs GetMetadataValue (enforceSessionBinding reads the
+	// identity binding through it on every tools/call), which newNoopMockFactory
+	// does not.
+	newFixture := func(t *testing.T, factory vmcpsession.MultiSessionFactory) (string, *backendCallRecorder) {
+		t.Helper()
+		rec := &backendCallRecorder{}
+		ts := buildTestServerWithOptions(t, factory, serverOptions{
+			tools: []vmcp.Tool{{
+				Name:        visibleTool,
+				Description: "advertised",
+				InputSchema: map[string]any{"type": schemaObject},
+			}},
+			hiddenTools: []vmcp.Tool{{
+				Name:        hiddenTool,
+				Description: "routable but withheld from tools/list",
+				InputSchema: map[string]any{"type": schemaObject},
+			}},
+			workflowDefs: map[string]*composer.WorkflowDefinition{
+				compositeWF: {
+					Name: compositeWF,
+					Steps: []composer.WorkflowStep{
+						{ID: "s1", Type: composer.StepTypeTool, Tool: hiddenTool},
+					},
+				},
+			},
+			onBackendCall: func(name string) { rec.record(name) },
+		})
+		return ts.URL, rec
+	}
+
+	t.Run("modern", func(t *testing.T) {
+		t.Parallel()
+		baseURL, rec := newFixture(t, newNoopMockFactory(t))
+
+		// tools/list must not leak the hidden tool.
+		listResp, listBody := postModern(t, baseURL, "tools/list", nil, 1, "")
+		defer listResp.Body.Close()
+		require.Equal(t, http.StatusOK, listResp.StatusCode, "decoded: %+v", listBody)
+		advertised := modernToolNames(t, listBody)
+		assert.Contains(t, advertised, visibleTool)
+		assert.NotContains(t, advertised, hiddenTool,
+			"a tool hidden by excludeAll/filter must not appear in tools/list")
+
+		// The advertised tool is callable, proving the fixture's happy path works and
+		// the rejection below is about visibility, not a broken harness.
+		okResp, okBody := postModern(t, baseURL, "tools/call",
+			map[string]any{"name": visibleTool, "arguments": map[string]any{}}, 2, visibleTool)
+		defer okResp.Body.Close()
+		assert.Equal(t, http.StatusOK, okResp.StatusCode, "decoded: %+v", okBody)
+		assert.NotContains(t, okBody, "error", "an advertised tool must remain callable: %+v", okBody)
+
+		// THE REGRESSION: calling the hidden tool by name must be refused with
+		// -32602 (HTTP 400), matching what the Legacy SDK path answers for a tool it
+		// never registered — not -32603, and certainly not a success.
+		hiddenResp, hiddenBody := postModern(t, baseURL, "tools/call",
+			map[string]any{"name": hiddenTool, "arguments": map[string]any{}}, 3, hiddenTool)
+		defer hiddenResp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, hiddenResp.StatusCode,
+			"an unadvertised tool name is caller input, so it must map to HTTP 400: %+v", hiddenBody)
+		errObj, ok := hiddenBody["error"].(map[string]any)
+		require.True(t, ok, "expected a JSON-RPC error envelope, got %+v", hiddenBody)
+		assert.Equal(t, float64(-32602), errObj["code"],
+			"a hidden tool must be answered as an unknown tool, not laundered into -32603")
+
+		// The security assertion: the call was refused BEFORE reaching the backend.
+		assert.NotContains(t, rec.got(), hiddenTool,
+			"vMCP must never forward a direct call to a tool hidden from tools/list")
+
+		// THE COUNTERWEIGHT: a composite tool whose step targets the hidden tool must
+		// still work, and the backend must actually receive the hidden tool name.
+		// This is what fails if the routing table is pruned instead (#3636).
+		wfResp, wfBody := postModern(t, baseURL, "tools/call",
+			map[string]any{"name": compositeWF, "arguments": map[string]any{}}, 4, compositeWF)
+		defer wfResp.Body.Close()
+		require.Equal(t, http.StatusOK, wfResp.StatusCode, "decoded: %+v", wfBody)
+		assert.Contains(t, rec.got(), hiddenTool,
+			"a composite workflow step must still reach a hidden backend tool (#3636)")
+	})
+
+	t.Run("legacy", func(t *testing.T) {
+		t.Parallel()
+		// The Serve path sources the advertised set from the aggregator, not the
+		// factory, so newMockFactory's tool argument only shapes its own routing
+		// table; it is used here for its GetMetadataValue stub.
+		factory, _ := newMockFactory(t, gomock.NewController(t), nil)
+		baseURL, rec := newFixture(t, factory)
+		sessionID := legacyInitialize(t, baseURL)
+
+		listBody := legacyCall(t, baseURL, sessionID, 2, "tools/list", nil)
+		assert.Contains(t, listBody, visibleTool)
+		assert.NotContains(t, listBody, hiddenTool,
+			"a tool hidden by excludeAll/filter must not appear in tools/list")
+
+		// Legacy has no dispatcher-level classification: the SDK simply never
+		// registered the hidden tool on the session, so it answers -32602 "unknown
+		// tool". Asserting the code (not just "some error") is what keeps the two
+		// eras from drifting apart on the same input.
+		hiddenBody := legacyCall(t, baseURL, sessionID, 3, "tools/call",
+			map[string]any{"name": hiddenTool, "arguments": map[string]any{}})
+		assert.Contains(t, hiddenBody, "-32602",
+			"Legacy must also refuse a hidden tool as an unknown tool: %s", hiddenBody)
+		assert.NotContains(t, rec.got(), hiddenTool,
+			"vMCP must never forward a direct call to a tool hidden from tools/list")
+
+		// Same counterweight as the Modern leg.
+		legacyCall(t, baseURL, sessionID, 4, "tools/call",
+			map[string]any{"name": compositeWF, "arguments": map[string]any{}})
+		assert.Contains(t, rec.got(), hiddenTool,
+			"a composite workflow step must still reach a hidden backend tool (#3636)")
+	})
+}
+
+// modernToolNames extracts result.tools[].name from a Modern tools/list envelope.
+func modernToolNames(t *testing.T, decoded map[string]any) []string {
+	t.Helper()
+	result, ok := decoded["result"].(map[string]any)
+	require.True(t, ok, "expected a result object, got %+v", decoded)
+	raw, ok := result["tools"].([]any)
+	require.True(t, ok, "expected result.tools, got %+v", result)
+	names := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		tool, ok := entry.(map[string]any)
+		require.True(t, ok, "expected a tool object, got %T", entry)
+		name, ok := tool["name"].(string)
+		require.True(t, ok, "expected tool.name, got %+v", tool)
+		names = append(names, name)
+	}
+	return names
+}
+
+// legacyInitialize performs the Legacy (session-based) handshake and returns the
+// session ID every subsequent request must carry.
+func legacyInitialize(t *testing.T, baseURL string) string {
+	t.Helper()
+	resp := postMCP(t, baseURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	}, "")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "initialize should succeed")
+	sessionID := resp.Header.Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID, "initialize must return a session ID")
+	return sessionID
+}
+
+// legacyCall sends a Legacy JSON-RPC request on an established session and returns
+// the raw response body. The body is returned as a string rather than a decoded
+// envelope because the SDK's streamable transport may answer as SSE, and these
+// assertions only need substring presence/absence of tool names and error codes.
+func legacyCall(t *testing.T, baseURL, sessionID string, id int, method string, params map[string]any) string {
+	t.Helper()
+	body := map[string]any{"jsonrpc": "2.0", "id": id, "method": method}
+	if params != nil {
+		body["params"] = params
+	}
+	resp := postMCP(t, baseURL, body, sessionID)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "%s should be answered; body: %s", method, string(raw))
+	// Sanity: the body must be a JSON-RPC payload (possibly SSE-framed), not empty.
+	require.NotEmpty(t, raw, "%s returned an empty body", method)
+	return string(raw)
+}

--- a/pkg/vmcp/server/hidden_tool_regression_test.go
+++ b/pkg/vmcp/server/hidden_tool_regression_test.go
@@ -4,6 +4,7 @@
 package server_test
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"sync"
@@ -167,19 +168,22 @@ func TestRegression_HiddenToolNotDirectlyCallable(t *testing.T) {
 		baseURL, rec := newFixture(t, factory)
 		sessionID := legacyInitialize(t, baseURL)
 
-		listBody := legacyCall(t, baseURL, sessionID, 2, "tools/list", nil)
-		assert.Contains(t, listBody, visibleTool)
-		assert.NotContains(t, listBody, hiddenTool,
+		names := listToolNames(t, baseURL, sessionID)
+		assert.Contains(t, names, visibleTool)
+		assert.NotContains(t, names, hiddenTool,
 			"a tool hidden by excludeAll/filter must not appear in tools/list")
 
 		// Legacy has no dispatcher-level classification: the SDK simply never
-		// registered the hidden tool on the session, so it answers -32602 "unknown
-		// tool". Asserting the code (not just "some error") is what keeps the two
-		// eras from drifting apart on the same input.
-		hiddenBody := legacyCall(t, baseURL, sessionID, 3, "tools/call",
-			map[string]any{"name": hiddenTool, "arguments": map[string]any{}})
-		assert.Contains(t, hiddenBody, "-32602",
-			"Legacy must also refuse a hidden tool as an unknown tool: %s", hiddenBody)
+		// registered the hidden tool on the session, so it answers -32602. Asserting
+		// the decoded error.code (not a substring of the body) is what keeps the two
+		// eras from drifting apart on the same input -- this is the same assertion
+		// the Modern leg makes above, so a divergence in either direction fails.
+		// The message text does differ by era: toolhive-core's mcpcompat rewrites
+		// go-sdk's `unknown tool "X"` to `tool "X" not found`, so only the code is
+		// compared.
+		hiddenErr := legacyCallError(t, baseURL, sessionID, 3, hiddenTool)
+		assert.Equal(t, float64(-32602), hiddenErr["code"],
+			"Legacy must also refuse a hidden tool as an unknown tool: %+v", hiddenErr)
 		assert.NotContains(t, rec.got(), hiddenTool,
 			"vMCP must never forward a direct call to a tool hidden from tools/list")
 
@@ -231,9 +235,9 @@ func legacyInitialize(t *testing.T, baseURL string) string {
 }
 
 // legacyCall sends a Legacy JSON-RPC request on an established session and returns
-// the raw response body. The body is returned as a string rather than a decoded
-// envelope because the SDK's streamable transport may answer as SSE, and these
-// assertions only need substring presence/absence of tool names and error codes.
+// the raw response body. Used where only "the call was answered" matters (the
+// composite counterweight); assertions on an error envelope go through
+// legacyCallError, which decodes.
 func legacyCall(t *testing.T, baseURL, sessionID string, id int, method string, params map[string]any) string {
 	t.Helper()
 	body := map[string]any{"jsonrpc": "2.0", "id": id, "method": method}
@@ -248,4 +252,29 @@ func legacyCall(t *testing.T, baseURL, sessionID string, id int, method string, 
 	// Sanity: the body must be a JSON-RPC payload (possibly SSE-framed), not empty.
 	require.NotEmpty(t, raw, "%s returned an empty body", method)
 	return string(raw)
+}
+
+// legacyCallError issues a Legacy tools/call for toolName and returns the decoded
+// JSON-RPC `error` object, failing the test if the response carries no error.
+// Decoding (rather than substring-matching the body) is what makes this assertion
+// as strong as the Modern leg's: it pins error.code for THIS request rather than
+// accepting the digits appearing anywhere in the payload.
+func legacyCallError(t *testing.T, baseURL, sessionID string, id int, toolName string) map[string]any {
+	t.Helper()
+	resp := postMCP(t, baseURL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  "tools/call",
+		"params":  map[string]any{"name": toolName, "arguments": map[string]any{}},
+	}, sessionID)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var env struct {
+		Error map[string]any `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env), "tools/call response was not JSON: %s", string(raw))
+	require.NotNil(t, env.Error, "expected a JSON-RPC error envelope, got: %s", string(raw))
+	return env.Error
 }

--- a/pkg/vmcp/server/modern_dispatch.go
+++ b/pkg/vmcp/server/modern_dispatch.go
@@ -300,18 +300,28 @@ func (s *Server) dispatchModernToolCall(
 		// not launder into writeModernCallFailure's generic -32603. core.CallTool
 		// holds tools/call to the advertised view (core_calls.go), so this is the
 		// answer for a name hidden from tools/list by excludeAllTools/excludeAll/
-		// filter -- matching what the Legacy SDK path already returns for a tool it
-		// never registered on the session (-32602 "unknown tool", go-sdk
-		// server.go:957), which writeModernError maps to HTTP 400.
+		// filter -- matching what the Legacy path already returns for a tool it
+		// never registered on the session (-32602, via toolhive-core mcpcompat's
+		// translateUnknownToolError, which rewrites go-sdk's "unknown tool" message
+		// to `tool "X" not found`), which writeModernError maps to HTTP 400. Same
+		// code either way; the two eras differ only in message text.
 		//
 		// Deliberately NOT folded into writeModernDispatchError: that helper is
 		// shared with resources/read, prompts/get and completion/complete, whose
 		// not-found classification is a separate decision. The message names no
 		// tool: an authorization denial is classified ahead of this (in
-		// core.CallTool, which authorizes before checking the advertised view), and
-		// echoing the name back here would turn the pair of answers into a probe
-		// for which denied tools exist.
-		if errors.Is(err, vmcp.ErrNotFound) {
+		// core.CallTool, which authorizes before checking the advertised view).
+		// Omitting the name is a conservative choice rather than a mitigation --
+		// a denial already answers 403 + JSONRPCCodeDenied against this 400 +
+		// -32602, so the two are distinguishable either way.
+		//
+		// ErrAuthorizationFailed is excluded explicitly so this cannot depend on
+		// branch order: authorizeToolCall wraps with a double %w (core_checks.go:84),
+		// so errors.Is matches through both, and an Admission implementation whose
+		// error happened to carry ErrNotFound would otherwise answer 400 instead of
+		// 403. Not reachable today (pkg/authz does not import pkg/vmcp), but
+		// ErrNotFound is exported and Admission is a public interface.
+		if errors.Is(err, vmcp.ErrNotFound) && !errors.Is(err, vmcp.ErrAuthorizationFailed) {
 			writeModernError(w, parsed.ID, jsonRPCCodeInvalidParams, "unknown tool")
 			return
 		}

--- a/pkg/vmcp/server/modern_dispatch.go
+++ b/pkg/vmcp/server/modern_dispatch.go
@@ -296,6 +296,25 @@ func (s *Server) dispatchModernToolCall(
 	ctx, refusal := withCapabilityRefusalRecorder(ctx)
 	result, err := s.core.CallTool(ctx, identity, parsed.ResourceID, parsed.Arguments, parsed.Meta)
 	if err != nil {
+		// An unadvertised tool name is caller input, not a server fault, so it must
+		// not launder into writeModernCallFailure's generic -32603. core.CallTool
+		// holds tools/call to the advertised view (core_calls.go), so this is the
+		// answer for a name hidden from tools/list by excludeAllTools/excludeAll/
+		// filter -- matching what the Legacy SDK path already returns for a tool it
+		// never registered on the session (-32602 "unknown tool", go-sdk
+		// server.go:957), which writeModernError maps to HTTP 400.
+		//
+		// Deliberately NOT folded into writeModernDispatchError: that helper is
+		// shared with resources/read, prompts/get and completion/complete, whose
+		// not-found classification is a separate decision. The message names no
+		// tool: an authorization denial is classified ahead of this (in
+		// core.CallTool, which authorizes before checking the advertised view), and
+		// echoing the name back here would turn the pair of answers into a probe
+		// for which denied tools exist.
+		if errors.Is(err, vmcp.ErrNotFound) {
+			writeModernError(w, parsed.ID, jsonRPCCodeInvalidParams, "unknown tool")
+			return
+		}
 		writeModernCallFailure(w, parsed, refusal, vmcp.DenyMessageToolCall, err)
 		return
 	}

--- a/pkg/vmcp/server/session_management_integration_test.go
+++ b/pkg/vmcp/server/session_management_integration_test.go
@@ -157,9 +157,19 @@ type serverOptions struct {
 	// session factory), so tests provide it here; buildTestServerWithOptions builds a stub
 	// aggregator from it (and a routing table so composite-tool reachability and call
 	// routing work).
-	tools            []vmcp.Tool
+	tools []vmcp.Tool
+	// hiddenTools are put in the routing table but NOT the advertised list,
+	// reproducing what excludeAllTools / per-workload excludeAll / filter produce
+	// (aggregator/default_aggregator.go:349): routable so composite workflow steps
+	// can reach them, absent from tools/list. Used by the hidden-tool regression
+	// test; leave nil otherwise.
+	hiddenTools      []vmcp.Tool
 	workflowDefs     map[string]*composer.WorkflowDefinition
 	optimizerFactory func(context.Context, []mcpsdk.ServerTool) (optimizer.Optimizer, error)
+	// onBackendCall, when set, is invoked with the tool name of every call that
+	// reaches BackendClient.CallTool. Lets a test assert a name was never
+	// forwarded, which a response-level assertion alone cannot prove.
+	onBackendCall func(toolName string)
 }
 
 // capsFromTools builds the AggregatedCapabilities the stub aggregator returns: the tools
@@ -167,10 +177,16 @@ type serverOptions struct {
 // This mirrors the routing table the legacy mock session built (newMockFactory), so the
 // core advertises the tools, resolves composite-tool reachability, and routes tools/call
 // through BackendClient.CallTool.
-func capsFromTools(tools []vmcp.Tool) *aggregator.AggregatedCapabilities {
-	rt := &vmcp.RoutingTable{Tools: make(map[string]*vmcp.BackendTarget, len(tools))}
+//
+// hidden names land in the routing table only, never in the advertised list — see
+// serverOptions.hiddenTools.
+func capsFromTools(tools, hidden []vmcp.Tool) *aggregator.AggregatedCapabilities {
+	rt := &vmcp.RoutingTable{Tools: make(map[string]*vmcp.BackendTarget, len(tools)+len(hidden))}
 	for i := range tools {
 		rt.Tools[tools[i].Name] = &vmcp.BackendTarget{WorkloadID: tools[i].Name}
+	}
+	for i := range hidden {
+		rt.Tools[hidden[i].Name] = &vmcp.BackendTarget{WorkloadID: hidden[i].Name}
 	}
 	return &aggregator.AggregatedCapabilities{Tools: tools, RoutingTable: rt}
 }
@@ -210,10 +226,19 @@ func buildTestServerWithOptions(
 	// Stop is called when the server is stopped (not via httptest but via session manager cleanup).
 	// tools/call routes through core.CallTool → BackendClient.CallTool (the session factory's
 	// own CallTool is bypassed on the Serve path). Return a deterministic result so call
-	// tests can assert on it.
+	// tests can assert on it. opts.onBackendCall (when set) records the tool name each
+	// forwarded call carries, letting a test assert a name never reached the backend at all.
 	mockBackendClient.EXPECT().
 		CallTool(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&vmcp.ToolCallResult{Content: []vmcp.Content{{Type: "text", Text: "fake result"}}}, nil).
+		DoAndReturn(func(
+			_ context.Context, _ *vmcp.BackendTarget, toolName string,
+			_ map[string]any, _ map[string]any, _ map[string]string,
+		) (*vmcp.ToolCallResult, error) {
+			if opts.onBackendCall != nil {
+				opts.onBackendCall(toolName)
+			}
+			return &vmcp.ToolCallResult{Content: []vmcp.Content{{Type: "text", Text: "fake result"}}}, nil
+		}).
 		AnyTimes()
 
 	rt := router.NewSessionRouter(&vmcp.RoutingTable{})
@@ -226,7 +251,7 @@ func buildTestServerWithOptions(
 			SessionTTL:       5 * time.Minute,
 			SessionFactory:   factory,
 			OptimizerFactory: opts.optimizerFactory,
-			Aggregator:       newStubAggregator(capsFromTools(opts.tools)),
+			Aggregator:       newStubAggregator(capsFromTools(opts.tools, opts.hiddenTools)),
 		},
 		rt,
 		mockBackendClient,


### PR DESCRIPTION
## Summary

vMCP tool filtering (`aggregation.tools`, `filter`, `excludeAll`, `excludeAllTools`) is enforced on the Legacy path but not on the Modern one, so a Modern client that knows the name of a filtered-out tool can call it successfully. Filtering is understood as an access-control boundary — #6073 uses a filtered vMCP to constrain unsupervised agents — so the same config silently means something different depending on which revision a client speaks.

The aggregator deliberately puts **every** backend tool in the routing table — including ones withheld from `tools/list` — so composite-tool workflow steps can still reach them (#3636, `default_aggregator.go:349`). Legacy registers one SDK handler per *advertised* tool, so registration is the gate and a filtered name is rejected as unknown. Modern is stateless with no registration step: `tools/call` goes from the request to `core.CallTool` (`modern_dispatch.go:297`), which resolves the name against the unfiltered table (`core_calls.go:64`). Nothing narrows it. `CallTool`'s doc comment already promised `ErrNotFound` for an unadvertised name; nothing enforced it.

- **Hold `tools/call` to the advertised view in the core**, not in the Modern dispatcher, so every consumer inherits the contract (Modern, `codemode`, `ratelimit`, any future `VMCP` decorator) rather than one transport being patched — see the reviewer note below on why this is broader than the issue proposed. The check reuses `advertisedTools`/`findAdvertisedTool` against the `agg` already in hand — no extra aggregation or backend fan-out.
- Checked **after** `authorizeToolCall`, so a denied tool keeps returning `ErrAuthorizationFailed`. If the order were reversed, `ErrNotFound` vs. denial would tell an unauthorized caller which hidden tools exist.
- **Classify the refusal as `-32602` (HTTP 400) on the Modern path**, at the `tools/call` site. Without this, `ErrNotFound` launders into `-32603`/HTTP 200 and the two eras still disagree on the same input — Legacy answers `-32602` "unknown tool" (go-sdk `server.go:957`).

**Composite tools are unaffected, with no exemption code.** A workflow enters `CallTool` once under its own (advertised) name; its steps then run `composer → router.RouteTool → backendClient.CallTool` (`workflow_engine.go:428,486`) and never re-enter the core. #3636 is preserved exactly.

Fixes #6217

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

`task lint-fix` reports 4 issues (3 gosec, 1 staticcheck), all pre-existing in files this PR does not touch — verified identical on a clean `main` checkout.

**Both failure directions were verified by deliberately breaking the code**, because this invariant has two halves that must move in opposite directions:

| Injected mistake | Result |
|---|---|
| Revert the advertised-view guard | Modern leg fails — `hidden_tool` returns `fake result`, i.e. a **successful** filtered-tool call (Legacy still passes, reproducing the asymmetry the issue describes) |
| Prune hidden tools from the routing table instead (the tempting wrong fix) | Both legs fail on `a composite workflow step must still reach a hidden backend tool (#3636)` |

That second row is the point: pruning the routing table would satisfy every "filtered tool is rejected" assertion while silently re-breaking #3636. A single-direction test is what let this bug ship in the first place.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/core/core_calls.go` | `CallTool` resolves against the advertised view, after authz; doc comment now states which view "unadvertised" means |
| `pkg/vmcp/server/modern_dispatch.go` | `ErrNotFound` on `tools/call` → `-32602`/HTTP 400 instead of `-32603` |
| `pkg/vmcp/server/hidden_tool_regression_test.go` | New: both-eras, both-directions regression guard with a backend-call recorder |
| `pkg/vmcp/server/session_management_integration_test.go` | `serverOptions.hiddenTools` (routing-table-only names) and `onBackendCall` (records forwarded tool names) |
| `pkg/vmcp/core/core_calls_test.go` | New rejection test; two fixtures that only passed because the contract was unenforced |
| `pkg/vmcp/core/core_checks_test.go` | New: denial takes precedence over not-found for a filtered **and** denied tool |

## Does this introduce a user-facing change?

Yes — two related narrowings, both deliberate:

1. **A tool filtered out of `tools/list` is no longer directly callable.** This is the point of the fix: filtering now holds identically on both revisions. Anyone relying on invoking an `excludeAll`/`filter`-hidden tool by name loses that. Because the fix is in the core rather than the Modern dispatcher, it applies to every path (Modern, `codemode`, `ratelimit`), not just Modern. Composite tools calling filtered tools continue to work, which is the supported way to reach one.
2. **`RouteTool`'s `{workloadID}.{toolName}` alias is no longer accepted for a direct call.** An alias is by definition not an advertised name, so accepting one would leave a second bypass of exactly the boundary this PR closes. It exists so composite *workflow step definitions* survive conflict-resolution renames and keeps working there, inside the composer. Nothing in-tree called the core with an alias (`codemode` binds `innerTools`; the optimizer and Legacy bind advertised names), so this affects only an external core-library consumer that constructed one by hand.

## Special notes for reviewers

**Two scrutiny requests:**

1. **Why the core and not the Modern dispatcher.** #6217 proposes refusing to route *a Modern call*; this fixes it one layer down. A dispatcher-only guard was considered and rejected: it would cost an extra aggregation per `tools/call` (via `LookupTool`), leave `core.CallTool`'s documented `ErrNotFound` contract false for library consumers, and — given the issue frames filtering as an access-control boundary — fix only the transport that happens to expose the gap today, leaving the next stateless consumer to re-open it. The work item that prompted this assumed a core guard would need an explicit composite-step exemption; it does not, because steps never reach `core.CallTool`. That's the load-bearing fact — if it's wrong, this design is wrong.

2. **`-32602` is scoped to `tools/call` on purpose.** It is written at the call site rather than added to `writeModernDispatchError`, which is shared with `resources/read`, `prompts/get` and `completion/complete` — their not-found classification is a separate decision, out of scope here. Consequence: those verbs still answer `-32603` for a not-found, so Modern is briefly inconsistent across verbs. Worth a follow-up, but bundling it would mix scopes.

**Deliberate rewrite worth a close look:** `TestCallTool_ResolvesRenamedTool` previously asserted that `CallTool("be1.echo")` *succeeds* while only `be1_echo` is advertised — it pinned the dot alias as callable through the core. It is now split into a resolved-name success leg and an alias-rejection leg. This is the one existing assertion this PR intentionally inverts.

The error message deliberately does **not** name the requested tool. Echoing it back would turn the not-found/denied pair into a probe for which denied tools exist; `TestCallTool_DenialPrecedesNotFound` pins that ordering.

No e2e run: the existing e2e coverage (`test/e2e/vmcp_cli_features_test.go:248-347`) only asserts filtered tools are absent from `tools/list` and never that they are uncallable — which is precisely the blind spot that let this ship. Adding a Modern callability leg there is worth a follow-up; the new integration test covers both eras in-process in the meantime.

Generated with [Claude Code](https://claude.com/claude-code)