### PR TITLE
Pass CA-aware HTTP client to JWKS registration

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -708,8 +708,11 @@ func (v *TokenValidator) ensureJWKSRegistered(ctx context.Context) error {
 	registrationCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	// Attempt registration
-	if err := v.jwksClient.Register(registrationCtx, v.jwksURL); err != nil {
+	// Attempt registration. The CA-aware client must be passed per-resource:
+	// jwx >= 3.1.0 injects its own default client at the resource level when
+	// none is given here, which takes precedence over the client-level one
+	// configured in NewTokenValidator and silently drops custom CA support.
+	if err := v.jwksClient.Register(registrationCtx, v.jwksURL, jwk.WithHTTPClient(v.client)); err != nil {
 		v.jwksRegistrationErr = fmt.Errorf("failed to register JWKS URL: %w", err)
 		// Do NOT set jwksRegistered = true -- allow retry on next call
 		return v.jwksRegistrationErr


### PR DESCRIPTION
## Summary

jwx v3.1.0 changed `jwk.Cache.Register` to inject jwx's own default HTTP client as a resource-level option whenever the caller doesn't supply one, and httprc gives the resource-level client precedence at fetch time. ToolHive only attaches its CA-aware client (custom CA bundle, private-IP policy, auth token support) at the httprc client level, so on jwx >= 3.1.0 every JWKS fetch silently bypasses it and fails TLS verification against issuers using a private CA (e.g. Keycloak with `caBundleRef`). Diagnosed on a downstream build that already bundles jwx v3.1.0; OSS is unaffected on the current v3.0.13 pin but would break on the next jwx bump.

- Pass the CA-aware client per-resource via `jwk.WithHTTPClient(v.client)` at `Register` time. `jwk.WithHTTPClient` maps to the resource-level httprc option in both v3.0.13 and v3.1.0, so this is a no-op on the current pin and keeps JWKS fetches on the correct client across the upgrade.
- No new test: the existing TLS-with-custom-CA registration tests in `token_test.go` exercise this exact path and become the regression canary (they fail on a jwx >= 3.1.0 bump without this change).

Fixes #6219

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Unit tests pass (`pkg/auth/...` with the Taskfile's race/ldflags settings)
- [x] Lint passes on the changed package (`task lint-fix` currently fails on a pre-existing, unrelated gosec finding in `cmd/thv/app/upgrade.go:204`)
- [x] `task build` succeeds

## Does this introduce a user-facing change?

No (behavior is unchanged on the pinned jwx v3.0.13; this prevents a regression on future jwx upgrades).

## Special notes for reviewers

The sibling issue #6218 (the `ErrNotReady` retry deadlock that turned this one failed fetch into a permanently dead validator) will be fixed in a follow-up PR that touches the same `Register` call site; this PR intentionally lands first.

Generated with [Claude Code](https://claude.com/claude-code)