### PR TITLE
Pin actions to commit SHAs and fix stale version comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Security: Restrict tools to prevent arbitrary code execution.

--- a/.github/workflows/helm-charts-test.yml
+++ b/.github/workflows/helm-charts-test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/image-build-and-publish.yml
+++ b/.github/workflows/image-build-and-publish.yml
@@ -155,7 +155,7 @@ jobs:
           go-version: 'stable'
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,7 +42,7 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -117,7 +117,7 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -172,7 +172,7 @@ jobs:
         cache: true
         
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
       with:
         version: 3.44.1
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -200,7 +200,7 @@ jobs:
         sudo systemctl restart docker
 
     - name: Create KIND Cluster
-      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # pin@v1.12.0
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         cluster_name: toolhive
         version: v0.31.0 # kind

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Generate release notes with Claude
         id: claude
-        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         env:
           # gh CLI used by the skill (read-only PR/issue lookups) authenticates
           # via GH_TOKEN. Read access is sufficient — publishing happens in a

--- a/.github/workflows/test-e2e-lifecycle.yml
+++ b/.github/workflows/test-e2e-lifecycle.yml
@@ -67,13 +67,13 @@ jobs:
         cache: true
 
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
       with:
         version: 3.44.1
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create KIND Cluster with port mappings
-      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # pin@v1.12.0
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         cluster_name: toolhive
         version: v0.31.0 # kind

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-gen.yml
+++ b/.github/workflows/verify-gen.yml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-go-codegen-tools-${{ steps.setup-go.outputs.go-version }}-
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.44.1
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- **`arduino/setup-task@v2` is a branch, not a tag.** Eleven references across six workflows point at it, so whatever that branch happens to be at run time is what executes in CI. It currently resolves to `b91d5d2c96a56797b48ac1e0e89220bf64044611` — which is already the pin used in `e2e-tests.yml` — so pinning the rest to that SHA **changes nothing today** while removing the mutable-ref exposure and making the repo internally consistent.
- **Four pins had a version comment that named a different version than the commit.** The pin is what actually executes, so this is an audit and review problem rather than a functional one — but a wrong comment is worse than no comment, because reviewers trust it when deciding whether a bump is safe. Every corrected value is copied from an existing pin of the *identical SHA* elsewhere in this repo, so nothing here is a guess.

| File | Was | Now | Taken from |
|---|---|---|---|
| `claude.yml` | `# v1` | `# v1.0.183` | `issue-triage.yml` |
| `release-notes.yml` | `# v1` | `# v1.0.183` | `issue-triage.yml` |
| `operator-ci.yml` | `# pin@v1.12.0` | `# v1.14.0` | `helm-charts-test.yml` |
| `test-e2e-lifecycle.yml` | `# pin@v1.12.0` | `# v1.14.0` | `helm-charts-test.yml` |

No action is upgraded or downgraded by this PR — every SHA that was already pinned stays exactly as it was.

Part of #6253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): CI configuration

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- Confirmed via the GitHub API that `arduino/setup-task` has **no** `v2` tag — `refs/heads/v2` is a branch, currently at `b91d5d2c`, matching the pin already in `e2e-tests.yml`.
- Confirmed each corrected comment against an existing unflagged pin of the same SHA in this repo.
- `actionlint` reports nothing new; all workflows still parse as YAML.
- `zizmor` `unpinned-uses` goes 11 → 0 and `ref-version-mismatch` 5 → 1, the remainder being the `upload-sarif` pin fixed separately in #6251.
- Every touched workflow runs on pull requests, so this PR exercises all of them directly.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

The six `operator-ci.yml` changes are the same one-line edit repeated per job.

Generated with [Claude Code](https://claude.com/claude-code)