### PR TITLE
fix(auth): bind OAuth callback listener to loopback only

### DIFF
--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -187,6 +187,14 @@ func (f *Flow) generateState() error {
 	return nil
 }
 
+// listenAddr returns the address the callback server binds to. The redirect
+// URL points at localhost, so the listener is bound to the IPv4 loopback
+// instead of all interfaces: a wildcard bind would expose the callback
+// endpoint to every host on the LAN for the lifetime of the login.
+func (f *Flow) listenAddr() string {
+	return fmt.Sprintf("127.0.0.1:%d", f.port)
+}
+
 // Start starts the OAuth authentication flow
 func (f *Flow) Start(ctx context.Context, skipBrowser bool) (*TokenResult, error) {
 	// Create channels for communication
@@ -199,7 +207,7 @@ func (f *Flow) Start(ctx context.Context, skipBrowser bool) (*TokenResult, error
 	mux.HandleFunc("/", f.handleRoot())
 
 	f.server = &http.Server{
-		Addr:              fmt.Sprintf(":%d", f.port),
+		Addr:              f.listenAddr(),
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}

--- a/pkg/auth/oauth/flow_test.go
+++ b/pkg/auth/oauth/flow_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -737,6 +738,26 @@ func TestStart(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListenAddrLoopback(t *testing.T) {
+	t.Parallel()
+	config := &Config{
+		ClientID: "test-client",
+		AuthURL:  "https://example.com/auth",
+		TokenURL: "https://example.com/token",
+	}
+
+	flow, err := NewFlow(config)
+	require.NoError(t, err)
+
+	host, port, err := net.SplitHostPort(flow.listenAddr())
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%d", flow.port), port, "listen address should use the flow's callback port")
+
+	ip := net.ParseIP(host)
+	require.NotNil(t, ip, "listen host should be an IP address, got %q", host)
+	assert.True(t, ip.IsLoopback(), "callback listener must bind to a loopback address, got %q", host)
 }
 
 func TestWriteSuccessPage(t *testing.T) {


### PR DESCRIPTION
Anyone on the local network can cancel your ToolHive login while you are signing in.

## Problem

The OAuth callback server used during interactive login binds `:port` (all interfaces) for the whole login flow, while the redirect URL it advertises is `http://localhost:<port>/callback`:

```go
f.server = &http.Server{
    Addr:              fmt.Sprintf(":%d", f.port),
    Handler:           mux,
    ReadHeaderTimeout: 10 * time.Second,
}
```

Any host on the LAN can therefore reach the callback endpoint while a login is in progress and:

- observe that a ToolHive login is happening, and
- abort it by requesting `/callback?error=access_denied` (the error path does not require the `state` parameter) or by sending a wrong `state`.

Login-code theft is **not** possible: the 128-bit random state is validated before any token exchange, so an attacker cannot inject their own authorization code. The impact is an unauthenticated remote denial of service of interactive logins, plus an HTTP surface on every interface that has no reason to be reachable off-host.

## Fix

Bind the listener to `127.0.0.1` explicitly via a small `listenAddr()` helper. This matches the redirect URL's localhost semantics and the loopback address the port-availability probe (`networking.IsAvailable`) already uses when selecting the callback port.

## Tests

Added `TestListenAddrLoopback`, which asserts the listener address parses to a loopback IP on the flow's callback port. The `pkg/auth/oauth`, `pkg/auth/tokensource`, and `pkg/auth/discovery` suites pass.

Made with [Cursor](https://cursor.com)