### PR TITLE
Resolve relative --project-root for ai-plugin too

### DIFF
--- a/cmd/thv/app/ai_plugin_info.go
+++ b/cmd/thv/app/ai_plugin_info.go
@@ -48,10 +48,15 @@ func init() {
 func aiPluginInfoCmdFunc(cmd *cobra.Command, args []string) error {
 	c := newAIPluginClient(cmd.Context())
 
+	projectRoot, err := absProjectRoot(aiPluginInfoProjectRoot)
+	if err != nil {
+		return err
+	}
+
 	info, err := c.Info(cmd.Context(), plugins.InfoOptions{
 		Name:        args[0],
 		Scope:       plugins.Scope(aiPluginInfoScope),
-		ProjectRoot: aiPluginInfoProjectRoot,
+		ProjectRoot: projectRoot,
 	})
 	if err != nil {
 		return formatAIPluginError("get plugin info", err)

--- a/cmd/thv/app/ai_plugin_install.go
+++ b/cmd/thv/app/ai_plugin_install.go
@@ -49,12 +49,17 @@ func init() {
 func aiPluginInstallCmdFunc(cmd *cobra.Command, args []string) error {
 	c := newAIPluginClient(cmd.Context())
 
-	_, err := c.Install(cmd.Context(), plugins.InstallOptions{
+	projectRoot, err := absProjectRoot(aiPluginInstallProjectRoot)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Install(cmd.Context(), plugins.InstallOptions{
 		Name:        args[0],
 		Scope:       plugins.Scope(aiPluginInstallScope),
 		Clients:     parseSkillInstallClients(aiPluginInstallClientsRaw),
 		Force:       aiPluginInstallForce,
-		ProjectRoot: aiPluginInstallProjectRoot,
+		ProjectRoot: projectRoot,
 		Group:       aiPluginInstallGroup,
 	})
 	if err != nil {

--- a/cmd/thv/app/ai_plugin_list.go
+++ b/cmd/thv/app/ai_plugin_list.go
@@ -49,10 +49,15 @@ func init() {
 func aiPluginListCmdFunc(cmd *cobra.Command, _ []string) error {
 	c := newAIPluginClient(cmd.Context())
 
+	projectRoot, err := absProjectRoot(aiPluginListProjectRoot)
+	if err != nil {
+		return err
+	}
+
 	installed, err := c.List(cmd.Context(), plugins.ListOptions{
 		Scope:       plugins.Scope(aiPluginListScope),
 		ClientApp:   aiPluginListClient,
-		ProjectRoot: aiPluginListProjectRoot,
+		ProjectRoot: projectRoot,
 		Group:       aiPluginListGroup,
 	})
 	if err != nil {

--- a/cmd/thv/app/ai_plugin_uninstall.go
+++ b/cmd/thv/app/ai_plugin_uninstall.go
@@ -41,10 +41,15 @@ func init() {
 func aiPluginUninstallCmdFunc(cmd *cobra.Command, args []string) error {
 	c := newAIPluginClient(cmd.Context())
 
-	err := c.Uninstall(cmd.Context(), plugins.UninstallOptions{
+	projectRoot, err := absProjectRoot(aiPluginUninstallProjectRoot)
+	if err != nil {
+		return err
+	}
+
+	err = c.Uninstall(cmd.Context(), plugins.UninstallOptions{
 		Name:        args[0],
 		Scope:       plugins.Scope(aiPluginUninstallScope),
-		ProjectRoot: aiPluginUninstallProjectRoot,
+		ProjectRoot: projectRoot,
 	})
 	if err != nil {
 		return formatAIPluginError("uninstall plugin", err)

--- a/cmd/thv/app/project_root.go
+++ b/cmd/thv/app/project_root.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// absProjectRoot makes a user-supplied --project-root absolute, leaving an
+// empty value empty — for most commands that means "not project-scoped", and
+// substituting the working directory there would silently change the scope.
+//
+// The API server requires an absolute project root, so a relative value would
+// otherwise travel all the way to the server and come back as a validation
+// error naming the wire field rather than the flag the user typed.
+//
+// Shared by the skill and ai-plugin commands: both take a --project-root flag
+// and both validate it through skills.ValidateProjectRoot server-side (the
+// plugins package re-exports it), so they need the same normalization.
+func absProjectRoot(explicit string) (string, error) {
+	if explicit == "" {
+		return "", nil
+	}
+	abs, err := filepath.Abs(explicit)
+	if err != nil {
+		return "", fmt.Errorf("resolving --project-root %q: %w", explicit, err)
+	}
+	return abs, nil
+}

--- a/cmd/thv/app/project_root_test.go
+++ b/cmd/thv/app/project_root_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // uses t.Chdir, incompatible with t.Parallel
+func TestAbsProjectRoot(t *testing.T) {
+	cwd := t.TempDir()
+	resolvedCwd, err := filepath.EvalSymlinks(cwd)
+	require.NoError(t, err)
+	t.Chdir(resolvedCwd)
+
+	tests := []struct {
+		name     string
+		explicit string
+		want     string
+	}{
+		{
+			name:     "empty stays empty so the scope is not silently changed",
+			explicit: "",
+			want:     "",
+		},
+		{
+			name:     "dot resolves to the working directory",
+			explicit: ".",
+			want:     resolvedCwd,
+		},
+		{
+			name:     "relative child resolves against the working directory",
+			explicit: "child",
+			want:     filepath.Join(resolvedCwd, "child"),
+		},
+		{
+			name:     "an absolute path is returned unchanged",
+			explicit: resolvedCwd,
+			want:     resolvedCwd,
+		},
+		{
+			name:     "traversal is cleaned rather than rejected",
+			explicit: filepath.Join(resolvedCwd, "a", ".."),
+			want:     resolvedCwd,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := absProjectRoot(tc.explicit)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestAbsProjectRootSharedBySkillAndPlugin documents why this helper is not
+// in skill_helpers.go: thv ai-plugin takes the same --project-root flag and
+// its server-side validation is literally the same function (pkg/plugins
+// re-exports skills.ValidateProjectRoot), so both surfaces need identical
+// normalization. A relative value from either must not reach the API.
+//
+//nolint:paralleltest // uses t.Chdir, incompatible with t.Parallel
+func TestAbsProjectRootSharedBySkillAndPlugin(t *testing.T) {
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	t.Chdir(resolved)
+
+	for _, flagValue := range []string{".", "./", "sub/dir"} {
+		got, err := absProjectRoot(flagValue)
+		require.NoError(t, err)
+		assert.True(t, filepath.IsAbs(got),
+			"--project-root %q must be absolute before it reaches the API server", flagValue)
+	}
+}

--- a/cmd/thv/app/skill_helpers.go
+++ b/cmd/thv/app/skill_helpers.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -66,24 +65,6 @@ func validateProjectRootForScope(scopeVar, projectRootVar *string) func(*cobra.C
 		}
 		return nil
 	}
-}
-
-// absProjectRoot makes a user-supplied --project-root absolute, leaving an
-// empty value empty — for most commands that means "not project-scoped", and
-// substituting the working directory there would silently change the scope.
-//
-// The API server requires an absolute project root, so a relative value would
-// otherwise travel all the way to the server and come back as a validation
-// error naming the wire field rather than the flag the user typed.
-func absProjectRoot(explicit string) (string, error) {
-	if explicit == "" {
-		return "", nil
-	}
-	abs, err := filepath.Abs(explicit)
-	if err != nil {
-		return "", fmt.Errorf("resolving --project-root %q: %w", explicit, err)
-	}
-	return abs, nil
 }
 
 // resolveProjectRoot returns explicit if set, otherwise auto-detects the

--- a/cmd/thv/app/skill_helpers_test.go
+++ b/cmd/thv/app/skill_helpers_test.go
@@ -11,53 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:paralleltest // uses t.Chdir, incompatible with t.Parallel
-func TestAbsProjectRoot(t *testing.T) {
-	cwd := t.TempDir()
-	resolvedCwd, err := filepath.EvalSymlinks(cwd)
-	require.NoError(t, err)
-	t.Chdir(resolvedCwd)
-
-	tests := []struct {
-		name     string
-		explicit string
-		want     string
-	}{
-		{
-			name:     "empty stays empty so the scope is not silently changed",
-			explicit: "",
-			want:     "",
-		},
-		{
-			name:     "dot resolves to the working directory",
-			explicit: ".",
-			want:     resolvedCwd,
-		},
-		{
-			name:     "relative child resolves against the working directory",
-			explicit: "child",
-			want:     filepath.Join(resolvedCwd, "child"),
-		},
-		{
-			name:     "an absolute path is returned unchanged",
-			explicit: resolvedCwd,
-			want:     resolvedCwd,
-		},
-		{
-			name:     "traversal is cleaned rather than rejected",
-			explicit: filepath.Join(resolvedCwd, "a", ".."),
-			want:     resolvedCwd,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := absProjectRoot(tc.explicit)
-			require.NoError(t, err)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
 // TestResolveProjectRootAbsolutizesExplicit covers the sync/upgrade path,
 // where an explicit value short-circuits auto-detection — it must still be
 // made absolute, which is the regression behind #6211.


### PR DESCRIPTION
## Summary

#6211 fixed `thv skill` rejecting a relative `--project-root`. I flagged in that PR that `thv ai-plugin` looked like it had the same bug; it does, and it is not a coincidence — the two surfaces validate through literally the same function:

```go
// pkg/plugins/project_root.go
var ValidateProjectRoot = skills.ValidateProjectRoot
```

So `thv ai-plugin list --project-root .` fails exactly the way `thv skill` used to, with an error naming the wire field instead of the flag:

```
project_root must be absolute, got "."
```

- `absProjectRoot` moves out of `skill_helpers.go` into `project_root.go`. It is no longer skill-specific, and leaving it in a file named for one of its two callers would invite the next person to write a second copy.
- Applied to `ai-plugin` `install`, `info`, `list`, and `uninstall` — the four commands that pass the flag straight through.

No behaviour change for skills; the helper is byte-identical, just relocated.

Follows #6211.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

`TestAbsProjectRoot` moves alongside the helper, plus a new `TestAbsProjectRootSharedBySkillAndPlugin` that records *why* the helper is shared, so the reason survives the next refactor.

Manually, against a local `thv serve` — first confirming the server-side rejection is real rather than assumed, then that the CLI no longer trips it:

```console
$ curl -s 'http://127.0.0.1:18080/api/v1beta/plugins?scope=project&project_root=.'
project_root must be absolute, got "."

$ thv ai-plugin list --scope project --project-root .
No plugins found matching filters
```

## Does this introduce a user-facing change?

Yes. `thv ai-plugin` commands now accept a relative `--project-root` (including `.`), matching `thv skill`. Absolute paths are unaffected.

Generated with [Claude Code](https://claude.com/claude-code)