### PR TITLE
Resolve relative --project-root before the API call

### DIFF
--- a/cmd/thv/app/skill_helpers.go
+++ b/cmd/thv/app/skill_helpers.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -67,13 +68,31 @@ func validateProjectRootForScope(scopeVar, projectRootVar *string) func(*cobra.C
 	}
 }
 
+// absProjectRoot makes a user-supplied --project-root absolute, leaving an
+// empty value empty — for most commands that means "not project-scoped", and
+// substituting the working directory there would silently change the scope.
+//
+// The API server requires an absolute project root, so a relative value would
+// otherwise travel all the way to the server and come back as a validation
+// error naming the wire field rather than the flag the user typed.
+func absProjectRoot(explicit string) (string, error) {
+	if explicit == "" {
+		return "", nil
+	}
+	abs, err := filepath.Abs(explicit)
+	if err != nil {
+		return "", fmt.Errorf("resolving --project-root %q: %w", explicit, err)
+	}
+	return abs, nil
+}
+
 // resolveProjectRoot returns explicit if set, otherwise auto-detects the
 // project root by walking up from the current directory looking for .git —
 // used by commands (sync, upgrade) that operate on "the project you're in"
 // rather than requiring --project-root on every invocation.
 func resolveProjectRoot(explicit string) (string, error) {
 	if explicit != "" {
-		return explicit, nil
+		return absProjectRoot(explicit)
 	}
 	root, err := tclient.DetectProjectRoot("")
 	if err != nil {

--- a/cmd/thv/app/skill_helpers_test.go
+++ b/cmd/thv/app/skill_helpers_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // uses t.Chdir, incompatible with t.Parallel
+func TestAbsProjectRoot(t *testing.T) {
+	cwd := t.TempDir()
+	resolvedCwd, err := filepath.EvalSymlinks(cwd)
+	require.NoError(t, err)
+	t.Chdir(resolvedCwd)
+
+	tests := []struct {
+		name     string
+		explicit string
+		want     string
+	}{
+		{
+			name:     "empty stays empty so the scope is not silently changed",
+			explicit: "",
+			want:     "",
+		},
+		{
+			name:     "dot resolves to the working directory",
+			explicit: ".",
+			want:     resolvedCwd,
+		},
+		{
+			name:     "relative child resolves against the working directory",
+			explicit: "child",
+			want:     filepath.Join(resolvedCwd, "child"),
+		},
+		{
+			name:     "an absolute path is returned unchanged",
+			explicit: resolvedCwd,
+			want:     resolvedCwd,
+		},
+		{
+			name:     "traversal is cleaned rather than rejected",
+			explicit: filepath.Join(resolvedCwd, "a", ".."),
+			want:     resolvedCwd,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := absProjectRoot(tc.explicit)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestResolveProjectRootAbsolutizesExplicit covers the sync/upgrade path,
+// where an explicit value short-circuits auto-detection — it must still be
+// made absolute, which is the regression behind #6211.
+//
+//nolint:paralleltest // uses t.Chdir, incompatible with t.Parallel
+func TestResolveProjectRootAbsolutizesExplicit(t *testing.T) {
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	t.Chdir(resolved)
+
+	got, err := resolveProjectRoot(".")
+	require.NoError(t, err)
+	assert.Equal(t, resolved, got)
+	assert.True(t, filepath.IsAbs(got), "an explicit --project-root must reach the API server absolute")
+}

--- a/cmd/thv/app/skill_info.go
+++ b/cmd/thv/app/skill_info.go
@@ -45,10 +45,15 @@ func init() {
 func skillInfoCmdFunc(cmd *cobra.Command, args []string) error {
 	c := newSkillClient(cmd.Context())
 
+	projectRoot, err := absProjectRoot(skillInfoProjectRoot)
+	if err != nil {
+		return err
+	}
+
 	info, err := c.Info(cmd.Context(), skills.InfoOptions{
 		Name:        args[0],
 		Scope:       skills.Scope(skillInfoScope),
-		ProjectRoot: skillInfoProjectRoot,
+		ProjectRoot: projectRoot,
 	})
 	if err != nil {
 		return formatSkillError("get skill info", err)

--- a/cmd/thv/app/skill_install.go
+++ b/cmd/thv/app/skill_install.go
@@ -50,12 +50,17 @@ func init() {
 func skillInstallCmdFunc(cmd *cobra.Command, args []string) error {
 	c := newSkillClient(cmd.Context())
 
-	_, err := c.Install(cmd.Context(), skills.InstallOptions{
+	projectRoot, err := absProjectRoot(skillInstallProjectRoot)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Install(cmd.Context(), skills.InstallOptions{
 		Name:          args[0],
 		Scope:         skills.Scope(skillInstallScope),
 		Clients:       parseSkillInstallClients(skillInstallClientsRaw),
 		Force:         skillInstallForce,
-		ProjectRoot:   skillInstallProjectRoot,
+		ProjectRoot:   projectRoot,
 		Group:         skillInstallGroup,
 		AllowUnsigned: skillInstallAllowUnsigned,
 	})

--- a/cmd/thv/app/skill_list.go
+++ b/cmd/thv/app/skill_list.go
@@ -49,10 +49,15 @@ func init() {
 func skillListCmdFunc(cmd *cobra.Command, _ []string) error {
 	c := newSkillClient(cmd.Context())
 
+	projectRoot, err := absProjectRoot(skillListProjectRoot)
+	if err != nil {
+		return err
+	}
+
 	installed, err := c.List(cmd.Context(), skills.ListOptions{
 		Scope:       skills.Scope(skillListScope),
 		ClientApp:   skillListClient,
-		ProjectRoot: skillListProjectRoot,
+		ProjectRoot: projectRoot,
 		Group:       skillListGroup,
 	})
 	if err != nil {

--- a/cmd/thv/app/skill_uninstall.go
+++ b/cmd/thv/app/skill_uninstall.go
@@ -41,10 +41,15 @@ func init() {
 func skillUninstallCmdFunc(cmd *cobra.Command, args []string) error {
 	c := newSkillClient(cmd.Context())
 
-	err := c.Uninstall(cmd.Context(), skills.UninstallOptions{
+	projectRoot, err := absProjectRoot(skillUninstallProjectRoot)
+	if err != nil {
+		return err
+	}
+
+	err = c.Uninstall(cmd.Context(), skills.UninstallOptions{
 		Name:        args[0],
 		Scope:       skills.Scope(skillUninstallScope),
-		ProjectRoot: skillUninstallProjectRoot,
+		ProjectRoot: projectRoot,
 	})
 	if err != nil {
 		return formatSkillError("uninstall skill", err)


### PR DESCRIPTION
## Summary

`--project-root .` is the natural thing to write when scripting `thv skill` commands, but it does not work. The CLI forwards the flag verbatim to the API server, which requires an absolute path, so the command fails with a validation error naming the wire field rather than the flag the user typed:

```
Error: failed to upgrade skills: project_root must be absolute, got "."
```

Two things made this worse than a cosmetic message problem:

- The auto-detected path (used when `--project-root` is omitted) *is* absolute, so the flag behaved differently from its own default — surprising, and only at the point of failure.
- `thv skill upgrade` exited **1**, outside its documented 0/2/3/4 exit-code contract. A CI job branching on those codes sees an unexpected value instead of a clear failure.

What changed:

- New `absProjectRoot` helper in `skill_helpers.go` resolves a user-supplied value with `filepath.Abs`, and leaves an empty value empty — for most skill commands empty means "not project-scoped", so substituting the working directory would silently change the scope.
- `resolveProjectRoot` (sync, upgrade) now absolutizes the explicit branch, which previously short-circuited untouched.
- `install`, `info`, `list`, and `uninstall` normalize before building their options.

Closes #6211

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

New table-driven `TestAbsProjectRoot` covers empty / `.` / relative child / already-absolute / traversal-cleaning, plus `TestResolveProjectRootAbsolutizesExplicit` pinning the specific branch that regressed.

Manually, against a local `thv serve`:

```console
$ thv skill list --scope project --project-root .
NAME                  SCOPE     STATUS      REFERENCE
gha-security-review   project   installed   ghcr.io/stacklok/dockyard/skills/gha-security-review:0.2.0
```

and confirmed the server-side validation is unchanged — it still rejects a relative root, so the normalization is genuinely happening client-side:

```console
$ curl -s 'http://127.0.0.1:18080/api/v1beta/skills?scope=project&project_root=.'
project_root must be absolute, got "."
```

## Does this introduce a user-facing change?

Yes. `thv skill` commands now accept a relative `--project-root` (including `.`), resolving it against the working directory. Absolute paths behave exactly as before.

## Special notes for reviewers

Deliberately scoped to `thv skill`, matching the issue. The `thv ai-plugin` commands take the same flag and validate through the parallel `pkg/plugins/validator.go`, so they almost certainly have the identical bug — happy to fix them here instead if you'd rather it were one sweep, but it seemed better not to widen a bug fix into a package the issue never mentioned.

Generated with [Claude Code](https://claude.com/claude-code)