### PR TITLE
Keep the OIDC callback listener alive when an LLM proxy client disconnects

### DIFF
--- a/pkg/llm/proxy/proxy.go
+++ b/pkg/llm/proxy/proxy.go
@@ -30,6 +30,12 @@ import (
 // still does. Once a token is cached, subsequent requests are served from cache
 // and return well within this bound, so the only request that ever approaches it
 // is the initial login.
+//
+// The token source serializes Token() internally, so requests that arrive while
+// that initial login is in flight queue behind it and are then served from the
+// resulting cached token — one browser flow, however many concurrent requests.
+// Their own clients may time out and disconnect first; that is fine, since the
+// login they were waiting on completes regardless and their retry hits the cache.
 const tokenFetchTimeout = 3 * time.Minute
 
 // TokenSource obtains fresh OIDC access tokens for the LLM gateway.

--- a/pkg/llm/proxy/proxy.go
+++ b/pkg/llm/proxy/proxy.go
@@ -21,12 +21,15 @@ import (
 	"github.com/stacklok/toolhive/pkg/networking"
 )
 
-// tokenFetchTimeout bounds the per-request token fetch. It is deliberately
-// generous: the first request after a lazy setup ("thv llm setup --lazy") drives
-// the interactive OIDC browser login through the token source, and a human needs
-// time to complete it. Once a token is cached, subsequent requests are served
-// from cache and return well within this bound, so the only request that ever
-// approaches it is the initial login.
+// tokenFetchTimeout bounds the per-request token fetch. The bound is achievable
+// because the fetch is rooted in the proxy-lifetime context passed to Start, not
+// in the inbound request's context: the first request after a lazy setup
+// ("thv llm setup --lazy") drives the interactive OIDC browser login through the
+// token source, and a human needs time to complete it. An impatient client
+// disconnecting no longer cancels the login, but Ctrl+C (cancelling Start's ctx)
+// still does. Once a token is cached, subsequent requests are served from cache
+// and return well within this bound, so the only request that ever approaches it
+// is the initial login.
 const tokenFetchTimeout = 3 * time.Minute
 
 // TokenSource obtains fresh OIDC access tokens for the LLM gateway.
@@ -155,8 +158,10 @@ func (p *Proxy) Addr() string {
 }
 
 // handler returns an http.Handler that injects a fresh OIDC token and proxies
-// the request to the upstream gateway.
-func (p *Proxy) handler() http.Handler {
+// the request to the upstream gateway. The token fetch is bounded by baseCtx
+// (the proxy lifetime context passed to Start), not the inbound request's
+// context, so a client disconnect cannot abort an in-flight interactive login.
+func (p *Proxy) handler(baseCtx context.Context) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Guard against DNS-rebinding attacks: reject requests whose Host header
 		// does not resolve to a loopback address. A loopback-only bind prevents
@@ -167,7 +172,7 @@ func (p *Proxy) handler() http.Handler {
 			return
 		}
 
-		tokenCtx, cancel := context.WithTimeout(r.Context(), tokenFetchTimeout)
+		tokenCtx, cancel := context.WithTimeout(baseCtx, tokenFetchTimeout)
 		defer cancel()
 		token, err := p.tokenSource.Token(tokenCtx)
 		if err != nil {
@@ -206,7 +211,7 @@ func (p *Proxy) handler() http.Handler {
 // cancelled, then performs a graceful shutdown with a 5-second timeout.
 func (p *Proxy) Start(ctx context.Context) error {
 	p.server = &http.Server{
-		Handler:           p.handler(),
+		Handler:           p.handler(ctx),
 		ReadHeaderTimeout: 30 * time.Second,
 	}
 

--- a/pkg/llm/proxy/proxy_test.go
+++ b/pkg/llm/proxy/proxy_test.go
@@ -119,7 +119,7 @@ func TestHandler_InjectsToken(t *testing.T) {
 	req := loopbackRequest("/v1/models")
 	req.Header.Set("Authorization", "Bearer old-token")
 	w := httptest.NewRecorder()
-	p.handler().ServeHTTP(w, req)
+	p.handler(context.Background()).ServeHTTP(w, req)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -145,7 +145,7 @@ func TestHandler_StripsIncomingAuthorization(t *testing.T) {
 	req := loopbackRequest("/v1/models")
 	req.Header.Set("Authorization", "Bearer user-supplied-token")
 	w := httptest.NewRecorder()
-	p.handler().ServeHTTP(w, req)
+	p.handler(context.Background()).ServeHTTP(w, req)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -168,7 +168,7 @@ func TestHandler_RejectsDNSRebindingHost(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
 		req.Host = host
 		w := httptest.NewRecorder()
-		p.handler().ServeHTTP(w, req)
+		p.handler(context.Background()).ServeHTTP(w, req)
 		assert.Equal(t, http.StatusForbidden, w.Code, "host %q should be rejected", host)
 	}
 
@@ -177,7 +177,7 @@ func TestHandler_RejectsDNSRebindingHost(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
 		req.Host = host
 		w := httptest.NewRecorder()
-		p.handler().ServeHTTP(w, req)
+		p.handler(context.Background()).ServeHTTP(w, req)
 		assert.NotEqual(t, http.StatusForbidden, w.Code, "host %q should be allowed", host)
 	}
 }
@@ -194,7 +194,7 @@ func TestHandler_Returns502OnTokenError(t *testing.T) {
 
 	req := loopbackRequest("/v1/chat/completions")
 	w := httptest.NewRecorder()
-	p.handler().ServeHTTP(w, req)
+	p.handler(context.Background()).ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadGateway, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -215,7 +215,7 @@ func TestHandler_Returns401WithActionableMessageOnErrTokenRequired(t *testing.T)
 
 	req := loopbackRequest("/v1/chat/completions")
 	w := httptest.NewRecorder()
-	p.handler().ServeHTTP(w, req)
+	p.handler(context.Background()).ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -364,7 +364,7 @@ func TestWithTLSSkipVerify(t *testing.T) {
 
 		req := loopbackRequest("/v1/models")
 		w := httptest.NewRecorder()
-		p.handler().ServeHTTP(w, req)
+		p.handler(context.Background()).ServeHTTP(w, req)
 
 		// Certificate verification failure surfaces as 502 Bad Gateway.
 		assert.Equal(t, http.StatusBadGateway, w.Code)
@@ -382,7 +382,7 @@ func TestWithTLSSkipVerify(t *testing.T) {
 
 		req := loopbackRequest("/v1/models")
 		w := httptest.NewRecorder()
-		p.handler().ServeHTTP(w, req)
+		p.handler(context.Background()).ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 	})

--- a/pkg/llm/proxy/proxy_test.go
+++ b/pkg/llm/proxy/proxy_test.go
@@ -26,9 +26,18 @@ import (
 type stubTokenSource struct {
 	token string
 	err   error
+	// block, if non-nil, is invoked from Token. Tests use it to observe the
+	// ctx the proxy passed in and to control timing at the observable boundary
+	// (when the fetch resolves). It receives the token-fetch ctx and the token
+	// the stub will return once it unblocks. This is test-only instrumentation;
+	// production structs are unchanged.
+	block func(ctx context.Context, token string)
 }
 
-func (s *stubTokenSource) Token(_ context.Context) (string, error) {
+func (s *stubTokenSource) Token(ctx context.Context) (string, error) {
+	if s.block != nil {
+		s.block(ctx, s.token)
+	}
 	return s.token, s.err
 }
 
@@ -407,5 +416,147 @@ func TestProxy_PassesThroughErrorResponses(t *testing.T) {
 
 			assert.Equal(t, statusCode, resp.StatusCode, "error response must pass through unmodified")
 		})
+	}
+}
+
+// newBlockingTokenProxy builds a Proxy whose token source blocks inside Token
+// until the returned release channel is closed (or the fetch ctx is cancelled,
+// whichever is first). It also hands the fetch ctx to sawCtx, exactly once,
+// so the caller can inspect the context the proxy rooted the fetch in.
+//
+// The gateway returns 200 so that, once the token is delivered, the handler
+// completes normally; tests that only care about the fetch phase never reach it.
+func newBlockingTokenProxy(t *testing.T) (p *Proxy, release chan struct{}, sawCtx chan context.Context) {
+	t.Helper()
+
+	gateway := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(gateway.Close)
+
+	cfg := &llm.Config{
+		GatewayURL: gateway.URL,
+		Proxy:      llm.ProxyConfig{ListenPort: freePort(t)},
+	}
+	release = make(chan struct{})
+	sawCtx = make(chan context.Context, 1)
+	src := &stubTokenSource{
+		token: "fresh-token",
+		block: func(ctx context.Context, _ string) {
+			select {
+			case sawCtx <- ctx:
+			default:
+			}
+			// Block until the test releases us or the proxy cancels the fetch.
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+		},
+	}
+	p, err := New(cfg, src)
+	require.NoError(t, err)
+	p.transport = gateway.Client().Transport
+	t.Cleanup(func() { _ = p.listener.Close() })
+	return p, release, sawCtx
+}
+
+// waitForFetchCtx waits for the stubbed Token to report the fetch ctx, failing
+// fast on timeout so a miswire never hangs the suite.
+func waitForFetchCtx(t *testing.T, sawCtx <-chan context.Context) context.Context {
+	t.Helper()
+	select {
+	case ctx := <-sawCtx:
+		return ctx
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for token fetch to start")
+		return nil
+	}
+}
+
+// TestHandler_TokenFetchSurvivesClientDisconnect pins the Step 1 contract that a
+// client disconnecting mid-request does NOT cancel the token fetch: the fetch is
+// rooted in the proxy-lifetime baseCtx, not the inbound request's context.
+func TestHandler_TokenFetchSurvivesClientDisconnect(t *testing.T) {
+	t.Parallel()
+	p, release, sawCtx := newBlockingTokenProxy(t)
+
+	baseCtx, baseCancel := context.WithCancel(context.Background())
+	t.Cleanup(baseCancel)
+
+	// Inbound request carries its own cancellable context, as a real
+	// disconnected client would. Host is loopback to pass the DNS-rebinding guard.
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	t.Cleanup(reqCancel)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(""))
+	req = req.WithContext(reqCtx)
+	req.Host = "127.0.0.1"
+
+	handlerDone := make(chan struct{})
+	go func() {
+		w := httptest.NewRecorder()
+		p.handler(baseCtx).ServeHTTP(w, req)
+		close(handlerDone)
+	}()
+
+	fetchCtx := waitForFetchCtx(t, sawCtx)
+
+	// Disconnect the client while the fetch is still in flight.
+	reqCancel()
+
+	// Give the cancellation a moment to propagate, then assert the fetch ctx is
+	// untouched: under the Step 1 contract the fetch is rooted in baseCtx, which
+	// is still alive, so the fetch must keep running.
+	select {
+	case <-fetchCtx.Done():
+		t.Fatal("fetch ctx was cancelled by request ctx — fetch must be rooted in baseCtx, not r.Context()")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Releasing the stub delivers the token and the handler finishes normally.
+	close(release)
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after token was delivered")
+	}
+}
+
+// TestHandler_TokenFetchCancelsWithStartContext pins the other half of the
+// Step 1 contract: cancelling Start's ctx (baseCtx) — e.g. via Ctrl+C — DOES
+// cancel the in-flight token fetch.
+func TestHandler_TokenFetchCancelsWithStartContext(t *testing.T) {
+	t.Parallel()
+	p, _, sawCtx := newBlockingTokenProxy(t)
+
+	baseCtx, baseCancel := context.WithCancel(context.Background())
+	t.Cleanup(baseCancel)
+
+	req := loopbackRequest("/v1/models")
+	handlerDone := make(chan struct{})
+	go func() {
+		w := httptest.NewRecorder()
+		p.handler(baseCtx).ServeHTTP(w, req)
+		close(handlerDone)
+	}()
+
+	fetchCtx := waitForFetchCtx(t, sawCtx)
+
+	// Cancel Start's lifetime context, exactly as Ctrl+C would.
+	baseCancel()
+
+	// The fetch ctx is derived from baseCtx, so it must be cancelled now.
+	select {
+	case <-fetchCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("fetch ctx was not cancelled when baseCtx was cancelled")
+	}
+
+	// And the handler must unwind: the stub also returns on ctx.Done(), so the
+	// token is delivered and the handler completes via the 200 proxy path.
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after baseCtx cancellation")
 	}
 }

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -39,7 +39,10 @@ type TokenSource = tokensource.OAuthTokenSource
 // secretsProvider may be nil if the secrets store is unavailable.
 // tokenRefUpdater is called after login/refresh to persist the token reference
 // into config — pass nil to skip config persistence (useful in tests).
-// Set interactive to false for non-interactive callers such as thv llm token.
+// interactive controls whether a genuine cache miss may launch the browser
+// OIDC flow. thv llm token passes true so a prior "thv llm setup --lazy" signs
+// the user in transparently on first use; cached tokens are served without a
+// browser prompt either way.
 // When skipBrowser is true, an interactive login prints the authorization URL
 // instead of opening a browser (headless/SSH/CI use); it has no effect unless
 // interactive is also true.


### PR DESCRIPTION
## Summary

- On a cold start, `thv llm proxy` opens the browser for the OIDC login but the callback listener is gone before the user can finish authenticating, so `thv llm setup --lazy` cannot complete a login through the proxy. The token fetch was rooted in the inbound request's context, which bounds the login's lifetime by the calling client's patience — and no HTTP client waits the 30-90s a person needs at an IdP. When the client gives up, `net/http` cancels `r.Context()`, `oauth.Flow.Start` returns at `flow.go:255`, and its deferred `Shutdown` tears down the callback server mid-login.
- Root the token fetch in the proxy-lifetime context passed to `Start` instead. A client disconnect can no longer abort a login in progress; Ctrl+C (which cancels `Start`'s ctx) still can.
- This also removes a second failure mode: previously a retrying client would start a *fresh* flow on the same pinned callback port with a new `state`, so a completed login on the user's original tab was rejected as `invalid state parameter`. With the flow no longer dying on disconnect, there is no successor flow to invalidate the open tab.
- Corrects two doc comments that no longer matched behaviour: the `interactive` parameter on `llm.NewTokenSource` (`runLLMToken` has passed `true` since lazy setup landed), and `tokenFetchTimeout`, which now explains what a *queued* request experiences during the initial login.

Closes #6227

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests — `go test -race ./pkg/llm/...` green (the full `task test` suite has not been run on this branch)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing

Manual: reproduced the original failure with `thv llm setup --lazy` + `thv llm proxy` against Okta — browser opened, the calling tool timed out, and the callback landed on a dead listener. With this change the login completes after the client has already disconnected, and the client's retry is served from the cached token.

Two new unit tests pin both halves of the contract:

- `TestHandler_TokenFetchSurvivesClientDisconnect` — cancelling the request ctx does not cancel the fetch ctx.
- `TestHandler_TokenFetchCancelsWithStartContext` — cancelling `Start`'s ctx does.

## Changes

| File | Change |
|------|--------|
| `pkg/llm/proxy/proxy.go` | `handler` takes the proxy-lifetime ctx; token fetch derives from it instead of `r.Context()`. Expanded the `tokenFetchTimeout` comment. |
| `pkg/llm/proxy/proxy_test.go` | Two tests for the disconnect/lifetime contract; existing tests updated for the `handler` signature. |
| `pkg/llm/tokensource.go` | Doc comment only — describe what `interactive` actually gates. |

## Does this introduce a user-facing change?

Yes. Interactive OIDC login through `thv llm proxy` now works when the calling client times out mid-login, which is the normal case for `thv llm setup --lazy`. Previously the login could not be completed at all.

## Special notes for reviewers

The behavioural trade is deliberate and worth a look: a handler goroutine's lifetime is no longer bounded by its client's connection, so during the login window a disconnected client's handler stays parked until the token arrives or `tokenFetchTimeout` (3 min) elapses. That is what makes the login survivable. The token source serializes `Token()` internally, so concurrent requests queue behind the one login rather than each starting their own browser flow — one flow, however many requests. This is documented at the `tokenFetchTimeout` declaration.

Follow-ups I deliberately left out of scope:

1. `thv llm token` invoked as an `apiKeyHelper` shows the same symptom from a different cause — the client kills the child process, so the listener dies with it. No amount of context rooting fixes that; it needs either an eager login or a process-independent listener.
2. `oauth.Flow` binds `:port` rather than `127.0.0.1:port` (`flow.go:202`) and treats a foreign `state` as fatal instead of returning 400 and continuing to wait (`flow.go:322-327`). Together that is a LAN-reachable way to kill someone's in-progress login. Worth its own PR.
3. Priming the token once in `Start` before `Serve` (warn-and-continue on failure) would move the cold-start browser tab to the moment the user typed the command, out of the concurrent HTTP path entirely, without breaking what `--lazy` promises.

Generated with [Claude Code](https://claude.com/claude-code)
