### PR TITLE
Report unsupported external auth types

### DIFF
--- a/cmd/thv-operator/api/v1beta1/conditions.go
+++ b/cmd/thv-operator/api/v1beta1/conditions.go
@@ -7,4 +7,8 @@ package v1beta1
 const (
 	ConditionTypeValid           = "Valid"
 	ConditionTypeDeletionBlocked = "DeletionBlocked"
+
+	// ConditionReasonUnsupportedAuthType indicates that an MCPExternalAuthConfig
+	// type is not implemented by the resource that references it.
+	ConditionReasonUnsupportedAuthType = "UnsupportedAuthType"
 )

--- a/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
@@ -59,8 +59,9 @@ const (
 type ExternalAuthType string
 
 // MCPExternalAuthConfigSpec defines the desired state of MCPExternalAuthConfig.
-// MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-// MCPServer resources in the same namespace.
+// MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+// MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+// the same namespace. Each consumer supports only a subset of authentication types.
 //
 // +kubebuilder:validation:XValidation:rule="self.type == 'tokenExchange' ? has(self.tokenExchange) : !has(self.tokenExchange)",message="tokenExchange configuration must be set if and only if type is 'tokenExchange'"
 // +kubebuilder:validation:XValidation:rule="self.type == 'headerInjection' ? has(self.headerInjection) : !has(self.headerInjection)",message="headerInjection configuration must be set if and only if type is 'headerInjection'"
@@ -75,10 +76,22 @@ type ExternalAuthType string
 //nolint:lll // CEL validation rules exceed line length limit
 type MCPExternalAuthConfigSpec struct {
 	// Type is the type of external authentication to configure.
-	// When set to "obo", the cluster must run a build that has registered an
-	// OBO handler via controllerutil.RegisterOBOHandler; upstream-only builds
-	// surface status.conditions[Valid] = False with Reason: EnterpriseRequired
-	// for obo-typed configs.
+	// Consumer support is as follows:
+	//   - tokenExchange and unauthenticated: MCPServer, MCPRemoteProxy,
+	//     MCPServerEntry, and VirtualMCPServer outgoing authentication.
+	//   - headerInjection, upstreamInject, and xaa: MCPServerEntry and
+	//     VirtualMCPServer outgoing authentication.
+	//   - bearerToken: MCPRemoteProxy.
+	//   - embeddedAuthServer: MCPServer and MCPRemoteProxy.
+	//   - awsSts: MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer outgoing
+	//     authentication.
+	//   - obo: all four consumers when the cluster build has registered an OBO
+	//     handler via controllerutil.RegisterOBOHandler.
+	//
+	// Upstream-only builds surface status.conditions[Valid] = False with Reason:
+	// EnterpriseRequired for obo-typed configs. Other unsupported consumer/type
+	// combinations are reported on the consuming resource with Reason:
+	// UnsupportedAuthType.
 	// +kubebuilder:validation:Enum=tokenExchange;headerInjection;bearerToken;unauthenticated;embeddedAuthServer;awsSts;upstreamInject;obo;xaa
 	// +kubebuilder:validation:Required
 	Type ExternalAuthType `json:"type"`
@@ -1524,9 +1537,10 @@ type MCPExternalAuthConfigStatus struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // MCPExternalAuthConfig is the Schema for the mcpexternalauthconfigs API.
-// MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-// MCPServer resources within the same namespace. Cross-namespace references
-// are not supported for security and isolation reasons.
+// MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+// MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+// the same namespace. Cross-namespace references are not supported for security
+// and isolation reasons. Each consumer supports only a subset of authentication types.
 type MCPExternalAuthConfig struct {
 	metav1.TypeMeta   `json:",inline"` // nolint:revive
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/thv-operator/api/v1beta1/mcpremoteproxy_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpremoteproxy_types.go
@@ -71,8 +71,11 @@ type MCPRemoteProxySpec struct {
 	// +optional
 	OIDCConfigRef *MCPOIDCConfigReference `json:"oidcConfigRef,omitempty"`
 
-	// ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange.
-	// When specified, the proxy will exchange validated incoming tokens for remote service tokens.
+	// ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+	// Supported types are tokenExchange, bearerToken, unauthenticated,
+	// embeddedAuthServer, awsSts, and obo when an enterprise handler is registered.
+	// For new embedded authorization server configurations, prefer AuthServerRef.
+	// Unsupported types are reported in status.conditions with Reason: UnsupportedAuthType.
 	// The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPRemoteProxy.
 	// +optional
 	ExternalAuthConfigRef *ExternalAuthConfigRef `json:"externalAuthConfigRef,omitempty"`

--- a/cmd/thv-operator/api/v1beta1/mcpserver_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpserver_types.go
@@ -123,6 +123,10 @@ const (
 )
 
 const (
+	// ConditionReasonExternalAuthConfigValid indicates the referenced ExternalAuthConfig
+	// is valid and supported by MCPServer.
+	ConditionReasonExternalAuthConfigValid = "ExternalAuthConfigValid"
+
 	// ConditionReasonExternalAuthConfigMultiUpstream indicates the ExternalAuthConfig has multiple upstreams,
 	// which is not supported for MCPServer (use VirtualMCPServer for multi-upstream).
 	ConditionReasonExternalAuthConfigMultiUpstream = "MultiUpstreamNotSupported"
@@ -337,7 +341,11 @@ type MCPServerSpec struct {
 	// +optional
 	ToolConfigRef *ToolConfigRef `json:"toolConfigRef,omitempty"`
 
-	// ExternalAuthConfigRef references a MCPExternalAuthConfig resource for external authentication.
+	// ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+	// Supported types are tokenExchange, unauthenticated, embeddedAuthServer, and
+	// obo when an enterprise handler is registered. For new embedded authorization
+	// server configurations, prefer AuthServerRef. Unsupported types are reported
+	// in status.conditions with Reason: UnsupportedAuthType.
 	// The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPServer.
 	// +optional
 	ExternalAuthConfigRef *ExternalAuthConfigRef `json:"externalAuthConfigRef,omitempty"`
@@ -748,7 +756,8 @@ type ConfigMapAuthzRef struct {
 }
 
 // ExternalAuthConfigRef defines a reference to a MCPExternalAuthConfig resource.
-// The referenced MCPExternalAuthConfig must be in the same namespace as the MCPServer.
+// The referenced MCPExternalAuthConfig must be in the same namespace as the
+// resource containing the reference.
 type ExternalAuthConfigRef struct {
 	// Name is the name of the MCPExternalAuthConfig resource
 	// +kubebuilder:validation:Required

--- a/cmd/thv-operator/api/v1beta1/mcpserverentry_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpserverentry_types.go
@@ -29,9 +29,12 @@ type MCPServerEntrySpec struct {
 	// +kubebuilder:validation:Required
 	GroupRef *MCPGroupRef `json:"groupRef"`
 
-	// ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange
-	// when connecting to the remote MCP server. The referenced MCPExternalAuthConfig must
-	// exist in the same namespace as this MCPServerEntry.
+	// ExternalAuthConfigRef references an MCPExternalAuthConfig resource when connecting
+	// to the remote MCP server. Supported types are tokenExchange, headerInjection,
+	// unauthenticated, awsSts, upstreamInject, xaa, and obo when an enterprise handler
+	// is registered. Unsupported types are reported in status.conditions with Reason:
+	// UnsupportedAuthType. The referenced MCPExternalAuthConfig must exist in the same
+	// namespace as this MCPServerEntry.
 	// +optional
 	ExternalAuthConfigRef *ExternalAuthConfigRef `json:"externalAuthConfigRef,omitempty"`
 

--- a/cmd/thv-operator/api/v1beta1/virtualmcpserver_types.go
+++ b/cmd/thv-operator/api/v1beta1/virtualmcpserver_types.go
@@ -31,10 +31,14 @@ type VirtualMCPServerSpec struct {
 	// +kubebuilder:validation:Required
 	IncomingAuth *IncomingAuthConfig `json:"incomingAuth"`
 
-	// OutgoingAuth configures authentication from Virtual MCP to backend MCPServers.
+	// OutgoingAuth configures authentication from Virtual MCP to backend resources.
 	// This field takes precedence over config.OutgoingAuth and should be preferred because it
 	// supports Kubernetes-native secret references (SecretKeyRef, ConfigMapRef) for secure
 	// dynamic discovery of credentials, rather than requiring secrets to be embedded in config.
+	// Referenced MCPExternalAuthConfig types supported by VirtualMCPServer are tokenExchange,
+	// headerInjection, unauthenticated, awsSts, upstreamInject, xaa, and obo when an
+	// enterprise handler is registered. Unsupported types are reported per backend in
+	// status.conditions with Reason: UnsupportedAuthType.
 	// +optional
 	OutgoingAuth *OutgoingAuthConfig `json:"outgoingAuth,omitempty"`
 
@@ -204,10 +208,14 @@ type IncomingAuthConfig struct {
 	AuthzConfigRef *MCPAuthzConfigReference `json:"authzConfigRef,omitempty"`
 }
 
-// OutgoingAuthConfig configures authentication from Virtual MCP to backend MCPServers
+// OutgoingAuthConfig configures authentication from Virtual MCP to backend resources.
+// Referenced MCPExternalAuthConfig resources support tokenExchange, headerInjection,
+// unauthenticated, awsSts, upstreamInject, xaa, and obo when an enterprise handler
+// is registered.
 type OutgoingAuthConfig struct {
 	// Source defines how backend authentication configurations are determined
-	// - discovered: Automatically discover from backend's MCPServer.spec.externalAuthConfigRef
+	// - discovered: Automatically discover from backend MCPServer, MCPRemoteProxy,
+	//   and MCPServerEntry externalAuthConfigRef fields
 	// - inline: Explicit per-backend configuration in VirtualMCPServer
 	// +kubebuilder:validation:Enum=discovered;inline
 	// +kubebuilder:default=discovered
@@ -224,15 +232,18 @@ type OutgoingAuthConfig struct {
 	Backends map[string]BackendAuthConfig `json:"backends,omitempty"`
 }
 
-// BackendAuthConfig defines authentication configuration for a backend MCPServer
+// BackendAuthConfig defines authentication configuration for a backend resource.
 type BackendAuthConfig struct {
 	// Type defines the authentication type
 	// +kubebuilder:validation:Enum=discovered;externalAuthConfigRef
 	// +kubebuilder:validation:Required
 	Type string `json:"type"`
 
-	// ExternalAuthConfigRef references an MCPExternalAuthConfig resource
-	// Only used when Type is "externalAuthConfigRef"
+	// ExternalAuthConfigRef references an MCPExternalAuthConfig resource.
+	// Only used when Type is "externalAuthConfigRef". Supported referenced types are
+	// tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,
+	// and obo when an enterprise handler is registered. Unsupported types are reported
+	// for the affected backend in status.conditions with Reason: UnsupportedAuthType.
 	// +optional
 	ExternalAuthConfigRef *ExternalAuthConfigRef `json:"externalAuthConfigRef,omitempty"`
 }

--- a/cmd/thv-operator/controllers/external_auth_mirror.go
+++ b/cmd/thv-operator/controllers/external_auth_mirror.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 )
 
 // Status Condition Parity machinery for #5347. The probe reads a referenced
@@ -69,6 +70,30 @@ func mirroredReasonFromError(err error) string {
 		return mirrored.Reason
 	}
 	return ""
+}
+
+// externalAuthReasonFromError returns a stable condition reason for typed
+// external-auth failures. Source-level invalidity keeps its mirrored reason;
+// consumer/type incompatibility uses the shared UnsupportedAuthType taxonomy.
+func externalAuthReasonFromError(err error) string {
+	if reason := mirroredReasonFromError(err); reason != "" {
+		return reason
+	}
+
+	var unsupported *externalauthsupport.UnsupportedTypeError
+	if stderrors.As(err, &unsupported) {
+		return mcpv1beta1.ConditionReasonUnsupportedAuthType
+	}
+	return ""
+}
+
+// isTerminalExternalAuthError reports whether err represents a configuration
+// state that can only heal after the consumer spec or its referenced
+// MCPExternalAuthConfig changes. Both resources are watched by the consumer
+// controllers, so rate-limited retries of the same generation add noise but
+// cannot make progress.
+func isTerminalExternalAuthError(err error) bool {
+	return externalAuthReasonFromError(err) != ""
 }
 
 // mirrorInvalidOnMCPServer mirrors the source's Valid=False condition onto the

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller.go
@@ -30,6 +30,7 @@ import (
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/kubernetes/rbac"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
@@ -88,6 +89,12 @@ func (r *MCPRemoteProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if stderrors.Is(err, errInvalidMCPRemoteProxyPodTemplateSpec) {
 			return ctrl.Result{}, nil
 		}
+		if isTerminalExternalAuthError(err) {
+			// Consumer/type incompatibility and source Valid=False are terminal
+			// configuration errors. A watched resource change will enqueue
+			// reconciliation; returning an error here would only create a backoff loop.
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -108,6 +115,7 @@ func (r *MCPRemoteProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // validateAndHandleConfigs validates spec and handles referenced configurations
 func (r *MCPRemoteProxyReconciler) validateAndHandleConfigs(ctx context.Context, proxy *mcpv1beta1.MCPRemoteProxy) error {
 	ctxLogger := log.FromContext(ctx)
+	originalStatus := proxy.DeepCopy().Status
 
 	if err := r.validateSpecAndPodTemplate(ctx, proxy); err != nil {
 		return err
@@ -149,8 +157,19 @@ func (r *MCPRemoteProxyReconciler) validateAndHandleConfigs(ctx context.Context,
 	if err := r.handleExternalAuthConfig(ctx, proxy); err != nil {
 		ctxLogger.Error(err, "Failed to handle MCPExternalAuthConfig")
 		proxy.Status.Phase = mcpv1beta1.MCPRemoteProxyPhaseFailed
-		if statusErr := r.Status().Update(ctx, proxy); statusErr != nil {
-			ctxLogger.Error(statusErr, "Failed to update MCPRemoteProxy status after MCPExternalAuthConfig error")
+		proxy.Status.Message = "External authentication configuration is invalid"
+		meta.SetStatusCondition(&proxy.Status.Conditions, metav1.Condition{
+			Type:               mcpv1beta1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             mcpv1beta1.ConditionReasonAuthInvalid,
+			Message:            fmt.Sprintf("External authentication configuration is invalid: %v", err),
+			ObservedGeneration: proxy.Generation,
+		})
+		if !equality.Semantic.DeepEqual(originalStatus, proxy.Status) {
+			if statusErr := r.Status().Update(ctx, proxy); statusErr != nil {
+				ctxLogger.Error(statusErr, "Failed to update MCPRemoteProxy status after MCPExternalAuthConfig error")
+				return fmt.Errorf("failed to update MCPRemoteProxy status after MCPExternalAuthConfig error: %w", statusErr)
+			}
 		}
 		return err
 	}
@@ -846,6 +865,20 @@ func (r *MCPRemoteProxyReconciler) handleExternalAuthConfig(ctx context.Context,
 	// user having to inspect the referenced MCPExternalAuthConfig).
 	if mirrored, err := mirrorInvalidOnRemoteProxy(proxy, externalAuthConfig); mirrored {
 		return err
+	}
+
+	if err := externalauthsupport.Validate(
+		externalauthsupport.ConsumerMCPRemoteProxy,
+		externalAuthConfig.Spec.Type,
+	); err != nil {
+		meta.SetStatusCondition(&proxy.Status.Conditions, metav1.Condition{
+			Type:               mcpv1beta1.ConditionTypeMCPRemoteProxyExternalAuthConfigValidated,
+			Status:             metav1.ConditionFalse,
+			Reason:             mcpv1beta1.ConditionReasonUnsupportedAuthType,
+			Message:            err.Error(),
+			ObservedGeneration: proxy.Generation,
+		})
+		return fmt.Errorf("MCPExternalAuthConfig %s/%s: %w", proxy.Namespace, externalAuthConfig.Name, err)
 	}
 
 	// MCPRemoteProxy supports only single-upstream embedded auth server configs.

--- a/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_controller_test.go
@@ -690,6 +690,145 @@ func TestHandleExternalAuthConfig(t *testing.T) {
 	}
 }
 
+func TestHandleExternalAuthConfig_UnsupportedAuthType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		authType mcpv1beta1.ExternalAuthType
+	}{
+		{name: "header injection", authType: mcpv1beta1.ExternalAuthTypeHeaderInjection},
+		{name: "upstream injection", authType: mcpv1beta1.ExternalAuthTypeUpstreamInject},
+		{name: "XAA", authType: mcpv1beta1.ExternalAuthTypeXAA},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const (
+				generation   int64 = 23
+				previousHash       = "previous-supported-hash"
+			)
+			authConfig := newExternalAuthConfigForConsumerTest(t, "auth-config", tt.authType)
+			authConfig.Status.ConfigHash = "unsupported-hash"
+			proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+				v1beta1test.WithRemoteProxyURL("https://backend.example/mcp"),
+				v1beta1test.WithRemoteProxyExternalAuthConfigRef(authConfig.Name),
+				v1beta1test.WithRemoteProxyStatus(mcpv1beta1.MCPRemoteProxyStatus{
+					ExternalAuthConfigHash: previousHash,
+				}),
+				v1beta1test.MutateRemoteProxy(func(p *mcpv1beta1.MCPRemoteProxy) {
+					p.Generation = generation
+				}),
+			)
+
+			scheme := testutil.NewScheme(t)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(authConfig, proxy).
+				WithStatusSubresource(&mcpv1beta1.MCPRemoteProxy{}).
+				Build()
+			reconciler := &MCPRemoteProxyReconciler{Client: fakeClient, Scheme: scheme}
+
+			err := reconciler.handleExternalAuthConfig(t.Context(), proxy)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), string(tt.authType))
+			assert.Contains(t, err.Error(), "MCPRemoteProxy")
+			cond := meta.FindStatusCondition(
+				proxy.Status.Conditions, mcpv1beta1.ConditionTypeMCPRemoteProxyExternalAuthConfigValidated)
+			require.NotNil(t, cond)
+			assert.Equal(t, metav1.ConditionFalse, cond.Status)
+			assert.Equal(t, mcpv1beta1.ConditionReasonUnsupportedAuthType, cond.Reason)
+			assert.Equal(t, generation, cond.ObservedGeneration)
+			assert.Contains(t, cond.Message, string(tt.authType))
+			assert.Contains(t, cond.Message, "MCPRemoteProxy")
+			assert.Equal(t, previousHash, proxy.Status.ExternalAuthConfigHash,
+				"an unsupported config must not advance the last applied config hash")
+		})
+	}
+}
+
+func TestMCPRemoteProxyReconciler_UnsupportedExternalAuthIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	authConfig := newExternalAuthConfigForConsumerTest(
+		t, "auth-config", mcpv1beta1.ExternalAuthTypeHeaderInjection)
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+		v1beta1test.WithRemoteProxyURL("https://backend.example/mcp"),
+		v1beta1test.WithRemoteProxyExternalAuthConfigRef(authConfig.Name),
+	)
+	proxy.Status.Phase = mcpv1beta1.MCPRemoteProxyPhaseReady
+	proxy.Status.Conditions = []metav1.Condition{{
+		Type:               mcpv1beta1.ConditionTypeReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             mcpv1beta1.ConditionReasonDeploymentReady,
+		Message:            "Deployment is ready and running",
+		ObservedGeneration: proxy.Generation,
+	}}
+	reconciler, fakeClient := newTestMCPRemoteProxyReconciler(t, authConfig, proxy)
+	request := ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: proxy.Name, Namespace: proxy.Namespace,
+	}}
+
+	result, err := reconciler.Reconcile(t.Context(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsZero(), "unsupported auth should be terminal until a watched resource changes")
+
+	afterFirst := &mcpv1beta1.MCPRemoteProxy{}
+	require.NoError(t, fakeClient.Get(t.Context(), request.NamespacedName, afterFirst))
+	condition := meta.FindStatusCondition(
+		afterFirst.Status.Conditions, mcpv1beta1.ConditionTypeMCPRemoteProxyExternalAuthConfigValidated)
+	require.NotNil(t, condition)
+	assert.Equal(t, mcpv1beta1.ConditionReasonUnsupportedAuthType, condition.Reason)
+	assert.Equal(t, mcpv1beta1.MCPRemoteProxyPhaseFailed, afterFirst.Status.Phase)
+	ready := meta.FindStatusCondition(afterFirst.Status.Conditions, mcpv1beta1.ConditionTypeReady)
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, mcpv1beta1.ConditionReasonAuthInvalid, ready.Reason)
+
+	result, err = reconciler.Reconcile(t.Context(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsZero())
+
+	afterSecond := &mcpv1beta1.MCPRemoteProxy{}
+	require.NoError(t, fakeClient.Get(t.Context(), request.NamespacedName, afterSecond))
+	assert.Equal(t, afterFirst.Status, afterSecond.Status,
+		"a repeated terminal reconcile must preserve the failed status")
+}
+
+func TestMCPRemoteProxyReconciler_MirroredInvalidExternalAuthIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	authConfig := newExternalAuthConfigForConsumerTest(t, "auth-config", mcpv1beta1.ExternalAuthTypeOBO)
+	authConfig.Status.Conditions = []metav1.Condition{{
+		Type:    mcpv1beta1.ConditionTypeValid,
+		Status:  metav1.ConditionFalse,
+		Reason:  mcpv1beta1.ConditionReasonEnterpriseRequired,
+		Message: "enterprise feature required",
+	}}
+	proxy := v1beta1test.NewMCPRemoteProxy("test-proxy", "default",
+		v1beta1test.WithRemoteProxyURL("https://backend.example/mcp"),
+		v1beta1test.WithRemoteProxyExternalAuthConfigRef(authConfig.Name),
+	)
+	reconciler, fakeClient := newTestMCPRemoteProxyReconciler(t, authConfig, proxy)
+	request := ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: proxy.Name, Namespace: proxy.Namespace,
+	}}
+
+	result, err := reconciler.Reconcile(t.Context(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsZero(), "source Valid=False should wait for the referenced resource watch")
+
+	updated := &mcpv1beta1.MCPRemoteProxy{}
+	require.NoError(t, fakeClient.Get(t.Context(), request.NamespacedName, updated))
+	condition := meta.FindStatusCondition(
+		updated.Status.Conditions, mcpv1beta1.ConditionTypeMCPRemoteProxyExternalAuthConfigValidated)
+	require.NotNil(t, condition)
+	assert.Equal(t, mcpv1beta1.ConditionReasonEnterpriseRequired, condition.Reason)
+}
+
 // TestLabelsForMCPRemoteProxy tests label generation
 func TestLabelsForMCPRemoteProxy(t *testing.T) {
 	t.Parallel()

--- a/cmd/thv-operator/controllers/mcpremoteproxy_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpremoteproxy_runconfig.go
@@ -15,6 +15,7 @@ import (
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/kubernetes/configmaps"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc"
 	runconfig "github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig"
@@ -140,8 +141,8 @@ func (r *MCPRemoteProxyReconciler) createRunConfigFromMCPRemoteProxy(
 	// Add external auth configuration if specified (updated call)
 	// Will fail if embedded auth server is used without OIDC config or resourceUrl
 	if err := ctrlutil.AddExternalAuthConfigOptions(
-		apiCtx, r.Client, proxy.Namespace, proxy.Name, proxy.Spec.ExternalAuthConfigRef,
-		resolvedOIDCConfig, &options,
+		apiCtx, r.Client, proxy.Namespace, proxy.Name, externalauthsupport.ConsumerMCPRemoteProxy,
+		proxy.Spec.ExternalAuthConfigRef, resolvedOIDCConfig, &options,
 	); err != nil {
 		return nil, fmt.Errorf("failed to process ExternalAuthConfig: %w", err)
 	}

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -38,6 +38,7 @@ import (
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/kubernetes/rbac"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
@@ -191,6 +192,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		ctxLogger.Error(err, "Failed to get MCPServer")
 		return ctrl.Result{}, err
 	}
+	originalStatus := mcpServer.DeepCopy().Status
 
 	// Check if the MCPServer instance is marked to be deleted — do this before
 	// any validation or external API calls to avoid unnecessary work during deletion
@@ -278,8 +280,17 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Update status to reflect the error
 		mcpServer.Status.Phase = mcpv1beta1.MCPServerPhaseFailed
 		setReadyCondition(mcpServer, metav1.ConditionFalse, mcpv1beta1.ConditionReasonNotReady, err.Error())
-		if statusErr := r.Status().Update(ctx, mcpServer); statusErr != nil {
-			ctxLogger.Error(statusErr, "Failed to update MCPServer status after MCPExternalAuthConfig error")
+		if !equality.Semantic.DeepEqual(originalStatus, mcpServer.Status) {
+			if statusErr := r.Status().Update(ctx, mcpServer); statusErr != nil {
+				ctxLogger.Error(statusErr, "Failed to update MCPServer status after MCPExternalAuthConfig error")
+				return ctrl.Result{}, statusErr
+			}
+		}
+		if isTerminalExternalAuthError(err) {
+			// Consumer/type incompatibility and source Valid=False are both
+			// configuration errors. A spec or referenced-config change will enqueue
+			// reconciliation; retrying the same generation cannot heal the resource.
+			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -2181,6 +2192,20 @@ func (r *MCPServerReconciler) handleExternalAuthConfig(ctx context.Context, m *m
 		return err
 	}
 
+	if err := externalauthsupport.Validate(
+		externalauthsupport.ConsumerMCPServer,
+		externalAuthConfig.Spec.Type,
+	); err != nil {
+		meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
+			Type:               mcpv1beta1.ConditionTypeExternalAuthConfigValidated,
+			Status:             metav1.ConditionFalse,
+			Reason:             mcpv1beta1.ConditionReasonUnsupportedAuthType,
+			Message:            err.Error(),
+			ObservedGeneration: m.Generation,
+		})
+		return fmt.Errorf("MCPExternalAuthConfig %s/%s: %w", m.Namespace, externalAuthConfig.Name, err)
+	}
+
 	// MCPServer supports only single-upstream embedded auth server configs.
 	// Multi-upstream requires VirtualMCPServer.
 	if embeddedCfg := externalAuthConfig.Spec.EmbeddedAuthServer; embeddedCfg != nil && len(embeddedCfg.UpstreamProviders) > 1 {
@@ -2199,6 +2224,17 @@ func (r *MCPServerReconciler) handleExternalAuthConfig(ctx context.Context, m *m
 				"but only 1 is supported; use VirtualMCPServer",
 			m.Namespace, m.Name, len(embeddedCfg.UpstreamProviders))
 	}
+
+	// The config passed every check above. Set the condition back to True so a
+	// resource does not stay stuck at False after its referenced config is fixed
+	// (for example, edited from two upstream providers down to one).
+	meta.SetStatusCondition(&m.Status.Conditions, metav1.Condition{
+		Type:               mcpv1beta1.ConditionTypeExternalAuthConfigValidated,
+		Status:             metav1.ConditionTrue,
+		Reason:             mcpv1beta1.ConditionReasonExternalAuthConfigValid,
+		Message:            fmt.Sprintf("MCPExternalAuthConfig '%s' is valid", externalAuthConfig.Name),
+		ObservedGeneration: m.Generation,
+	})
 
 	// Check if the MCPExternalAuthConfig hash has changed
 	if m.Status.ExternalAuthConfigHash != externalAuthConfig.Status.ConfigHash {

--- a/cmd/thv-operator/controllers/mcpserver_externalauth_runconfig_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_externalauth_runconfig_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 	"github.com/stacklok/toolhive/pkg/runner"
@@ -167,7 +168,7 @@ func TestAddExternalAuthConfigOptions(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errContains: "unsupported external auth type",
+			errContains: "is not supported by MCPServer",
 		},
 		{
 			name: "valid embedded auth server configuration",
@@ -499,7 +500,11 @@ func TestAddExternalAuthConfigOptions(t *testing.T) {
 			ctx := t.Context()
 			var options []runner.RunConfigBuilderOption
 
-			err := ctrlutil.AddExternalAuthConfigOptions(ctx, reconciler.Client, tt.mcpServer.Namespace, tt.mcpServer.Name, tt.mcpServer.Spec.ExternalAuthConfigRef, tt.oidcConfig, &options)
+			err := ctrlutil.AddExternalAuthConfigOptions(
+				ctx, reconciler.Client, tt.mcpServer.Namespace, tt.mcpServer.Name,
+				externalauthsupport.ConsumerMCPServer,
+				tt.mcpServer.Spec.ExternalAuthConfigRef, tt.oidcConfig, &options,
+			)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/cmd/thv-operator/controllers/mcpserver_externalauth_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_externalauth_test.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -35,6 +37,70 @@ import (
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/pkg/container/kubernetes"
 )
+
+func newExternalAuthConfigForConsumerTest(
+	t *testing.T,
+	name string,
+	authType mcpv1beta1.ExternalAuthType,
+) *mcpv1beta1.MCPExternalAuthConfig {
+	t.Helper()
+
+	config := &mcpv1beta1.MCPExternalAuthConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       mcpv1beta1.MCPExternalAuthConfigSpec{Type: authType},
+	}
+	switch authType {
+	case mcpv1beta1.ExternalAuthTypeTokenExchange:
+		config.Spec.TokenExchange = &mcpv1beta1.TokenExchangeConfig{
+			TokenURL: "https://issuer.example/token",
+			ClientID: "client-id",
+			Audience: "backend",
+		}
+	case mcpv1beta1.ExternalAuthTypeHeaderInjection:
+		config.Spec.HeaderInjection = &mcpv1beta1.HeaderInjectionConfig{
+			HeaderName:     "X-Backend-Token",
+			ValueSecretRef: &mcpv1beta1.SecretKeyRef{Name: "header-secret", Key: "value"},
+		}
+	case mcpv1beta1.ExternalAuthTypeBearerToken:
+		config.Spec.BearerToken = &mcpv1beta1.BearerTokenConfig{
+			TokenSecretRef: &mcpv1beta1.SecretKeyRef{Name: "bearer-secret", Key: "token"},
+		}
+	case mcpv1beta1.ExternalAuthTypeUnauthenticated:
+		// No type-specific configuration is valid for unauthenticated.
+	case mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer:
+		config.Spec.EmbeddedAuthServer = &mcpv1beta1.EmbeddedAuthServerConfig{
+			Issuer: "https://auth.example.com",
+			UpstreamProviders: []mcpv1beta1.UpstreamProviderConfig{{
+				Name: "oidc",
+				Type: mcpv1beta1.UpstreamProviderTypeOIDC,
+				OIDCConfig: &mcpv1beta1.OIDCUpstreamConfig{
+					IssuerURL: "https://idp.example.com",
+					ClientID:  "client-id",
+				},
+			}},
+		}
+	case mcpv1beta1.ExternalAuthTypeAWSSts:
+		config.Spec.AWSSts = &mcpv1beta1.AWSStsConfig{
+			Region:          "us-east-1",
+			FallbackRoleArn: "arn:aws:iam::123456789012:role/toolhive-test",
+		}
+	case mcpv1beta1.ExternalAuthTypeUpstreamInject:
+		config.Spec.UpstreamInject = &mcpv1beta1.UpstreamInjectSpec{ProviderName: "oidc"}
+	case mcpv1beta1.ExternalAuthTypeOBO:
+		config.Spec.OBO = &mcpv1beta1.OBOConfig{}
+	case mcpv1beta1.ExternalAuthTypeXAA:
+		config.Spec.XAA = &mcpv1beta1.XAASpec{
+			IDPTokenURL:    "https://idp.example.com/token",
+			TargetTokenURL: "https://target.example.com/token",
+			TargetAudience: "https://target.example.com",
+			TargetResource: "https://backend.example.com/mcp",
+		}
+	default:
+		t.Fatalf("unsupported test auth type %q", authType)
+	}
+
+	return config
+}
 
 func TestMCPServerReconciler_handleExternalAuthConfig(t *testing.T) {
 	t.Parallel()
@@ -207,6 +273,193 @@ func TestMCPServerReconciler_handleExternalAuthConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMCPServerReconciler_handleExternalAuthConfig_UnsupportedAuthType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		authType mcpv1beta1.ExternalAuthType
+	}{
+		{name: "header injection", authType: mcpv1beta1.ExternalAuthTypeHeaderInjection},
+		{name: "bearer token", authType: mcpv1beta1.ExternalAuthTypeBearerToken},
+		{name: "AWS STS", authType: mcpv1beta1.ExternalAuthTypeAWSSts},
+		{name: "upstream injection", authType: mcpv1beta1.ExternalAuthTypeUpstreamInject},
+		{name: "XAA", authType: mcpv1beta1.ExternalAuthTypeXAA},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const (
+				generation   int64 = 17
+				previousHash       = "previous-supported-hash"
+			)
+			authConfig := newExternalAuthConfigForConsumerTest(t, "auth-config", tt.authType)
+			authConfig.Status.ConfigHash = "unsupported-hash"
+			mcpServer := v1beta1test.NewMCPServer("test-server", "default",
+				v1beta1test.WithImage("test-image"),
+				v1beta1test.WithExternalAuthConfigRef(authConfig.Name),
+				v1beta1test.WithStatus(mcpv1beta1.MCPServerStatus{ExternalAuthConfigHash: previousHash}),
+				v1beta1test.Mutate(func(server *mcpv1beta1.MCPServer) {
+					server.Generation = generation
+				}),
+			)
+
+			scheme := testutil.NewScheme(t)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(authConfig, mcpServer).
+				WithStatusSubresource(&mcpv1beta1.MCPServer{}).
+				Build()
+			reconciler := newTestMCPServerReconciler(fakeClient, scheme, kubernetes.PlatformKubernetes)
+
+			err := reconciler.handleExternalAuthConfig(t.Context(), mcpServer)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), string(tt.authType))
+			assert.Contains(t, err.Error(), "MCPServer")
+			cond := meta.FindStatusCondition(
+				mcpServer.Status.Conditions, mcpv1beta1.ConditionTypeExternalAuthConfigValidated)
+			require.NotNil(t, cond)
+			assert.Equal(t, metav1.ConditionFalse, cond.Status)
+			assert.Equal(t, mcpv1beta1.ConditionReasonUnsupportedAuthType, cond.Reason)
+			assert.Equal(t, generation, cond.ObservedGeneration)
+			assert.Contains(t, cond.Message, string(tt.authType))
+			assert.Contains(t, cond.Message, "MCPServer")
+			assert.Equal(t, previousHash, mcpServer.Status.ExternalAuthConfigHash,
+				"an unsupported config must not advance the last applied config hash")
+		})
+	}
+}
+
+func TestMCPServerReconciler_handleExternalAuthConfig_RecoversFromUnsupportedAuthType(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace = "default"
+		authName  = "auth-config"
+	)
+	authConfig := newExternalAuthConfigForConsumerTest(
+		t, authName, mcpv1beta1.ExternalAuthTypeHeaderInjection)
+	authConfig.Status.ConfigHash = "unsupported-hash"
+	mcpServer := v1beta1test.NewMCPServer("test-server", namespace,
+		v1beta1test.WithImage("test-image"),
+		v1beta1test.WithExternalAuthConfigRef(authName),
+	)
+	scheme := testutil.NewScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(authConfig, mcpServer).
+		WithStatusSubresource(&mcpv1beta1.MCPServer{}).
+		Build()
+	reconciler := newTestMCPServerReconciler(fakeClient, scheme, kubernetes.PlatformKubernetes)
+
+	require.Error(t, reconciler.handleExternalAuthConfig(t.Context(), mcpServer))
+	cond := meta.FindStatusCondition(
+		mcpServer.Status.Conditions, mcpv1beta1.ConditionTypeExternalAuthConfigValidated)
+	require.NotNil(t, cond)
+	assert.Equal(t, mcpv1beta1.ConditionReasonUnsupportedAuthType, cond.Reason)
+
+	var updatedConfig mcpv1beta1.MCPExternalAuthConfig
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: authName, Namespace: namespace}, &updatedConfig))
+	updatedConfig.Spec = mcpv1beta1.MCPExternalAuthConfigSpec{
+		Type: mcpv1beta1.ExternalAuthTypeTokenExchange,
+		TokenExchange: &mcpv1beta1.TokenExchangeConfig{
+			TokenURL: "https://issuer.example/token",
+			ClientID: "client-id",
+			Audience: "backend",
+		},
+	}
+	updatedConfig.Status.ConfigHash = "supported-hash"
+	require.NoError(t, fakeClient.Update(t.Context(), &updatedConfig))
+
+	require.NoError(t, reconciler.handleExternalAuthConfig(t.Context(), mcpServer))
+	recovered := meta.FindStatusCondition(
+		mcpServer.Status.Conditions, mcpv1beta1.ConditionTypeExternalAuthConfigValidated)
+	require.NotNil(t, recovered,
+		"the condition must flip to True after the source becomes supported, not linger at False")
+	assert.Equal(t, metav1.ConditionTrue, recovered.Status)
+	assert.Equal(t, mcpv1beta1.ConditionReasonExternalAuthConfigValid, recovered.Reason)
+	assert.Equal(t, "supported-hash", mcpServer.Status.ExternalAuthConfigHash)
+}
+
+func TestMCPServerReconciler_UnsupportedExternalAuthIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	authConfig := newExternalAuthConfigForConsumerTest(
+		t, "auth-config", mcpv1beta1.ExternalAuthTypeHeaderInjection)
+	mcpServer := v1beta1test.NewMCPServer("test-server", "default",
+		v1beta1test.WithImage("test-image"),
+		v1beta1test.WithExternalAuthConfigRef(authConfig.Name),
+		v1beta1test.Mutate(func(server *mcpv1beta1.MCPServer) {
+			server.Finalizers = []string{MCPServerFinalizerName}
+		}),
+	)
+
+	scheme := testutil.NewScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(authConfig, mcpServer).
+		WithStatusSubresource(&mcpv1beta1.MCPServer{}).
+		Build()
+	reconciler := newTestMCPServerReconciler(fakeClient, scheme, kubernetes.PlatformKubernetes)
+	request := ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: mcpServer.Name, Namespace: mcpServer.Namespace,
+	}}
+
+	result, err := reconciler.Reconcile(t.Context(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsZero(), "unsupported auth should be terminal until a watched resource changes")
+
+	afterFirst := &mcpv1beta1.MCPServer{}
+	require.NoError(t, fakeClient.Get(t.Context(), request.NamespacedName, afterFirst))
+	condition := meta.FindStatusCondition(
+		afterFirst.Status.Conditions, mcpv1beta1.ConditionTypeExternalAuthConfigValidated)
+	require.NotNil(t, condition)
+	assert.Equal(t, mcpv1beta1.ConditionReasonUnsupportedAuthType, condition.Reason)
+}
+
+func TestMCPServerReconciler_MirroredInvalidExternalAuthIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	authConfig := newExternalAuthConfigForConsumerTest(t, "auth-config", mcpv1beta1.ExternalAuthTypeOBO)
+	authConfig.Status.Conditions = []metav1.Condition{{
+		Type:    mcpv1beta1.ConditionTypeValid,
+		Status:  metav1.ConditionFalse,
+		Reason:  mcpv1beta1.ConditionReasonEnterpriseRequired,
+		Message: "enterprise feature required",
+	}}
+	mcpServer := v1beta1test.NewMCPServer("test-server", "default",
+		v1beta1test.WithImage("test-image"),
+		v1beta1test.WithExternalAuthConfigRef(authConfig.Name),
+		v1beta1test.Mutate(func(server *mcpv1beta1.MCPServer) {
+			server.Finalizers = []string{MCPServerFinalizerName}
+		}),
+	)
+	scheme := testutil.NewScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(authConfig, mcpServer).
+		WithStatusSubresource(&mcpv1beta1.MCPServer{}).
+		Build()
+	reconciler := newTestMCPServerReconciler(fakeClient, scheme, kubernetes.PlatformKubernetes)
+	request := ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: mcpServer.Name, Namespace: mcpServer.Namespace,
+	}}
+
+	result, err := reconciler.Reconcile(t.Context(), request)
+	require.NoError(t, err)
+	assert.True(t, result.IsZero(), "source Valid=False should wait for the referenced resource watch")
+
+	updated := &mcpv1beta1.MCPServer{}
+	require.NoError(t, fakeClient.Get(t.Context(), request.NamespacedName, updated))
+	condition := meta.FindStatusCondition(
+		updated.Status.Conditions, mcpv1beta1.ConditionTypeExternalAuthConfigValidated)
+	require.NotNil(t, condition)
+	assert.Equal(t, mcpv1beta1.ConditionReasonEnterpriseRequired, condition.Reason)
 }
 
 func TestMCPServerReconciler_handleExternalAuthConfig_SameNamespace(t *testing.T) {
@@ -513,11 +766,12 @@ func TestMCPServerReconciler_handleExternalAuthConfig_MirrorsInvalidCondition(t 
 
 			if !tt.wantMirrored {
 				assert.NoError(t, err, "no error expected when source is valid")
-				if tt.wantPreexistingCleared {
-					assert.Nil(t, cond, "stale mirror condition must be cleared once source has healed")
-				} else {
-					assert.Nil(t, cond, "no mirror condition expected when source is valid")
-				}
+				// A healthy source now lands on the success setter: the mirror
+				// (or its absence) is replaced by an explicit True condition, so
+				// the resource does not stay stuck at False once the source heals.
+				require.NotNil(t, cond, "valid source must produce an explicit True condition")
+				assert.Equal(t, metav1.ConditionTrue, cond.Status)
+				assert.Equal(t, mcpv1beta1.ConditionReasonExternalAuthConfigValid, cond.Reason)
 				return
 			}
 

--- a/cmd/thv-operator/controllers/mcpserver_runconfig.go
+++ b/cmd/thv-operator/controllers/mcpserver_runconfig.go
@@ -17,6 +17,7 @@ import (
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/kubernetes/configmaps"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc"
 	runconfig "github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig"
@@ -248,8 +249,8 @@ func (r *MCPServerReconciler) createRunConfigFromMCPServer(m *mcpv1beta1.MCPServ
 	// Add external auth configuration if specified (updated call)
 	// Will fail if embedded auth server is used without OIDC config or resourceUrl
 	if err := ctrlutil.AddExternalAuthConfigOptions(
-		ctx, r.Client, m.Namespace, m.Name, m.Spec.ExternalAuthConfigRef,
-		resolvedOIDCConfig, &options,
+		ctx, r.Client, m.Namespace, m.Name, externalauthsupport.ConsumerMCPServer,
+		m.Spec.ExternalAuthConfigRef, resolvedOIDCConfig, &options,
 	); err != nil {
 		return nil, fmt.Errorf("failed to process ExternalAuthConfig: %w", err)
 	}

--- a/cmd/thv-operator/controllers/mcpserverentry_controller.go
+++ b/cmd/thv-operator/controllers/mcpserverentry_controller.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/validation"
 )
 
@@ -66,6 +68,7 @@ func (r *MCPServerEntryReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		ctxLogger.Error(err, "Failed to get MCPServerEntry")
 		return ctrl.Result{}, err
 	}
+	originalStatus := entry.DeepCopy().Status
 
 	// Validate all referenced resources. Transient errors are returned directly
 	// to force a requeue rather than persisting a misleading condition.
@@ -102,6 +105,9 @@ func (r *MCPServerEntryReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Persist status
 	entry.Status.ObservedGeneration = entry.Generation
+	if equality.Semantic.DeepEqual(originalStatus, entry.Status) {
+		return ctrl.Result{}, nil
+	}
 	if err := r.Status().Update(ctx, entry); err != nil {
 		if errors.IsConflict(err) {
 			return ctrl.Result{RequeueAfter: mcpServerEntryRequeueDelay}, nil
@@ -287,6 +293,36 @@ func (r *MCPServerEntryReconciler) validateExternalAuthConfigRef(
 		}
 		ctxLogger.Error(err, "Failed to get referenced MCPExternalAuthConfig")
 		return false, err
+	}
+
+	// Surface a source-level validation failure (for example, an OBO config
+	// rejected by an upstream-only build with EnterpriseRequired) on the
+	// consumer before checking the type support matrix. The source failure is
+	// more specific than consumer compatibility and is terminal until either
+	// resource changes, so return false without an error to avoid a retry loop.
+	if mirrored := mirroredExternalAuthConfigInvalid(authConfig); mirrored != nil {
+		meta.SetStatusCondition(&entry.Status.Conditions, metav1.Condition{
+			Type:               mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated,
+			Status:             metav1.ConditionFalse,
+			Reason:             mirrored.Reason,
+			Message:            mirrored.Message,
+			ObservedGeneration: entry.Generation,
+		})
+		return false, nil
+	}
+
+	if err := externalauthsupport.Validate(
+		externalauthsupport.ConsumerMCPServerEntry,
+		authConfig.Spec.Type,
+	); err != nil {
+		meta.SetStatusCondition(&entry.Status.Conditions, metav1.Condition{
+			Type:               mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated,
+			Status:             metav1.ConditionFalse,
+			Reason:             mcpv1beta1.ConditionReasonUnsupportedAuthType,
+			Message:            err.Error(),
+			ObservedGeneration: entry.Generation,
+		})
+		return false, nil
 	}
 
 	meta.SetStatusCondition(&entry.Status.Conditions, metav1.Condition{

--- a/cmd/thv-operator/controllers/mcpserverentry_controller_test.go
+++ b/cmd/thv-operator/controllers/mcpserverentry_controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
+	"github.com/stacklok/toolhive/pkg/auth/obo"
 )
 
 const (
@@ -76,14 +77,19 @@ func newMCPServerEntry(
 // newMCPExternalAuthConfig creates a minimal MCPExternalAuthConfig object.
 func newMCPExternalAuthConfig(name, namespace string) *mcpv1beta1.MCPExternalAuthConfig {
 	return &mcpv1beta1.MCPExternalAuthConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
 			Type: mcpv1beta1.ExternalAuthTypeUnauthenticated,
 		},
 	}
+}
+
+func newMCPExternalAuthConfigOfType(
+	t *testing.T,
+	authType mcpv1beta1.ExternalAuthType,
+) *mcpv1beta1.MCPExternalAuthConfig {
+	t.Helper()
+	return newExternalAuthConfigForConsumerTest(t, testAuthConfig, authType)
 }
 
 // newConfigMap creates a minimal ConfigMap object.
@@ -223,6 +229,107 @@ func TestMCPServerEntryReconciler_Reconcile(t *testing.T) {
 				{mcpv1beta1.ConditionTypeMCPServerEntryGroupRefValidated, metav1.ConditionTrue, mcpv1beta1.ConditionReasonMCPServerEntryGroupRefValidated},
 				{mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated, metav1.ConditionFalse, mcpv1beta1.ConditionReasonMCPServerEntryAuthConfigNotFound},
 				{mcpv1beta1.ConditionTypeMCPServerEntryValid, metav1.ConditionFalse, mcpv1beta1.ConditionReasonMCPServerEntryInvalid},
+			},
+		},
+		{
+			name: "OBO source validation failure is mirrored before support validation",
+			entry: func() *mcpv1beta1.MCPServerEntry {
+				entry := newMCPServerEntry(testEntryGroupRef,
+					&mcpv1beta1.ExternalAuthConfigRef{Name: testAuthConfig}, nil)
+				entry.Generation = 33
+				return entry
+			}(),
+			objects: []client.Object{
+				newMCPGroup(mcpv1beta1.MCPGroupPhaseReady),
+				func() *mcpv1beta1.MCPExternalAuthConfig {
+					authConfig := newMCPExternalAuthConfigOfType(t, mcpv1beta1.ExternalAuthTypeOBO)
+					authConfig.Status.Conditions = []metav1.Condition{{
+						Type:    mcpv1beta1.ConditionTypeValid,
+						Status:  metav1.ConditionFalse,
+						Reason:  mcpv1beta1.ConditionReasonEnterpriseRequired,
+						Message: obo.ErrEnterpriseRequired.Error(),
+					}}
+					return authConfig
+				}(),
+			},
+			wantPhase: mcpv1beta1.MCPServerEntryPhaseFailed,
+			conditions: []struct {
+				condType string
+				status   metav1.ConditionStatus
+				reason   string
+			}{
+				{mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated, metav1.ConditionFalse, mcpv1beta1.ConditionReasonEnterpriseRequired},
+				{mcpv1beta1.ConditionTypeMCPServerEntryValid, metav1.ConditionFalse, mcpv1beta1.ConditionReasonMCPServerEntryInvalid},
+			},
+			extraCheck: func(t *testing.T, entry *mcpv1beta1.MCPServerEntry) {
+				t.Helper()
+				cond := meta.FindStatusCondition(
+					entry.Status.Conditions, mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated)
+				require.NotNil(t, cond)
+				assert.Equal(t, entry.Generation, cond.ObservedGeneration)
+				assert.Equal(t, obo.ErrEnterpriseRequired.Error(), cond.Message)
+			},
+		},
+		{
+			name: "bearer token auth is unsupported",
+			entry: func() *mcpv1beta1.MCPServerEntry {
+				entry := newMCPServerEntry(testEntryGroupRef,
+					&mcpv1beta1.ExternalAuthConfigRef{Name: testAuthConfig}, nil)
+				entry.Generation = 31
+				return entry
+			}(),
+			objects: []client.Object{
+				newMCPGroup(mcpv1beta1.MCPGroupPhaseReady),
+				newMCPExternalAuthConfigOfType(t, mcpv1beta1.ExternalAuthTypeBearerToken),
+			},
+			wantPhase: mcpv1beta1.MCPServerEntryPhaseFailed,
+			conditions: []struct {
+				condType string
+				status   metav1.ConditionStatus
+				reason   string
+			}{
+				{mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated, metav1.ConditionFalse, mcpv1beta1.ConditionReasonUnsupportedAuthType},
+				{mcpv1beta1.ConditionTypeMCPServerEntryValid, metav1.ConditionFalse, mcpv1beta1.ConditionReasonMCPServerEntryInvalid},
+			},
+			extraCheck: func(t *testing.T, entry *mcpv1beta1.MCPServerEntry) {
+				t.Helper()
+				cond := meta.FindStatusCondition(
+					entry.Status.Conditions, mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated)
+				require.NotNil(t, cond)
+				assert.Equal(t, entry.Generation, cond.ObservedGeneration)
+				assert.Contains(t, cond.Message, string(mcpv1beta1.ExternalAuthTypeBearerToken))
+				assert.Contains(t, cond.Message, "MCPServerEntry")
+			},
+		},
+		{
+			name: "embedded auth server is unsupported",
+			entry: func() *mcpv1beta1.MCPServerEntry {
+				entry := newMCPServerEntry(testEntryGroupRef,
+					&mcpv1beta1.ExternalAuthConfigRef{Name: testAuthConfig}, nil)
+				entry.Generation = 32
+				return entry
+			}(),
+			objects: []client.Object{
+				newMCPGroup(mcpv1beta1.MCPGroupPhaseReady),
+				newMCPExternalAuthConfigOfType(t, mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer),
+			},
+			wantPhase: mcpv1beta1.MCPServerEntryPhaseFailed,
+			conditions: []struct {
+				condType string
+				status   metav1.ConditionStatus
+				reason   string
+			}{
+				{mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated, metav1.ConditionFalse, mcpv1beta1.ConditionReasonUnsupportedAuthType},
+				{mcpv1beta1.ConditionTypeMCPServerEntryValid, metav1.ConditionFalse, mcpv1beta1.ConditionReasonMCPServerEntryInvalid},
+			},
+			extraCheck: func(t *testing.T, entry *mcpv1beta1.MCPServerEntry) {
+				t.Helper()
+				cond := meta.FindStatusCondition(
+					entry.Status.Conditions, mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated)
+				require.NotNil(t, cond)
+				assert.Equal(t, entry.Generation, cond.ObservedGeneration)
+				assert.Contains(t, cond.Message, string(mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer))
+				assert.Contains(t, cond.Message, "MCPServerEntry")
 			},
 		},
 		{
@@ -532,6 +639,127 @@ func TestMCPServerEntryReconciler_Reconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMCPServerEntryReconciler_ExternalAuthConfigMirrorRecovery(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	scheme := testutil.NewScheme(t)
+
+	entry := newMCPServerEntry(testEntryGroupRef,
+		&mcpv1beta1.ExternalAuthConfigRef{Name: testAuthConfig}, nil)
+	entry.Generation = 41
+	authConfig := newMCPExternalAuthConfigOfType(t, mcpv1beta1.ExternalAuthTypeOBO)
+	authConfig.Status.Conditions = []metav1.Condition{{
+		Type:    mcpv1beta1.ConditionTypeValid,
+		Status:  metav1.ConditionFalse,
+		Reason:  mcpv1beta1.ConditionReasonEnterpriseRequired,
+		Message: obo.ErrEnterpriseRequired.Error(),
+	}}
+
+	fakeClient := newEntryFakeClient(
+		t,
+		scheme,
+		entry,
+		newMCPGroup(mcpv1beta1.MCPGroupPhaseReady),
+		authConfig,
+	)
+	reconciler := &MCPServerEntryReconciler{Client: fakeClient}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{
+		Name:      entry.Name,
+		Namespace: entry.Namespace,
+	}}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, result.IsZero(), "source validation failure should be terminal until a watched resource changes")
+
+	var failedEntry mcpv1beta1.MCPServerEntry
+	require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, &failedEntry))
+	assert.Equal(t, mcpv1beta1.MCPServerEntryPhaseFailed, failedEntry.Status.Phase)
+	failedCondition := meta.FindStatusCondition(
+		failedEntry.Status.Conditions, mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated)
+	require.NotNil(t, failedCondition)
+	assert.Equal(t, metav1.ConditionFalse, failedCondition.Status)
+	assert.Equal(t, mcpv1beta1.ConditionReasonEnterpriseRequired, failedCondition.Reason)
+	assert.Equal(t, obo.ErrEnterpriseRequired.Error(), failedCondition.Message)
+	assert.Equal(t, failedEntry.Generation, failedCondition.ObservedGeneration)
+
+	var healedAuthConfig mcpv1beta1.MCPExternalAuthConfig
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+		Name: testAuthConfig, Namespace: testEntryNS,
+	}, &healedAuthConfig))
+	meta.SetStatusCondition(&healedAuthConfig.Status.Conditions, metav1.Condition{
+		Type:               mcpv1beta1.ConditionTypeValid,
+		Status:             metav1.ConditionTrue,
+		Reason:             "ValidationSucceeded",
+		Message:            "External auth configuration is valid",
+		ObservedGeneration: healedAuthConfig.Generation,
+	})
+	require.NoError(t, fakeClient.Update(ctx, &healedAuthConfig))
+
+	result, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, result.IsZero(), "healed source should reconcile without an explicit retry")
+
+	var recoveredEntry mcpv1beta1.MCPServerEntry
+	require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, &recoveredEntry))
+	assert.Equal(t, mcpv1beta1.MCPServerEntryPhaseValid, recoveredEntry.Status.Phase)
+	recoveredCondition := meta.FindStatusCondition(
+		recoveredEntry.Status.Conditions, mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated)
+	require.NotNil(t, recoveredCondition)
+	assert.Equal(t, metav1.ConditionTrue, recoveredCondition.Status)
+	assert.Equal(t, mcpv1beta1.ConditionReasonMCPServerEntryAuthConfigValid, recoveredCondition.Reason)
+	assert.Equal(t, "Referenced MCPExternalAuthConfig exists", recoveredCondition.Message)
+	assert.Equal(t, recoveredEntry.Generation, recoveredCondition.ObservedGeneration)
+	assertCondition(t, recoveredEntry.Status.Conditions,
+		mcpv1beta1.ConditionTypeMCPServerEntryValid,
+		metav1.ConditionTrue,
+		mcpv1beta1.ConditionReasonMCPServerEntryValid,
+	)
+}
+
+func TestMCPServerEntryReconciler_TerminalExternalAuthStatusIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	scheme := testutil.NewScheme(t)
+	entry := newMCPServerEntry(testEntryGroupRef,
+		&mcpv1beta1.ExternalAuthConfigRef{Name: testAuthConfig}, nil)
+	entry.Generation = 42
+	fakeClient := newEntryFakeClient(
+		t,
+		scheme,
+		entry,
+		newMCPGroup(mcpv1beta1.MCPGroupPhaseReady),
+		newMCPExternalAuthConfigOfType(t, mcpv1beta1.ExternalAuthTypeBearerToken),
+	)
+	reconciler := &MCPServerEntryReconciler{Client: fakeClient}
+	request := reconcile.Request{NamespacedName: types.NamespacedName{
+		Name: entry.Name, Namespace: entry.Namespace,
+	}}
+
+	result, err := reconciler.Reconcile(ctx, request)
+	require.NoError(t, err)
+	assert.True(t, result.IsZero())
+
+	afterFirst := &mcpv1beta1.MCPServerEntry{}
+	require.NoError(t, fakeClient.Get(ctx, request.NamespacedName, afterFirst))
+	condition := meta.FindStatusCondition(
+		afterFirst.Status.Conditions, mcpv1beta1.ConditionTypeMCPServerEntryAuthConfigValidated)
+	require.NotNil(t, condition)
+	assert.Equal(t, mcpv1beta1.ConditionReasonUnsupportedAuthType, condition.Reason)
+	steadyResourceVersion := afterFirst.ResourceVersion
+
+	result, err = reconciler.Reconcile(ctx, request)
+	require.NoError(t, err)
+	assert.True(t, result.IsZero())
+
+	afterSecond := &mcpv1beta1.MCPServerEntry{}
+	require.NoError(t, fakeClient.Get(ctx, request.NamespacedName, afterSecond))
+	assert.Equal(t, steadyResourceVersion, afterSecond.ResourceVersion,
+		"steady terminal status must not enqueue itself through another status write")
 }
 
 // TestMCPGroupReconciler_MCPServerEntryIntegration verifies the MCPGroup controller

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -37,6 +37,7 @@ import (
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/imagepullsecrets"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/kubernetes/rbac"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
@@ -2222,6 +2223,13 @@ func createVmcpServiceURL(vmcpName, namespace string, port int32) string {
 func (*VirtualMCPServerReconciler) convertExternalAuthConfigToStrategy(
 	externalAuthConfig *mcpv1beta1.MCPExternalAuthConfig,
 ) (*authtypes.BackendAuthStrategy, error) {
+	if err := externalauthsupport.Validate(
+		externalauthsupport.ConsumerVirtualMCPServer,
+		externalAuthConfig.Spec.Type,
+	); err != nil {
+		return nil, err
+	}
+
 	// Use the converter registry to convert to typed strategy
 	registry := converters.DefaultRegistry()
 	converter, err := registry.GetConverter(externalAuthConfig.Spec.Type)
@@ -2265,10 +2273,13 @@ func (r *VirtualMCPServerReconciler) convertBackendAuthConfigToVMCP(
 	namespace string,
 	crdConfig *mcpv1beta1.BackendAuthConfig,
 ) (*authtypes.BackendAuthStrategy, error) {
-	// For type="discovered", return a minimal strategy (will be populated by discovery)
+	// A type="discovered" entry converts to the unauthenticated fallback, the
+	// same contract the deleted converter-package copy of this function used
+	// for the ConfigMap. In discovered source mode, auth found on the backend
+	// resource itself still takes precedence at runtime.
 	if crdConfig.Type == mcpv1beta1.BackendAuthTypeDiscovered {
 		return &authtypes.BackendAuthStrategy{
-			Type: crdConfig.Type,
+			Type: authtypes.StrategyTypeUnauthenticated,
 		}, nil
 	}
 
@@ -2426,6 +2437,7 @@ func (r *VirtualMCPServerReconciler) discoverExternalAuthConfigs(
 				Context:     fmt.Sprintf("%s%s", authContextDiscoveredPrefix, workloadInfo.Name),
 				BackendName: workloadInfo.Name,
 				Error:       fmt.Errorf("failed to convert MCPExternalAuthConfig: %w", err),
+				Reason:      externalAuthReasonFromError(err),
 			})
 			continue
 		}
@@ -2524,7 +2536,7 @@ func (r *VirtualMCPServerReconciler) buildOutgoingAuthConfig(
 				Context:     authContextDefault,
 				BackendName: "",
 				Error:       fmt.Errorf("failed to convert default auth config: %w", err),
-				Reason:      mirroredReasonFromError(err),
+				Reason:      externalAuthReasonFromError(err),
 			})
 		} else if injected, injectErr := injectSubjectProviderIfNeeded(defaultStrategy, vmcp.Spec.AuthServerConfig); injectErr != nil {
 			allAuthErrors = append(allAuthErrors, AuthConfigError{
@@ -2557,7 +2569,7 @@ func (r *VirtualMCPServerReconciler) buildOutgoingAuthConfig(
 					Context:     fmt.Sprintf("%s%s", authContextBackendPrefix, backendName),
 					BackendName: backendName,
 					Error:       fmt.Errorf("failed to convert backend auth config: %w", err),
-					Reason:      mirroredReasonFromError(err),
+					Reason:      externalAuthReasonFromError(err),
 				})
 			} else if injected, injectErr := injectSubjectProviderIfNeeded(strategy, vmcp.Spec.AuthServerConfig); injectErr != nil {
 				allAuthErrors = append(allAuthErrors, AuthConfigError{

--- a/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_externalauth_test.go
@@ -362,6 +362,59 @@ func TestBuildOutgoingAuthConfig(t *testing.T) {
 			},
 		},
 		{
+			// The discovered-mode case from #5930: bearerToken works on the
+			// MCPRemoteProxy itself but has no vMCP converter, so fronting that
+			// proxy with a discovered-mode vMCP used to drop the backend with
+			// only a log line. The failure must now be a per-backend condition
+			// with the UnsupportedAuthType reason instead of a silent gap.
+			name: "discovered mode reports unsupported auth type per backend",
+			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+				v1beta1test.WithVMCPGroupRef("test-group"),
+				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
+					Source: "discovered",
+				}),
+			),
+			mcpServers: []mcpv1beta1.MCPServer{
+				*v1beta1test.NewMCPServer("backend-1", "default",
+					v1beta1test.WithExternalAuthConfigRef("bearer-auth"),
+				),
+			},
+			authConfigs: []mcpv1beta1.MCPExternalAuthConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bearer-auth",
+						Namespace: "default",
+					},
+					Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
+						Type: mcpv1beta1.ExternalAuthTypeBearerToken,
+						BearerToken: &mcpv1beta1.BearerTokenConfig{
+							TokenSecretRef: &mcpv1beta1.SecretKeyRef{Name: "token-secret", Key: "token"},
+						},
+					},
+				},
+			},
+			workloadNames: []workloads.TypedWorkload{
+				{
+					Name: "backend-1",
+					Type: workloads.WorkloadTypeMCPServer,
+				},
+			},
+			expectAuthErrors: true,
+			validate: func(t *testing.T, config *vmcpconfig.OutgoingAuthConfig) {
+				t.Helper()
+				assert.NotContains(t, config.Backends, "backend-1",
+					"an unsupported auth type must not produce a strategy")
+			},
+			validateErrors: func(t *testing.T, authErrors []AuthConfigError) {
+				t.Helper()
+				require.Len(t, authErrors, 1)
+				assert.Equal(t, "backend-1", authErrors[0].BackendName)
+				assert.Equal(t, mcpv1beta1.ConditionReasonUnsupportedAuthType, authErrors[0].Reason)
+				assert.Contains(t, authErrors[0].Error.Error(), "bearerToken")
+				assert.Contains(t, authErrors[0].Error.Error(), "VirtualMCPServer")
+			},
+		},
+		{
 			name: "discovered mode with inline overrides",
 			vmcp: v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
 				v1beta1test.WithVMCPGroupRef("test-group"),

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
@@ -50,6 +50,13 @@ func (r *VirtualMCPServerReconciler) ensureVmcpConfigConfigMap(
 		return fmt.Errorf("failed to create vmcp Config from VirtualMCPServer: %w", err)
 	}
 
+	// Outgoing auth is owned by processOutgoingAuth, not by the generic
+	// converter: one invalid backend has to surface as a per-backend status
+	// condition while the remaining valid backends stay served, which the
+	// converter's all-or-nothing conversion cannot express. Start from the
+	// source selected on the resource; processOutgoingAuth fills in the rest.
+	config.OutgoingAuth = &vmcpconfig.OutgoingAuthConfig{Source: outgoingAuthSource(vmcp)}
+
 	// Process outgoing auth configuration for both inline and discovered modes
 	if err := r.processOutgoingAuth(ctx, vmcp, config, typedWorkloads, statusManager); err != nil {
 		return err
@@ -405,6 +412,30 @@ func determineValidInlineBackends(authConfig *vmcpconfig.OutgoingAuthConfig, inl
 	return valid
 }
 
+// persistDiscoveredModeAuth writes the discovered-mode outgoing auth into the
+// ConfigMap-bound config: only what the spec declares — the default strategy
+// and inline per-backend entries. Strategies discovered from backend resources
+// stay out of the ConfigMap; the runtime rediscovers them and resolves their
+// secrets itself.
+func persistDiscoveredModeAuth(
+	config *vmcpconfig.Config,
+	vmcp *mcpv1beta1.VirtualMCPServer,
+	authConfig *vmcpconfig.OutgoingAuthConfig,
+) {
+	config.OutgoingAuth.Default = authConfig.Default
+	if vmcp.Spec.OutgoingAuth == nil || len(vmcp.Spec.OutgoingAuth.Backends) == 0 {
+		return
+	}
+
+	specBackends := make(map[string]*authtypes.BackendAuthStrategy, len(vmcp.Spec.OutgoingAuth.Backends))
+	for backendName := range vmcp.Spec.OutgoingAuth.Backends {
+		if strategy := authConfig.Backends[backendName]; strategy != nil {
+			specBackends[backendName] = strategy
+		}
+	}
+	config.OutgoingAuth.Backends = specBackends
+}
+
 // processOutgoingAuth processes outgoing auth configuration for both inline and discovered modes.
 // It builds auth configs, sets status conditions for all auth config types, and configures static backends for inline mode.
 func (r *VirtualMCPServerReconciler) processOutgoingAuth(
@@ -457,6 +488,10 @@ func (r *VirtualMCPServerReconciler) processOutgoingAuth(
 		validInlineBackends,
 		allAuthErrors,
 	)
+
+	if isDiscoveredMode && authConfig != nil {
+		persistDiscoveredModeAuth(config, vmcp, authConfig)
+	}
 
 	// Static mode (inline): Embed full backend details in ConfigMap
 	if isInlineMode {

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig_test.go
@@ -89,8 +89,10 @@ func TestCreateVmcpConfigFromVirtualMCPServer(t *testing.T) {
 	}
 }
 
-// TestConvertOutgoingAuth tests outgoing auth configuration conversion
-func TestConvertOutgoingAuth(t *testing.T) {
+// TestBuildOutgoingAuthConfig_SourceModes tests outgoing auth conversion through
+// the reconciler, which owns it now that the generic converter no longer
+// converts OutgoingAuth (see processOutgoingAuth).
+func TestBuildOutgoingAuthConfig_SourceModes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -142,23 +144,27 @@ func TestConvertOutgoingAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcpServer := v1beta1test.NewVirtualMCPServer("", "",
+			vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
 				v1beta1test.WithVMCPGroupRef("test-group"),
 				v1beta1test.WithVMCPOutgoingAuth(tt.outgoingAuth),
 			)
 
-			converter := newTestConverter(t, newNoOpMockResolver(t))
-			config, _, err := converter.Convert(context.Background(), vmcpServer, nil)
-			require.NoError(t, err)
+			scheme := testutil.NewScheme(t)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconciler := &VirtualMCPServerReconciler{Client: fakeClient, Scheme: scheme}
 
-			require.NotNil(t, config.OutgoingAuth)
-			assert.Equal(t, tt.expectedSource, config.OutgoingAuth.Source)
+			authConfig, _, authErrors := reconciler.buildOutgoingAuthConfig(
+				context.Background(), vmcpServer, nil)
+			require.Empty(t, authErrors)
+
+			require.NotNil(t, authConfig)
+			assert.Equal(t, tt.expectedSource, authConfig.Source)
 
 			if tt.hasDefault {
-				assert.NotNil(t, config.OutgoingAuth.Default)
+				assert.NotNil(t, authConfig.Default)
 			}
 
-			assert.Len(t, config.OutgoingAuth.Backends, tt.backendCount)
+			assert.Len(t, authConfig.Backends, tt.backendCount)
 		})
 	}
 }
@@ -198,18 +204,11 @@ func TestConvertBackendAuthConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			vmcpServer := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
-				v1beta1test.WithVMCPGroupRef("test-group"),
-				v1beta1test.WithVMCPOutgoingAuth(&mcpv1beta1.OutgoingAuthConfig{
-					Default: tt.authConfig,
-				}),
-			)
-
 			// For externalAuthConfigRef test, create the referenced MCPExternalAuthConfig
-			var converter *vmcpconfigconv.Converter
+			scheme := testutil.NewScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(scheme)
 			if tt.authConfig.Type == mcpv1beta1.BackendAuthTypeExternalAuthConfigRef {
-				// Create a fake MCPExternalAuthConfig
-				externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{
+				builder = builder.WithObjects(&mcpv1beta1.MCPExternalAuthConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "auth-config",
 						Namespace: "default",
@@ -217,27 +216,13 @@ func TestConvertBackendAuthConfig(t *testing.T) {
 					Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
 						Type: mcpv1beta1.ExternalAuthTypeUnauthenticated,
 					},
-				}
-
-				// Create converter with fake client that has the external auth config
-				scheme := testutil.NewScheme(t)
-				fakeClient := fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithObjects(externalAuthConfig).
-					Build()
-				var err error
-				converter, err = vmcpconfigconv.NewConverter(newNoOpMockResolver(t), fakeClient)
-				require.NoError(t, err)
-			} else {
-				converter = newTestConverter(t, newNoOpMockResolver(t))
+				})
 			}
+			reconciler := &VirtualMCPServerReconciler{Client: builder.Build(), Scheme: scheme}
 
-			config, _, err := converter.Convert(context.Background(), vmcpServer, nil)
+			strategy, err := reconciler.convertBackendAuthConfigToVMCP(
+				context.Background(), "default", tt.authConfig)
 			require.NoError(t, err)
-
-			require.NotNil(t, config.OutgoingAuth)
-			require.NotNil(t, config.OutgoingAuth.Default)
-			strategy := config.OutgoingAuth.Default
 
 			require.NotNil(t, strategy)
 			assert.Equal(t, tt.expectedType, strategy.Type)

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/oidc"
 	"github.com/stacklok/toolhive/pkg/auth/awssts"
 	"github.com/stacklok/toolhive/pkg/auth/obo"
@@ -209,6 +210,14 @@ func GenerateTokenExchangeEnvVars(
 // This creates token exchange configuration which will be automatically converted to middleware by
 // PopulateMiddlewareConfigs() when the runner starts. This ensures correct middleware ordering.
 //
+// The consumer parameter identifies the resource kind building the run config.
+// The externalauthsupport matrix is enforced here, at the one dispatch point
+// both MCPServer and MCPRemoteProxy route through, so an unsupported type
+// results in an UnsupportedTypeError instead of a silent no-op (#5930). The
+// consumer controllers validate earlier and surface the failure as a status
+// condition; this guard keeps the run-config path honest even for a caller
+// that skips that step.
+//
 // The oidcConfig parameter is used for embedded auth server configuration to populate:
 //   - AllowedAudiences from oidcConfig.ResourceURL
 //   - ScopesSupported from oidcConfig.Scopes
@@ -219,6 +228,7 @@ func AddExternalAuthConfigOptions(
 	c client.Client,
 	namespace string,
 	mcpServerName string,
+	consumer externalauthsupport.Consumer,
 	externalAuthConfigRef *mcpv1beta1.ExternalAuthConfigRef,
 	oidcConfig *oidc.OIDCConfig,
 	options *[]runner.RunConfigBuilderOption,
@@ -233,12 +243,14 @@ func AddExternalAuthConfigOptions(
 		return fmt.Errorf("failed to get MCPExternalAuthConfig: %w", err)
 	}
 
+	if err := externalauthsupport.Validate(consumer, externalAuthConfig.Spec.Type); err != nil {
+		return err
+	}
+
 	// Handle different auth types
 	switch externalAuthConfig.Spec.Type {
 	case mcpv1beta1.ExternalAuthTypeTokenExchange:
 		return addTokenExchangeConfig(ctx, c, namespace, externalAuthConfig, options)
-	case mcpv1beta1.ExternalAuthTypeHeaderInjection:
-		return addHeaderInjectionConfig(ctx, c, namespace, externalAuthConfig, options)
 	case mcpv1beta1.ExternalAuthTypeBearerToken:
 		return addBearerTokenConfig(ctx, c, namespace, externalAuthConfig, options)
 	case mcpv1beta1.ExternalAuthTypeUnauthenticated:
@@ -248,9 +260,6 @@ func AddExternalAuthConfigOptions(
 		return AddEmbeddedAuthServerConfigOptions(ctx, c, namespace, mcpServerName, externalAuthConfigRef, oidcConfig, options)
 	case mcpv1beta1.ExternalAuthTypeAWSSts:
 		return addAWSStsConfig(externalAuthConfig, options)
-	case mcpv1beta1.ExternalAuthTypeUpstreamInject:
-		// Upstream inject is handled by the vMCP converter at runtime
-		return nil
 	case mcpv1beta1.ExternalAuthTypeOBO:
 		// Dispatch through the registered handler. In upstream-only builds the
 		// default handler returns obo.ErrEnterpriseRequired; an out-of-tree
@@ -258,11 +267,17 @@ func AddExternalAuthConfigOptions(
 		// default's "unsupported external auth type" path so callers can
 		// distinguish via errors.Is(err, obo.ErrEnterpriseRequired).
 		return OBOApplyRunConfig(ctx, c, namespace, externalAuthConfig, options)
-	case mcpv1beta1.ExternalAuthTypeXAA:
-		// XAA is handled by the vMCP converter at runtime
-		return nil
+	case mcpv1beta1.ExternalAuthTypeHeaderInjection,
+		mcpv1beta1.ExternalAuthTypeUpstreamInject,
+		mcpv1beta1.ExternalAuthTypeXAA:
+		// Unreachable today: the support-matrix check above rejects these for
+		// both consumers that route through this dispatcher. They used to be
+		// silent no-op arms — the failure mode behind #5930 — so if a matrix
+		// edit ever admits one of them, fail loudly until a real arm exists.
+		return fmt.Errorf("external auth type %q passed the support matrix but has no dispatch arm here",
+			externalAuthConfig.Spec.Type)
 	default:
-		return fmt.Errorf("unsupported external auth type: %s", externalAuthConfig.Spec.Type)
+		return fmt.Errorf("unknown external auth type: %s", externalAuthConfig.Spec.Type)
 	}
 }
 
@@ -380,23 +395,6 @@ func addTokenExchangeConfig(
 	// The middleware will be automatically created by PopulateMiddlewareConfigs() in the correct order
 	*options = append(*options, runner.WithTokenExchangeConfig(tokenExchangeConfig))
 
-	return nil
-}
-
-// addHeaderInjectionConfig adds header injection configuration to runner options
-// For now, this is a no-op as header injection for MCPServer is not implemented
-// Header injection is primarily used for vMCP outgoing auth, not for MCPServer incoming auth
-func addHeaderInjectionConfig(
-	_ context.Context,
-	_ client.Client,
-	_ string,
-	_ *mcpv1beta1.MCPExternalAuthConfig,
-	_ *[]runner.RunConfigBuilderOption,
-) error {
-	// Header injection for MCPServer is not yet implemented
-	// This is a placeholder to avoid the "unsupported auth type" error
-	// MCPServer's ExternalAuthConfigRef is meant for incoming auth configuration
-	// but header injection doesn't make sense in that context
 	return nil
 }
 

--- a/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
+++ b/cmd/thv-operator/pkg/controllerutil/tokenexchange_test.go
@@ -6,6 +6,7 @@ package controllerutil
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ import (
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
+	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/externalauthsupport"
 	"github.com/stacklok/toolhive/pkg/auth/obo"
 	"github.com/stacklok/toolhive/pkg/runner"
 )
@@ -272,6 +274,7 @@ func TestAddExternalAuthConfigOptions_OBO(t *testing.T) {
 		fakeClient,
 		"default",
 		"server-name",
+		externalauthsupport.ConsumerMCPServer,
 		&mcpv1beta1.ExternalAuthConfigRef{Name: authCfg.Name},
 		nil, // oidcConfig — not required for OBO
 		&options,
@@ -286,6 +289,78 @@ func TestAddExternalAuthConfigOptions_OBO(t *testing.T) {
 	assert.NotContains(t, err.Error(), "unsupported external auth type")
 	assert.NotContains(t, err.Error(), "unknown middleware type")
 	assert.Empty(t, options, "default OBO handler must not append to the options slice")
+}
+
+// TestAddExternalAuthConfigOptions_EnforcesSupportMatrix drives the run-config
+// dispatch with every ExternalAuthType for both consumers that route through
+// it, and requires the outcome to agree with the externalauthsupport matrix:
+// an unsupported type must surface as UnsupportedTypeError (never a silent
+// no-op — the failure mode behind #5930), and a supported type must get past
+// the support check (later errors, e.g. a missing secret, are fine but must
+// not be UnsupportedTypeError). Because it exercises the real dispatch, this
+// test fails when the matrix and the switch drift apart in either direction.
+func TestAddExternalAuthConfigOptions_EnforcesSupportMatrix(t *testing.T) {
+	t.Parallel()
+
+	scheme := testutil.NewScheme(t)
+	const ns = "default"
+
+	allTypes := []mcpv1beta1.ExternalAuthType{
+		mcpv1beta1.ExternalAuthTypeTokenExchange,
+		mcpv1beta1.ExternalAuthTypeHeaderInjection,
+		mcpv1beta1.ExternalAuthTypeBearerToken,
+		mcpv1beta1.ExternalAuthTypeUnauthenticated,
+		mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer,
+		mcpv1beta1.ExternalAuthTypeAWSSts,
+		mcpv1beta1.ExternalAuthTypeUpstreamInject,
+		mcpv1beta1.ExternalAuthTypeOBO,
+		mcpv1beta1.ExternalAuthTypeXAA,
+	}
+
+	consumers := []externalauthsupport.Consumer{
+		externalauthsupport.ConsumerMCPServer,
+		externalauthsupport.ConsumerMCPRemoteProxy,
+	}
+
+	for _, consumer := range consumers {
+		for _, authType := range allTypes {
+			t.Run(fmt.Sprintf("%s/%s", consumer, authType), func(t *testing.T) {
+				t.Parallel()
+
+				cfg := &mcpv1beta1.MCPExternalAuthConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: ns},
+					Spec:       mcpv1beta1.MCPExternalAuthConfigSpec{Type: authType},
+				}
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cfg).Build()
+
+				var options []runner.RunConfigBuilderOption
+				err := AddExternalAuthConfigOptions(
+					t.Context(),
+					fakeClient,
+					ns,
+					"server-name",
+					consumer,
+					&mcpv1beta1.ExternalAuthConfigRef{Name: cfg.Name},
+					nil,
+					&options,
+				)
+
+				var unsupported *externalauthsupport.UnsupportedTypeError
+				if externalauthsupport.Supports(consumer, authType) {
+					if err != nil {
+						assert.False(t, errors.As(err, &unsupported),
+							"supported type %q must pass the support check; got %v", authType, err)
+					}
+				} else {
+					require.Error(t, err, "unsupported type %q must not silently no-op", authType)
+					require.ErrorAs(t, err, &unsupported)
+					assert.Equal(t, consumer, unsupported.Consumer)
+					assert.Equal(t, authType, unsupported.AuthType)
+					assert.Empty(t, options, "an unsupported type must not contribute run-config options")
+				}
+			})
+		}
+	}
 }
 
 // TestAddOBOSecretEnvVars covers the OBO-only secret-env dispatcher across every

--- a/cmd/thv-operator/pkg/externalauthsupport/support.go
+++ b/cmd/thv-operator/pkg/externalauthsupport/support.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package externalauthsupport defines which MCPExternalAuthConfig types each
+// consumer kind implements, shared by the operator controllers.
+package externalauthsupport
+
+import (
+	"fmt"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/pkg/vmcp/auth/converters"
+)
+
+// Consumer identifies a resource kind that consumes an MCPExternalAuthConfig.
+type Consumer string
+
+const (
+	// ConsumerMCPServer identifies MCPServer.spec.externalAuthConfigRef.
+	ConsumerMCPServer Consumer = "MCPServer"
+	// ConsumerMCPRemoteProxy identifies MCPRemoteProxy.spec.externalAuthConfigRef.
+	ConsumerMCPRemoteProxy Consumer = "MCPRemoteProxy"
+	// ConsumerVirtualMCPServer identifies VirtualMCPServer outgoing authentication.
+	ConsumerVirtualMCPServer Consumer = "VirtualMCPServer"
+	// ConsumerMCPServerEntry identifies MCPServerEntry.spec.externalAuthConfigRef.
+	ConsumerMCPServerEntry Consumer = "MCPServerEntry"
+)
+
+// supportMatrix records which auth types each consumer implements. It is
+// treated as immutable after initialization.
+//
+// The vMCP-backed rows (VirtualMCPServer, MCPServerEntry) are derived from the
+// converter registry, so registering a new converter extends their support
+// automatically. The MCPServer and MCPRemoteProxy rows are declared here and
+// enforced at the run-config dispatch in controllerutil.AddExternalAuthConfigOptions,
+// which returns UnsupportedTypeError for anything outside the row — the tests
+// in controllerutil exercise that dispatch against every type, so these rows
+// cannot silently drift from what the dispatcher implements.
+//
+// OBO appears for every consumer because enterprise builds may register the
+// required handler; upstream-only builds reject OBO separately with
+// EnterpriseRequired.
+var supportMatrix = map[Consumer]map[mcpv1beta1.ExternalAuthType]struct{}{
+	ConsumerMCPServer: {
+		mcpv1beta1.ExternalAuthTypeTokenExchange:      {},
+		mcpv1beta1.ExternalAuthTypeUnauthenticated:    {},
+		mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer: {},
+		mcpv1beta1.ExternalAuthTypeOBO:                {},
+	},
+	ConsumerMCPRemoteProxy: {
+		mcpv1beta1.ExternalAuthTypeTokenExchange:      {},
+		mcpv1beta1.ExternalAuthTypeBearerToken:        {},
+		mcpv1beta1.ExternalAuthTypeUnauthenticated:    {},
+		mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer: {},
+		mcpv1beta1.ExternalAuthTypeAWSSts:             {},
+		mcpv1beta1.ExternalAuthTypeOBO:                {},
+	},
+	ConsumerVirtualMCPServer: converterBackedTypes(),
+	ConsumerMCPServerEntry:   converterBackedTypes(),
+}
+
+// converterBackedTypes builds a support row from the types registered in the
+// vMCP converter registry — the code path these consumers actually route
+// through at conversion time.
+func converterBackedTypes() map[mcpv1beta1.ExternalAuthType]struct{} {
+	registered := converters.DefaultRegistry().RegisteredTypes()
+	row := make(map[mcpv1beta1.ExternalAuthType]struct{}, len(registered))
+	for _, authType := range registered {
+		row[authType] = struct{}{}
+	}
+	return row
+}
+
+// UnsupportedTypeError reports an MCPExternalAuthConfig type that cannot be
+// used by a particular consumer.
+type UnsupportedTypeError struct {
+	Consumer Consumer
+	AuthType mcpv1beta1.ExternalAuthType
+}
+
+// Error implements error.
+func (e *UnsupportedTypeError) Error() string {
+	return fmt.Sprintf("external auth type %q is not supported by %s", e.AuthType, e.Consumer)
+}
+
+// Supports reports whether consumer implements authType.
+func Supports(consumer Consumer, authType mcpv1beta1.ExternalAuthType) bool {
+	supported, knownConsumer := supportMatrix[consumer]
+	if !knownConsumer {
+		return false
+	}
+	_, ok := supported[authType]
+	return ok
+}
+
+// Validate returns an UnsupportedTypeError when consumer does not implement
+// authType.
+func Validate(consumer Consumer, authType mcpv1beta1.ExternalAuthType) error {
+	if Supports(consumer, authType) {
+		return nil
+	}
+
+	return &UnsupportedTypeError{
+		Consumer: consumer,
+		AuthType: authType,
+	}
+}

--- a/cmd/thv-operator/pkg/externalauthsupport/support_test.go
+++ b/cmd/thv-operator/pkg/externalauthsupport/support_test.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package externalauthsupport
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/pkg/vmcp/auth/converters"
+)
+
+// allAuthTypes mirrors the CRD enum on MCPExternalAuthConfigSpec.Type. If a
+// new type is added to the enum without being classified here, the coverage
+// assertions below start failing on the registry comparison, which is the
+// reminder to think about every consumer.
+var allAuthTypes = []mcpv1beta1.ExternalAuthType{
+	mcpv1beta1.ExternalAuthTypeTokenExchange,
+	mcpv1beta1.ExternalAuthTypeHeaderInjection,
+	mcpv1beta1.ExternalAuthTypeBearerToken,
+	mcpv1beta1.ExternalAuthTypeUnauthenticated,
+	mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer,
+	mcpv1beta1.ExternalAuthTypeAWSSts,
+	mcpv1beta1.ExternalAuthTypeUpstreamInject,
+	mcpv1beta1.ExternalAuthTypeOBO,
+	mcpv1beta1.ExternalAuthTypeXAA,
+}
+
+// TestVMCPRowsTrackConverterRegistry pins the property the vMCP-backed rows
+// are built on: a type is supported by VirtualMCPServer outgoing auth and
+// MCPServerEntry exactly when the converter registry has a converter for it.
+// Registering a new converter must extend both rows without any edit here;
+// this fails if the derivation wiring is ever replaced with a literal again.
+func TestVMCPRowsTrackConverterRegistry(t *testing.T) {
+	t.Parallel()
+
+	registered := make(map[mcpv1beta1.ExternalAuthType]struct{})
+	for _, authType := range converters.DefaultRegistry().RegisteredTypes() {
+		registered[authType] = struct{}{}
+	}
+	require.NotEmpty(t, registered, "converter registry must have built-in converters")
+
+	for _, authType := range allAuthTypes {
+		_, hasConverter := registered[authType]
+		assert.Equal(t, hasConverter, Supports(ConsumerVirtualMCPServer, authType),
+			"VirtualMCPServer support for %q must equal converter registry membership", authType)
+		assert.Equal(t, hasConverter, Supports(ConsumerMCPServerEntry, authType),
+			"MCPServerEntry support for %q must equal converter registry membership", authType)
+	}
+}
+
+// TestDeclaredRowsMatchKnownRuntimeBehavior documents the hand-declared
+// MCPServer and MCPRemoteProxy rows. These rows are enforced at the run-config
+// dispatch (controllerutil.AddExternalAuthConfigOptions), and the behavioral
+// test there drives that dispatch with every type for both consumers — so a
+// row edited here without a matching dispatch arm (or vice versa) fails that
+// test rather than drifting silently. What this test pins down is the intent:
+// which combinations are meant to work.
+func TestDeclaredRowsMatchKnownRuntimeBehavior(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, Supports(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeTokenExchange))
+	assert.True(t, Supports(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeUnauthenticated))
+	assert.True(t, Supports(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeEmbeddedAuthServer))
+	assert.True(t, Supports(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeOBO))
+	// bearerToken wires runner.WithRemoteAuth, which only takes effect with a
+	// RemoteURL — MCPServer never sets one, so the credential would silently
+	// never be injected (#5930).
+	assert.False(t, Supports(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeBearerToken))
+	// awsSts fails the empty-RemoteURL check at runtime rather than no-opping;
+	// rejecting it at reconcile time gives the user the failure where they can
+	// see it.
+	assert.False(t, Supports(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeAWSSts))
+	assert.False(t, Supports(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeHeaderInjection))
+	assert.False(t, Supports(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeUpstreamInject))
+	assert.False(t, Supports(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeXAA))
+
+	// MCPRemoteProxy is MCPServer plus the remote-only types: it always has a
+	// RemoteURL, so bearerToken and awsSts genuinely work there.
+	assert.True(t, Supports(ConsumerMCPRemoteProxy, mcpv1beta1.ExternalAuthTypeBearerToken))
+	assert.True(t, Supports(ConsumerMCPRemoteProxy, mcpv1beta1.ExternalAuthTypeAWSSts))
+	assert.False(t, Supports(ConsumerMCPRemoteProxy, mcpv1beta1.ExternalAuthTypeHeaderInjection))
+	assert.False(t, Supports(ConsumerMCPRemoteProxy, mcpv1beta1.ExternalAuthTypeUpstreamInject))
+	assert.False(t, Supports(ConsumerMCPRemoteProxy, mcpv1beta1.ExternalAuthTypeXAA))
+}
+
+func TestSupportsUnknownConsumer(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, Supports(Consumer("SomethingElse"), mcpv1beta1.ExternalAuthTypeTokenExchange),
+		"an unknown consumer must never report support")
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, Validate(ConsumerMCPRemoteProxy, mcpv1beta1.ExternalAuthTypeBearerToken))
+
+	err := Validate(ConsumerMCPServer, mcpv1beta1.ExternalAuthTypeHeaderInjection)
+	require.Error(t, err)
+
+	var unsupported *UnsupportedTypeError
+	require.True(t, errors.As(err, &unsupported), "Validate must return a typed UnsupportedTypeError")
+	assert.Equal(t, ConsumerMCPServer, unsupported.Consumer)
+	assert.Equal(t, mcpv1beta1.ExternalAuthTypeHeaderInjection, unsupported.AuthType)
+	assert.Contains(t, err.Error(), "headerInjection")
+	assert.Contains(t, err.Error(), "MCPServer")
+}

--- a/cmd/thv-operator/pkg/vmcpconfig/converter.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter.go
@@ -20,8 +20,6 @@ import (
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/spectoconfig"
 	"github.com/stacklok/toolhive/pkg/authserver"
 	"github.com/stacklok/toolhive/pkg/telemetry"
-	"github.com/stacklok/toolhive/pkg/vmcp/auth/converters"
-	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 )
 
@@ -110,12 +108,11 @@ func (c *Converter) Convert(
 		config.IncomingAuth = incomingAuth
 	}
 
-	// Convert OutgoingAuth - always set with defaults if not specified
-	outgoingAuth, err := c.convertOutgoingAuthWithDefaults(ctx, vmcp)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to convert outgoing auth: %w", err)
-	}
-	config.OutgoingAuth = outgoingAuth
+	// OutgoingAuth is deliberately not converted here. The VirtualMCPServer
+	// reconciler owns it (see processOutgoingAuth): outgoing auth needs
+	// per-backend error reporting via status conditions, and a single failing
+	// backend must not fail the whole conversion. Whatever the embedded config
+	// carries in this field is superseded by the reconciler.
 
 	// Convert Aggregation - always set with defaults if not specified
 	agg, err := c.convertAggregationWithDefaults(ctx, vmcp)
@@ -587,19 +584,6 @@ func deriveScopesSupported(config *vmcpconfig.Config) []string {
 	return config.IncomingAuth.OIDC.Scopes
 }
 
-// convertOutgoingAuthWithDefaults converts OutgoingAuthConfig or returns defaults.
-func (c *Converter) convertOutgoingAuthWithDefaults(
-	ctx context.Context,
-	vmcp *mcpv1beta1.VirtualMCPServer,
-) (*vmcpconfig.OutgoingAuthConfig, error) {
-	if vmcp.Spec.OutgoingAuth != nil {
-		return c.convertOutgoingAuth(ctx, vmcp)
-	}
-	return &vmcpconfig.OutgoingAuthConfig{
-		Source: "discovered", // Default to discovered mode
-	}, nil
-}
-
 // convertAggregationWithDefaults converts AggregationConfig or returns defaults.
 func (c *Converter) convertAggregationWithDefaults(
 	ctx context.Context,
@@ -614,112 +598,6 @@ func (c *Converter) convertAggregationWithDefaults(
 			PrefixFormat: "{workload}_",
 		},
 	}, nil
-}
-
-// convertOutgoingAuth converts OutgoingAuthConfig from CRD to vmcp config
-func (c *Converter) convertOutgoingAuth(
-	ctx context.Context,
-	vmcp *mcpv1beta1.VirtualMCPServer,
-) (*vmcpconfig.OutgoingAuthConfig, error) {
-	outgoing := &vmcpconfig.OutgoingAuthConfig{
-		Source:   vmcp.Spec.OutgoingAuth.Source,
-		Backends: make(map[string]*authtypes.BackendAuthStrategy),
-	}
-
-	// Convert Default
-	if vmcp.Spec.OutgoingAuth.Default != nil {
-		defaultStrategy, err := c.convertBackendAuthConfig(ctx, vmcp, "default", vmcp.Spec.OutgoingAuth.Default)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert default backend auth: %w", err)
-		}
-		outgoing.Default = defaultStrategy
-	}
-
-	// Convert per-backend overrides
-	for backendName, backendAuth := range vmcp.Spec.OutgoingAuth.Backends {
-		strategy, err := c.convertBackendAuthConfig(ctx, vmcp, backendName, &backendAuth)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert backend auth for %s: %w", backendName, err)
-		}
-		outgoing.Backends[backendName] = strategy
-	}
-
-	return outgoing, nil
-}
-
-// convertBackendAuthConfig converts BackendAuthConfig from CRD to vmcp config
-func (c *Converter) convertBackendAuthConfig(
-	ctx context.Context,
-	vmcp *mcpv1beta1.VirtualMCPServer,
-	backendName string,
-	crdConfig *mcpv1beta1.BackendAuthConfig,
-) (*authtypes.BackendAuthStrategy, error) {
-	// If type is "discovered", return unauthenticated strategy
-	if crdConfig.Type == mcpv1beta1.BackendAuthTypeDiscovered {
-		return &authtypes.BackendAuthStrategy{
-			Type: authtypes.StrategyTypeUnauthenticated,
-		}, nil
-	}
-
-	// If type is "externalAuthConfigRef", resolve the MCPExternalAuthConfig
-	if crdConfig.Type == mcpv1beta1.BackendAuthTypeExternalAuthConfigRef {
-		if crdConfig.ExternalAuthConfigRef == nil {
-			return nil, fmt.Errorf("backend %s: externalAuthConfigRef type requires externalAuthConfigRef field", backendName)
-		}
-
-		// Fetch the MCPExternalAuthConfig resource
-		externalAuthConfig := &mcpv1beta1.MCPExternalAuthConfig{}
-		err := c.k8sClient.Get(ctx, types.NamespacedName{
-			Name:      crdConfig.ExternalAuthConfigRef.Name,
-			Namespace: vmcp.Namespace,
-		}, externalAuthConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get MCPExternalAuthConfig %s/%s: %w",
-				vmcp.Namespace, crdConfig.ExternalAuthConfigRef.Name, err)
-		}
-
-		// Convert the external auth config to backend auth strategy
-		return c.convertExternalAuthConfigToStrategy(ctx, externalAuthConfig)
-	}
-
-	// Unknown type
-	return nil, fmt.Errorf("backend %s: unknown auth type %q", backendName, crdConfig.Type)
-}
-
-// convertExternalAuthConfigToStrategy converts MCPExternalAuthConfig to BackendAuthStrategy.
-// This uses the converter registry to consolidate conversion logic and apply token type normalization consistently.
-// The registry pattern makes adding new auth types easier and ensures conversion happens in one place.
-func (*Converter) convertExternalAuthConfigToStrategy(
-	_ context.Context,
-	externalAuthConfig *mcpv1beta1.MCPExternalAuthConfig,
-) (*authtypes.BackendAuthStrategy, error) {
-	// Use the converter registry to convert to typed strategy
-	registry := converters.DefaultRegistry()
-	converter, err := registry.GetConverter(externalAuthConfig.Spec.Type)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert to typed BackendAuthStrategy (applies token type normalization)
-	strategy, err := converter.ConvertToStrategy(externalAuthConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert external auth config to strategy: %w", err)
-	}
-
-	// Enrich with unique env var names per ExternalAuthConfig to avoid conflicts
-	// when multiple configs of the same type reference different secrets
-	if strategy.TokenExchange != nil &&
-		externalAuthConfig.Spec.TokenExchange != nil &&
-		externalAuthConfig.Spec.TokenExchange.ClientSecretRef != nil {
-		strategy.TokenExchange.ClientSecretEnv = controllerutil.GenerateUniqueTokenExchangeEnvVarName(externalAuthConfig.Name)
-	}
-	if strategy.HeaderInjection != nil &&
-		externalAuthConfig.Spec.HeaderInjection != nil &&
-		externalAuthConfig.Spec.HeaderInjection.ValueSecretRef != nil {
-		strategy.HeaderInjection.HeaderValueEnv = controllerutil.GenerateUniqueHeaderInjectionEnvVarName(externalAuthConfig.Name)
-	}
-
-	return strategy, nil
 }
 
 // convertAggregation converts AggregationConfig from config.Config, resolving ToolConfigRef references

--- a/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_controller_integration_test.go
+++ b/cmd/thv-operator/test-integration/mcp-remote-proxy/mcpremoteproxy_controller_integration_test.go
@@ -385,13 +385,10 @@ var _ = Describe("MCPRemoteProxy Controller", Label("k8s", "remoteproxy"), func(
 						Namespace: testNamespace,
 					},
 					Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
-						Type: mcpv1beta1.ExternalAuthTypeHeaderInjection,
-						HeaderInjection: &mcpv1beta1.HeaderInjectionConfig{
-							HeaderName: "X-API-Key",
-							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-								Name: "api-key-secret",
-								Key:  "key",
-							},
+						Type: mcpv1beta1.ExternalAuthTypeTokenExchange,
+						TokenExchange: &mcpv1beta1.TokenExchangeConfig{
+							TokenURL: "https://oauth.example.com/token",
+							Audience: "remote-service",
 						},
 					},
 				}
@@ -444,13 +441,10 @@ var _ = Describe("MCPRemoteProxy Controller", Label("k8s", "remoteproxy"), func(
 						Namespace: testNamespace,
 					},
 					Spec: mcpv1beta1.MCPExternalAuthConfigSpec{
-						Type: mcpv1beta1.ExternalAuthTypeHeaderInjection,
-						HeaderInjection: &mcpv1beta1.HeaderInjectionConfig{
-							HeaderName: "X-Original-Header",
-							ValueSecretRef: &mcpv1beta1.SecretKeyRef{
-								Name: "original-secret",
-								Key:  "key",
-							},
+						Type: mcpv1beta1.ExternalAuthTypeTokenExchange,
+						TokenExchange: &mcpv1beta1.TokenExchangeConfig{
+							TokenURL: "https://oauth.example.com/token",
+							Audience: "original-audience",
 						},
 					},
 				}
@@ -493,7 +487,7 @@ var _ = Describe("MCPRemoteProxy Controller", Label("k8s", "remoteproxy"), func(
 					}, config); err != nil {
 						return err
 					}
-					config.Spec.HeaderInjection.HeaderName = "X-Updated-Header"
+					config.Spec.TokenExchange.Audience = "updated-audience"
 					return k8sClient.Update(testCtx, config)
 				}, MediumTimeout, DefaultPollingInterval).Should(Succeed())
 

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -59,8 +59,9 @@ spec:
           spec:
             description: |-
               MCPExternalAuthConfigSpec defines the desired state of MCPExternalAuthConfig.
-              MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-              MCPServer resources in the same namespace.
+              MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+              MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+              the same namespace. Each consumer supports only a subset of authentication types.
             properties:
               awsSts:
                 description: |-
@@ -1421,10 +1422,22 @@ spec:
               type:
                 description: |-
                   Type is the type of external authentication to configure.
-                  When set to "obo", the cluster must run a build that has registered an
-                  OBO handler via controllerutil.RegisterOBOHandler; upstream-only builds
-                  surface status.conditions[Valid] = False with Reason: EnterpriseRequired
-                  for obo-typed configs.
+                  Consumer support is as follows:
+                    - tokenExchange and unauthenticated: MCPServer, MCPRemoteProxy,
+                      MCPServerEntry, and VirtualMCPServer outgoing authentication.
+                    - headerInjection, upstreamInject, and xaa: MCPServerEntry and
+                      VirtualMCPServer outgoing authentication.
+                    - bearerToken: MCPRemoteProxy.
+                    - embeddedAuthServer: MCPServer and MCPRemoteProxy.
+                    - awsSts: MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer outgoing
+                      authentication.
+                    - obo: all four consumers when the cluster build has registered an OBO
+                      handler via controllerutil.RegisterOBOHandler.
+
+                  Upstream-only builds surface status.conditions[Valid] = False with Reason:
+                  EnterpriseRequired for obo-typed configs. Other unsupported consumer/type
+                  combinations are reported on the consuming resource with Reason:
+                  UnsupportedAuthType.
                 enum:
                 - tokenExchange
                 - headerInjection
@@ -1680,9 +1693,10 @@ spec:
       openAPIV3Schema:
         description: |-
           MCPExternalAuthConfig is the Schema for the mcpexternalauthconfigs API.
-          MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-          MCPServer resources within the same namespace. Cross-namespace references
-          are not supported for security and isolation reasons.
+          MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+          MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+          the same namespace. Cross-namespace references are not supported for security
+          and isolation reasons. Each consumer supports only a subset of authentication types.
         properties:
           apiVersion:
             description: |-
@@ -1704,8 +1718,9 @@ spec:
           spec:
             description: |-
               MCPExternalAuthConfigSpec defines the desired state of MCPExternalAuthConfig.
-              MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-              MCPServer resources in the same namespace.
+              MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+              MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+              the same namespace. Each consumer supports only a subset of authentication types.
             properties:
               awsSts:
                 description: |-
@@ -3066,10 +3081,22 @@ spec:
               type:
                 description: |-
                   Type is the type of external authentication to configure.
-                  When set to "obo", the cluster must run a build that has registered an
-                  OBO handler via controllerutil.RegisterOBOHandler; upstream-only builds
-                  surface status.conditions[Valid] = False with Reason: EnterpriseRequired
-                  for obo-typed configs.
+                  Consumer support is as follows:
+                    - tokenExchange and unauthenticated: MCPServer, MCPRemoteProxy,
+                      MCPServerEntry, and VirtualMCPServer outgoing authentication.
+                    - headerInjection, upstreamInject, and xaa: MCPServerEntry and
+                      VirtualMCPServer outgoing authentication.
+                    - bearerToken: MCPRemoteProxy.
+                    - embeddedAuthServer: MCPServer and MCPRemoteProxy.
+                    - awsSts: MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer outgoing
+                      authentication.
+                    - obo: all four consumers when the cluster build has registered an OBO
+                      handler via controllerutil.RegisterOBOHandler.
+
+                  Upstream-only builds surface status.conditions[Valid] = False with Reason:
+                  EnterpriseRequired for obo-typed configs. Other unsupported consumer/type
+                  combinations are reported on the consuming resource with Reason:
+                  UnsupportedAuthType.
                 enum:
                 - tokenExchange
                 - headerInjection

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -229,8 +229,11 @@ spec:
                 type: string
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange.
-                  When specified, the proxy will exchange validated incoming tokens for remote service tokens.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+                  Supported types are tokenExchange, bearerToken, unauthenticated,
+                  embeddedAuthServer, awsSts, and obo when an enterprise handler is registered.
+                  For new embedded authorization server configurations, prefer AuthServerRef.
+                  Unsupported types are reported in status.conditions with Reason: UnsupportedAuthType.
                   The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPRemoteProxy.
                 properties:
                   name:
@@ -967,8 +970,11 @@ spec:
                 type: string
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange.
-                  When specified, the proxy will exchange validated incoming tokens for remote service tokens.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+                  Supported types are tokenExchange, bearerToken, unauthenticated,
+                  embeddedAuthServer, awsSts, and obo when an enterprise handler is registered.
+                  For new embedded authorization server configurations, prefer AuthServerRef.
+                  Unsupported types are reported in status.conditions with Reason: UnsupportedAuthType.
                   The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPRemoteProxy.
                 properties:
                   name:

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpserverentries.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpserverentries.yaml
@@ -100,9 +100,12 @@ spec:
                 type: object
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange
-                  when connecting to the remote MCP server. The referenced MCPExternalAuthConfig must
-                  exist in the same namespace as this MCPServerEntry.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource when connecting
+                  to the remote MCP server. Supported types are tokenExchange, headerInjection,
+                  unauthenticated, awsSts, upstreamInject, xaa, and obo when an enterprise handler
+                  is registered. Unsupported types are reported in status.conditions with Reason:
+                  UnsupportedAuthType. The referenced MCPExternalAuthConfig must exist in the same
+                  namespace as this MCPServerEntry.
                 properties:
                   name:
                     description: Name is the name of the MCPExternalAuthConfig resource
@@ -354,9 +357,12 @@ spec:
                 type: object
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange
-                  when connecting to the remote MCP server. The referenced MCPExternalAuthConfig must
-                  exist in the same namespace as this MCPServerEntry.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource when connecting
+                  to the remote MCP server. Supported types are tokenExchange, headerInjection,
+                  unauthenticated, awsSts, upstreamInject, xaa, and obo when an enterprise handler
+                  is registered. Unsupported types are reported in status.conditions with Reason:
+                  UnsupportedAuthType. The referenced MCPExternalAuthConfig must exist in the same
+                  namespace as this MCPServerEntry.
                 properties:
                   name:
                     description: Name is the name of the MCPExternalAuthConfig resource

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
@@ -266,7 +266,11 @@ spec:
                 x-kubernetes-list-type: map
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for external authentication.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+                  Supported types are tokenExchange, unauthenticated, embeddedAuthServer, and
+                  obo when an enterprise handler is registered. For new embedded authorization
+                  server configurations, prefer AuthServerRef. Unsupported types are reported
+                  in status.conditions with Reason: UnsupportedAuthType.
                   The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPServer.
                 properties:
                   name:
@@ -1210,7 +1214,11 @@ spec:
                 x-kubernetes-list-type: map
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for external authentication.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+                  Supported types are tokenExchange, unauthenticated, embeddedAuthServer, and
+                  obo when an enterprise handler is registered. For new embedded authorization
+                  server configurations, prefer AuthServerRef. Unsupported types are reported
+                  in status.conditions with Reason: UnsupportedAuthType.
                   The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPServer.
                 properties:
                   name:

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -2111,6 +2111,7 @@ spec:
                       OutgoingAuth configures how the virtual MCP server authenticates to backends.
                       When using the Kubernetes operator, this is populated by the converter from
                       VirtualMCPServerSpec.OutgoingAuth and any values set here will be superseded.
+                      See VirtualMCPServerSpec.OutgoingAuth for supported MCPExternalAuthConfig types.
                     properties:
                       backends:
                         additionalProperties:
@@ -2726,7 +2727,8 @@ spec:
                         description: |-
                           Source defines how to discover backend auth: "inline", "discovered"
                           - inline: Explicit configuration in OutgoingAuth
-                          - discovered: Auto-discover from backend MCPServer.externalAuthConfigRef (Kubernetes only)
+                          - discovered: Auto-discover from backend MCPServer, MCPRemoteProxy, and
+                            MCPServerEntry externalAuthConfigRef fields (Kubernetes only)
                         type: string
                     required:
                     - source
@@ -3260,20 +3262,27 @@ spec:
                   rule: '!(has(self.authzConfig) && has(self.authzConfigRef))'
               outgoingAuth:
                 description: |-
-                  OutgoingAuth configures authentication from Virtual MCP to backend MCPServers.
+                  OutgoingAuth configures authentication from Virtual MCP to backend resources.
                   This field takes precedence over config.OutgoingAuth and should be preferred because it
                   supports Kubernetes-native secret references (SecretKeyRef, ConfigMapRef) for secure
                   dynamic discovery of credentials, rather than requiring secrets to be embedded in config.
+                  Referenced MCPExternalAuthConfig types supported by VirtualMCPServer are tokenExchange,
+                  headerInjection, unauthenticated, awsSts, upstreamInject, xaa, and obo when an
+                  enterprise handler is registered. Unsupported types are reported per backend in
+                  status.conditions with Reason: UnsupportedAuthType.
                 properties:
                   backends:
                     additionalProperties:
                       description: BackendAuthConfig defines authentication configuration
-                        for a backend MCPServer
+                        for a backend resource.
                       properties:
                         externalAuthConfigRef:
                           description: |-
-                            ExternalAuthConfigRef references an MCPExternalAuthConfig resource
-                            Only used when Type is "externalAuthConfigRef"
+                            ExternalAuthConfigRef references an MCPExternalAuthConfig resource.
+                            Only used when Type is "externalAuthConfigRef". Supported referenced types are
+                            tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,
+                            and obo when an enterprise handler is registered. Unsupported types are reported
+                            for the affected backend in status.conditions with Reason: UnsupportedAuthType.
                           properties:
                             name:
                               description: Name is the name of the MCPExternalAuthConfig
@@ -3301,8 +3310,11 @@ spec:
                     properties:
                       externalAuthConfigRef:
                         description: |-
-                          ExternalAuthConfigRef references an MCPExternalAuthConfig resource
-                          Only used when Type is "externalAuthConfigRef"
+                          ExternalAuthConfigRef references an MCPExternalAuthConfig resource.
+                          Only used when Type is "externalAuthConfigRef". Supported referenced types are
+                          tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,
+                          and obo when an enterprise handler is registered. Unsupported types are reported
+                          for the affected backend in status.conditions with Reason: UnsupportedAuthType.
                         properties:
                           name:
                             description: Name is the name of the MCPExternalAuthConfig
@@ -3324,7 +3336,8 @@ spec:
                     default: discovered
                     description: |-
                       Source defines how backend authentication configurations are determined
-                      - discovered: Automatically discover from backend's MCPServer.spec.externalAuthConfigRef
+                      - discovered: Automatically discover from backend MCPServer, MCPRemoteProxy,
+                        and MCPServerEntry externalAuthConfigRef fields
                       - inline: Explicit per-backend configuration in VirtualMCPServer
                     enum:
                     - discovered
@@ -5741,6 +5754,7 @@ spec:
                       OutgoingAuth configures how the virtual MCP server authenticates to backends.
                       When using the Kubernetes operator, this is populated by the converter from
                       VirtualMCPServerSpec.OutgoingAuth and any values set here will be superseded.
+                      See VirtualMCPServerSpec.OutgoingAuth for supported MCPExternalAuthConfig types.
                     properties:
                       backends:
                         additionalProperties:
@@ -6356,7 +6370,8 @@ spec:
                         description: |-
                           Source defines how to discover backend auth: "inline", "discovered"
                           - inline: Explicit configuration in OutgoingAuth
-                          - discovered: Auto-discover from backend MCPServer.externalAuthConfigRef (Kubernetes only)
+                          - discovered: Auto-discover from backend MCPServer, MCPRemoteProxy, and
+                            MCPServerEntry externalAuthConfigRef fields (Kubernetes only)
                         type: string
                     required:
                     - source
@@ -6890,20 +6905,27 @@ spec:
                   rule: '!(has(self.authzConfig) && has(self.authzConfigRef))'
               outgoingAuth:
                 description: |-
-                  OutgoingAuth configures authentication from Virtual MCP to backend MCPServers.
+                  OutgoingAuth configures authentication from Virtual MCP to backend resources.
                   This field takes precedence over config.OutgoingAuth and should be preferred because it
                   supports Kubernetes-native secret references (SecretKeyRef, ConfigMapRef) for secure
                   dynamic discovery of credentials, rather than requiring secrets to be embedded in config.
+                  Referenced MCPExternalAuthConfig types supported by VirtualMCPServer are tokenExchange,
+                  headerInjection, unauthenticated, awsSts, upstreamInject, xaa, and obo when an
+                  enterprise handler is registered. Unsupported types are reported per backend in
+                  status.conditions with Reason: UnsupportedAuthType.
                 properties:
                   backends:
                     additionalProperties:
                       description: BackendAuthConfig defines authentication configuration
-                        for a backend MCPServer
+                        for a backend resource.
                       properties:
                         externalAuthConfigRef:
                           description: |-
-                            ExternalAuthConfigRef references an MCPExternalAuthConfig resource
-                            Only used when Type is "externalAuthConfigRef"
+                            ExternalAuthConfigRef references an MCPExternalAuthConfig resource.
+                            Only used when Type is "externalAuthConfigRef". Supported referenced types are
+                            tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,
+                            and obo when an enterprise handler is registered. Unsupported types are reported
+                            for the affected backend in status.conditions with Reason: UnsupportedAuthType.
                           properties:
                             name:
                               description: Name is the name of the MCPExternalAuthConfig
@@ -6931,8 +6953,11 @@ spec:
                     properties:
                       externalAuthConfigRef:
                         description: |-
-                          ExternalAuthConfigRef references an MCPExternalAuthConfig resource
-                          Only used when Type is "externalAuthConfigRef"
+                          ExternalAuthConfigRef references an MCPExternalAuthConfig resource.
+                          Only used when Type is "externalAuthConfigRef". Supported referenced types are
+                          tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,
+                          and obo when an enterprise handler is registered. Unsupported types are reported
+                          for the affected backend in status.conditions with Reason: UnsupportedAuthType.
                         properties:
                           name:
                             description: Name is the name of the MCPExternalAuthConfig
@@ -6954,7 +6979,8 @@ spec:
                     default: discovered
                     description: |-
                       Source defines how backend authentication configurations are determined
-                      - discovered: Automatically discover from backend's MCPServer.spec.externalAuthConfigRef
+                      - discovered: Automatically discover from backend MCPServer, MCPRemoteProxy,
+                        and MCPServerEntry externalAuthConfigRef fields
                       - inline: Explicit per-backend configuration in VirtualMCPServer
                     enum:
                     - discovered

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -62,8 +62,9 @@ spec:
           spec:
             description: |-
               MCPExternalAuthConfigSpec defines the desired state of MCPExternalAuthConfig.
-              MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-              MCPServer resources in the same namespace.
+              MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+              MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+              the same namespace. Each consumer supports only a subset of authentication types.
             properties:
               awsSts:
                 description: |-
@@ -1424,10 +1425,22 @@ spec:
               type:
                 description: |-
                   Type is the type of external authentication to configure.
-                  When set to "obo", the cluster must run a build that has registered an
-                  OBO handler via controllerutil.RegisterOBOHandler; upstream-only builds
-                  surface status.conditions[Valid] = False with Reason: EnterpriseRequired
-                  for obo-typed configs.
+                  Consumer support is as follows:
+                    - tokenExchange and unauthenticated: MCPServer, MCPRemoteProxy,
+                      MCPServerEntry, and VirtualMCPServer outgoing authentication.
+                    - headerInjection, upstreamInject, and xaa: MCPServerEntry and
+                      VirtualMCPServer outgoing authentication.
+                    - bearerToken: MCPRemoteProxy.
+                    - embeddedAuthServer: MCPServer and MCPRemoteProxy.
+                    - awsSts: MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer outgoing
+                      authentication.
+                    - obo: all four consumers when the cluster build has registered an OBO
+                      handler via controllerutil.RegisterOBOHandler.
+
+                  Upstream-only builds surface status.conditions[Valid] = False with Reason:
+                  EnterpriseRequired for obo-typed configs. Other unsupported consumer/type
+                  combinations are reported on the consuming resource with Reason:
+                  UnsupportedAuthType.
                 enum:
                 - tokenExchange
                 - headerInjection
@@ -1683,9 +1696,10 @@ spec:
       openAPIV3Schema:
         description: |-
           MCPExternalAuthConfig is the Schema for the mcpexternalauthconfigs API.
-          MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-          MCPServer resources within the same namespace. Cross-namespace references
-          are not supported for security and isolation reasons.
+          MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+          MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+          the same namespace. Cross-namespace references are not supported for security
+          and isolation reasons. Each consumer supports only a subset of authentication types.
         properties:
           apiVersion:
             description: |-
@@ -1707,8 +1721,9 @@ spec:
           spec:
             description: |-
               MCPExternalAuthConfigSpec defines the desired state of MCPExternalAuthConfig.
-              MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-              MCPServer resources in the same namespace.
+              MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+              MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+              the same namespace. Each consumer supports only a subset of authentication types.
             properties:
               awsSts:
                 description: |-
@@ -3069,10 +3084,22 @@ spec:
               type:
                 description: |-
                   Type is the type of external authentication to configure.
-                  When set to "obo", the cluster must run a build that has registered an
-                  OBO handler via controllerutil.RegisterOBOHandler; upstream-only builds
-                  surface status.conditions[Valid] = False with Reason: EnterpriseRequired
-                  for obo-typed configs.
+                  Consumer support is as follows:
+                    - tokenExchange and unauthenticated: MCPServer, MCPRemoteProxy,
+                      MCPServerEntry, and VirtualMCPServer outgoing authentication.
+                    - headerInjection, upstreamInject, and xaa: MCPServerEntry and
+                      VirtualMCPServer outgoing authentication.
+                    - bearerToken: MCPRemoteProxy.
+                    - embeddedAuthServer: MCPServer and MCPRemoteProxy.
+                    - awsSts: MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer outgoing
+                      authentication.
+                    - obo: all four consumers when the cluster build has registered an OBO
+                      handler via controllerutil.RegisterOBOHandler.
+
+                  Upstream-only builds surface status.conditions[Valid] = False with Reason:
+                  EnterpriseRequired for obo-typed configs. Other unsupported consumer/type
+                  combinations are reported on the consuming resource with Reason:
+                  UnsupportedAuthType.
                 enum:
                 - tokenExchange
                 - headerInjection

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpremoteproxies.yaml
@@ -232,8 +232,11 @@ spec:
                 type: string
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange.
-                  When specified, the proxy will exchange validated incoming tokens for remote service tokens.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+                  Supported types are tokenExchange, bearerToken, unauthenticated,
+                  embeddedAuthServer, awsSts, and obo when an enterprise handler is registered.
+                  For new embedded authorization server configurations, prefer AuthServerRef.
+                  Unsupported types are reported in status.conditions with Reason: UnsupportedAuthType.
                   The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPRemoteProxy.
                 properties:
                   name:
@@ -970,8 +973,11 @@ spec:
                 type: string
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange.
-                  When specified, the proxy will exchange validated incoming tokens for remote service tokens.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+                  Supported types are tokenExchange, bearerToken, unauthenticated,
+                  embeddedAuthServer, awsSts, and obo when an enterprise handler is registered.
+                  For new embedded authorization server configurations, prefer AuthServerRef.
+                  Unsupported types are reported in status.conditions with Reason: UnsupportedAuthType.
                   The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPRemoteProxy.
                 properties:
                   name:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpserverentries.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpserverentries.yaml
@@ -103,9 +103,12 @@ spec:
                 type: object
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange
-                  when connecting to the remote MCP server. The referenced MCPExternalAuthConfig must
-                  exist in the same namespace as this MCPServerEntry.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource when connecting
+                  to the remote MCP server. Supported types are tokenExchange, headerInjection,
+                  unauthenticated, awsSts, upstreamInject, xaa, and obo when an enterprise handler
+                  is registered. Unsupported types are reported in status.conditions with Reason:
+                  UnsupportedAuthType. The referenced MCPExternalAuthConfig must exist in the same
+                  namespace as this MCPServerEntry.
                 properties:
                   name:
                     description: Name is the name of the MCPExternalAuthConfig resource
@@ -357,9 +360,12 @@ spec:
                 type: object
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange
-                  when connecting to the remote MCP server. The referenced MCPExternalAuthConfig must
-                  exist in the same namespace as this MCPServerEntry.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource when connecting
+                  to the remote MCP server. Supported types are tokenExchange, headerInjection,
+                  unauthenticated, awsSts, upstreamInject, xaa, and obo when an enterprise handler
+                  is registered. Unsupported types are reported in status.conditions with Reason:
+                  UnsupportedAuthType. The referenced MCPExternalAuthConfig must exist in the same
+                  namespace as this MCPServerEntry.
                 properties:
                   name:
                     description: Name is the name of the MCPExternalAuthConfig resource

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpservers.yaml
@@ -269,7 +269,11 @@ spec:
                 x-kubernetes-list-type: map
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for external authentication.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+                  Supported types are tokenExchange, unauthenticated, embeddedAuthServer, and
+                  obo when an enterprise handler is registered. For new embedded authorization
+                  server configurations, prefer AuthServerRef. Unsupported types are reported
+                  in status.conditions with Reason: UnsupportedAuthType.
                   The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPServer.
                 properties:
                   name:
@@ -1213,7 +1217,11 @@ spec:
                 x-kubernetes-list-type: map
               externalAuthConfigRef:
                 description: |-
-                  ExternalAuthConfigRef references a MCPExternalAuthConfig resource for external authentication.
+                  ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.
+                  Supported types are tokenExchange, unauthenticated, embeddedAuthServer, and
+                  obo when an enterprise handler is registered. For new embedded authorization
+                  server configurations, prefer AuthServerRef. Unsupported types are reported
+                  in status.conditions with Reason: UnsupportedAuthType.
                   The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPServer.
                 properties:
                   name:

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -2114,6 +2114,7 @@ spec:
                       OutgoingAuth configures how the virtual MCP server authenticates to backends.
                       When using the Kubernetes operator, this is populated by the converter from
                       VirtualMCPServerSpec.OutgoingAuth and any values set here will be superseded.
+                      See VirtualMCPServerSpec.OutgoingAuth for supported MCPExternalAuthConfig types.
                     properties:
                       backends:
                         additionalProperties:
@@ -2729,7 +2730,8 @@ spec:
                         description: |-
                           Source defines how to discover backend auth: "inline", "discovered"
                           - inline: Explicit configuration in OutgoingAuth
-                          - discovered: Auto-discover from backend MCPServer.externalAuthConfigRef (Kubernetes only)
+                          - discovered: Auto-discover from backend MCPServer, MCPRemoteProxy, and
+                            MCPServerEntry externalAuthConfigRef fields (Kubernetes only)
                         type: string
                     required:
                     - source
@@ -3263,20 +3265,27 @@ spec:
                   rule: '!(has(self.authzConfig) && has(self.authzConfigRef))'
               outgoingAuth:
                 description: |-
-                  OutgoingAuth configures authentication from Virtual MCP to backend MCPServers.
+                  OutgoingAuth configures authentication from Virtual MCP to backend resources.
                   This field takes precedence over config.OutgoingAuth and should be preferred because it
                   supports Kubernetes-native secret references (SecretKeyRef, ConfigMapRef) for secure
                   dynamic discovery of credentials, rather than requiring secrets to be embedded in config.
+                  Referenced MCPExternalAuthConfig types supported by VirtualMCPServer are tokenExchange,
+                  headerInjection, unauthenticated, awsSts, upstreamInject, xaa, and obo when an
+                  enterprise handler is registered. Unsupported types are reported per backend in
+                  status.conditions with Reason: UnsupportedAuthType.
                 properties:
                   backends:
                     additionalProperties:
                       description: BackendAuthConfig defines authentication configuration
-                        for a backend MCPServer
+                        for a backend resource.
                       properties:
                         externalAuthConfigRef:
                           description: |-
-                            ExternalAuthConfigRef references an MCPExternalAuthConfig resource
-                            Only used when Type is "externalAuthConfigRef"
+                            ExternalAuthConfigRef references an MCPExternalAuthConfig resource.
+                            Only used when Type is "externalAuthConfigRef". Supported referenced types are
+                            tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,
+                            and obo when an enterprise handler is registered. Unsupported types are reported
+                            for the affected backend in status.conditions with Reason: UnsupportedAuthType.
                           properties:
                             name:
                               description: Name is the name of the MCPExternalAuthConfig
@@ -3304,8 +3313,11 @@ spec:
                     properties:
                       externalAuthConfigRef:
                         description: |-
-                          ExternalAuthConfigRef references an MCPExternalAuthConfig resource
-                          Only used when Type is "externalAuthConfigRef"
+                          ExternalAuthConfigRef references an MCPExternalAuthConfig resource.
+                          Only used when Type is "externalAuthConfigRef". Supported referenced types are
+                          tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,
+                          and obo when an enterprise handler is registered. Unsupported types are reported
+                          for the affected backend in status.conditions with Reason: UnsupportedAuthType.
                         properties:
                           name:
                             description: Name is the name of the MCPExternalAuthConfig
@@ -3327,7 +3339,8 @@ spec:
                     default: discovered
                     description: |-
                       Source defines how backend authentication configurations are determined
-                      - discovered: Automatically discover from backend's MCPServer.spec.externalAuthConfigRef
+                      - discovered: Automatically discover from backend MCPServer, MCPRemoteProxy,
+                        and MCPServerEntry externalAuthConfigRef fields
                       - inline: Explicit per-backend configuration in VirtualMCPServer
                     enum:
                     - discovered
@@ -5744,6 +5757,7 @@ spec:
                       OutgoingAuth configures how the virtual MCP server authenticates to backends.
                       When using the Kubernetes operator, this is populated by the converter from
                       VirtualMCPServerSpec.OutgoingAuth and any values set here will be superseded.
+                      See VirtualMCPServerSpec.OutgoingAuth for supported MCPExternalAuthConfig types.
                     properties:
                       backends:
                         additionalProperties:
@@ -6359,7 +6373,8 @@ spec:
                         description: |-
                           Source defines how to discover backend auth: "inline", "discovered"
                           - inline: Explicit configuration in OutgoingAuth
-                          - discovered: Auto-discover from backend MCPServer.externalAuthConfigRef (Kubernetes only)
+                          - discovered: Auto-discover from backend MCPServer, MCPRemoteProxy, and
+                            MCPServerEntry externalAuthConfigRef fields (Kubernetes only)
                         type: string
                     required:
                     - source
@@ -6893,20 +6908,27 @@ spec:
                   rule: '!(has(self.authzConfig) && has(self.authzConfigRef))'
               outgoingAuth:
                 description: |-
-                  OutgoingAuth configures authentication from Virtual MCP to backend MCPServers.
+                  OutgoingAuth configures authentication from Virtual MCP to backend resources.
                   This field takes precedence over config.OutgoingAuth and should be preferred because it
                   supports Kubernetes-native secret references (SecretKeyRef, ConfigMapRef) for secure
                   dynamic discovery of credentials, rather than requiring secrets to be embedded in config.
+                  Referenced MCPExternalAuthConfig types supported by VirtualMCPServer are tokenExchange,
+                  headerInjection, unauthenticated, awsSts, upstreamInject, xaa, and obo when an
+                  enterprise handler is registered. Unsupported types are reported per backend in
+                  status.conditions with Reason: UnsupportedAuthType.
                 properties:
                   backends:
                     additionalProperties:
                       description: BackendAuthConfig defines authentication configuration
-                        for a backend MCPServer
+                        for a backend resource.
                       properties:
                         externalAuthConfigRef:
                           description: |-
-                            ExternalAuthConfigRef references an MCPExternalAuthConfig resource
-                            Only used when Type is "externalAuthConfigRef"
+                            ExternalAuthConfigRef references an MCPExternalAuthConfig resource.
+                            Only used when Type is "externalAuthConfigRef". Supported referenced types are
+                            tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,
+                            and obo when an enterprise handler is registered. Unsupported types are reported
+                            for the affected backend in status.conditions with Reason: UnsupportedAuthType.
                           properties:
                             name:
                               description: Name is the name of the MCPExternalAuthConfig
@@ -6934,8 +6956,11 @@ spec:
                     properties:
                       externalAuthConfigRef:
                         description: |-
-                          ExternalAuthConfigRef references an MCPExternalAuthConfig resource
-                          Only used when Type is "externalAuthConfigRef"
+                          ExternalAuthConfigRef references an MCPExternalAuthConfig resource.
+                          Only used when Type is "externalAuthConfigRef". Supported referenced types are
+                          tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,
+                          and obo when an enterprise handler is registered. Unsupported types are reported
+                          for the affected backend in status.conditions with Reason: UnsupportedAuthType.
                         properties:
                           name:
                             description: Name is the name of the MCPExternalAuthConfig
@@ -6957,7 +6982,8 @@ spec:
                     default: discovered
                     description: |-
                       Source defines how backend authentication configurations are determined
-                      - discovered: Automatically discover from backend's MCPServer.spec.externalAuthConfigRef
+                      - discovered: Automatically discover from backend MCPServer, MCPRemoteProxy,
+                        and MCPServerEntry externalAuthConfigRef fields
                       - inline: Explicit per-backend configuration in VirtualMCPServer
                     enum:
                     - discovered

--- a/docs/arch/09-operator-architecture.md
+++ b/docs/arch/09-operator-architecture.md
@@ -102,7 +102,7 @@ MCPServer is the fundamental building block. All other CRDs either **organize**,
 | **MCPServerEntry** | Zero-infrastructure declaration of a remote MCP endpoint |
 | **MCPGroup** | Logical grouping of workloads (status tracking only) |
 | **MCPToolConfig** | Tool filtering and renaming configuration |
-| **MCPExternalAuthConfig** | Token exchange / header injection configuration |
+| **MCPExternalAuthConfig** | Reusable, consumer-specific external authentication configuration |
 | **MCPOIDCConfig** | Shared OIDC provider settings referenced by workload CRDs |
 | **MCPTelemetryConfig** | Shared OpenTelemetry/Prometheus settings referenced by workload CRDs |
 | **MCPWebhookConfig** | Validating/mutating webhook middleware definitions referenced by MCPServer |
@@ -172,7 +172,7 @@ MCPServer resources support various transport types (stdio, SSE, streamable-http
 MCPServer supports referencing shared configuration CRDs:
 - `oidcConfigRef` — references an MCPOIDCConfig for shared OIDC settings
 - `telemetryConfigRef` — references an MCPTelemetryConfig for shared telemetry settings
-- `externalAuthConfigRef` — references an MCPExternalAuthConfig for outgoing auth (token exchange, AWS STS, bearer token injection, etc.)
+- `externalAuthConfigRef` — references an MCPExternalAuthConfig for outgoing auth. MCPServer supports `tokenExchange`, `unauthenticated`, and `obo`; `embeddedAuthServer` remains supported on this field for backward compatibility.
 - `authServerRef` — references an MCPExternalAuthConfig of type `embeddedAuthServer` for incoming auth (the embedded OAuth 2.0/OIDC authorization server that authenticates MCP clients). This is the preferred path for configuring the embedded auth server, keeping incoming auth separate from `externalAuthConfigRef` which handles outgoing auth.
 
 **Backward compatibility**: Existing configurations using `externalAuthConfigRef` with `type: embeddedAuthServer` continue to work. The `authServerRef` field is optional and additive.
@@ -218,17 +218,24 @@ MCPToolConfig allows you to filter which tools are exposed by an MCP server and 
 
 ### MCPExternalAuthConfig
 
-Manages external authentication configurations that can be shared across multiple MCPServer resources.
+Manages reusable external authentication configurations. Each consumer supports
+a defined subset of auth types; incompatible references are reported with an
+`UnsupportedAuthType` condition rather than ignored.
 
 **Implementation**: `cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go`
 
-MCPExternalAuthConfig allows you to define reusable authentication configurations that can be referenced by multiple MCPServer and MCPRemoteProxy resources. When using the embedded auth server type, the `storage` field supports configuring Redis Sentinel as a shared storage backend for horizontal scaling. See [Auth Server Storage](11-auth-server-storage.md) for details.
+MCPExternalAuthConfig allows you to define reusable authentication configurations referenced by MCPServer, MCPRemoteProxy, VirtualMCPServer, and MCPServerEntry resources. When using the embedded auth server type, the `storage` field supports configuring Redis Sentinel as a shared storage backend for horizontal scaling. See [Auth Server Storage](11-auth-server-storage.md) for details.
+
+VirtualMCPServer records a per-backend status condition when a referenced
+strategy fails to convert — including references to types it does not
+support, reported with reason `UnsupportedAuthType` — and continues
+reconciling with the remaining valid backends.
 
 MCPExternalAuthConfig resources can be referenced via two paths:
-- `externalAuthConfigRef` — for outgoing auth types (token exchange, AWS STS, bearer token injection). This is the original reference path.
+- `externalAuthConfigRef` — for outgoing auth. The supported type subset depends on whether the consumer is MCPServer, MCPRemoteProxy, VirtualMCPServer, or MCPServerEntry.
 - `authServerRef` — for the embedded auth server type (`embeddedAuthServer`) only. This dedicated reference path makes it possible to configure both incoming auth (embedded auth server) and outgoing auth (e.g., AWS STS) on the same workload resource.
 
-**Referenced by MCPServer and MCPRemoteProxy** using `externalAuthConfigRef` or `authServerRef`.
+**Referenced by MCPServer, MCPRemoteProxy, VirtualMCPServer, and MCPServerEntry** using `externalAuthConfigRef`. MCPServer and MCPRemoteProxy may also use `authServerRef` for `embeddedAuthServer`.
 
 **Controller**: `cmd/thv-operator/controllers/mcpexternalauthconfig_controller.go`
 
@@ -314,7 +321,7 @@ Defines a proxy for remote MCP servers with authentication, authorization, audit
 **Key fields:**
 - `remoteUrl` - URL of the remote MCP server to proxy
 - `oidcConfigRef` - Reference to shared MCPOIDCConfig (with per-server `audience`, `scopes`, and `resourceUrl`)
-- `externalAuthConfigRef` - Outgoing auth for remote service authentication (token exchange, AWS STS, bearer token injection)
+- `externalAuthConfigRef` - Outgoing auth for remote service authentication (`tokenExchange`, `bearerToken`, `unauthenticated`, `embeddedAuthServer`, `awsSts`, or `obo`)
 - `authServerRef` - Incoming auth via the embedded OAuth 2.0/OIDC authorization server (references an MCPExternalAuthConfig of type `embeddedAuthServer`)
 - `authzConfig` - Authorization policies
 - `telemetryConfigRef` - Reference to shared MCPTelemetryConfig (replaces deprecated inline `telemetry`)
@@ -350,10 +357,10 @@ Declares a remote MCP endpoint as a zero-infrastructure catalog entry. Unlike MC
 **Key fields:**
 - `remoteUrl` - URL of the remote MCP server (required)
 - `groupRef` - MCPGroup membership for discovery by VirtualMCPServer
-- `externalAuthConfigRef` - Token exchange for remote service authentication
+- `externalAuthConfigRef` - Outgoing auth for vMCP connections (`tokenExchange`, `headerInjection`, `unauthenticated`, `awsSts`, `upstreamInject`, `obo`, or `xaa`)
 - `caBundleRef` - Reference to a ConfigMap containing CA certificate data for TLS verification
 
-The MCPServerEntry controller is validation-only: it validates that referenced resources (groupRef, externalAuthConfigRef, caBundleRef ConfigMap) exist and updates status conditions accordingly. It never probes the remote URL or creates infrastructure.
+The MCPServerEntry controller is validation-only: it validates that referenced resources (groupRef, externalAuthConfigRef, caBundleRef ConfigMap) exist, verifies that the referenced external-auth type is supported, and updates status conditions accordingly. It never probes the remote URL or creates infrastructure.
 
 MCPServerEntry backends are discovered by vMCP in both static mode (listed at startup) and dynamic mode (watched by the BackendReconciler). In dynamic mode, ConfigMap changes trigger re-reconciliation of affected MCPServerEntry backends via a field-indexed watch on `spec.caBundleRef.configMapRef.name`.
 

--- a/docs/operator/crd-api.md
+++ b/docs/operator/crd-api.md
@@ -408,7 +408,7 @@ _Appears in:_
 | `groupRef` _string_ | Group references an existing MCPGroup that defines backend workloads.<br />In standalone CLI mode, this is set from the YAML config file.<br />In Kubernetes, the operator populates this from spec.groupRef during conversion. |  | Optional: \{\} <br /> |
 | `backends` _[vmcp.config.StaticBackendConfig](#vmcpconfigstaticbackendconfig) array_ | Backends defines pre-configured backend servers for static mode.<br />When OutgoingAuth.Source is "inline", this field contains the full list of backend<br />servers with their URLs and transport types, eliminating the need for K8s API access.<br />When OutgoingAuth.Source is "discovered", this field is empty and backends are<br />discovered at runtime via Kubernetes API. |  | Optional: \{\} <br /> |
 | `incomingAuth` _[vmcp.config.IncomingAuthConfig](#vmcpconfigincomingauthconfig)_ | IncomingAuth configures how clients authenticate to the virtual MCP server.<br />When using the Kubernetes operator, this is populated by the converter from<br />VirtualMCPServerSpec.IncomingAuth and any values set here will be superseded. |  | Optional: \{\} <br /> |
-| `outgoingAuth` _[vmcp.config.OutgoingAuthConfig](#vmcpconfigoutgoingauthconfig)_ | OutgoingAuth configures how the virtual MCP server authenticates to backends.<br />When using the Kubernetes operator, this is populated by the converter from<br />VirtualMCPServerSpec.OutgoingAuth and any values set here will be superseded. |  | Optional: \{\} <br /> |
+| `outgoingAuth` _[vmcp.config.OutgoingAuthConfig](#vmcpconfigoutgoingauthconfig)_ | OutgoingAuth configures how the virtual MCP server authenticates to backends.<br />When using the Kubernetes operator, this is populated by the converter from<br />VirtualMCPServerSpec.OutgoingAuth and any values set here will be superseded.<br />See VirtualMCPServerSpec.OutgoingAuth for supported MCPExternalAuthConfig types. |  | Optional: \{\} <br /> |
 | `aggregation` _[vmcp.config.AggregationConfig](#vmcpconfigaggregationconfig)_ | Aggregation defines tool aggregation and conflict resolution strategies.<br />Supports ToolConfigRef for Kubernetes-native MCPToolConfig resource references. |  | Optional: \{\} <br /> |
 | `compositeTools` _[vmcp.config.CompositeToolConfig](#vmcpconfigcompositetoolconfig) array_ | CompositeTools defines inline composite tool workflows.<br />Full workflow definitions are embedded in the configuration.<br />For Kubernetes, complex workflows can also reference VirtualMCPCompositeToolDefinition CRDs. |  | Optional: \{\} <br /> |
 | `compositeToolRefs` _[vmcp.config.CompositeToolRef](#vmcpconfigcompositetoolref) array_ | CompositeToolRefs references VirtualMCPCompositeToolDefinition resources<br />for complex, reusable workflows. Only applicable when running in Kubernetes.<br />Referenced resources must be in the same namespace as the VirtualMCPServer. |  | Optional: \{\} <br /> |
@@ -643,7 +643,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `source` _string_ | Source defines how to discover backend auth: "inline", "discovered"<br />- inline: Explicit configuration in OutgoingAuth<br />- discovered: Auto-discover from backend MCPServer.externalAuthConfigRef (Kubernetes only) |  |  |
+| `source` _string_ | Source defines how to discover backend auth: "inline", "discovered"<br />- inline: Explicit configuration in OutgoingAuth<br />- discovered: Auto-discover from backend MCPServer, MCPRemoteProxy, and<br />  MCPServerEntry externalAuthConfigRef fields (Kubernetes only) |  |  |
 | `default` _[auth.types.BackendAuthStrategy](#authtypesbackendauthstrategy)_ | Default is the default auth strategy for backends without explicit config. |  |  |
 | `backends` _object (keys:string, values:[auth.types.BackendAuthStrategy](#authtypesbackendauthstrategy))_ | Backends contains per-backend auth configuration. |  |  |
 
@@ -1786,7 +1786,7 @@ _Appears in:_
 
 
 
-BackendAuthConfig defines authentication configuration for a backend MCPServer
+BackendAuthConfig defines authentication configuration for a backend resource.
 
 
 
@@ -1796,7 +1796,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `type` _string_ | Type defines the authentication type |  | Enum: [discovered externalAuthConfigRef] <br />Required: \{\} <br /> |
-| `externalAuthConfigRef` _[api.v1beta1.ExternalAuthConfigRef](#apiv1beta1externalauthconfigref)_ | ExternalAuthConfigRef references an MCPExternalAuthConfig resource<br />Only used when Type is "externalAuthConfigRef" |  | Optional: \{\} <br /> |
+| `externalAuthConfigRef` _[api.v1beta1.ExternalAuthConfigRef](#apiv1beta1externalauthconfigref)_ | ExternalAuthConfigRef references an MCPExternalAuthConfig resource.<br />Only used when Type is "externalAuthConfigRef". Supported referenced types are<br />tokenExchange, headerInjection, unauthenticated, awsSts, upstreamInject, xaa,<br />and obo when an enterprise handler is registered. Unsupported types are reported<br />for the affected backend in status.conditions with Reason: UnsupportedAuthType. |  | Optional: \{\} <br /> |
 
 
 #### api.v1beta1.BearerTokenConfig
@@ -2153,7 +2153,8 @@ _Appears in:_
 
 
 ExternalAuthConfigRef defines a reference to a MCPExternalAuthConfig resource.
-The referenced MCPExternalAuthConfig must be in the same namespace as the MCPServer.
+The referenced MCPExternalAuthConfig must be in the same namespace as the
+resource containing the reference.
 
 
 
@@ -2474,9 +2475,10 @@ _Appears in:_
 
 
 MCPExternalAuthConfig is the Schema for the mcpexternalauthconfigs API.
-MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-MCPServer resources within the same namespace. Cross-namespace references
-are not supported for security and isolation reasons.
+MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+the same namespace. Cross-namespace references are not supported for security
+and isolation reasons. Each consumer supports only a subset of authentication types.
 
 
 
@@ -2519,8 +2521,9 @@ MCPExternalAuthConfigList contains a list of MCPExternalAuthConfig
 
 
 MCPExternalAuthConfigSpec defines the desired state of MCPExternalAuthConfig.
-MCPExternalAuthConfig resources are namespace-scoped and can only be referenced by
-MCPServer resources in the same namespace.
+MCPExternalAuthConfig resources are namespace-scoped and may be referenced by
+MCPServer, MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer resources in
+the same namespace. Each consumer supports only a subset of authentication types.
 
 
 
@@ -2529,7 +2532,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _[api.v1beta1.ExternalAuthType](#apiv1beta1externalauthtype)_ | Type is the type of external authentication to configure.<br />When set to "obo", the cluster must run a build that has registered an<br />OBO handler via controllerutil.RegisterOBOHandler; upstream-only builds<br />surface status.conditions[Valid] = False with Reason: EnterpriseRequired<br />for obo-typed configs. |  | Enum: [tokenExchange headerInjection bearerToken unauthenticated embeddedAuthServer awsSts upstreamInject obo xaa] <br />Required: \{\} <br /> |
+| `type` _[api.v1beta1.ExternalAuthType](#apiv1beta1externalauthtype)_ | Type is the type of external authentication to configure.<br />Consumer support is as follows:<br />  - tokenExchange and unauthenticated: MCPServer, MCPRemoteProxy,<br />    MCPServerEntry, and VirtualMCPServer outgoing authentication.<br />  - headerInjection, upstreamInject, and xaa: MCPServerEntry and<br />    VirtualMCPServer outgoing authentication.<br />  - bearerToken: MCPRemoteProxy.<br />  - embeddedAuthServer: MCPServer and MCPRemoteProxy.<br />  - awsSts: MCPRemoteProxy, MCPServerEntry, and VirtualMCPServer outgoing<br />    authentication.<br />  - obo: all four consumers when the cluster build has registered an OBO<br />    handler via controllerutil.RegisterOBOHandler.<br />Upstream-only builds surface status.conditions[Valid] = False with Reason:<br />EnterpriseRequired for obo-typed configs. Other unsupported consumer/type<br />combinations are reported on the consuming resource with Reason:<br />UnsupportedAuthType. |  | Enum: [tokenExchange headerInjection bearerToken unauthenticated embeddedAuthServer awsSts upstreamInject obo xaa] <br />Required: \{\} <br /> |
 | `tokenExchange` _[api.v1beta1.TokenExchangeConfig](#apiv1beta1tokenexchangeconfig)_ | TokenExchange configures RFC-8693 OAuth 2.0 Token Exchange<br />Only used when Type is "tokenExchange" |  | Optional: \{\} <br /> |
 | `headerInjection` _[api.v1beta1.HeaderInjectionConfig](#apiv1beta1headerinjectionconfig)_ | HeaderInjection configures custom HTTP header injection<br />Only used when Type is "headerInjection" |  | Optional: \{\} <br /> |
 | `bearerToken` _[api.v1beta1.BearerTokenConfig](#apiv1beta1bearertokenconfig)_ | BearerToken configures bearer token authentication<br />Only used when Type is "bearerToken" |  | Optional: \{\} <br /> |
@@ -2990,7 +2993,7 @@ _Appears in:_
 | `proxyPort` _integer_ | ProxyPort is the port to expose the MCP proxy on | 8080 | Maximum: 65535 <br />Minimum: 1 <br /> |
 | `transport` _string_ | Transport is the transport method for the remote proxy (sse or streamable-http) | streamable-http | Enum: [sse streamable-http] <br /> |
 | `oidcConfigRef` _[api.v1beta1.MCPOIDCConfigReference](#apiv1beta1mcpoidcconfigreference)_ | OIDCConfigRef references a shared MCPOIDCConfig resource for OIDC authentication.<br />The referenced MCPOIDCConfig must exist in the same namespace as this MCPRemoteProxy.<br />Per-server overrides (audience, scopes) are specified here; shared provider config<br />lives in the MCPOIDCConfig resource.<br />SECURITY: if this field is omitted and no other authentication source is configured,<br />the proxy runs UNAUTHENTICATED. It accepts every request that can reach its port and<br />forwards it to the remote MCP server under a synthetic local-user identity, with no<br />token or credential check. Set this field to enforce identity-based access control<br />per request. |  | Optional: \{\} <br /> |
-| `externalAuthConfigRef` _[api.v1beta1.ExternalAuthConfigRef](#apiv1beta1externalauthconfigref)_ | ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange.<br />When specified, the proxy will exchange validated incoming tokens for remote service tokens.<br />The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPRemoteProxy. |  | Optional: \{\} <br /> |
+| `externalAuthConfigRef` _[api.v1beta1.ExternalAuthConfigRef](#apiv1beta1externalauthconfigref)_ | ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.<br />Supported types are tokenExchange, bearerToken, unauthenticated,<br />embeddedAuthServer, awsSts, and obo when an enterprise handler is registered.<br />For new embedded authorization server configurations, prefer AuthServerRef.<br />Unsupported types are reported in status.conditions with Reason: UnsupportedAuthType.<br />The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPRemoteProxy. |  | Optional: \{\} <br /> |
 | `authServerRef` _[api.v1beta1.AuthServerRef](#apiv1beta1authserverref)_ | AuthServerRef optionally references a resource that configures an embedded<br />OAuth 2.0/OIDC authorization server to authenticate MCP clients.<br />Currently the only supported kind is MCPExternalAuthConfig (type: embeddedAuthServer). |  | Optional: \{\} <br /> |
 | `headerForward` _[api.v1beta1.HeaderForwardConfig](#apiv1beta1headerforwardconfig)_ | HeaderForward configures headers to inject into requests to the remote MCP server.<br />Use this to add custom headers like X-Tenant-ID or correlation IDs. |  | Optional: \{\} <br /> |
 | `authzConfig` _[api.v1beta1.AuthzConfigRef](#apiv1beta1authzconfigref)_ | AuthzConfig defines authorization policy configuration for the proxy.<br />AuthzConfig and AuthzConfigRef are mutually exclusive. |  | Optional: \{\} <br /> |
@@ -3140,7 +3143,7 @@ _Appears in:_
 | `remoteUrl` _string_ | RemoteURL is the URL of the remote MCP server.<br />Both HTTP and HTTPS schemes are accepted at admission time. |  | Pattern: `^https?://` <br />Required: \{\} <br /> |
 | `transport` _string_ | Transport is the transport method for the remote server (sse or streamable-http).<br />No default is set (unlike MCPRemoteProxy) because MCPServerEntry points at external<br />servers the user doesn't control — requiring explicit transport avoids silent mismatches. |  | Enum: [sse streamable-http] <br />Required: \{\} <br /> |
 | `groupRef` _[api.v1beta1.MCPGroupRef](#apiv1beta1mcpgroupref)_ | GroupRef references the MCPGroup this entry belongs to.<br />Required — every MCPServerEntry must be part of a group for vMCP discovery. |  | Required: \{\} <br /> |
-| `externalAuthConfigRef` _[api.v1beta1.ExternalAuthConfigRef](#apiv1beta1externalauthconfigref)_ | ExternalAuthConfigRef references a MCPExternalAuthConfig resource for token exchange<br />when connecting to the remote MCP server. The referenced MCPExternalAuthConfig must<br />exist in the same namespace as this MCPServerEntry. |  | Optional: \{\} <br /> |
+| `externalAuthConfigRef` _[api.v1beta1.ExternalAuthConfigRef](#apiv1beta1externalauthconfigref)_ | ExternalAuthConfigRef references an MCPExternalAuthConfig resource when connecting<br />to the remote MCP server. Supported types are tokenExchange, headerInjection,<br />unauthenticated, awsSts, upstreamInject, xaa, and obo when an enterprise handler<br />is registered. Unsupported types are reported in status.conditions with Reason:<br />UnsupportedAuthType. The referenced MCPExternalAuthConfig must exist in the same<br />namespace as this MCPServerEntry. |  | Optional: \{\} <br /> |
 | `headerForward` _[api.v1beta1.HeaderForwardConfig](#apiv1beta1headerforwardconfig)_ | HeaderForward configures headers to inject into requests to the remote MCP server.<br />Use this to add custom headers like API keys or correlation IDs. |  | Optional: \{\} <br /> |
 | `caBundleRef` _[api.v1beta1.CABundleSource](#apiv1beta1cabundlesource)_ | CABundleRef references a ConfigMap containing CA certificates for TLS verification<br />when connecting to the remote MCP server. |  | Optional: \{\} <br /> |
 
@@ -3236,7 +3239,7 @@ _Appears in:_
 | `authzConfigRef` _[api.v1beta1.MCPAuthzConfigReference](#apiv1beta1mcpauthzconfigreference)_ | AuthzConfigRef references a shared MCPAuthzConfig resource for authorization.<br />The referenced MCPAuthzConfig must exist in the same namespace as this MCPServer.<br />Mutually exclusive with authzConfig. |  | Optional: \{\} <br /> |
 | `audit` _[api.v1beta1.AuditConfig](#apiv1beta1auditconfig)_ | Audit defines audit logging configuration for the MCP server |  | Optional: \{\} <br /> |
 | `toolConfigRef` _[api.v1beta1.ToolConfigRef](#apiv1beta1toolconfigref)_ | ToolConfigRef references a MCPToolConfig resource for tool filtering and renaming.<br />The referenced MCPToolConfig must exist in the same namespace as this MCPServer.<br />Cross-namespace references are not supported for security and isolation reasons. |  | Optional: \{\} <br /> |
-| `externalAuthConfigRef` _[api.v1beta1.ExternalAuthConfigRef](#apiv1beta1externalauthconfigref)_ | ExternalAuthConfigRef references a MCPExternalAuthConfig resource for external authentication.<br />The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPServer. |  | Optional: \{\} <br /> |
+| `externalAuthConfigRef` _[api.v1beta1.ExternalAuthConfigRef](#apiv1beta1externalauthconfigref)_ | ExternalAuthConfigRef references an MCPExternalAuthConfig resource for external authentication.<br />Supported types are tokenExchange, unauthenticated, embeddedAuthServer, and<br />obo when an enterprise handler is registered. For new embedded authorization<br />server configurations, prefer AuthServerRef. Unsupported types are reported<br />in status.conditions with Reason: UnsupportedAuthType.<br />The referenced MCPExternalAuthConfig must exist in the same namespace as this MCPServer. |  | Optional: \{\} <br /> |
 | `webhookConfigRef` _[api.v1beta1.WebhookConfigRef](#apiv1beta1webhookconfigref)_ | WebhookConfigRef references a MCPWebhookConfig resource for webhook middleware configuration.<br />The referenced MCPWebhookConfig must exist in the same namespace as this MCPServer. |  | Optional: \{\} <br /> |
 | `authServerRef` _[api.v1beta1.AuthServerRef](#apiv1beta1authserverref)_ | AuthServerRef optionally references a resource that configures an embedded<br />OAuth 2.0/OIDC authorization server to authenticate MCP clients.<br />Currently the only supported kind is MCPExternalAuthConfig (type: embeddedAuthServer). |  | Optional: \{\} <br /> |
 | `telemetryConfigRef` _[api.v1beta1.MCPTelemetryConfigReference](#apiv1beta1mcptelemetryconfigreference)_ | TelemetryConfigRef references an MCPTelemetryConfig resource for shared telemetry configuration.<br />The referenced MCPTelemetryConfig must exist in the same namespace as this MCPServer.<br />Cross-namespace references are not supported for security and isolation reasons. |  | Optional: \{\} <br /> |
@@ -3746,7 +3749,10 @@ _Appears in:_
 
 
 
-OutgoingAuthConfig configures authentication from Virtual MCP to backend MCPServers
+OutgoingAuthConfig configures authentication from Virtual MCP to backend resources.
+Referenced MCPExternalAuthConfig resources support tokenExchange, headerInjection,
+unauthenticated, awsSts, upstreamInject, xaa, and obo when an enterprise handler
+is registered.
 
 
 
@@ -3755,7 +3761,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `source` _string_ | Source defines how backend authentication configurations are determined<br />- discovered: Automatically discover from backend's MCPServer.spec.externalAuthConfigRef<br />- inline: Explicit per-backend configuration in VirtualMCPServer | discovered | Enum: [discovered inline] <br />Optional: \{\} <br /> |
+| `source` _string_ | Source defines how backend authentication configurations are determined<br />- discovered: Automatically discover from backend MCPServer, MCPRemoteProxy,<br />  and MCPServerEntry externalAuthConfigRef fields<br />- inline: Explicit per-backend configuration in VirtualMCPServer | discovered | Enum: [discovered inline] <br />Optional: \{\} <br /> |
 | `default` _[api.v1beta1.BackendAuthConfig](#apiv1beta1backendauthconfig)_ | Default defines default behavior for backends without explicit auth config |  | Optional: \{\} <br /> |
 | `backends` _object (keys:string, values:[api.v1beta1.BackendAuthConfig](#apiv1beta1backendauthconfig))_ | Backends defines per-backend authentication overrides<br />Works in all modes (discovered, inline) |  | Optional: \{\} <br /> |
 
@@ -4580,7 +4586,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `incomingAuth` _[api.v1beta1.IncomingAuthConfig](#apiv1beta1incomingauthconfig)_ | IncomingAuth configures authentication for clients connecting to the Virtual MCP server.<br />Must be explicitly set - use "anonymous" type when no authentication is required.<br />This field takes precedence over config.IncomingAuth and should be preferred because it<br />supports Kubernetes-native secret references (SecretKeyRef, ConfigMapRef) for secure<br />dynamic discovery of credentials, rather than requiring secrets to be embedded in config. |  | Required: \{\} <br /> |
-| `outgoingAuth` _[api.v1beta1.OutgoingAuthConfig](#apiv1beta1outgoingauthconfig)_ | OutgoingAuth configures authentication from Virtual MCP to backend MCPServers.<br />This field takes precedence over config.OutgoingAuth and should be preferred because it<br />supports Kubernetes-native secret references (SecretKeyRef, ConfigMapRef) for secure<br />dynamic discovery of credentials, rather than requiring secrets to be embedded in config. |  | Optional: \{\} <br /> |
+| `outgoingAuth` _[api.v1beta1.OutgoingAuthConfig](#apiv1beta1outgoingauthconfig)_ | OutgoingAuth configures authentication from Virtual MCP to backend resources.<br />This field takes precedence over config.OutgoingAuth and should be preferred because it<br />supports Kubernetes-native secret references (SecretKeyRef, ConfigMapRef) for secure<br />dynamic discovery of credentials, rather than requiring secrets to be embedded in config.<br />Referenced MCPExternalAuthConfig types supported by VirtualMCPServer are tokenExchange,<br />headerInjection, unauthenticated, awsSts, upstreamInject, xaa, and obo when an<br />enterprise handler is registered. Unsupported types are reported per backend in<br />status.conditions with Reason: UnsupportedAuthType. |  | Optional: \{\} <br /> |
 | `passthroughHeaders` _string array_ | PassthroughHeaders is an allowlist of incoming client request header names<br />forwarded verbatim to all backends (e.g. an API key the backend resolves to<br />a user). Takes precedence over config.PassthroughHeaders. Names must not be<br />restricted headers (Host, hop-by-hop, X-Forwarded-*). Forwarded headers are<br />attacker-influenceable unless a trusted upstream sets them. |  | Optional: \{\} <br /> |
 | `serviceType` _string_ | ServiceType specifies the Kubernetes service type for the Virtual MCP server | ClusterIP | Enum: [ClusterIP NodePort LoadBalancer] <br />Optional: \{\} <br /> |
 | `sessionAffinity` _string_ | SessionAffinity controls whether the Service routes repeated client connections to the same pod.<br />MCP protocols (SSE, streamable-http) are stateful, so ClientIP is the default.<br />Set to "None" for stateless servers or when using an external load balancer with its own affinity. | ClientIP | Enum: [ClientIP None] <br />Optional: \{\} <br /> |

--- a/docs/operator/virtualmcpserver-api.md
+++ b/docs/operator/virtualmcpserver-api.md
@@ -145,13 +145,13 @@ spec:
 
 ### `.spec.outgoingAuth` (optional)
 
-Configures authentication from Virtual MCP to backend MCPServers.
+Configures authentication from Virtual MCP to backend resources.
 
 **Type**: `OutgoingAuthConfig`
 
 **Fields**:
 - `source` (string, optional): How backend authentication configurations are determined
-  - `discovered` (default): Automatically discover from backend's `MCPServer.spec.externalAuthConfigRef`
+  - `discovered` (default): Automatically discover from backend `MCPServer`, `MCPRemoteProxy`, and `MCPServerEntry` `externalAuthConfigRef` fields
   - `inline`: Explicit per-backend configuration in VirtualMCPServer
 - `default` (BackendAuthConfig, optional): Default behavior for backends without explicit auth config
 - `backends` (map[string]BackendAuthConfig, optional): Per-backend authentication overrides
@@ -176,13 +176,9 @@ spec:
         externalAuthConfigRef:
           name: github-token-exchange
       slack:
-        type: service_account
-        serviceAccount:
-          credentialsRef:
-            name: slack-bot-token
-            key: token
-          headerName: Authorization
-          headerFormat: "Bearer {token}"
+        type: externalAuthConfigRef
+        externalAuthConfigRef:
+          name: slack-header-injection
 ```
 
 #### BackendAuthConfig
@@ -192,6 +188,11 @@ spec:
   - `discovered`: Automatically discover from backend
   - `externalAuthConfigRef`: Reference an MCPExternalAuthConfig resource
 - `externalAuthConfigRef` (ExternalAuthConfigRef, optional): Auth config reference (when type=externalAuthConfigRef)
+
+Referenced `MCPExternalAuthConfig` resources support `tokenExchange`,
+`headerInjection`, `unauthenticated`, `awsSts`, `upstreamInject`, `obo`, and
+`xaa`. Unsupported types are reported through an `UnsupportedAuthType`
+condition instead of being silently ignored.
 
 ### `.spec.passthroughHeaders` (optional)
 
@@ -594,11 +595,9 @@ spec:
       type: discovered
     backends:
       slack:  # Override for specific backend
-        type: service_account
-        serviceAccount:
-          credentialsRef:
-            name: slack-bot-token
-            key: token
+        type: externalAuthConfigRef
+        externalAuthConfigRef:
+          name: slack-header-injection
 
   # Composite tools
   compositeTools:

--- a/docs/operator/virtualmcpserver-kubernetes-guide.md
+++ b/docs/operator/virtualmcpserver-kubernetes-guide.md
@@ -464,7 +464,11 @@ spec:
   # No pods deployed, VirtualMCPServer connects directly
 ```
 
-MCPServerEntry supports the same auth mechanisms as other backends via `externalAuthConfigRef`, and can use `caBundleRef` for internal CA certificates. See the [examples](../../examples/operator/mcp-server-entries/) for complete configurations.
+MCPServerEntry supports `tokenExchange`, `headerInjection`, `unauthenticated`,
+`awsSts`, `upstreamInject`, `obo`, and `xaa` via
+`externalAuthConfigRef`, and can use `caBundleRef` for internal CA certificates.
+See the [examples](../../examples/operator/mcp-server-entries/) for complete
+configurations.
 
 ## Troubleshooting
 
@@ -778,13 +782,22 @@ All resources must be in the same namespace. Move resources if needed.
 
 When using `outgoingAuth.source: discovered`:
 
+Inspect the backend resource that vMCP discovered:
+
 ```bash
-kubectl get mcpserver <backend-name> -o yaml | grep externalAuthConfigRef
+kubectl get mcpserver <backend-name> -o yaml
+kubectl get mcpremoteproxy <backend-name> -o yaml
+kubectl get mcpserverentry <backend-name> -o yaml
 ```
+
+If the referenced auth type is not supported by that consumer, its validation
+condition reports `Reason: UnsupportedAuthType`, and the VirtualMCPServer
+reports a condition for the affected backend as well.
 
 **Solution**: Either:
 - Create MCPExternalAuthConfig if backend requires auth
 - Remove `externalAuthConfigRef` from backend if no auth required
+- Select an auth type supported by that backend resource
 - Use `outgoingAuth.source: inline` and configure explicitly
 
 ### Tool Conflict Issues

--- a/pkg/vmcp/auth/converters/interface.go
+++ b/pkg/vmcp/auth/converters/interface.go
@@ -88,6 +88,22 @@ func (r *Registry) Register(authType mcpv1beta1.ExternalAuthType, converter Stra
 	r.converters[authType] = converter
 }
 
+// RegisteredTypes returns the auth types that have a registered converter.
+// This is the set of MCPExternalAuthConfig types a vMCP backend can actually
+// use, so consumers that route through this registry (VirtualMCPServer
+// outgoing auth, MCPServerEntry) derive their support from it rather than
+// keeping a separate hand-maintained list.
+func (r *Registry) RegisteredTypes() []mcpv1beta1.ExternalAuthType {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	registered := make([]mcpv1beta1.ExternalAuthType, 0, len(r.converters))
+	for authType := range r.converters {
+		registered = append(registered, authType)
+	}
+	return registered
+}
+
 // GetConverter retrieves a converter by auth type
 func (r *Registry) GetConverter(authType mcpv1beta1.ExternalAuthType) (StrategyConverter, error) {
 	r.mu.RLock()

--- a/pkg/vmcp/config/config.go
+++ b/pkg/vmcp/config/config.go
@@ -122,6 +122,7 @@ type Config struct {
 	// OutgoingAuth configures how the virtual MCP server authenticates to backends.
 	// When using the Kubernetes operator, this is populated by the converter from
 	// VirtualMCPServerSpec.OutgoingAuth and any values set here will be superseded.
+	// See VirtualMCPServerSpec.OutgoingAuth for supported MCPExternalAuthConfig types.
 	// +optional
 	OutgoingAuth *OutgoingAuthConfig `json:"outgoingAuth,omitempty" yaml:"outgoingAuth,omitempty"`
 
@@ -395,7 +396,8 @@ type StaticBackendConfig struct {
 type OutgoingAuthConfig struct {
 	// Source defines how to discover backend auth: "inline", "discovered"
 	// - inline: Explicit configuration in OutgoingAuth
-	// - discovered: Auto-discover from backend MCPServer.externalAuthConfigRef (Kubernetes only)
+	// - discovered: Auto-discover from backend MCPServer, MCPRemoteProxy, and
+	//   MCPServerEntry externalAuthConfigRef fields (Kubernetes only)
 	Source string `json:"source" yaml:"source"`
 
 	// Default is the default auth strategy for backends without explicit config.


### PR DESCRIPTION
## Summary

MCPExternalAuthConfig has nine `spec.type` values, but each consumer kind implements only a subset, and the unsupported combinations fail silently: the resource reads as valid, the workload runs, and the credential is never injected. This PR delivers the two things #5930 asks for:

- **Reconcile-time validation surfaced as status conditions.** An unsupported consumer/type combination sets `ExternalAuthConfigValidated=False` with reason `UnsupportedAuthType` on MCPServer, MCPRemoteProxy, and MCPServerEntry, and a per-backend condition on VirtualMCPServer (including the discovered-mode case where a `bearerToken`-backed MCPRemoteProxy used to vanish from aggregation with only a log line). Terminal configuration errors return without requeueing; the existing watches trigger reconciliation when the spec or the referenced config changes.
- **Supported consumer kinds documented in the CRD.** Field godoc on `MCPExternalAuthConfigSpec.Type` and on every consumer's `externalAuthConfigRef`, flowing into the generated CRD schemas and reference docs.

The support matrix lives in `cmd/thv-operator/pkg/externalauthsupport` and cannot drift from the code: the VirtualMCPServer/MCPServerEntry rows derive from the converter registry (`converters.DefaultRegistry().RegisteredTypes()`), and the MCPServer/MCPRemoteProxy rows are enforced at the run-config dispatch — `AddExternalAuthConfigOptions` now takes the consumer, validates against the matrix, and the silent no-op arms for `headerInjection`/`upstreamInject`/`xaa` are gone. `TestAddExternalAuthConfigOptions_EnforcesSupportMatrix` drives the real dispatch with all nine types for both consumers and requires agreement with the matrix in both directions.

Two consolidations that fell out of review:

- The generic vMCP converter no longer converts outgoing auth. The reconciler's status-aware path (`processOutgoingAuth`) was already the authority and is now the only implementation; the converter's copy (`convertOutgoingAuthWithDefaults`/`convertOutgoingAuth`/`convertBackendAuthConfig`) is deleted rather than bypassed with a modified input. Discovered mode persists exactly what the spec declares (default + inline entries), as before. The one behaviour change is intentional and in scope: a single broken backend in inline mode now degrades to a per-backend condition instead of failing the whole conversion.
- `handleExternalAuthConfig` on MCPServer sets the condition back to True once a previously rejected config is fixed (it previously had no success setter, so the condition stuck at False forever), and MCPRemoteProxy reports `Ready=False` with reason `AuthInvalid` instead of `DeploymentNotReady` for an auth configuration failure.

## Out of scope, split out per review

- The outgoing-auth precedence change and the fail-closed routing rework (ExplicitBackends/ExcludedBackends/DefaultAuthFailed) are fully reverted — `pkg/vmcp` runtime (discoverer, watcher, backend reconciler, workloads, CLI) is untouched by this PR. The precedence question is now #6329.
- The examples casing fix is now #6330.

## Validation

- `go build ./...` and `golangci-lint run` on the touched trees: clean
- `go test ./cmd/thv-operator/... ./pkg/vmcp/...`: all unit suites pass
- full `test-integration` suite under envtest (all 11 packages, including mcp-remote-proxy and virtualmcp): pass
- rebased on current `main`