### PR TITLE
fix(vmcp): reject Authorization and Cookie in passthroughHeaders, as documented

### DIFF
--- a/pkg/vmcp/config/validator.go
+++ b/pkg/vmcp/config/validator.go
@@ -591,6 +591,16 @@ func (*DefaultValidator) validateCompositeToolRefs(refs []CompositeToolRef) erro
 	return nil
 }
 
+// The standalone header-forward middleware deliberately allows Authorization
+// (an operator may legitimately forward it), but for vMCP passthrough the
+// documented contract is stricter: Authorization and Cookie are rejected at
+// startup because forwarding caller-supplied credentials verbatim to every
+// backend is a credential-leak footgun, not a pass-through use case.
+var vmcpRestrictedHeaders = map[string]bool{
+	"Authorization": true,
+	"Cookie":        true,
+}
+
 func (*DefaultValidator) validatePassthroughHeaders(cfg *Config) error {
 	for i, name := range cfg.PassthroughHeaders {
 		if name == "" {
@@ -599,7 +609,7 @@ func (*DefaultValidator) validatePassthroughHeaders(cfg *Config) error {
 
 		canonical := http.CanonicalHeaderKey(name)
 
-		if middleware.RestrictedHeaders[canonical] {
+		if middleware.RestrictedHeaders[canonical] || vmcpRestrictedHeaders[canonical] {
 			return fmt.Errorf("passthroughHeaders[%d]: %q is a restricted header and cannot be forwarded", i, canonical)
 		}
 

--- a/pkg/vmcp/config/validator_test.go
+++ b/pkg/vmcp/config/validator_test.go
@@ -1496,6 +1496,21 @@ func TestValidator_ValidatePassthroughHeaders(t *testing.T) {
 			errMsg:  "X-Forwarded-For",
 		},
 		{
+			// Documented contract (virtualmcpserver-api.md): Authorization is
+			// rejected at startup. Forwarding caller-supplied credentials
+			// verbatim to every backend is a credential-leak footgun.
+			name:    "Authorization is restricted",
+			headers: []string{"authorization"},
+			wantErr: true,
+			errMsg:  "Authorization",
+		},
+		{
+			name:    "Cookie is restricted",
+			headers: []string{"Cookie"},
+			wantErr: true,
+			errMsg:  "Cookie",
+		},
+		{
 			name:    "empty string header name is rejected",
 			headers: []string{""},
 			wantErr: true,


### PR DESCRIPTION
## Problem

`validatePassthroughHeaders` checks names against `middleware.RestrictedHeaders` only. That map's omission of `Authorization` is deliberate for its original consumer (the standalone header-forward middleware, where `TestCreateHeaderForwardMiddleware_AuthorizationAllowed` asserts it stays forwardable) — but for **vMCP passthrough** the documented contract is stricter:

> *virtualmcpserver-api.md*: "restricted headers (`Host`, `Authorization`, `X-Forwarded-*`, hop-by-hop) are rejected at startup"

The validator contradicts the doc: `passthroughHeaders: [authorization]` starts cleanly, and the client's `Authorization` (or `Cookie`) header is then forwarded **verbatim to every backend** — leaking the caller's incoming credential to all upstream MCP servers. The sibling `embeddingHeaders` field already excludes `authorization` via CEL validation (config.go:976), so the codebase's own convention says these headers don't belong in operator-configured forward lists.

## Fix

The vMCP validator rejects `Authorization` and `Cookie` at startup with the same error shape as the other restricted headers. The standalone middleware's behavior (and its test) is untouched — the stricter set lives in the vMCP validator where the documented contract applies.

## Tests

Added "Authorization is restricted" (lowercase input, exercising canonicalization) and "Cookie is restricted" cases to `TestValidator_ValidatePassthroughHeaders`. Full `pkg/vmcp/config` suite passes.

Related: #6234 (non-JSON POST authz skip) — same seam family, independent fix.

Made with Cursor

Made with [Cursor](https://cursor.com)