### PR TITLE
Add opt-in CORS support to the MCP proxy

### DIFF
--- a/cmd/thv/app/proxy.go
+++ b/cmd/thv/app/proxy.go
@@ -137,9 +137,10 @@ func init() {
 	proxyCmd.Flags().StringVar(&proxyHost, "host", transport.LocalhostIPv4, "Host for the HTTP proxy to listen on (IP or hostname)")
 	proxyCmd.Flags().IntVar(&proxyPort, "port", 0, "Port for the HTTP proxy to listen on (host port)")
 	proxyCmd.Flags().StringArrayVar(&proxyAllowedOrigins, "allowed-origins", nil,
-		"Exact-match allowlist for the HTTP Origin header (repeatable). Recommended when binding publicly; "+
-			"loopback binds derive a default allowlist automatically, non-loopback binds log a warning when "+
-			"no value is supplied. Example: https://my-mcp.example.com")
+		"Exact-match allowlist for the HTTP Origin header (repeatable). When set, also enables CORS for exactly "+
+			"these origins on the MCP proxy endpoint. CORS is disabled by default; omit this flag when CORS is "+
+			"handled by an upstream gateway. Loopback binds derive a default origin allowlist automatically but "+
+			"never enable CORS. Example: https://my-mcp.example.com")
 	proxyCmd.Flags().StringVar(
 		&proxyTargetURI,
 		"target-uri",
@@ -244,18 +245,7 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 	// Origin-header validation (DNS-rebinding protection per MCP 2025-11-25
 	// §"Security Warning"). Added after body-limit so disallowed Origins are
 	// rejected before authentication or any outbound token acquisition runs.
-	if allowed := origin.ResolveAllowedOrigins(proxyHost, port, proxyAllowedOrigins); len(allowed) > 0 {
-		middlewares = append(middlewares, types.NamedMiddleware{
-			Name:     origin.MiddlewareType,
-			Function: origin.NewHandler(allowed),
-		})
-	} else {
-		slog.Warn("Origin validation disabled — no allowlist configured for non-loopback bind",
-			"host", proxyHost,
-			"port", port,
-			"hint", "pass --allowed-origins=https://your-client.example to enable DNS-rebind protection",
-		)
-	}
+	addOriginMiddleware(&middlewares, proxyHost, port)
 
 	// Get OIDC configuration if enabled (for protecting the proxy endpoint)
 	oidcConfig := getProxyOIDCConfig(cmd)
@@ -286,8 +276,14 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 	slog.Debug(fmt.Sprintf("Setting up transparent proxy to forward from host port %d to %s",
 		port, proxyTargetURI))
 
+	// Build optional functional options (e.g. CORS), only when configured.
+	proxyOptions, err := buildCORSProxyOptions(proxyAllowedOrigins)
+	if err != nil {
+		return fmt.Errorf("invalid --allowed-origins: %w", err)
+	}
+
 	// Create the transparent proxy with middlewares
-	proxy := transparent.NewTransparentProxy(
+	proxy := transparent.NewTransparentProxyWithOptions(
 		proxyHost,
 		port,
 		proxyTargetURI,
@@ -301,7 +297,8 @@ func proxyCmdFunc(cmd *cobra.Command, args []string) error {
 		nil,   // onUnauthorizedResponse - not needed for local proxies
 		"",    // endpointPrefix - not configured for proxy command
 		false, // trustProxyHeaders - not configured for proxy command
-		middlewares...)
+		middlewares,
+		proxyOptions...)
 	if err := proxy.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start proxy: %w", err)
 	}
@@ -503,6 +500,25 @@ func addExternalTokenMiddleware(middlewares *[]types.NamedMiddleware, tokenSourc
 	return nil
 }
 
+// addOriginMiddleware appends the Origin-header validation middleware
+// (DNS-rebinding protection per MCP 2025-11-25 §"Security Warning"), built
+// from the effective allowlist for the given host/port. It logs a warning when
+// no allowlist could be resolved (non-loopback bind with no explicit origins).
+func addOriginMiddleware(middlewares *[]types.NamedMiddleware, host string, port int) {
+	if allowed := origin.ResolveAllowedOrigins(host, port, proxyAllowedOrigins); len(allowed) > 0 {
+		*middlewares = append(*middlewares, types.NamedMiddleware{
+			Name:     origin.MiddlewareType,
+			Function: origin.NewHandler(allowed),
+		})
+	} else {
+		slog.Warn("Origin validation disabled — no allowlist configured for non-loopback bind",
+			"host", host,
+			"port", port,
+			"hint", "pass --allowed-origins=https://your-client.example to enable DNS-rebind protection",
+		)
+	}
+}
+
 // addHeaderForwardMiddleware adds header forward middleware to the middleware chain if headers are configured.
 // Secret references are resolved immediately via the secrets manager.
 func addHeaderForwardMiddleware(
@@ -561,4 +577,20 @@ func validateProxyTargetURI(targetURI string) error {
 	}
 
 	return nil
+}
+
+// buildCORSProxyOptions validates the explicit --allowed-origins list and
+// builds the transparent-proxy option that enables CORS for those origins.
+// It returns no options when the list is empty so default behaviour is
+// unchanged. Invalid entries (missing scheme, wildcard, garbage) fail loudly
+// at startup instead of silently never matching a browser Origin.
+func buildCORSProxyOptions(allowedOrigins []string) ([]transparent.Option, error) {
+	if len(allowedOrigins) == 0 {
+		return nil, nil
+	}
+	validated, err := middleware.ValidateAllowedOrigins(allowedOrigins)
+	if err != nil {
+		return nil, err
+	}
+	return []transparent.Option{transparent.WithAllowedOrigins(validated)}, nil
 }

--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -172,9 +172,10 @@ func AddRunFlags(cmd *cobra.Command, config *RunFlags) {
 	cmd.Flags().StringVar(&config.Group, "group", "default", "Name of the group this workload should belong to")
 	cmd.Flags().StringVar(&config.Host, "host", transport.LocalhostIPv4, "Host for the HTTP proxy to listen on (IP or hostname)")
 	cmd.Flags().StringArrayVar(&config.AllowedOrigins, "allowed-origins", nil,
-		"Exact-match allowlist for the HTTP Origin header (repeatable). Recommended when binding publicly; "+
-			"loopback binds derive a default allowlist automatically, non-loopback binds log a warning when "+
-			"no value is supplied. Example: https://my-mcp.example.com")
+		"Exact-match allowlist for the HTTP Origin header (repeatable). When set, also enables CORS for exactly "+
+			"these origins on the MCP proxy endpoint. CORS is disabled by default; omit this flag when CORS is "+
+			"handled by an upstream gateway. Loopback binds derive a default origin allowlist automatically but "+
+			"never enable CORS. Example: https://my-mcp.example.com")
 	cmd.Flags().IntVar(&config.ProxyPort, "proxy-port", 0, "Port for the HTTP proxy to listen on (host port)")
 	cmd.Flags().IntVar(&config.TargetPort, "target-port", 0,
 		"Port for the container to expose (only applicable to SSE or Streamable HTTP transport)")

--- a/docs/cli/thv_proxy.md
+++ b/docs/cli/thv_proxy.md
@@ -97,7 +97,7 @@ thv proxy [flags] SERVER_NAME
 ### Options
 
 ```
-      --allowed-origins stringArray                 Exact-match allowlist for the HTTP Origin header (repeatable). Recommended when binding publicly; loopback binds derive a default allowlist automatically, non-loopback binds log a warning when no value is supplied. Example: https://my-mcp.example.com
+      --allowed-origins stringArray                 Exact-match allowlist for the HTTP Origin header (repeatable). When set, also enables CORS for exactly these origins on the MCP proxy endpoint. CORS is disabled by default; omit this flag when CORS is handled by an upstream gateway. Loopback binds derive a default origin allowlist automatically but never enable CORS. Example: https://my-mcp.example.com
   -h, --help                                        help for proxy
       --host string                                 Host for the HTTP proxy to listen on (IP or hostname) (default "127.0.0.1")
       --oidc-audience string                        Expected audience for the token

--- a/docs/cli/thv_run.md
+++ b/docs/cli/thv_run.md
@@ -112,7 +112,7 @@ thv run [flags] SERVER_OR_IMAGE_OR_PROTOCOL [-- ARGS...]
 
 ```
       --allow-docker-gateway                        Allow outbound connections to Docker gateway addresses (host.docker.internal, gateway.docker.internal, 172.17.0.1). Only applies when --isolate-network is set. These are blocked by default even when insecure_allow_all is enabled. Gateway access is port-independent: it ignores the permission profile's allowed ports, so once enabled the gateway is reachable on any port.
-      --allowed-origins stringArray                 Exact-match allowlist for the HTTP Origin header (repeatable). Recommended when binding publicly; loopback binds derive a default allowlist automatically, non-loopback binds log a warning when no value is supplied. Example: https://my-mcp.example.com
+      --allowed-origins stringArray                 Exact-match allowlist for the HTTP Origin header (repeatable). When set, also enables CORS for exactly these origins on the MCP proxy endpoint. CORS is disabled by default; omit this flag when CORS is handled by an upstream gateway. Loopback binds derive a default origin allowlist automatically but never enable CORS. Example: https://my-mcp.example.com
       --audit-config string                         Path to the audit configuration file
       --authz-config string                         Path to the authorization configuration file
       --build-with stringArray                      Build-time dependency constraint for protocol scheme builds, interpreted per package ecosystem (uvx://: PEP 508 specifier passed to 'uv tool install --with', e.g. --build-with 'mcp<2'); errors on ecosystems without constraint support (can be specified multiple times)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -222,6 +222,10 @@ func (r *Runner) Run(ctx context.Context) error {
 		StrictProtocolValidation: r.Config.StrictProtocolValidation,
 		EndpointPrefix:           r.Config.EndpointPrefix,
 		SessionTTL:               effectiveSessionTTL,
+		// CORS is enabled only from the EXPLICIT --allowed-origins list. The
+		// loopback-derived defaults resolved in prependOriginMiddleware must
+		// never reach CORS, so only the raw config value is passed here.
+		AllowedCORSOrigins: r.Config.AllowedOrigins,
 	}
 
 	// Set proxy mode for stdio transport

--- a/pkg/transport/factory.go
+++ b/pkg/transport/factory.go
@@ -82,6 +82,7 @@ func (*Factory) Create(config types.Config, opts ...Option) (types.Transport, er
 		)
 		httpTransport.sessionStorage = config.SessionStorage
 		httpTransport.sessionTTL = config.SessionTTL
+		httpTransport.corsOrigins = config.AllowedCORSOrigins
 		tr = httpTransport
 	case types.TransportTypeStreamableHTTP:
 		httpTransport := NewHTTPTransport(
@@ -101,6 +102,7 @@ func (*Factory) Create(config types.Config, opts ...Option) (types.Transport, er
 		)
 		httpTransport.sessionStorage = config.SessionStorage
 		httpTransport.sessionTTL = config.SessionTTL
+		httpTransport.corsOrigins = config.AllowedCORSOrigins
 		tr = httpTransport
 	case types.TransportTypeInspector:
 		// HTTP transport is not implemented yet

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -86,6 +86,10 @@ type HTTPTransport struct {
 	// underlying proxy. Zero uses the proxy's default.
 	sessionTTL time.Duration
 
+	// corsOrigins is the explicit Origin allowlist that enables CORS on the
+	// transparent MCP proxy. Empty (default) leaves CORS disabled.
+	corsOrigins []string
+
 	// Transparent proxy
 	proxy types.Proxy
 
@@ -442,6 +446,9 @@ func (t *HTTPTransport) buildProxyOptions(remoteBasePath, remoteRawQuery string)
 	}
 	if t.sessionStorage != nil {
 		opts = append(opts, transparent.WithSessionStorage(t.sessionStorage))
+	}
+	if len(t.corsOrigins) > 0 {
+		opts = append(opts, transparent.WithAllowedOrigins(t.corsOrigins))
 	}
 	return opts
 }

--- a/pkg/transport/middleware/cors.go
+++ b/pkg/transport/middleware/cors.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/stacklok/toolhive/pkg/transport/middleware/origin"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+const (
+	// corsAllowedHeaders lists request headers MCP clients may send. The
+	// CORS-unsafelisted MCP-Protocol-Version must be allow-listed: ToolHive
+	// reads and validates it on the request path, so a browser MCP client
+	// cannot send it through CORS unless it is listed here. Last-Event-ID is
+	// needed for SSE stream resumption (also not CORS-safelisted).
+	corsAllowedHeaders = "Content-Type, Accept, Authorization, Mcp-Session-Id, MCP-Protocol-Version, Last-Event-ID"
+
+	// corsExposedHeaders lists response headers that browsers may read.
+	// MCP-Protocol-Version is exposed so a browser client can read the
+	// negotiated protocol version back.
+	corsExposedHeaders = "Mcp-Session-Id, MCP-Protocol-Version"
+
+	// corsMaxAge is the preflight cache lifetime in seconds (24 hours).
+	corsMaxAge = "86400"
+)
+
+// CORS returns a middleware that handles CORS preflight (OPTIONS) requests and
+// injects Access-Control-Allow-* response headers on responses whose Origin
+// header matches an allowed entry. When allowedOrigins is empty the middleware
+// is a no-op, preserving the default security posture.
+//
+// Origin matching is exact and uses the same canonicalization as the origin
+// middleware (origin.CanonicalizeOrigin): scheme and host are lowercased per
+// RFC 6454 §4, and there is no wildcard and no scheme+host prefix matching.
+// The allowlist is canonicalized once at construction; the request Origin is
+// canonicalized per request. The Access-Control-Allow-Origin value echoes the
+// matched canonicalized origin, which is always what the browser compares
+// against (browsers serialize Origin with a lowercase scheme+host).
+//
+// All OPTIONS requests are handled directly (returning 204) when this
+// middleware is active so that CORS preflights never reach the backend, which
+// previously returned 405 Method Not Allowed. An unmatched origin gets 204
+// without CORS headers — the browser will reject the follow-up request, which
+// is the correct fail-closed outcome.
+//
+// Preflight is intentionally unauthenticated: it runs outermost (before the
+// method gate, auth middleware, and the backend) and its response leaks only
+// static allowlist headers.
+//
+// allowedMethods is the value advertised in Access-Control-Allow-Methods. It
+// should reflect the methods the backend actually accepts so a preflight never
+// succeeds for a method the real request would reject.
+func CORS(allowedOrigins []string, allowedMethods string) types.MiddlewareFunction {
+	origins := slices.Clone(allowedOrigins)
+	origins = slices.DeleteFunc(origins, func(o string) bool { return strings.TrimSpace(o) == "" })
+	if len(origins) == 0 {
+		return func(next http.Handler) http.Handler { return next }
+	}
+
+	allowedSet := make(map[string]struct{}, len(origins))
+	for _, o := range origins {
+		allowedSet[origin.CanonicalizeOrigin(o)] = struct{}{}
+	}
+	slog.Debug("CORS middleware configured",
+		"allowed_origin_count", len(allowedSet), "allowed_methods", allowedMethods)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var matched string
+			if rawOrigin := r.Header.Get("Origin"); rawOrigin != "" {
+				canonical := origin.CanonicalizeOrigin(rawOrigin)
+				if _, ok := allowedSet[canonical]; ok {
+					matched = canonical
+				}
+			}
+
+			if matched != "" {
+				h := w.Header()
+				h.Set("Access-Control-Allow-Origin", matched)
+				h.Set("Access-Control-Allow-Methods", allowedMethods)
+				h.Set("Access-Control-Allow-Headers", corsAllowedHeaders)
+				h.Set("Access-Control-Expose-Headers", corsExposedHeaders)
+				h.Add("Vary", "Origin")
+			}
+
+			if r.Method == http.MethodOptions {
+				if matched != "" {
+					w.Header().Set("Access-Control-Max-Age", corsMaxAge)
+				}
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// ValidateAllowedOrigins validates configured CORS origins and returns a
+// canonicalized copy. It surfaces misconfiguration at startup instead of
+// letting an origin silently never match (which produces a broken browser
+// experience with no signal):
+//
+//   - Empty entries (after trimming whitespace) are dropped.
+//   - Entries that cannot parse as a scheme://host[:port] origin — e.g. a
+//     missing scheme ("localhost:6274"), a wildcard ("*"), or garbage — are
+//     rejected with an error.
+//   - A trailing slash (e.g. "http://localhost:6274/") is normalized away, as
+//     a browser Origin header never carries one.
+//
+// Canonicalization matches origin.CanonicalizeOrigin, so the returned entries
+// behave identically in both the origin validator and the CORS middleware.
+func ValidateAllowedOrigins(origins []string) ([]string, error) {
+	validated := make([]string, 0, len(origins))
+	for _, raw := range origins {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		canonical := origin.CanonicalizeOrigin(entry)
+		if strings.HasPrefix(canonical, "\x00") {
+			return nil, fmt.Errorf(
+				"invalid CORS origin %q: must be a scheme://host[:port] URL (e.g. %q)", raw, "http://localhost:6274")
+		}
+		validated = append(validated, canonical)
+	}
+	return validated, nil
+}

--- a/pkg/transport/middleware/cors_test.go
+++ b/pkg/transport/middleware/cors_test.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runCORS applies the CORS middleware to a stub handler, issues a request with
+// the given method and Origin header (skipped when empty), and returns the
+// response and whether the next handler was invoked.
+func runCORS(t *testing.T, allowedOrigins []string, allowedMethods, method, origin string) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+	var nextCalled bool
+	mw := CORS(allowedOrigins, allowedMethods)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(method, "/mcp", nil)
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec, nextCalled
+}
+
+func TestCORS_PreflightAllowedOrigin(t *testing.T) {
+	t.Parallel()
+	rec, nextCalled := runCORS(t, []string{"http://localhost:6274"}, "POST, OPTIONS", http.MethodOptions, "http://localhost:6274")
+
+	assert.False(t, nextCalled, "OPTIONS preflight must be intercepted, never forwarded")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "http://localhost:6274", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "POST, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+	// MCP-Protocol-Version and Last-Event-ID are not CORS-safelisted request
+	// headers; omitting them breaks spec-compliant browser clients (the #5588
+	// ship-blocker).
+	assert.Equal(t, "Content-Type, Accept, Authorization, Mcp-Session-Id, MCP-Protocol-Version, Last-Event-ID",
+		rec.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "Mcp-Session-Id, MCP-Protocol-Version",
+		rec.Header().Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "86400", rec.Header().Get("Access-Control-Max-Age"))
+	assert.Contains(t, rec.Header().Values("Vary"), "Origin", "Vary: Origin must be added so caches key on Origin")
+}
+
+func TestCORS_PreflightDisallowedOrigin(t *testing.T) {
+	t.Parallel()
+	rec, nextCalled := runCORS(t, []string{"http://localhost:6274"}, "POST, OPTIONS", http.MethodOptions, "http://evil.example")
+
+	assert.False(t, nextCalled, "OPTIONS preflight must be intercepted, never forwarded")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	// Fail closed: no ACAO means the browser rejects the follow-up request.
+	assert.Equal(t, "", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "", rec.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "", rec.Header().Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "", rec.Header().Get("Access-Control-Max-Age"))
+}
+
+func TestCORS_ActualRequestAllowedOrigin(t *testing.T) {
+	t.Parallel()
+	rec, nextCalled := runCORS(t, []string{"http://localhost:6274"}, "GET, POST, DELETE, OPTIONS", http.MethodGet, "http://localhost:6274")
+
+	assert.True(t, nextCalled, "non-OPTIONS request must be forwarded")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "http://localhost:6274", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "GET, POST, DELETE, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+	assert.Contains(t, rec.Header().Values("Vary"), "Origin")
+	assert.Equal(t, "", rec.Header().Get("Access-Control-Max-Age"), "Max-Age is preflight-only")
+}
+
+func TestCORS_ActualRequestWithoutOrigin(t *testing.T) {
+	t.Parallel()
+	rec, nextCalled := runCORS(t, []string{"http://localhost:6274"}, "POST, OPTIONS", http.MethodPost, "")
+
+	assert.True(t, nextCalled)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "", rec.Header().Get("Access-Control-Allow-Methods"))
+}
+
+func TestCORS_EmptyOriginsIsNoOp(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		method string
+		origin string
+	}{
+		{http.MethodGet, "http://localhost:6274"},
+		{http.MethodOptions, "http://localhost:6274"},
+	} {
+		rec, nextCalled := runCORS(t, nil, "POST, OPTIONS", tc.method, tc.origin)
+		assert.True(t, nextCalled, "empty allowlist must be a pure passthrough for %s", tc.method)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "", rec.Header().Get("Access-Control-Allow-Origin"))
+	}
+}
+
+func TestCORS_ExactMatchOnly(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		allowed  []string
+		origin   string
+		expected string
+	}{
+		// The allowed entry must never act as a prefix: no CWE-942 style
+		// scheme+host prefix matching at all.
+		{"different port rejected", []string{"http://localhost:6274"}, "http://localhost:9999", ""},
+		{"evil subdomain rejected", []string{"http://localhost"}, "http://localhost.evil.com", ""},
+		{"evil subdomain vs port-bearing entry rejected", []string{"http://localhost:6274"}, "http://localhost.evil.com", ""},
+		{"evil subdomain with port rejected", []string{"http://localhost"}, "http://localhost.evil.com:6274", ""},
+		{"scheme difference rejected", []string{"http://localhost:6274"}, "https://localhost:6274", ""},
+		{"exact match accepted", []string{"http://localhost:6274"}, "http://localhost:6274", "http://localhost:6274"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec, _ := runCORS(t, tc.allowed, "POST, OPTIONS", http.MethodGet, tc.origin)
+			assert.Equal(t, tc.expected, rec.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+func TestCORS_CaseVariantMatches(t *testing.T) {
+	t.Parallel()
+	// Matching must be canonicalized identically to the origin middleware
+	// (RFC 6454: scheme and host are ASCII-case-insensitive), so a case-variant
+	// allowlist entry produces the same ACAO as a verbatim one.
+	rec, _ := runCORS(t, []string{"HTTP://Localhost:6274"}, "POST, OPTIONS", http.MethodOptions, "http://localhost:6274")
+	assert.Equal(t, "http://localhost:6274", rec.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestValidateAllowedOrigins(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		origins []string
+		want    []string
+		wantErr bool
+	}{
+		{"nil input yields empty result", nil, []string{}, false},
+		{"empty entries dropped", []string{"", "http://localhost:6274", "  "}, []string{"http://localhost:6274"}, false},
+		{"trailing slash normalized", []string{"http://localhost:6274/"}, []string{"http://localhost:6274"}, false},
+		{"valid entries preserved", []string{"https://my-mcp.example.com"}, []string{"https://my-mcp.example.com"}, false},
+		{"missing scheme rejected", []string{"localhost:6274"}, nil, true},
+		{"wildcard rejected", []string{"*"}, nil, true},
+		{"garbage rejected", []string{"not a url"}, nil, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateAllowedOrigins(tc.origins)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/transport/middleware/origin/origin.go
+++ b/pkg/transport/middleware/origin/origin.go
@@ -115,7 +115,7 @@ func NewHandler(allowedOrigins []string) types.MiddlewareFunction {
 	// insensitive) match predictably. Preserve the sorted list for logging.
 	allowedSet := make(map[string]struct{}, len(allowedOrigins))
 	for _, o := range allowedOrigins {
-		allowedSet[canonicalizeOrigin(o)] = struct{}{}
+		allowedSet[CanonicalizeOrigin(o)] = struct{}{}
 	}
 	slog.Debug("origin middleware configured",
 		"allowed_origin_count", len(allowedSet),
@@ -147,7 +147,7 @@ func NewHandler(allowedOrigins []string) types.MiddlewareFunction {
 				next.ServeHTTP(w, r)
 				return
 			}
-			if _, ok := allowedSet[canonicalizeOrigin(origin)]; !ok {
+			if _, ok := allowedSet[CanonicalizeOrigin(origin)]; !ok {
 				slog.Warn("rejecting request with disallowed Origin",
 					"origin", origin,
 					"method", r.Method,
@@ -162,7 +162,7 @@ func NewHandler(allowedOrigins []string) types.MiddlewareFunction {
 	}
 }
 
-// canonicalizeOrigin normalizes an Origin value for exact-match comparison.
+// CanonicalizeOrigin normalizes an Origin value for exact-match comparison.
 // It parses the value with net/url.Parse and rebuilds it as
 // "scheme://host[:port]" with the scheme and host lowercased (RFC 6454 §4
 // makes both ASCII-case-insensitive) and the port preserved verbatim. Using
@@ -176,7 +176,11 @@ func NewHandler(allowedOrigins []string) types.MiddlewareFunction {
 // legitimate allowlist entry. This makes such values fail closed: a malformed
 // configured entry will not match anything, and a malformed request Origin
 // will not match the allowlist.
-func canonicalizeOrigin(raw string) string {
+//
+// Exported so the CORS middleware (pkg/transport/middleware) matches origins
+// with exactly the same canonicalization as this request-time validator,
+// keeping the "preflight-allowed iff request-allowed" invariant.
+func CanonicalizeOrigin(raw string) string {
 	if raw == "" {
 		return raw
 	}

--- a/pkg/transport/proxy/transparent/cors_test.go
+++ b/pkg/transport/proxy/transparent/cors_test.go
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package transparent
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/transport/middleware/origin"
+	"github.com/stacklok/toolhive/pkg/transport/types"
+)
+
+// corsBackend mimics a containerized MCP server behind `thv run`: POST and GET
+// succeed, OPTIONS returns 405 (no CORS handling of its own).
+func corsBackend(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, "event: endpoint\ndata: /sse?sessionId=abc123\n\n")
+		case http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// startCORSProxy boots a TransparentProxy in front of backendURL with the origin
+// middleware allow-listing allowedOrigin (mirroring `thv run`/`thv proxy`) and
+// any extra functional options.
+func startCORSProxy(t *testing.T, backendURL, allowedOrigin string, opts ...Option) *TransparentProxy {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	middlewares := []types.NamedMiddleware{{
+		Name:     origin.MiddlewareType,
+		Function: origin.NewHandler([]string{allowedOrigin}),
+	}}
+	p := NewTransparentProxyWithOptions(
+		"127.0.0.1",
+		0,
+		backendURL,
+		nil, // prometheusHandler
+		nil, // authInfoHandler
+		nil, // prefixHandlers
+		false,
+		false, // isRemote
+		"sse",
+		nil, // onHealthCheckFailed
+		nil, // onUnauthorizedResponse
+		"",  // endpointPrefix
+		false,
+		middlewares,
+		opts...,
+	)
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("proxy.Start: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = p.Stop(stopCtx)
+	})
+	return p
+}
+
+func doCORSRequest(t *testing.T, method, url, allowedOrigin string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	require.NoError(t, err)
+	if allowedOrigin != "" {
+		req.Header.Set("Origin", allowedOrigin)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp
+}
+
+// The core issue-#4297 regression pair: with WithAllowedOrigins the proxy
+// answers the preflight itself (204 + ACAO) instead of relaying the backend's
+// 405, and an allowed-origin GET carries ACAO.
+func TestCORSProxy_WithAllowedOrigins(t *testing.T) {
+	t.Parallel()
+	const allowedOrigin = "http://localhost:6274"
+	backend := corsBackend(t)
+	proxy := startCORSProxy(t, backend.URL, allowedOrigin, WithAllowedOrigins([]string{allowedOrigin}))
+	base := "http://" + proxy.ListenerAddr()
+
+	preflight := doCORSRequest(t, http.MethodOptions, base+"/mcp", allowedOrigin)
+	assert.Equal(t, http.StatusNoContent, preflight.StatusCode,
+		"preflight must be answered by the proxy, not relayed as the backend's 405")
+	assert.Equal(t, allowedOrigin, preflight.Header.Get("Access-Control-Allow-Origin"))
+	t.Logf("OPTIONS /mcp + allowed origin -> status=%d ACAO=%q", preflight.StatusCode, preflight.Header.Get("Access-Control-Allow-Origin"))
+
+	get := doCORSRequest(t, http.MethodGet, base+"/mcp", allowedOrigin)
+	assert.Equal(t, http.StatusOK, get.StatusCode)
+	assert.Equal(t, allowedOrigin, get.Header.Get("Access-Control-Allow-Origin"))
+	t.Logf("GET /mcp + allowed origin -> status=%d ACAO=%q", get.StatusCode, get.Header.Get("Access-Control-Allow-Origin"))
+}
+
+// Control: without WithAllowedOrigins the behavior is unchanged — the OPTIONS
+// preflight is forwarded and the backend's 405 is relayed, with no ACAO.
+func TestCORSProxy_WithoutOptionIsUnchanged(t *testing.T) {
+	t.Parallel()
+	const allowedOrigin = "http://localhost:6274"
+	backend := corsBackend(t)
+	proxy := startCORSProxy(t, backend.URL, allowedOrigin)
+	base := "http://" + proxy.ListenerAddr()
+
+	preflight := doCORSRequest(t, http.MethodOptions, base+"/mcp", allowedOrigin)
+	assert.Equal(t, http.StatusMethodNotAllowed, preflight.StatusCode,
+		"without the option the backend 405 must be preserved")
+	assert.Equal(t, "", preflight.Header.Get("Access-Control-Allow-Origin"))
+
+	get := doCORSRequest(t, http.MethodGet, base+"/mcp", allowedOrigin)
+	assert.Equal(t, http.StatusOK, get.StatusCode)
+	assert.Equal(t, "", get.Header.Get("Access-Control-Allow-Origin"))
+}
+
+// The origin middleware must remain the authoritative request-time gate: a
+// disallowed origin still gets 403 and no ACAO, even with CORS active.
+func TestCORSProxy_DisallowedOriginStill403(t *testing.T) {
+	t.Parallel()
+	const allowedOrigin = "http://localhost:6274"
+	backend := corsBackend(t)
+	proxy := startCORSProxy(t, backend.URL, allowedOrigin, WithAllowedOrigins([]string{allowedOrigin}))
+	base := "http://" + proxy.ListenerAddr()
+
+	get := doCORSRequest(t, http.MethodGet, base+"/mcp", "http://evil.example")
+	assert.Equal(t, http.StatusForbidden, get.StatusCode, "origin middleware must still reject disallowed origins")
+	assert.Equal(t, "", get.Header.Get("Access-Control-Allow-Origin"))
+	assert.True(t, strings.Contains(strings.ToLower(get.Header.Get("Content-Type")), "application/json"))
+}

--- a/pkg/transport/proxy/transparent/transparent_proxy.go
+++ b/pkg/transport/proxy/transparent/transparent_proxy.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,6 +34,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/bodylimit"
 	"github.com/stacklok/toolhive/pkg/healthcheck"
 	"github.com/stacklok/toolhive/pkg/mcp"
+	"github.com/stacklok/toolhive/pkg/transport/middleware"
 	"github.com/stacklok/toolhive/pkg/transport/proxy/socket"
 	"github.com/stacklok/toolhive/pkg/transport/session"
 	"github.com/stacklok/toolhive/pkg/transport/types"
@@ -150,6 +152,12 @@ type TransparentProxy struct {
 
 	// Shutdown timeout for graceful HTTP server shutdown (default: 30 seconds)
 	shutdownTimeout time.Duration
+
+	// corsOrigins holds the list of allowed CORS origins. When non-empty, the
+	// proxy answers OPTIONS preflights with 204 and injects
+	// Access-Control-Allow-* headers for these origins. Empty (default) keeps
+	// the current behaviour with no CORS support.
+	corsOrigins []string
 }
 
 const (
@@ -334,6 +342,26 @@ func WithReadTimeout(d time.Duration) Option {
 			return
 		}
 		p.readTimeout = d
+	}
+}
+
+// WithAllowedOrigins enables CORS support on the transparent proxy by setting
+// the list of permitted origins. An empty slice (the default) leaves CORS
+// disabled so the security posture is unchanged for deployments that do not
+// need browser access.
+//
+// Each entry is matched exactly (canonicalized like the origin middleware):
+// only an Origin header that equals one of these values after RFC 6454
+// canonicalization receives Access-Control-Allow-* headers.
+//
+// The caller's slice is cloned before storage so later mutations cannot race
+// with the running middleware, which keeps the list for the process lifetime.
+func WithAllowedOrigins(origins []string) Option {
+	return func(p *TransparentProxy) {
+		cloned := slices.Clone(origins)
+		if len(cloned) > 0 {
+			p.corsOrigins = cloned
+		}
 	}
 }
 
@@ -1338,6 +1366,20 @@ func (p *TransparentProxy) Start(ctx context.Context) error {
 	// Note: No manual path checking needed - ServeMux longest-match routing ensures
 	// more specific paths registered above take precedence over this catch-all.
 	finalHandler = p.methodGate(finalHandler)
+
+	// 6. Apply CORS as the outermost wrapper on the catch-all so OPTIONS
+	// preflights are intercepted before the method gate, auth middleware, or
+	// backend can reject them. Only active when corsOrigins is non-empty
+	// (opt-in, no behaviour change by default). /health, /metrics,
+	// /.well-known/, and prefix handlers stay outside this wrapper — they are
+	// mounted separately above.
+	if len(p.corsOrigins) > 0 {
+		corsMethods := p.corsAllowedMethods()
+		finalHandler = middleware.CORS(p.corsOrigins, corsMethods)(finalHandler)
+		slog.Debug("CORS middleware applied",
+			"allowed_origin_count", len(p.corsOrigins), "allowed_methods", corsMethods)
+	}
+
 	mux.Handle("/", finalHandler)
 
 	// Use ListenConfig with SO_REUSEADDR to allow port reuse after unclean shutdown
@@ -1594,6 +1636,35 @@ func (*TransparentProxy) ForwardResponseToClients(_ context.Context, _ jsonrpc2.
 	return fmt.Errorf("ForwardResponseToClients not implemented for TransparentProxy")
 }
 
+// HTTP method sets advertised to clients. These are the single source of truth
+// shared by methodGate's "Allow" header and the CORS preflight
+// (Access-Control-Allow-Methods) so a browser never preflights a method the
+// backend would then reject.
+const (
+	// statelessAllowedMethods are the methods a stateless (POST-only) MCP server
+	// accepts. OPTIONS is included for CORS preflight handling.
+	statelessAllowedMethods = "POST, OPTIONS"
+
+	// statefulAllowedMethods are the methods a full streamable-HTTP MCP server
+	// accepts (GET for the SSE stream, DELETE for session teardown).
+	statefulAllowedMethods = "GET, POST, DELETE, OPTIONS"
+)
+
+// corsAllowedMethods returns the method set the CORS preflight should advertise
+// for this proxy, derived from the same source of truth the request path
+// enforces (see methodGate).
+//
+// Known limitation: under the Modern (2026-07-28) revision the stateful
+// preflight advertises GET/DELETE while methodGate may still 405 those methods
+// for requests tagged with the Modern version. Modern clients use POST only,
+// so this asymmetry is theoretical; behavior is intentionally unchanged.
+func (p *TransparentProxy) corsAllowedMethods() string {
+	if p.stateless {
+		return statelessAllowedMethods
+	}
+	return statefulAllowedMethods
+}
+
 // methodGate wraps a handler to reject GET, HEAD, and DELETE requests with 405
 // when the proxy is running stateless (--stateless) or the request is tagged
 // with the Modern (stateless-only) MCP-Protocol-Version: neither has any
@@ -1613,7 +1684,7 @@ func (p *TransparentProxy) methodGate(next http.Handler) http.Handler {
 		isGateableMethod := r.Method == http.MethodGet || r.Method == http.MethodHead || r.Method == http.MethodDelete
 		isModern := r.Header.Get("MCP-Protocol-Version") == mcp.MCPVersionModern
 		if isGateableMethod && (p.stateless || isModern) {
-			w.Header().Set("Allow", "POST, OPTIONS")
+			w.Header().Set("Allow", statelessAllowedMethods)
 			http.Error(w, "method not allowed: server is stateless / stateless MCP revision (POST only)", http.StatusMethodNotAllowed)
 			return
 		}

--- a/pkg/transport/types/transport.go
+++ b/pkg/transport/types/transport.go
@@ -288,6 +288,12 @@ type Config struct {
 	// Sessions idle for longer than this duration are cleaned up by the session
 	// manager's background worker. Zero uses session.DefaultSessionTTL.
 	SessionTTL time.Duration
+
+	// AllowedCORSOrigins is the explicit Origin allowlist used to enable CORS
+	// on the transparent MCP proxy. Empty (default) leaves CORS disabled.
+	// Unlike the origin middleware, it must only ever be fed the explicit
+	// operator-supplied list — loopback-derived defaults must never enable CORS.
+	AllowedCORSOrigins []string
 }
 
 // ProxyMode represents the proxy mode for stdio transport.


### PR DESCRIPTION
## Summary

Browser-based MCP clients (for example MCP Inspector) cannot use the transparent MCP proxy endpoint: the browser's OPTIONS preflight is forwarded to the backend MCP server, which answers 405 Method Not Allowed, and proxied responses carry no Access-Control-Allow-* headers, so the browser blocks them with a CORS error.

This adds opt-in CORS support to the proxy. Setting --allowed-origins on thv proxy or thv run enables CORS for exactly those origins:

- OPTIONS preflights from an allowed origin are answered by the proxy with 204 and never reach the backend.
- Access-Control-Allow-Origin (the matched origin), Access-Control-Allow-Methods, Access-Control-Allow-Headers, Access-Control-Expose-Headers, and Vary: Origin are injected on matching responses.
- The allowlist is the same explicit list already enforced by the Origin-header validation middleware, so CORS never widens access: an origin that passes preflight is exactly an origin that passes request-time Origin validation. There is no wildcard and no reflection of arbitrary origins.
- CORS stays disabled by default and is a no-op when no origins are configured.

Access-Control-Allow-Headers includes MCP-Protocol-Version (ToolHive reads and validates it on the request path) and Last-Event-ID (used for SSE stream resumption).

Fixes #4297

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Unit tests cover the new middleware (preflight 204 + headers for an allowed origin, no CORS when no origins are configured, exact-match only) and the proxy wiring (OPTIONS answered by the proxy instead of the backend 405; disallowed origins still 403 from Origin validation). Manually verified against a running proxy: an allow-listed origin now receives 204 + Access-Control-Allow-Origin on preflight and 200 + headers on the real request, while the default configuration keeps the previous backend 405 behavior.

## Changes

| File | Change |
|------|--------|
| pkg/transport/middleware/cors.go | New CORS middleware (exact-match allowlist, OPTIONS 204, header injection) |
| pkg/transport/middleware/cors_test.go | Middleware unit tests |
| pkg/transport/proxy/transparent/transparent_proxy.go | WithAllowedOrigins option; CORS applied outermost in Start(); shared method constants |
| pkg/transport/proxy/transparent/cors_test.go | Proxy-level CORS integration tests |
| cmd/thv/app/proxy.go | Enable CORS from --allowed-origins on thv proxy |
| cmd/thv/app/run_flags.go | Enable CORS from --allowed-origins on thv run |
| pkg/transport/middleware/origin/origin.go | Export CanonicalizeOrigin for shared matching |
| pkg/transport/types/transport.go | AllowedCORSOrigins transport config field |
| pkg/transport/http.go, pkg/transport/factory.go | Thread CORS origins through the HTTP transport |
| pkg/runner/runner.go | Pass the explicit origin allowlist to the transport |
| docs/cli/thv_proxy.md, docs/cli/thv_run.md | Regenerated CLI docs |

## Does this introduce a user-facing change?

Yes. --allowed-origins on thv proxy and thv run now also enables CORS for the listed origins on the MCP proxy endpoint, so browser-based clients (e.g. MCP Inspector) can connect. When the flag is omitted, behavior is unchanged: CORS stays disabled. Operators who handle CORS at an upstream gateway can keep omitting the flag.