### PR TITLE
Add zizmor to CI and stop double-running the security scan

### DIFF
--- a/.github/workflows/run-on-pr.yml
+++ b/.github/workflows/run-on-pr.yml
@@ -18,12 +18,8 @@ jobs:
   linting:
     name: Linting
     uses: ./.github/workflows/lint.yml
-  security-scan:
-    name: Security Scan
-    permissions:
-      contents: read
-      security-events: write
-    uses: ./.github/workflows/security-scan.yml
+  # Security Scan is not called from here: security-scan.yml has its own
+  # `pull_request` trigger, so calling it as well ran every scan twice per PR.
   tests:
     name: Tests
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,12 +1,14 @@
 name: Security Scan
 
 on:
+  # Called by run-on-main.yml on push to main, where image-build-and-push gates
+  # on the result. There is deliberately no `push:` trigger here as well — that
+  # would run every scan twice for each push to main.
   workflow_call:
   workflow_dispatch:
-  push:
-    branches: [ main ]
+  # PRs trigger this directly rather than through run-on-pr.yml, for the same
+  # reason. Unfiltered by branch, to match the coverage run-on-pr.yml gave.
   pull_request:
-    branches: [ main ]
   schedule:
     # Run daily at 2 AM UTC
     - cron: '0 2 * * *'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,6 +40,44 @@ jobs:
           sarif_file: ${{ steps.grype-scan.outputs.sarif }}
           category: "grype"
 
+  zizmor:
+    name: GitHub Actions Static Analysis
+    runs-on: ubuntu-latest
+    # --no-exit-codes stops *findings* failing the job; this stops a tool or
+    # network failure doing so. Both come off when the gate goes blocking.
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      # Advisory only for now: --no-exit-codes keeps the job green while the
+      # existing backlog is worked through, so this reports without blocking.
+      # Remove it (and add --min-severity) once the backlog is clear.
+      #
+      # Results are written straight to SARIF and never echoed. Workflow logs
+      # and job summaries are world-readable on a public repository, so
+      # printing findings would publish them; the SARIF upload keeps them in
+      # the Security tab, which requires write access to read.
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pipx run zizmor==1.29.0 \
+            --persona=regular \
+            --format=sarif \
+            --no-exit-codes \
+            --no-progress \
+            .github/ > zizmor.sarif
+
+      # Pull requests from forks get a read-only token, so the upload is
+      # skipped there; those workflows are still scanned on push to main.
+      - name: Upload zizmor results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        if: always() && !github.event.pull_request.head.repo.fork
+        with:
+          sarif_file: zizmor.sarif
+          category: "zizmor"
+
   govulncheck:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -34,7 +34,7 @@ jobs:
           fail-build: false
 
       - name: Upload Grype scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         if: always()
         with:
           sarif_file: ${{ steps.grype-scan.outputs.sarif }}
@@ -49,6 +49,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # This job only reads the workflow files; it never pushes.
+          persist-credentials: false
 
       # Advisory only for now: --no-exit-codes keeps the job green while the
       # existing backlog is worked through, so this reports without blocking.
@@ -72,7 +75,7 @@ jobs:
       # Pull requests from forks get a read-only token, so the upload is
       # skipped there; those workflows are still scanned on push to main.
       - name: Upload zizmor results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         if: always() && !github.event.pull_request.head.repo.fork
         with:
           sarif_file: zizmor.sarif


### PR DESCRIPTION
## Summary

- **We have no static analysis for our own workflows.** `security-scan.yml` runs Grype and govulncheck, which cover our dependencies and our Go code — nothing looks at `.github/` itself, so workflow anti-patterns accumulate with no signal. This adds [zizmor](https://docs.zizmor.sh/) as a job in the existing security scan.
- **Every security scan was running twice per PR.** `security-scan.yml` has its own `pull_request` trigger *and* was called as a reusable workflow from `run-on-pr.yml`, so Grype and govulncheck each ran two full times on every pull request. The same overlap existed on main, between the `push:` trigger and the call from `run-on-main.yml`. This keeps exactly one path each and reclaims the duplicate runs.

zizmor is deliberately **advisory** to start with. It reports 111 findings against the current tree, and gating on that today would just block every PR. `--no-exit-codes` stops findings failing the job and `continue-on-error` stops a tool or network failure doing so; both come off once the backlog is worked through, which is inventoried in #6253.

Closes #6250

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): CI configuration

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

No Go code changes, so the repo's own test tasks aren't meaningful here. What was verified locally:

- `actionlint` passes clean on both changed files.
- Both files parse as YAML.
- `zizmor 1.29.0` runs to completion against `.github/` and emits valid SARIF, exit code 0 with `--no-exit-codes` despite 111 findings.
- Confirmed nothing in `run-on-pr.yml` had `needs: security-scan`, so removing that job strands nothing.
- Confirmed `run-on-main.yml` still calls the workflow and `image-build-and-push` still gates on it via `needs`, so the main-branch path is unchanged.
- Confirmed via the branch protection and ruleset APIs that the only required status check is `CRD Schema Compatibility` — moving which workflow reports the security scan won't leave PRs waiting on a check that never runs.
- `pipx` is present on the `ubuntu-24.04` runner image, so no extra setup action is needed.

The zizmor job itself won't run on this PR — `security-scan.yml` has to be on the base branch before its `pull_request` trigger applies. Its first execution will be post-merge, or via `workflow_dispatch` from this branch if you'd like to see it before approving.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **Findings are never printed.** Workflow logs and job summaries are world-readable on a public repo, so the run writes SARIF straight to a file and uploads it to the Security tab, which requires write access to read. Worth preserving if this step is ever edited. Note this isn't secrecy for its own sake — `.github/` is public and zizmor is open source, so anyone can already run it against us; it just avoids handing over a pre-baked report.
- **The SARIF upload is skipped for fork PRs**, whose token is read-only and can't write security events. Those workflows are still scanned on push to main.
- **`pull_request` is intentionally unfiltered by branch.** `security-scan.yml`'s own trigger was `branches: [main]`, but `run-on-pr.yml` fired on all PRs — leaving the filter in place would have quietly narrowed coverage.
- The new `upload-sarif` line copies the existing pin from the Grype job. That pin's `# v4` comment doesn't match a real tag, which zizmor itself flags; left consistent with the existing line rather than fixed inline, and tracked in #6253. (Since fixed on this branch — see below.)

Generated with [Claude Code](https://claude.com/claude-code)


