### PR TITLE
Block only repository moves, not tag moves, on upgrade

### DIFF
--- a/cmd/thv/app/skill_upgrade.go
+++ b/cmd/thv/app/skill_upgrade.go
@@ -35,8 +35,9 @@ Skills pinned to an immutable reference (an OCI digest or a full git commit
 hash) are reported not-upgradable — there is nothing newer to resolve to.
 Use --preview to see what would change without persisting anything (OCI
 sources are still fetched into the local artifact store to compare digests),
-and --allow-ref-change to permit the resolved reference itself changing
-(e.g. a registry entry repointed at a different repository).
+and --allow-ref-change to permit the artifact moving to a different
+repository (a version bump within the same repository is not a change
+this guard blocks).
 --fail-on-changes evaluates the same plan and never installs: it is a CI
 freshness gate.
 
@@ -63,7 +64,7 @@ func init() {
 	skillUpgradeCmd.Flags().BoolVar(&skillUpgradeAllowSignerChange, "allow-signer-change", false,
 		"Permit upgrading to an artifact signed by a different identity; the new identity replaces the recorded one")
 	skillUpgradeCmd.Flags().BoolVar(&skillUpgradeAllowRefChange, "allow-ref-change", false,
-		"Permit the resolved reference itself to change during upgrade")
+		"Permit the artifact to move to a different repository during upgrade")
 	skillUpgradeCmd.Flags().BoolVar(&skillUpgradeYes, "yes", false,
 		"Skip the confirmation prompt (required when not running interactively)")
 	AddFormatFlag(skillUpgradeCmd, &skillUpgradeFormat)
@@ -164,7 +165,7 @@ func upgradeExitError(result *skills.UpgradeResult, preview, failOnChanges bool)
 	}
 	if !preview && !failOnChanges && refBlocked > 0 {
 		return withExitCode(
-			fmt.Errorf("%d skill(s) blocked by a reference change; use --allow-ref-change", refBlocked),
+			fmt.Errorf("%d skill(s) blocked by a repository change; use --allow-ref-change", refBlocked),
 			ExitCodePolicyRejection,
 		)
 	}
@@ -201,7 +202,8 @@ func printUpgradeResult(result *skills.UpgradeResult, format string, planOnly bo
 		case skills.UpgradeStatusNotUpgradable:
 			fmt.Printf("%s: not upgradable (pinned to an immutable reference)\n", o.Name)
 		case skills.UpgradeStatusRefChangeBlocked:
-			fmt.Printf("%s: reference change blocked (would move to %s; use --allow-ref-change)\n", o.Name, o.NewResolvedReference)
+			fmt.Printf("%s: repository change blocked (would move to %s; use --allow-ref-change)\n",
+				o.Name, o.NewResolvedReference)
 		case skills.UpgradeStatusSignerChangeBlocked:
 			newSigner := o.NewSignerIdentity
 			if newSigner == "" {

--- a/docs/cli/thv_skill_upgrade.md
+++ b/docs/cli/thv_skill_upgrade.md
@@ -24,8 +24,9 @@ Skills pinned to an immutable reference (an OCI digest or a full git commit
 hash) are reported not-upgradable — there is nothing newer to resolve to.
 Use --preview to see what would change without persisting anything (OCI
 sources are still fetched into the local artifact store to compare digests),
-and --allow-ref-change to permit the resolved reference itself changing
-(e.g. a registry entry repointed at a different repository).
+and --allow-ref-change to permit the artifact moving to a different
+repository (a version bump within the same repository is not a change
+this guard blocks).
 --fail-on-changes evaluates the same plan and never installs: it is a CI
 freshness gate.
 
@@ -40,7 +41,7 @@ thv skill upgrade [skill-name...] [flags]
 ### Options
 
 ```
-      --allow-ref-change      Permit the resolved reference itself to change during upgrade
+      --allow-ref-change      Permit the artifact to move to a different repository during upgrade
       --allow-signer-change   Permit upgrading to an artifact signed by a different identity; the new identity replaces the recorded one
       --clients string        Comma-separated target client apps (e.g. claude-code,opencode), or "all" for every available client
       --fail-on-changes       Report what would change without installing anything; a CI freshness gate

--- a/pkg/skills/options.go
+++ b/pkg/skills/options.go
@@ -314,7 +314,9 @@ type UpgradeOptions struct {
 	Preview bool `json:"preview,omitempty"`
 	// FailOnChanges exits with an error when any mutable source would upgrade.
 	FailOnChanges bool `json:"fail_on_changes,omitempty"`
-	// AllowRefChange permits resolvedReference changes during upgrade.
+	// AllowRefChange permits an upgrade whose candidate lives in a different
+	// repository. Tag moves within the same repository are always allowed —
+	// they are how a mutable source advances.
 	AllowRefChange bool `json:"allow_ref_change,omitempty"`
 	// AllowSignerChange permits upgrading to an artifact signed by a
 	// different identity than the one recorded in the lock file; the new

--- a/pkg/skills/skillsvc/pin.go
+++ b/pkg/skills/skillsvc/pin.go
@@ -30,6 +30,45 @@ func isImmutableSource(entry lockfile.Entry) bool {
 	return isDigest
 }
 
+// repositoryMoved reports whether two resolved references point at different
+// repositories, as opposed to differing only by tag. A tag move within one
+// repository is the normal way a mutable source advances; a repository move
+// means the artifact now comes from somewhere else, which is the case the
+// ref-change guard exists to catch.
+//
+// Both the registry and the repository path are compared, so ghcr.io ->
+// another registry, or a different org or path on the same registry, all
+// count as a move.
+func repositoryMoved(oldRef, newRef string) bool {
+	if oldRef == newRef {
+		return false
+	}
+	oldRepo, ok := referenceRepository(oldRef)
+	if !ok {
+		return true
+	}
+	newRepo, ok := referenceRepository(newRef)
+	if !ok {
+		return true
+	}
+	return oldRepo != newRepo
+}
+
+// referenceRepository returns the registry and repository portion of an OCI
+// reference, dropping any tag or digest. It reports false for git references
+// and for anything it cannot parse, so callers fall back to treating the
+// reference as moved rather than silently equating two unlike sources.
+func referenceRepository(ref string) (string, bool) {
+	if gitresolver.IsGitReference(ref) {
+		return "", false
+	}
+	parsed, err := nameref.ParseReference(ref)
+	if err != nil {
+		return "", false
+	}
+	return parsed.Context().String(), true
+}
+
 // isFullCommitHash accepts both hex cases: the sibling git resolver does
 // too, and classifying an uppercase-pinned source as mutable would
 // needlessly re-clone it on every upgrade despite the pin being immutable.

--- a/pkg/skills/skillsvc/pin_test.go
+++ b/pkg/skills/skillsvc/pin_test.go
@@ -179,7 +179,7 @@ func TestRepositoryMoved(t *testing.T) {
 			want:   true,
 		},
 		{
-			name:   "unparseable input fails closed",
+			name:   "unparsable input fails closed",
 			oldRef: "ghcr.io/org/skill:v1",
 			newRef: "not a valid reference at all",
 			want:   true,

--- a/pkg/skills/skillsvc/pin_test.go
+++ b/pkg/skills/skillsvc/pin_test.go
@@ -118,3 +118,77 @@ func hexDigestForTest() string {
 	const s = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 	return s[:64]
 }
+
+func TestRepositoryMoved(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		oldRef string
+		newRef string
+		want   bool
+	}{
+		{
+			name:   "identical references have not moved",
+			oldRef: "ghcr.io/org/skill:v1",
+			newRef: "ghcr.io/org/skill:v1",
+		},
+		{
+			name:   "a version bump is not a move",
+			oldRef: "ghcr.io/org/skill:0.1.0",
+			newRef: "ghcr.io/org/skill:0.2.0",
+		},
+		{
+			name:   "moving to a digest in the same repository is not a move",
+			oldRef: "ghcr.io/org/skill:0.1.0",
+			newRef: "ghcr.io/org/skill@" + ociTestDigest(1),
+		},
+		{
+			name:   "an implicit latest tag matches an explicit one",
+			oldRef: "ghcr.io/org/skill",
+			newRef: "ghcr.io/org/skill:latest",
+		},
+		{
+			name:   "a different repository path is a move",
+			oldRef: "ghcr.io/org/skill:v1",
+			newRef: "ghcr.io/org/other-skill:v1",
+			want:   true,
+		},
+		{
+			name:   "a different org on the same registry is a move",
+			oldRef: "ghcr.io/org/skill:v1",
+			newRef: "ghcr.io/attacker/skill:v1",
+			want:   true,
+		},
+		{
+			name:   "a different registry is a move",
+			oldRef: "ghcr.io/org/skill:v1",
+			newRef: "elsewhere.io/org/skill:v1",
+			want:   true,
+		},
+		{
+			name:   "git references fall back to exact comparison",
+			oldRef: "git://github.com/org/repo#skills/a",
+			newRef: "git://github.com/org/repo#skills/b",
+			want:   true,
+		},
+		{
+			name:   "an OCI reference replaced by a git one is a move",
+			oldRef: "ghcr.io/org/skill:v1",
+			newRef: "git://github.com/org/repo",
+			want:   true,
+		},
+		{
+			name:   "unparseable input fails closed",
+			oldRef: "ghcr.io/org/skill:v1",
+			newRef: "not a valid reference at all",
+			want:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, repositoryMoved(tc.oldRef, tc.newRef))
+		})
+	}
+}

--- a/pkg/skills/skillsvc/upgrade.go
+++ b/pkg/skills/skillsvc/upgrade.go
@@ -139,13 +139,17 @@ func (s *service) planUpgrade(ctx context.Context, opts skills.UpgradeOptions, e
 		return upgradePlan{entry: entry, outcome: outcome}
 	}
 
-	if newRef != entry.ResolvedReference && !opts.AllowRefChange {
-		outcome.Status = skills.UpgradeStatusRefChangeBlocked
-		outcome.NewResolvedReference = newRef
-		return upgradePlan{entry: entry, outcome: outcome}
-	}
 	if newRef != entry.ResolvedReference {
 		outcome.NewResolvedReference = newRef
+		// Only a move to a different repository is a supply-chain event. A
+		// tag moving within the same repository is how a catalog-sourced
+		// skill advances at all, and blocking it would force automation to
+		// pass --allow-ref-change on every routine upgrade — which would
+		// also disable the repository check this guard exists for.
+		if repositoryMoved(entry.ResolvedReference, newRef) && !opts.AllowRefChange {
+			outcome.Status = skills.UpgradeStatusRefChangeBlocked
+			return upgradePlan{entry: entry, outcome: outcome}
+		}
 	}
 
 	// Signer-change guard: when the entry records a signer identity, the

--- a/pkg/skills/skillsvc/upgrade_oci_test.go
+++ b/pkg/skills/skillsvc/upgrade_oci_test.go
@@ -180,3 +180,54 @@ func TestPlanUpgrade_RegistryFallbackSourceUpgrades(t *testing.T) {
 		"a registry-fallback-installed skill must be upgradable through the same fallback")
 	assert.Equal(t, ociTestDigest(3), plan.outcome.NewDigest)
 }
+
+// TestPlanUpgrade_TagMoveWithinRepositoryIsNotBlocked covers the routine
+// case a catalog-sourced skill hits on every release: the version moves, so
+// the resolved tag moves with it, but the artifact still comes from the same
+// repository. Blocking that would make --allow-ref-change mandatory for
+// ordinary upgrades and so disable the repository check it exists for (#6213).
+func TestPlanUpgrade_TagMoveWithinRepositoryIsNotBlocked(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	reg := ocimocks.NewMockRegistryClient(ctrl)
+	reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "ghcr.io/org/skill:v2").
+		Return(godigest.Digest(ociTestDigest(2)), nil)
+	svc := newOCIUpgradeService(t, reg, nil)
+
+	entry := lockfile.Entry{
+		Name:              "my-skill",
+		Source:            "ghcr.io/org/skill:v2",
+		ResolvedReference: "ghcr.io/org/skill:v1",
+		Digest:            ociTestDigest(1),
+	}
+
+	plan := svc.planUpgrade(t.Context(), skills.UpgradeOptions{}, entry)
+	assert.Equal(t, skills.UpgradeStatusUpgraded, plan.outcome.Status)
+	assert.Equal(t, "ghcr.io/org/skill:v2", plan.outcome.NewResolvedReference,
+		"the move is still reported even though it is permitted")
+	assert.NotEmpty(t, plan.pinnedRef, "a permitted plan must carry the pinned candidate")
+}
+
+// TestPlanUpgrade_RegistryChangeStaysBlocked keeps the guard meaningful: the
+// repository path is identical, only the registry host differs.
+func TestPlanUpgrade_RegistryChangeStaysBlocked(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	reg := ocimocks.NewMockRegistryClient(ctrl)
+	reg.EXPECT().Pull(gomock.Any(), gomock.Any(), "elsewhere.io/org/skill:v1").
+		Return(godigest.Digest(ociTestDigest(2)), nil)
+	svc := newOCIUpgradeService(t, reg, nil)
+
+	entry := lockfile.Entry{
+		Name:              "my-skill",
+		Source:            "elsewhere.io/org/skill:v1",
+		ResolvedReference: "ghcr.io/org/skill:v1",
+		Digest:            ociTestDigest(1),
+	}
+
+	plan := svc.planUpgrade(t.Context(), skills.UpgradeOptions{}, entry)
+	assert.Equal(t, skills.UpgradeStatusRefChangeBlocked, plan.outcome.Status)
+	assert.Empty(t, plan.pinnedRef)
+}


### PR DESCRIPTION
## Summary

A skill installed by catalog name records the resolved tag in its lock entry. When the catalog publishes a new version the tag moves with it, so `planUpgrade`'s ref-change guard fired on every ordinary upgrade:

```
tdd: reference change blocked
  (would move to ghcr.io/stacklok/dockyard/skills/tdd:0.2.0; use --allow-ref-change)
```

That is the *only* way a catalog-sourced skill ever advances, so keeping one current meant passing `--allow-ref-change` unconditionally — and passing it disabled the check the guard exists for: a registry entry being repointed at a different repository. A guard that everyone has to switch off protects nothing, so the flag had quietly become a no-op in practice.

The fix compares the registry and repository path rather than the whole tagged reference:

- a tag moving within one repository proceeds (`ghcr.io/org/skill:0.1.0` → `:0.2.0`)
- a move to a different repository, org, or registry still blocks
- git references and unparseable input fall back to exact comparison, so they fail closed

A permitted move is still *reported* — `new_resolved_reference` is populated on the outcome either way — so the tag change stays visible in output and in the lock diff.

Neither adjacent protection is weakened: the digest is still pinned from the plan (so a permitted tag move installs exactly what was resolved, not whatever the tag points at later), and the signer-change guard still runs independently, so identity substitution is caught regardless of where the artifact lives.

Closes #6213

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

`TestRepositoryMoved` is a table over the comparison itself: identical refs, version bump, tag→digest in the same repository, implicit vs explicit `latest`, different repository path, different org, different registry, git-to-git, OCI-to-git, and unparseable input. Plus `TestPlanUpgrade_TagMoveWithinRepositoryIsNotBlocked` and `TestPlanUpgrade_RegistryChangeStaysBlocked` at the plan level. The pre-existing `TestPlanUpgrade_OCIRefChangeGuard` passes unchanged — it exercises a genuine repository repoint, which still blocks.

Manually, against the real catalog with a lock entry pinned at `tdd:0.1.0` and `source: tdd`:

```json
// no --allow-ref-change
{"name": "tdd", "status": "upgraded",
 "new_resolved_reference": "ghcr.io/stacklok/dockyard/skills/tdd:0.2.0"}
```

then, with the lock's `resolvedReference` hand-edited to `ghcr.io/someone-else/skills/tdd:0.1.0` to simulate a repoint:

```json
{"name": "tdd", "status": "ref-change-blocked",
 "new_resolved_reference": "ghcr.io/stacklok/dockyard/skills/tdd:0.2.0"}
```

## Does this introduce a user-facing change?

Yes. `thv skill upgrade` no longer requires `--allow-ref-change` for a version bump within the same repository. The flag now means "permit the artifact to move to a different repository", and the blocked message says "repository change blocked". Anyone currently passing the flag keeps working — it is strictly more permissive than before.

`task docs` regenerated `docs/cli/thv_skill_upgrade.md` for the reworded flag help.

## Special notes for reviewers

**This loosens a security control, so it deserves a deliberate decision rather than a quiet merge.** The issue laid out three options; this implements option 1 (compare repository, not full reference), which the issue argues is closest to the guard's stated intent. Option 2 — keep blocking both but give callers a narrower flag — is also defensible and I'm happy to switch if you'd prefer the more conservative shape.

The one behaviour worth naming explicitly: a *downgrade* within the same repository (catalog moving `0.2.0` → `0.1.0`) is now permitted without the flag, where before it was blocked. It was already permitted with the flag, and the digest and signer checks still apply, but it is a real difference.

Generated with [Claude Code](https://claude.com/claude-code)