### PR TITLE
fix(auth): require audience when introspecting via Google tokeninfo

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -640,6 +640,19 @@ func NewTokenValidator(ctx context.Context, config TokenValidatorConfig, opts ..
 		return nil, ErrMissingIssuerAndJWKSURL
 	}
 
+	// Google's tokeninfo endpoint returns no iss claim - parseGoogleResponse
+	// synthesises iss locally, so a configured-issuer check against it is
+	// self-satisfying and proves nothing about which OAuth client the token
+	// was minted for. The only real binding to this deployment is the
+	// audience check, which is skipped when audience is empty. Without it,
+	// ANY valid Google access token (e.g. one minted for an attacker's own
+	// unrelated OAuth client) passes validation. Refuse the combination at
+	// startup instead of silently accepting cross-client tokens at runtime.
+	if config.IntrospectionURL == GoogleTokeninfoURL && config.Audience == "" {
+		return nil, fmt.Errorf("audience is required when using Google's tokeninfo endpoint for introspection: " +
+			"without it any valid Google access token is accepted regardless of the OAuth client it was minted for")
+	}
+
 	// Create HTTP client with CA bundle and auth token support for JWKS
 	httpClient, err := networking.NewHttpClientBuilder().
 		WithCABundle(config.CACertPath).

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -587,35 +587,18 @@ func resolveClientSecret(configSecret string, envReader env.Reader) string {
 	return ""
 }
 
-// NewTokenValidator creates a new token validator.
-func NewTokenValidator(ctx context.Context, config TokenValidatorConfig, opts ...TokenValidatorOption) (*TokenValidator, error) {
-	// Apply functional options
-	o := &tokenValidatorOptions{envReader: &env.OSReader{}}
-	for _, opt := range opts {
-		opt(o)
-	}
-
-	// Log warning if insecure HTTP is enabled
-	if config.InsecureAllowHTTP {
-		slog.Warn(
-			"insecure HTTP is enabled - "+
-				"HTTP OIDC URLs are allowed - this is INSECURE and should NEVER be used in production",
-			"issuer", config.Issuer,
-		)
-	}
-
+// resolveJWKSDiscovery determines the JWKS URL to use, and whether lazy OIDC
+// discovery is needed. Discovery is deferred when JWKS URL is not provided
+// but issuer is, allowing the validator to start before the OIDC provider is
+// ready; ensureOIDCDiscovered populates jwksURL on first use in that case.
+func resolveJWKSDiscovery(config TokenValidatorConfig, o *tokenValidatorOptions) (string, error) {
 	jwksURL := config.JWKSURL
-
-	// Determine if we need lazy OIDC discovery.
-	// Discovery is deferred when JWKS URL is not provided but issuer is,
-	// allowing the validator to start before the OIDC provider is ready.
-	// When set, ensureOIDCDiscovered will populate jwksURL on first use.
 
 	// Skip discovery if TOOLHIVE_SKIP_OIDC_DISCOVERY is set (for testing only)
 	skipDiscovery := o.envReader.Getenv("TOOLHIVE_SKIP_OIDC_DISCOVERY") == "true"
 	if skipDiscovery && config.Issuer != "" {
 		if jwksURL == "" {
-			return nil, fmt.Errorf(
+			return "", fmt.Errorf(
 				"TOOLHIVE_SKIP_OIDC_DISCOVERY=true requires explicit JWKSURL in config. " +
 					"This env var is for testing only and cannot guess provider-specific JWKS URLs",
 			)
@@ -637,20 +620,36 @@ func NewTokenValidator(ctx context.Context, config TokenValidatorConfig, opts ..
 	// Ensure we have either an explicit JWKS URL, an issuer to discover from,
 	// or a local key provider (embedded auth server).
 	if jwksURL == "" && config.Issuer == "" && o.keyProvider == nil {
-		return nil, ErrMissingIssuerAndJWKSURL
+		return "", ErrMissingIssuerAndJWKSURL
 	}
 
-	// Google's tokeninfo endpoint returns no iss claim - parseGoogleResponse
-	// synthesises iss locally, so a configured-issuer check against it is
-	// self-satisfying and proves nothing about which OAuth client the token
-	// was minted for. The only real binding to this deployment is the
-	// audience check, which is skipped when audience is empty. Without it,
-	// ANY valid Google access token (e.g. one minted for an attacker's own
-	// unrelated OAuth client) passes validation. Refuse the combination at
-	// startup instead of silently accepting cross-client tokens at runtime.
-	if config.IntrospectionURL == GoogleTokeninfoURL && config.Audience == "" {
-		return nil, fmt.Errorf("audience is required when using Google's tokeninfo endpoint for introspection: " +
-			"without it any valid Google access token is accepted regardless of the OAuth client it was minted for")
+	return jwksURL, nil
+}
+
+// NewTokenValidator creates a new token validator.
+func NewTokenValidator(ctx context.Context, config TokenValidatorConfig, opts ...TokenValidatorOption) (*TokenValidator, error) {
+	// Apply functional options
+	o := &tokenValidatorOptions{envReader: &env.OSReader{}}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Log warning if insecure HTTP is enabled
+	if config.InsecureAllowHTTP {
+		slog.Warn(
+			"insecure HTTP is enabled - "+
+				"HTTP OIDC URLs are allowed - this is INSECURE and should NEVER be used in production",
+			"issuer", config.Issuer,
+		)
+	}
+
+	jwksURL, err := resolveJWKSDiscovery(config, o)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateGoogleTokeninfoAudience(config); err != nil {
+		return nil, err
 	}
 
 	// Create HTTP client with CA bundle and auth token support for JWKS
@@ -702,6 +701,23 @@ func NewTokenValidator(ctx context.Context, config TokenValidatorConfig, opts ..
 	}
 
 	return validator, nil
+}
+
+// validateGoogleTokeninfoAudience rejects a Google tokeninfo introspection
+// config with no audience. Google's tokeninfo endpoint returns no iss claim -
+// parseGoogleResponse synthesises iss locally, so a configured-issuer check
+// against it is self-satisfying and proves nothing about which OAuth client
+// the token was minted for. The only real binding to this deployment is the
+// audience check, which is skipped when audience is empty. Without it, ANY
+// valid Google access token (e.g. one minted for an attacker's own unrelated
+// OAuth client) passes validation. Refuse the combination at startup instead
+// of silently accepting cross-client tokens at runtime.
+func validateGoogleTokeninfoAudience(config TokenValidatorConfig) error {
+	if config.IntrospectionURL == GoogleTokeninfoURL && strings.TrimSpace(config.Audience) == "" {
+		return fmt.Errorf("audience is required when using Google's tokeninfo endpoint for introspection: " +
+			"without it any valid Google access token is accepted regardless of the OAuth client it was minted for")
+	}
+	return nil
 }
 
 // ensureJWKSRegistered ensures that the JWKS URL is registered with the cache.

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -3075,3 +3075,30 @@ func TestEnsureJWKSRegistered_NonFatalRegistrationErrors(t *testing.T) {
 		require.True(t, validator.jwksRegistered)
 	})
 }
+
+func TestNewTokenValidator_GoogleTokeninfoRequiresAudience(t *testing.T) {
+	t.Setenv("TOOLHIVE_SKIP_OIDC_DISCOVERY", "true")
+
+	// Google tokeninfo + no audience must be rejected at startup: tokeninfo
+	// returns no iss claim (the provider synthesises it locally), so an
+	// issuer check is self-satisfying and the audience check is the only
+	// binding to this deployment. Without it, any valid Google access token
+	// passes regardless of which OAuth client minted it.
+	_, err := NewTokenValidator(context.Background(), TokenValidatorConfig{
+		Issuer:           "https://accounts.google.com",
+		JWKSURL:          "https://www.googleapis.com/oauth2/v3/certs",
+		IntrospectionURL: GoogleTokeninfoURL,
+		Audience:         "",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "audience is required")
+
+	// With an audience configured, the same setup must be accepted.
+	_, err = NewTokenValidator(context.Background(), TokenValidatorConfig{
+		Issuer:           "https://accounts.google.com",
+		JWKSURL:          "https://www.googleapis.com/oauth2/v3/certs",
+		IntrospectionURL: GoogleTokeninfoURL,
+		Audience:         "my-client-id.apps.googleusercontent.com",
+	})
+	require.NoError(t, err)
+}

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -3077,28 +3077,37 @@ func TestEnsureJWKSRegistered_NonFatalRegistrationErrors(t *testing.T) {
 }
 
 func TestNewTokenValidator_GoogleTokeninfoRequiresAudience(t *testing.T) {
-	t.Setenv("TOOLHIVE_SKIP_OIDC_DISCOVERY", "true")
+	t.Parallel()
 
-	// Google tokeninfo + no audience must be rejected at startup: tokeninfo
-	// returns no iss claim (the provider synthesises it locally), so an
-	// issuer check is self-satisfying and the audience check is the only
-	// binding to this deployment. Without it, any valid Google access token
-	// passes regardless of which OAuth client minted it.
-	_, err := NewTokenValidator(context.Background(), TokenValidatorConfig{
-		Issuer:           "https://accounts.google.com",
-		JWKSURL:          "https://www.googleapis.com/oauth2/v3/certs",
-		IntrospectionURL: GoogleTokeninfoURL,
-		Audience:         "",
-	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "audience is required")
+	// Google tokeninfo returns no iss claim (the provider synthesises it
+	// locally), so an issuer check is self-satisfying and the audience check
+	// is the only binding to this deployment. Without it, any valid Google
+	// access token passes regardless of which OAuth client minted it.
+	tests := []struct {
+		name      string
+		audience  string
+		expectErr bool
+	}{
+		{name: "empty audience rejected", audience: "", expectErr: true},
+		{name: "whitespace-only audience rejected", audience: "   ", expectErr: true},
+		{name: "audience configured accepted", audience: "my-client-id.apps.googleusercontent.com", expectErr: false},
+	}
 
-	// With an audience configured, the same setup must be accepted.
-	_, err = NewTokenValidator(context.Background(), TokenValidatorConfig{
-		Issuer:           "https://accounts.google.com",
-		JWKSURL:          "https://www.googleapis.com/oauth2/v3/certs",
-		IntrospectionURL: GoogleTokeninfoURL,
-		Audience:         "my-client-id.apps.googleusercontent.com",
-	})
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewTokenValidator(context.Background(), TokenValidatorConfig{
+				Issuer:           "https://accounts.google.com",
+				JWKSURL:          "https://www.googleapis.com/oauth2/v3/certs",
+				IntrospectionURL: GoogleTokeninfoURL,
+				Audience:         tt.audience,
+			})
+			if tt.expectErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "audience is required")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

The Google tokeninfo path has a validation hole:

1. Google's tokeninfo endpoint returns **no `iss` claim**. `GoogleProvider.parseGoogleResponse` (token.go) compensates by setting `claims["iss"] = "https://accounts.google.com"` locally.
2. `validateClaims` then compares that fabricated value against the configured issuer — a check that is **self-satisfying**: it passes for every token tokeninfo accepts and proves nothing about which OAuth client the token was minted for.
3. The only remaining binding to the deployment is the audience check, and it is conditional: `if v.audience != ""`. Audience is optional everywhere — `NewTokenValidator` doesn't require it, `--oidc-audience` defaults to empty, the operator CRD marks it Optional.

Net effect: a deployment configured with issuer `https://accounts.google.com` + introspection URL `https://oauth2.googleapis.com/tokeninfo` + **no audience** accepts **any valid Google OAuth access token** — including one minted for an unrelated attacker-registered OAuth client. That token passes `ValidateToken`, becomes an `auth.Identity`, and lands in the request context.

## Fix

`NewTokenValidator` refuses `IntrospectionURL == GoogleTokeninfoURL` with an empty audience at startup, with an error explaining why. Fail-closed beats a silently-accepting runtime.

## Tests

New `TestNewTokenValidator_GoogleTokeninfoRequiresAudience`: tokeninfo-without-audience is rejected with the explanatory error; the same config with an audience is accepted. Full `pkg/auth` suite passes.

Made with Cursor

Made with [Cursor](https://cursor.com)