### PR TITLE
Handle non-fatal httprc errors in JWKS registration

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -712,7 +712,26 @@ func (v *TokenValidator) ensureJWKSRegistered(ctx context.Context) error {
 	// jwx >= 3.1.0 injects its own default client at the resource level when
 	// none is given here, which takes precedence over the client-level one
 	// configured in NewTokenValidator and silently drops custom CA support.
-	if err := v.jwksClient.Register(registrationCtx, v.jwksURL, jwk.WithHTTPClient(v.client)); err != nil {
+	err := v.jwksClient.Register(registrationCtx, v.jwksURL, jwk.WithHTTPClient(v.client))
+	switch {
+	case err == nil:
+		// Registered and the first fetch succeeded.
+	case errors.Is(err, httprc.ErrNotReady()):
+		// The resource is registered and httprc will keep fetching it in the
+		// background; only the first fetch has not completed within the
+		// registration budget. Treat it as registered: Lookup returns a
+		// not-ready error until a background fetch succeeds. Retrying Register
+		// instead would fail with ErrResourceAlreadyExists forever.
+		//nolint:gosec // G706: JWKS URL is from server configuration or OIDC discovery
+		slog.Debug(
+			"JWKS URL registered but first fetch not ready; fetching continues in background",
+			"jwks_url", v.jwksURL, "error", err,
+		)
+	case errors.Is(err, httprc.ErrResourceAlreadyExists()):
+		// The URL is already in httprc's resource map, e.g. a previous attempt
+		// returned ErrNotReady before this state was tracked, or OIDC
+		// re-discovery produced the same URL after resetting the flag.
+	default:
 		v.jwksRegistrationErr = fmt.Errorf("failed to register JWKS URL: %w", err)
 		// Do NOT set jwksRegistered = true -- allow retry on next call
 		return v.jwksRegistrationErr

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -3011,3 +3011,67 @@ func TestValidateToken_DiscoveryFailsWithKeyProvider(t *testing.T) {
 		require.Contains(t, err.Error(), "local key provider could not resolve key")
 	})
 }
+
+func TestEnsureJWKSRegistered_NonFatalRegistrationErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ErrNotReady marks the JWKS as registered", func(t *testing.T) {
+		t.Parallel()
+		// A JWKS endpoint that never succeeds keeps the resource from
+		// becoming ready within the registration budget.
+		jwksServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(jwksServer.Close)
+		caCertPath := writeTestServerCert(t, jwksServer)
+
+		validator, err := NewTokenValidator(context.Background(), TokenValidatorConfig{
+			Issuer:         "test-issuer",
+			Audience:       "test-audience",
+			JWKSURL:        jwksServer.URL,
+			ClientID:       "test-client",
+			CACertPath:     caCertPath,
+			AllowPrivateIP: true,
+		})
+		require.NoError(t, err)
+
+		// Bound the ready-wait well below the 5s registration budget.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, validator.ensureJWKSRegistered(ctx),
+			"ErrNotReady must be treated as registered-but-pending")
+		require.True(t, validator.jwksRegistered)
+
+		// Lookup surfaces not-ready until a background fetch succeeds.
+		_, err = validator.jwksClient.Lookup(context.Background(), jwksServer.URL)
+		require.Error(t, err)
+	})
+
+	t.Run("ErrResourceAlreadyExists marks the JWKS as registered", func(t *testing.T) {
+		t.Parallel()
+		jwksServer, caCertPath := createTestJWKSServer(t, jwk.NewSet())
+		t.Cleanup(jwksServer.Close)
+
+		validator, err := NewTokenValidator(context.Background(), TokenValidatorConfig{
+			Issuer:         "test-issuer",
+			Audience:       "test-audience",
+			JWKSURL:        jwksServer.URL,
+			ClientID:       "test-client",
+			CACertPath:     caCertPath,
+			AllowPrivateIP: true,
+		})
+		require.NoError(t, err)
+		require.NoError(t, validator.ensureJWKSRegistered(context.Background()))
+
+		// Simulate the reset done after OIDC re-discovery: the flag is
+		// cleared but the URL is still in httprc's resource map, so the
+		// next registration attempt returns ErrResourceAlreadyExists.
+		validator.jwksRegistrationMu.Lock()
+		validator.jwksRegistered = false
+		validator.jwksRegistrationMu.Unlock()
+
+		require.NoError(t, validator.ensureJWKSRegistered(context.Background()),
+			"re-registering an already-registered URL must not fail")
+		require.True(t, validator.jwksRegistered)
+	})
+}


### PR DESCRIPTION
## Summary

`ensureJWKSRegistered` treats every `Register` error as fatal and leaves the registration flag unset for retry. But httprc returns `ErrNotReady` when the resource was successfully registered and only the first fetch hasn't completed; the resource is already in httprc's map, so every retry then fails with `ErrResourceAlreadyExists`. One slow or failed first JWKS fetch (a slow IdP, a network blip on the first authenticated request, or the client bypass fixed in #6220) permanently disabled token validation for the life of the process.

- Treat `ErrNotReady` as registered-but-pending: the validator proceeds and `Lookup` surfaces a not-ready key set until a background fetch succeeds, so transient first-fetch failures now self-heal.
- Treat `ErrResourceAlreadyExists` as already-registered. Besides being the escape hatch for the retry trap, this also covers OIDC re-discovery resolving to the same JWKS URL after the registration flag is reset.
- New tests cover both sentinels; each fails against the previous code with the exact error strings from the issue.

Fixes #6218

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Unit tests pass (`pkg/auth/...` with race detection; new tests verified to fail pre-fix)
- [x] `task lint` passes

## Does this introduce a user-facing change?

Transient failures fetching an external OIDC issuer's JWKS on first use no longer permanently disable token validation until restart; validation recovers once a background fetch succeeds.

## Special notes for reviewers

Stacked on #6220, which fixed the trigger that surfaced this; this PR hardens the retry path against any first-fetch failure. Review only this layer's diff via the stacked PR view.

Generated with [Claude Code](https://claude.com/claude-code)
