### PR TITLE
Stop persisting git credentials in CI workflow checkouts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-8cores-32gb
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -92,6 +94,8 @@ jobs:
             artifact: e2e-test-results-llm
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -202,6 +206,8 @@ jobs:
         target: [proxy, vmcp]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/helm-charts-test.yml
+++ b/.github/workflows/helm-charts-test.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-8cores-32gb
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-8cores-32gb
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -34,6 +36,8 @@ jobs:
     runs-on: ubuntu-8cores-32gb
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -55,6 +59,8 @@ jobs:
     runs-on: ubuntu-8cores-32gb
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -76,6 +82,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -109,6 +117,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -158,6 +168,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      with:
+        persist-credentials: false
       
     - name: Set up Helm
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/renovate-config-validation.yml
+++ b/.github/workflows/renovate-config-validation.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Verify configuration syntax
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Run Grype vulnerability scanner
         id: grype-scan
@@ -87,6 +89,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Run govulncheck
         uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - name: Codespell
         uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
         with:

--- a/.github/workflows/test-e2e-lifecycle.yml
+++ b/.github/workflows/test-e2e-lifecycle.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      with:
+        persist-credentials: false
 
     - name: Disable containerd image store
       # Workaround for https://github.com/kubernetes-sigs/kind/issues/3795

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/.github/workflows/verify-docgen.yml
+++ b/.github/workflows/verify-docgen.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: 'stable'

--- a/.github/workflows/verify-gen.yml
+++ b/.github/workflows/verify-gen.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         id: setup-go
         with:


### PR DESCRIPTION
> **Stacked on #6254.** Review that one first; this PR targets it as its base, so the diff shown here is only the checkout change. Rebase onto `main` once #6254 merges.

## Summary

- **`actions/checkout` stores the job token in `.git/config` and leaves it there.** Every subsequent step in the job — and every tool those steps invoke, including build scripts and test suites pulling in third-party code — can read it. `persist-credentials: false` scopes the credential to the checkout itself.
- **None of these jobs push.** They lint, generate, test, and run `git diff`/`git status`/`git ls-tree`, all of which are local operations that need no credential. This is 20 checkouts across 12 CI workflows.

`artipacked` goes 37 → 17. The 17 that remain are excluded deliberately, not missed:

| Excluded | Count | Why |
|---|---:|---|
| `create-release-pr`, `create-release-tag`, `helm-publish`, `releaser` | 7 | Release-only — no PR can exercise them, and a failure lands mid-release |
| `image-build-and-publish`, `skills-build-and-publish` | 6 | Publish path; same caution |
| `claude.yml`, `issue-triage.yml`, `release-notes.yml` | 3 | Run `claude-code-action`, which has broad shell access and may legitimately need to push |
| `api-compat.yml` | 1 | Does `git fetch origin refs/tags/...`, **and** is the repo's only required status check — breaking it blocks every PR |

`security-scan.yml`'s two checkouts (Grype and govulncheck) were initially held back because #6251 also edits that file, but a trial merge of the two branches is clean, so they are included here. Note #6251 does **not** fix them — it adds a third checkout that is already clean.

Part of #6253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): CI configuration

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- Audited every touched workflow for operations that need the credential: `git push`, `git commit`, PR-creating actions, and submodules. The only `git push` in the repo is in `create-release-tag.yml`, which is excluded; there are no submodules anywhere.
- All workflows still parse as YAML, including the two distinct checkout forms (bare `- uses:` and `- name:` + `uses:` with an existing `with:` block such as `fetch-depth: 0`).
- `actionlint` output is byte-identical before and after apart from line-number shifts — 12 findings both ways, all pre-existing.
- `zizmor` `artipacked` 37 → 17, with the remainder matching the exclusion table above exactly.
- Trial-merged this branch with #6251's to confirm the overlapping `security-scan.yml` edits do not conflict.
- **Every one of the 12 workflows runs on pull requests**, either directly or via `run-on-pr.yml`, so this PR exercises all of them. If a credential were actually needed somewhere, it fails here rather than after merge.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **This touches 12 files, above the usual 10-file guideline.** It's the same one-line addition in each, and splitting a uniform sweep into arbitrary file groups makes it harder to review, not easier — happy to split if you'd rather.
- The six `operator-ci.yml` changes are the same edit repeated per job.
- Worth a sanity check on `helm-charts-test.yml`: its checkout already had a `with: fetch-depth: 0`, so the new key is appended to the existing block rather than introducing a new one.

Generated with [Claude Code](https://claude.com/claude-code)

