### PR TITLE
fix(authz): make Cedar URI entity IDs collision-free

### DIFF
--- a/docs/authz.md
+++ b/docs/authz.md
@@ -192,8 +192,16 @@ In the context of MCP servers, the following entities are used:
   - Examples:
     - `Tool::"weather"`: The weather tool
     - `Prompt::"greeting"`: The greeting prompt
-    - `Resource::"data"`: The data resource
+    - `Resource::"data"`: A short resource name
+    - `Resource::"file:///etc/passwd"`: An MCP resource URI (exact URI is the Cedar entity ID)
     - `FeatureType::"tool"`: The tool feature type (used for list operations)
+
+  For `read_resource`, the Cedar entity ID is the **exact resource URI** (for example
+  `Resource::"file:///ok"` or `Resource::"mcp://srv/config:admin"`). Do not rewrite
+  characters such as `/`, `:`, or `?` into underscores; policies must name the URI as
+  the client and server see it. In Cedar source the ID is a double-quoted string
+  literal, so almost every URI character is ordinary, but `"` and `\` must be escaped
+  (for example `Resource::"file://C:\\share\\data"`).
 
 #### Example policies
 
@@ -221,7 +229,17 @@ This policy allows any client to get the greeting prompt.
 permit(principal, action == Action::"read_resource", resource == Resource::"data");
 ```
 
-This policy allows any client to read the data resource.
+This policy allows any client to read the resource whose entity ID is `data`.
+
+For URI-shaped MCP resources, name the exact URI:
+
+```plain
+permit(
+  principal,
+  action == Action::"read_resource",
+  resource == Resource::"file:///etc/passwd"
+);
+```
 
 ##### List operations
 

--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -1084,10 +1084,12 @@ func (a *Authorizer) authorizeResourceRead(
 	// Action is to read a resource
 	action := "Action::read_resource"
 
-	// Resource is the resource being accessed
-	// Use the URI as the resource ID, but sanitize it for Cedar
-	sanitizedURI := sanitizeURIForCedar(resourceURI)
-	resource := fmt.Sprintf("Resource::%s", sanitizedURI)
+	// Resource is the resource being accessed. Use the exact URI as the
+	// entity ID: entities are built programmatically via cedar.NewEntityUID,
+	// which accepts any string, so no character rewriting is needed. A lossy
+	// mapping would let distinct URIs collide onto one entity ID, and a
+	// policy grant on one URI would then silently cover every colliding URI.
+	resource := fmt.Sprintf("Resource::%s", resourceURI)
 
 	// Create attributes for the entities
 	attributes := mergeContexts(map[string]interface{}{
@@ -1159,25 +1161,6 @@ func parseCedarEntityID(entityID string) (string, string, error) {
 		return "", "", fmt.Errorf("invalid entity ID format: %s", entityID)
 	}
 	return parts[0], parts[1], nil
-}
-
-// sanitizeURIForCedar sanitizes a URI for use in Cedar policies.
-// Cedar entity IDs have restrictions on characters, so we need to sanitize the URI.
-func sanitizeURIForCedar(uri string) string {
-	// Replace characters that are not allowed in Cedar entity IDs
-	// This is a simple implementation - you may need to enhance it based on your needs
-	replacer := strings.NewReplacer(
-		":", "_",
-		"/", "_",
-		"\\", "_",
-		"?", "_",
-		"&", "_",
-		"=", "_",
-		"#", "_",
-		" ", "_",
-		".", "_",
-	)
-	return replacer.Replace(uri)
 }
 
 // AuthorizeWithJWTClaims demonstrates how to use JWT claims with the Cedar authorization middleware.

--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -1086,7 +1086,9 @@ func (a *Authorizer) authorizeResourceRead(
 
 	// Resource is the resource being accessed. Use the exact URI as the
 	// entity ID: entities are built programmatically via cedar.NewEntityUID,
-	// which accepts any string, so no character rewriting is needed. A lossy
+	// which accepts any string on the request side, so no character rewriting
+	// is needed. (Policy authors still write the ID as a Cedar string literal,
+	// so " and \ need escaping in policy source; see docs/authz.md.) A lossy
 	// mapping would let distinct URIs collide onto one entity ID, and a
 	// policy grant on one URI would then silently cover every colliding URI.
 	resource := fmt.Sprintf("Resource::%s", resourceURI)

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"maps"
 	"sync"
@@ -3347,38 +3348,61 @@ func TestParseCedarEntityID(t *testing.T) {
 	}
 }
 
-// TestSanitizeURIForCedar tests the sanitizeURIForCedar helper function.
-func TestSanitizeURIForCedar(t *testing.T) {
+// TestAuthorizeResourceReadEntityIDsCollisionFree verifies that resource URIs
+// become Cedar entity IDs verbatim. Distinct URIs that a lossy sanitization
+// would map onto the same entity ID must stay distinct, so a policy grant on
+// one URI never authorizes a colliding URI.
+func TestAuthorizeResourceReadEntityIDsCollisionFree(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		input string
-		want  string
+		name         string
+		grantedURI   string
+		collidingURI string
 	}{
-		{name: "empty_string", input: "", want: ""},
-		{name: "already_clean", input: "simple_resource", want: "simple_resource"},
-		{name: "colon", input: "a:b", want: "a_b"},
-		{name: "forward_slash", input: "a/b", want: "a_b"},
-		{name: "backslash", input: `a\b`, want: "a_b"},
-		{name: "question_mark", input: "a?b", want: "a_b"},
-		{name: "ampersand", input: "a&b", want: "a_b"},
-		{name: "equals", input: "a=b", want: "a_b"},
-		{name: "hash", input: "a#b", want: "a_b"},
-		{name: "space", input: "a b", want: "a_b"},
-		{name: "dot", input: "a.b", want: "a_b"},
 		{
-			name:  "complex_uri",
-			input: "https://api.example.com/v1/data?key=val&other=123#fragment",
-			want:  "https___api_example_com_v1_data_key_val_other_123_fragment",
+			name:         "file_uri_colon_and_slash_run",
+			grantedURI:   "file:///etc/passwd",
+			collidingURI: "file://_etc/passwd",
+		},
+		{
+			name:         "mcp_uri_colon_vs_slash",
+			grantedURI:   "mcp://srv/config:admin",
+			collidingURI: "mcp://srv/config/admin",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := sanitizeURIForCedar(tt.input)
-			assert.Equal(t, tt.want, got)
+
+			authorizer, err := NewCedarAuthorizer(ConfigOptions{
+				Policies: []string{
+					fmt.Sprintf(`permit(principal, action == Action::"read_resource", resource == Resource::"%s");`, tt.grantedURI),
+				},
+				EntitiesJSON: `[]`,
+			}, "")
+			require.NoError(t, err, "Failed to create Cedar authorizer")
+
+			identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{
+				Subject: "test-user",
+				Claims:  jwt.MapClaims{"sub": "user123"},
+			}}
+			claimsCtx := auth.WithIdentity(context.Background(), identity)
+
+			// The exact URI named in the policy is authorized.
+			authorized, err := authorizer.AuthorizeWithJWTClaims(
+				claimsCtx, authorizers.MCPFeatureResource, authorizers.MCPOperationRead, tt.grantedURI, nil)
+			require.NoError(t, err)
+			assert.True(t, authorized, "exact URI named in the policy should be authorized")
+
+			// The colliding URI, which mapped to the same entity ID under the
+			// previous lossy sanitization, must not be authorized.
+			authorized, err = authorizer.AuthorizeWithJWTClaims(
+				claimsCtx, authorizers.MCPFeatureResource, authorizers.MCPOperationRead, tt.collidingURI, nil)
+			require.NoError(t, err)
+			assert.False(t, authorized,
+				"colliding URI %q must not be authorized by a grant on %q", tt.collidingURI, tt.grantedURI)
 		})
 	}
 }


### PR DESCRIPTION
A permission granted to one resource URI can silently apply to a different, colliding URI.

## Problem

`authorizeResourceRead` turned resource URIs into Cedar entity IDs with a lossy sanitizer that rewrote `:`, `/`, `\`, `?`, `&`, `=`, `#`, space, and `.` to `_`. The mapping is many-to-one, so distinct URIs collide onto one entity ID:

- `file:///etc/passwd` and `file://_etc/passwd` both became `Resource::"file____etc_passwd"`
- `mcp://srv/config:admin` and `mcp://srv/config/admin` both became `Resource::"mcp___srv_config_admin"`

A policy granting `Resource::"file____etc_passwd"` therefore authorized reads of every URI in the collision class. The confused-deputy condition: an MCP server that serves both a permitted URI and a colliding sensitive URI (or one that lets users create resource URIs) gets the grant applied to a resource the policy author never named.

Severity framing, honestly stated: exploitation needs a policy author who grants by entity ID, plus a colliding pair where one side is permitted and the other is sensitive and server-distinguished. Attribute-based policies (`resource.name == ...`, `resource.uri == ...`) match on the exact URI and are unaffected.

## Fix

Entities are built programmatically with `cedar.NewEntityUID`, which accepts any string, so no character rewriting is needed at all. The exact URI is now the entity ID and the sanitizer is removed. Policy authors can name the real URI (for example `Resource::"file:///etc/passwd"`) instead of computing a mangled form.

Note for existing policies: a policy that references a sanitized ID (only possible for URIs containing the rewritten characters) must be updated to name the exact URI. Policies using plain IDs or attribute matching are unchanged.

## Tests

Replaced `TestSanitizeURIForCedar` with `TestAuthorizeResourceReadEntityIDsCollisionFree`: for both collision pairs above, a grant on the exact URI authorizes that URI and denies the formerly colliding URI. The `pkg/authz/...` and `pkg/vmcp/core` suites pass.

Made with [Cursor](https://cursor.com)