### PR TITLE
Guard against shell injection via github.ref in image workflow

### DIFF
--- a/.github/workflows/image-build-and-publish.yml
+++ b/.github/workflows/image-build-and-publish.yml
@@ -52,7 +52,7 @@ jobs:
           TAGS="-t $TAG"
 
           # Add latest tag only if building from a tag
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             TAGS="$TAGS -t latest"
           fi
 
@@ -68,7 +68,7 @@ jobs:
           cosign sign -y $BASE_REPO:$TAG
 
           # Sign the latest tag if building from a tag
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             cosign sign -y $BASE_REPO:latest
           fi
 
@@ -194,7 +194,7 @@ jobs:
           TAGS="-t $TAG"
 
           # Add latest tag only if building from a tag
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             TAGS="$TAGS -t latest"
           fi
 
@@ -210,7 +210,7 @@ jobs:
           cosign sign -y $BASE_REPO:$TAG
 
           # Sign the latest tag if building from a tag
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             cosign sign -y $BASE_REPO:latest
           fi
 
@@ -264,7 +264,7 @@ jobs:
           TAG=${{ steps.version-string.outputs.tag }}
           TAGS="-t $TAG"
           # Add latest tag only if building from a tag
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             TAGS="$TAGS -t latest"
           fi
           KO_DOCKER_REPO=$BASE_REPO ko build --platform=linux/amd64,linux/arm64 --bare $TAGS ./cmd/thv-proxyrunner \
@@ -279,7 +279,7 @@ jobs:
           cosign sign -y $BASE_REPO:$TAG
 
           # Sign the latest tag if building from a tag
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             cosign sign -y $BASE_REPO:latest
           fi
 
@@ -306,16 +306,16 @@ jobs:
       - name: Compute version number
         id: version-string
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             # For main branch, use semver with -dev suffix
             echo "tag=0.0.1-dev.$GITHUB_RUN_NUMBER+$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             # For tags, use the tag as is (assuming it's semver)
-            TAG="${{ github.ref_name }}"
+            TAG="$GITHUB_REF_NAME"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           else
             # For other branches, use branch name and run number
-            BRANCH="${{ github.ref_name }}"
+            BRANCH="$GITHUB_REF_NAME"
             echo "tag=0.0.1-$BRANCH.$GITHUB_RUN_NUMBER+$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
@@ -343,7 +343,7 @@ jobs:
           TAGS="-t $TAG"
 
           # Add latest tag only if building from a tag
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             TAGS="$TAGS -t latest"
           fi
 
@@ -359,6 +359,6 @@ jobs:
           cosign sign -y $BASE_REPO:$TAG
 
           # Sign the latest tag if building from a tag
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             cosign sign -y $BASE_REPO:latest
           fi


### PR DESCRIPTION
## Summary

- `image-build-and-publish.yml` interpolated `${{ github.ref }}` / `${{ github.ref_name }}` directly into bash `if`/`elif` checks and variable assignments. Git ref names can legally contain shell metacharacters (`$`, `` ` ``, `(`, `)`, `;`, etc.), so a maliciously-named branch or tag could inject commands into these steps. The steps run with `packages: write` and `id-token: write` permissions (GHCR push + Cosign signing), so the blast radius is our image-signing/publish credentials.
- Reachable today via manual `workflow_dispatch` (any existing ref) or a published release (tag name), both of which require push/release access to the repo. Not reachable via `pull_request`/fork PRs — the workflow is `workflow_call`-only.
- Fix: use the runner's default `$GITHUB_REF` / `$GITHUB_REF_NAME` environment variables in the shell instead of expression interpolation, so the ref value is passed as data rather than expanded into the script text before the shell runs. No `env:` block changes needed — these are already provided automatically by the Actions runner.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

Validated the workflow YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`). No Go code touched, so `task test`/`task lint-fix` don't apply; there's no repo lint step covering workflow YAML. Confirmed via `grep` that all shell-context `github.ref`/`github.ref_name` usages in this file are addressed, and that the remaining `github.ref` usages (in `if:` conditions and an action's `with:` input in the egress-proxy job) are pure Actions-expression contexts, not shell, so they're not part of this vulnerability class and were left untouched.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- This fixes the 7 lines flagged in security review, plus 2 identical occurrences in the same file that weren't in the reporter's list (proxyrunner job's sign step, and the vmcp job's version-compute step) — same anti-pattern, same file, fixed for consistency rather than leaving a known-vulnerable twin in place.
- Severity on the advisory is being accepted as Medium rather than the filed High/8.8, since exploitation requires an account that already has push/release access to this repo (no fork/PR path reaches this workflow). That's a risk-based call on our threat model — this PR is the agreed-upon fix regardless of the severity discussion.