### PR TITLE
Stop severing skill artifact pulls at fixed timeouts

### DIFF
--- a/cmd/thv/app/skill_helpers.go
+++ b/cmd/thv/app/skill_helpers.go
@@ -40,13 +40,21 @@ func completeSkillNames(cmd *cobra.Command, args []string, _ string) ([]string, 
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
-// formatSkillError wraps an error with contextual information. If the
-// underlying cause is ErrServerUnreachable it appends a helpful hint.
+// formatSkillError wraps an error with contextual information, appending a
+// hint that matches the actual failure — a timed-out request and an absent
+// server need different advice.
 func formatSkillError(action string, err error) error {
-	if errors.Is(err, skillclient.ErrServerUnreachable) {
+	switch {
+	case errors.Is(err, skillclient.ErrRequestTimeout):
+		return fmt.Errorf(
+			"failed to %s: %w\nHint: the server is running and was still working; "+
+				"raise the limit with TOOLHIVE_API_TIMEOUT (e.g. TOOLHIVE_API_TIMEOUT=30m)",
+			action, err)
+	case errors.Is(err, skillclient.ErrServerUnreachable):
 		return fmt.Errorf("failed to %s: %w\nHint: ensure 'thv serve' is running", action, err)
+	default:
+		return fmt.Errorf("failed to %s: %w", action, err)
 	}
-	return fmt.Errorf("failed to %s: %w", action, err)
 }
 
 // validateSkillScope returns a PreRunE that validates the --scope flag.

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -409,6 +409,10 @@ func (b *ServerBuilder) setupDefaultRoutes(r *chi.Mux) {
 		b.debugMode,
 	))
 
+	// Skills router does the same: install, sync, and upgrade pull OCI
+	// artifacts, so a flat 60s cap would sever them mid-transfer.
+	r.Mount("/api/v1beta/skills", v1.SkillsRouter(b.skillManager))
+
 	// All other routes get standard timeout
 	standardRouters := map[string]http.Handler{
 		"/health":               v1.HealthcheckRouter(b.containerRuntime, b.nonce),
@@ -418,7 +422,6 @@ func (b *ServerBuilder) setupDefaultRoutes(r *chi.Mux) {
 		"/api/v1beta/clients":   v1.ClientRouter(b.clientManager, b.workloadManager, b.groupManager),
 		"/api/v1beta/secrets":   v1.SecretsRouter(),
 		"/api/v1beta/groups":    v1.GroupsRouter(b.groupManager, b.workloadManager, b.clientManager),
-		"/api/v1beta/skills":    v1.SkillsRouter(b.skillManager),
 		"/api/v1beta/plugins":   v1.PluginsRouter(b.pluginManager),
 		"/registry":             v1.RegistryV01Router(),
 	}

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/stacklok/toolhive-core/httperr"
 	apierrors "github.com/stacklok/toolhive/pkg/api/errors"
@@ -34,19 +35,26 @@ func SkillsRouter(skillService skills.SkillService) http.Handler {
 		routes.lockService = lockSvc
 	}
 
+	// Mirrors WorkloadRouter: routes that move OCI artifacts get a timeout
+	// sized for the transfer, everything else keeps the short one. Without
+	// the split these routes inherit the flat 60s applied to standard
+	// routers, which severs a cold artifact pull mid-flight.
+	stdTimeout := middleware.Timeout(standardRouteTimeout)
+	longTimeout := middleware.Timeout(longRunningRouteTimeout)
+
 	r := chi.NewRouter()
-	r.Get("/", apierrors.ErrorHandler(routes.listSkills))
-	r.Post("/", apierrors.ErrorHandler(routes.installSkill))
-	r.Delete("/{name}", apierrors.ErrorHandler(routes.uninstallSkill))
-	r.Get("/{name}", apierrors.ErrorHandler(routes.getSkillInfo))
-	r.Post("/validate", apierrors.ErrorHandler(routes.validateSkill))
-	r.Post("/build", apierrors.ErrorHandler(routes.buildSkill))
-	r.Post("/push", apierrors.ErrorHandler(routes.pushSkill))
-	r.Get("/builds", apierrors.ErrorHandler(routes.listBuilds))
-	r.Delete("/builds/{tag}", apierrors.ErrorHandler(routes.deleteBuild))
-	r.Get("/content", apierrors.ErrorHandler(routes.getSkillContent))
-	r.Post("/sync", apierrors.ErrorHandler(routes.syncSkills))
-	r.Post("/upgrade", apierrors.ErrorHandler(routes.upgradeSkills))
+	r.With(stdTimeout).Get("/", apierrors.ErrorHandler(routes.listSkills))
+	r.With(longTimeout).Post("/", apierrors.ErrorHandler(routes.installSkill))
+	r.With(stdTimeout).Delete("/{name}", apierrors.ErrorHandler(routes.uninstallSkill))
+	r.With(stdTimeout).Get("/{name}", apierrors.ErrorHandler(routes.getSkillInfo))
+	r.With(stdTimeout).Post("/validate", apierrors.ErrorHandler(routes.validateSkill))
+	r.With(longTimeout).Post("/build", apierrors.ErrorHandler(routes.buildSkill))
+	r.With(longTimeout).Post("/push", apierrors.ErrorHandler(routes.pushSkill))
+	r.With(stdTimeout).Get("/builds", apierrors.ErrorHandler(routes.listBuilds))
+	r.With(stdTimeout).Delete("/builds/{tag}", apierrors.ErrorHandler(routes.deleteBuild))
+	r.With(stdTimeout).Get("/content", apierrors.ErrorHandler(routes.getSkillContent))
+	r.With(longTimeout).Post("/sync", apierrors.ErrorHandler(routes.syncSkills))
+	r.With(longTimeout).Post("/upgrade", apierrors.ErrorHandler(routes.upgradeSkills))
 
 	return r
 }

--- a/pkg/skills/client/client.go
+++ b/pkg/skills/client/client.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -24,10 +25,18 @@ import (
 )
 
 const (
-	skillsBasePath   = "/api/v1beta/skills"
-	defaultBaseURL   = "http://127.0.0.1:8080"
-	defaultTimeout   = 30 * time.Second
+	skillsBasePath = "/api/v1beta/skills"
+	defaultBaseURL = "http://127.0.0.1:8080"
+	// defaultTimeout is a backstop against a wedged server, not a budget for
+	// the operation. Install, sync, and upgrade pull OCI artifacts of
+	// unbounded size over the user's connection, so a timeout tight enough to
+	// feel responsive would abort legitimate work — and because giving up
+	// cancels the request context, it aborts it server-side too, leaving
+	// nothing for a retry to reuse. Callers who want to fail fast can set
+	// TOOLHIVE_API_TIMEOUT or pass WithTimeout.
+	defaultTimeout   = 10 * time.Minute
 	envAPIURL        = "TOOLHIVE_API_URL"
+	envAPITimeout    = "TOOLHIVE_API_TIMEOUT"
 	maxResponseSize  = 1 << 20 // 1 MiB — matches server-side maxRequestBodySize
 	maxErrorBodySize = 1 << 16 // 64 KiB — matches auth/token and DCR limits
 )
@@ -36,6 +45,13 @@ const (
 // ToolHive API server. The most common cause is that "thv serve" is not
 // running.
 var ErrServerUnreachable = errors.New("could not reach ToolHive API server — is 'thv serve' running?")
+
+// ErrRequestTimeout is returned when the server was reached but did not
+// respond within the client timeout. This is a distinct condition from
+// ErrServerUnreachable: the server is healthy and was working on the request.
+// Note that abandoning the request cancels its context server-side, so the
+// operation does not continue in the background and retrying restarts it.
+var ErrRequestTimeout = errors.New("the ToolHive API server did not respond within the client timeout")
 
 // Compile-time interface check.
 var _ skills.SkillService = (*Client)(nil)
@@ -97,23 +113,47 @@ type discoverFunc func(ctx context.Context) (string, []Option)
 // envReader and discover dependencies are injected so each resolution step
 // can be exercised in isolation.
 func newDefaultClientWithEnv(ctx context.Context, envReader env.Reader, discover discoverFunc, opts ...Option) *Client {
+	// An env-supplied timeout applies to every resolution path, but ranks
+	// below caller-supplied options so a WithTimeout argument still wins.
+	withEnvTimeout := func(base []Option) []Option {
+		merged := make([]Option, 0, len(base)+len(opts)+1)
+		merged = append(merged, base...)
+		if d, ok := timeoutFromEnv(envReader); ok {
+			merged = append(merged, WithTimeout(d))
+		}
+		return append(merged, opts...)
+	}
+
 	// 1. Explicit env var override always wins.
 	if base := envReader.Getenv(envAPIURL); base != "" {
-		return NewClient(base, opts...)
+		return NewClient(base, withEnvTimeout(nil)...)
 	}
 
 	// 2. Try server discovery.
 	if base, httpOpts := discover(ctx); base != "" {
 		// Discovery opts go first so caller-supplied opts can override them
 		// (e.g. a caller-provided WithTimeout replaces the discovery default).
-		merged := make([]Option, 0, len(httpOpts)+len(opts))
-		merged = append(merged, httpOpts...)
-		merged = append(merged, opts...)
-		return NewClient(base, merged...)
+		return NewClient(base, withEnvTimeout(httpOpts)...)
 	}
 
 	// 3. Fall back to the default URL.
-	return NewClient(defaultBaseURL, opts...)
+	return NewClient(defaultBaseURL, withEnvTimeout(nil)...)
+}
+
+// timeoutFromEnv reads TOOLHIVE_API_TIMEOUT as a Go duration (e.g. "45s",
+// "5m"). An unset, unparseable, or non-positive value is ignored so a typo
+// degrades to the default rather than disabling the timeout entirely.
+func timeoutFromEnv(envReader env.Reader) (time.Duration, bool) {
+	raw := strings.TrimSpace(envReader.Getenv(envAPITimeout))
+	if raw == "" {
+		return 0, false
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		slog.Warn("ignoring invalid "+envAPITimeout, "value", raw, "error", err)
+		return 0, false
+	}
+	return d, true
 }
 
 // resolveViaDiscovery attempts to find a running server via the discovery file.
@@ -350,7 +390,7 @@ func (c *Client) doJSONRequest(
 
 	resp, err := c.httpClient.Do(req) // #nosec G704 -- baseURL is a trusted local API server URL
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrServerUnreachable, err)
+		return fmt.Errorf("%w: %w", classifyTransportError(ctx, err), err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -366,6 +406,25 @@ func (c *Client) doJSONRequest(
 	}
 
 	return nil
+}
+
+// classifyTransportError decides which sentinel a failed round-trip belongs
+// to. Reporting a timeout as an unreachable server sends users to check
+// whether "thv serve" is running when it is running and was mid-operation.
+func classifyTransportError(ctx context.Context, err error) error {
+	// The caller's own context ending takes precedence — neither the server's
+	// availability nor the client timeout is why the request stopped.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return ErrRequestTimeout
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrRequestTimeout
+	}
+	return ErrServerUnreachable
 }
 
 // handleErrorResponse reads the response body and returns an *httperr.CodedError.

--- a/pkg/skills/client/client.go
+++ b/pkg/skills/client/client.go
@@ -141,7 +141,7 @@ func newDefaultClientWithEnv(ctx context.Context, envReader env.Reader, discover
 }
 
 // timeoutFromEnv reads TOOLHIVE_API_TIMEOUT as a Go duration (e.g. "45s",
-// "5m"). An unset, unparseable, or non-positive value is ignored so a typo
+// "5m"). An unset, unparsable, or non-positive value is ignored so a typo
 // degrades to the default rather than disabling the timeout entirely.
 func timeoutFromEnv(envReader env.Reader) (time.Duration, bool) {
 	raw := strings.TrimSpace(envReader.Getenv(envAPITimeout))

--- a/pkg/skills/client/client_test.go
+++ b/pkg/skills/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -656,6 +657,7 @@ func TestNewDefaultClient(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockEnv := envmocks.NewMockReader(ctrl)
 		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
+		mockEnv.EXPECT().Getenv(envAPITimeout).Return("").AnyTimes()
 
 		c := newDefaultClientWithEnv(t.Context(), mockEnv, noDiscovery)
 		assert.Equal(t, defaultBaseURL, c.baseURL)
@@ -666,6 +668,7 @@ func TestNewDefaultClient(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockEnv := envmocks.NewMockReader(ctrl)
 		mockEnv.EXPECT().Getenv(envAPIURL).Return("http://localhost:9999")
+		mockEnv.EXPECT().Getenv(envAPITimeout).Return("").AnyTimes()
 
 		c := newDefaultClientWithEnv(t.Context(), mockEnv, failDiscovery(t))
 		assert.Equal(t, "http://localhost:9999", c.baseURL)
@@ -676,6 +679,7 @@ func TestNewDefaultClient(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockEnv := envmocks.NewMockReader(ctrl)
 		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
+		mockEnv.EXPECT().Getenv(envAPITimeout).Return("").AnyTimes()
 
 		discover := func(context.Context) (string, []Option) {
 			return "http://127.0.0.1:54321", nil
@@ -689,6 +693,7 @@ func TestNewDefaultClient(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockEnv := envmocks.NewMockReader(ctrl)
 		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
+		mockEnv.EXPECT().Getenv(envAPITimeout).Return("").AnyTimes()
 
 		c := newDefaultClientWithEnv(t.Context(), mockEnv, noDiscovery, WithTimeout(5*time.Second))
 		assert.Equal(t, 5*time.Second, c.httpClient.Timeout)
@@ -787,4 +792,158 @@ func TestSyncCarriesAllowUnsigned(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, got.AllowUnsigned, "allow_unsigned must reach the server")
+}
+
+func TestTimeoutFromEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+		ok    bool
+	}{
+		{name: "unset falls back to the default", value: "", want: 0, ok: false},
+		{name: "a duration is honored", value: "45s", want: 45 * time.Second, ok: true},
+		{name: "minutes parse", value: "5m", want: 5 * time.Minute, ok: true},
+		{name: "surrounding whitespace is tolerated", value: "  90s ", want: 90 * time.Second, ok: true},
+		{name: "a bare number is not a duration", value: "60", want: 0, ok: false},
+		{name: "garbage degrades to the default", value: "soon", want: 0, ok: false},
+		{name: "zero would disable the timeout, so it is ignored", value: "0s", want: 0, ok: false},
+		{name: "negative is ignored", value: "-5s", want: 0, ok: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			mockEnv := envmocks.NewMockReader(ctrl)
+			mockEnv.EXPECT().Getenv(envAPITimeout).Return(tc.value)
+
+			got, ok := timeoutFromEnv(mockEnv)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNewDefaultClientTimeoutPrecedence(t *testing.T) {
+	t.Parallel()
+
+	noDiscovery := func(context.Context) (string, []Option) { return "", nil }
+
+	t.Run("defaults when the env is unset", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockEnv := envmocks.NewMockReader(ctrl)
+		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
+		mockEnv.EXPECT().Getenv(envAPITimeout).Return("")
+
+		c := newDefaultClientWithEnv(t.Context(), mockEnv, noDiscovery)
+		assert.Equal(t, defaultTimeout, c.httpClient.Timeout)
+	})
+
+	t.Run("env overrides the default", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockEnv := envmocks.NewMockReader(ctrl)
+		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
+		mockEnv.EXPECT().Getenv(envAPITimeout).Return("2m")
+
+		c := newDefaultClientWithEnv(t.Context(), mockEnv, noDiscovery)
+		assert.Equal(t, 2*time.Minute, c.httpClient.Timeout)
+	})
+
+	t.Run("an explicit option outranks the env", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockEnv := envmocks.NewMockReader(ctrl)
+		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
+		mockEnv.EXPECT().Getenv(envAPITimeout).Return("2m")
+
+		c := newDefaultClientWithEnv(t.Context(), mockEnv, noDiscovery, WithTimeout(7*time.Second))
+		assert.Equal(t, 7*time.Second, c.httpClient.Timeout)
+	})
+
+	t.Run("env overrides the timeout discovery installs", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		mockEnv := envmocks.NewMockReader(ctrl)
+		mockEnv.EXPECT().Getenv(envAPIURL).Return("")
+		mockEnv.EXPECT().Getenv(envAPITimeout).Return("3m")
+
+		discover := func(context.Context) (string, []Option) {
+			return "http://127.0.0.1:54321", []Option{WithHTTPClient(&http.Client{Timeout: defaultTimeout})}
+		}
+		c := newDefaultClientWithEnv(t.Context(), mockEnv, discover)
+		assert.Equal(t, 3*time.Minute, c.httpClient.Timeout,
+			"WithHTTPClient from discovery must not shadow an operator-set timeout")
+	})
+}
+
+// TestTimeoutIsReportedAsTimeoutNotUnreachable pins the distinction the CLI
+// hint depends on: a healthy-but-slow server must not be reported as absent.
+func TestTimeoutIsReportedAsTimeoutNotUnreachable(t *testing.T) {
+	t.Parallel()
+
+	blocked := make(chan struct{})
+	t.Cleanup(func() { close(blocked) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-blocked:
+		case <-r.Context().Done():
+		case <-time.After(30 * time.Second):
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, WithTimeout(50*time.Millisecond))
+	_, err := c.List(t.Context(), skills.ListOptions{})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRequestTimeout)
+	assert.NotErrorIs(t, err, ErrServerUnreachable,
+		"the server answered the connection; only the response was slow")
+}
+
+func TestUnreachableServerIsStillUnreachable(t *testing.T) {
+	t.Parallel()
+
+	// Bind and immediately release a port so nothing is listening on it.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+
+	c := NewClient("http://"+addr, WithTimeout(2*time.Second))
+	_, err = c.List(t.Context(), skills.ListOptions{})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrServerUnreachable)
+	assert.NotErrorIs(t, err, ErrRequestTimeout)
+}
+
+// TestCallerCancellationIsNeitherSentinel keeps a user pressing Ctrl-C from
+// being reported as a server problem.
+func TestCallerCancellationIsNeitherSentinel(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	c := NewClient(srv.URL, WithTimeout(30*time.Second))
+	_, err := c.List(ctx, skills.ListOptions{})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.NotErrorIs(t, err, ErrRequestTimeout)
+	assert.NotErrorIs(t, err, ErrServerUnreachable)
 }


### PR DESCRIPTION
## Summary

Installing a skill whose OCI artifact takes a while to pull fails, and the error blames the wrong thing:

```
Error: failed to install skill: could not reach ToolHive API server — is 'thv serve' running?
Hint: ensure 'thv serve' is running
```

The server is running. It was pulling the artifact. Investigating turned up **two** independent ceilings, and fixing only the client one is not enough — I verified that by fixing the client first and watching the same install fail again, 30s later:

**1. The client gave up at 30s** and reported unreachability. `WithTimeout` existed but was not reachable from the CLI, so there was no way out. Worse, abandoning the request cancels its context server-side, so the server logs `context canceled` and discards the work — retrying restarts from nothing rather than resuming.

**2. The skills router inherited a flat 60s cap.** It sat in `standardRouters` in `setupDefaultRoutes`, all of which get `middleware.Timeout(60s)`. The workload router is already mounted outside that set, with the comment *"image pulls can take minutes"*. Skills pull the same artifacts the same way; they were simply never given the same treatment.

Changes:

- `ErrRequestTimeout`, distinct from `ErrServerUnreachable`, so a healthy-but-slow server is not reported as absent. Caller cancellation (Ctrl-C) is classified as neither and surfaces as `context.Canceled`.
- Client default raised, with `TOOLHIVE_API_TIMEOUT` (a Go duration, e.g. `45s`, `30m`) as an override. An explicit `WithTimeout` still outranks the env var; an unparseable or non-positive value is ignored with a warning rather than disabling the timeout.
- `SkillsRouter` gains per-route timeouts mirroring `WorkloadRouter` — long on `install`, `sync`, `upgrade`, `build`, `push`; short on the read routes — and is mounted outside `standardRouters`.
- The CLI hint now matches the failure and names the override.

Closes #6212

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

New tests: `TestTimeoutFromEnv` (table: unset / durations / whitespace / bare number / garbage / zero / negative), `TestNewDefaultClientTimeoutPrecedence` (default → env → explicit option, plus env beating the client discovery installs), and three classification tests using real sockets — a slow server yields `ErrRequestTimeout` and *not* `ErrServerUnreachable`, a closed port yields the reverse, and a cancelled caller context yields neither.

Manually, a cold pull of `security-review` against a local `thv serve`:

- before: failed at 0:30 with the unreachable message; after raising only the client timeout, failed again at 1:00 with `Internal Server Error` and `context deadline exceeded` server-side
- after both fixes: **succeeded at 1:16**, with a correct lock entry and verified provenance, and zero `context canceled` / `context deadline exceeded` in the server log

```yaml
- name: security-review
  resolvedReference: ghcr.io/stacklok/dockyard/skills/security-review:0.1.1
  provenance:
    signerIdentity: /.github/workflows/build-skills.yml
    repositoryUri: https://github.com/stacklok/dockyard
```

## Does this introduce a user-facing change?

Yes. Skill operations that pull OCI artifacts no longer fail on slow or large pulls. Timeout failures now say the request timed out instead of claiming the server is unreachable, and `TOOLHIVE_API_TIMEOUT` overrides the client limit.

## Special notes for reviewers

Two things worth a deliberate look:

**Scope.** The issue is written about the client timeout, and this PR also changes server-side routing. I would normally split that, but the server cap makes the client fix useless on its own — the user-visible bug is not fixed by either half alone.

**The default.** The client default is now generous, on the reasoning that this timeout is a backstop against a wedged local server rather than a budget for the operation: the transfer size is unbounded, and cutting it short destroys the work instead of deferring it. If you would rather keep a short default and have callers opt in per-operation, say so — it is a one-line change plus threading an option through the pull-backed commands.

`PluginsRouter` is in `standardRouters` and `pluginsvc` pulls artifacts too, so it likely has the same 60s ceiling. Left alone here to keep this PR to the reported bug; happy to file it.

Generated with [Claude Code](https://claude.com/claude-code)