### PR TITLE
Derive PR number from the triggering run in the size labeler

### DIFF
--- a/.github/workflows/pr-size-label-apply.yml
+++ b/.github/workflows/pr-size-label-apply.yml
@@ -23,19 +23,56 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Read PR number and size label
-        id: read
-        run: |
-          PR_NUMBER=$(cat pr-size/pr-number.txt)
-          SIZE_LABEL=$(cat pr-size/label.txt | tr -d '"')
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "size_label=$SIZE_LABEL" >> $GITHUB_OUTPUT
-          echo "PR #$PR_NUMBER should get label: $SIZE_LABEL"
+      # The artifact is produced by a `pull_request` workflow, so its contents
+      # come from the pull request author — including authors from forks. This
+      # job runs in the base repository with `pull-requests: write`, so the
+      # artifact is treated as untrusted input: the label must be one we
+      # recognise, and the pull request number is derived from this job's own
+      # trigger event rather than read from the artifact.
+      - name: Resolve pull request and validate label
+        id: resolve
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const fs = require('fs');
+            const run = context.payload.workflow_run;
+
+            const ALLOWED = ['size/XS', 'size/S', 'size/M', 'size/L', 'size/XL'];
+            const label = fs.readFileSync('pr-size/label.txt', 'utf8').trim().replace(/^"|"$/g, '');
+            if (!ALLOWED.includes(label)) {
+              core.setFailed(`Refusing to apply unrecognised label ${JSON.stringify(label)}`);
+              return;
+            }
+
+            // workflow_run.pull_requests is empty for pull requests from forks,
+            // and frequently empty for same-repository ones too, so treat it as
+            // a fast path and fall back to looking the head commit up.
+            let number = run.pull_requests?.[0]?.number;
+            if (!number) {
+              const { data: associated } =
+                await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: run.head_sha,
+                });
+              const open = associated.filter((pr) => pr.state === 'open');
+              if (open.length !== 1) {
+                core.setFailed(
+                  `Expected exactly one open pull request for ${run.head_sha}, found ${open.length}`
+                );
+                return;
+              }
+              number = open[0].number;
+            }
+
+            console.log(`PR #${number} should get label: ${label}`);
+            core.setOutput('pr_number', String(number));
+            core.setOutput('size_label', label);
 
       - name: Remove old size labels
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          PR_NUMBER: ${{ steps.read.outputs.pr_number }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
         with:
           script: |
             const prNumber = parseInt(process.env.PR_NUMBER);
@@ -62,8 +99,8 @@ jobs:
       - name: Add new size label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          PR_NUMBER: ${{ steps.read.outputs.pr_number }}
-          SIZE_LABEL: ${{ steps.read.outputs.size_label }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+          SIZE_LABEL: ${{ steps.resolve.outputs.size_label }}
         with:
           script: |
             const prNumber = parseInt(process.env.PR_NUMBER);

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -62,11 +62,17 @@ jobs:
             console.log(`PR size: ${total} lines -> ${sizeLabel}`);
             return sizeLabel;
 
+      # Only the label goes in the artifact. The PR number is derived by the
+      # consumer from its own trigger event: this workflow runs on
+      # `pull_request`, so a pull request from a fork supplies the definition
+      # that produces these files, and nothing in them can be trusted to say
+      # which pull request to act on.
       - name: Save size label to artifact
+        env:
+          SIZE_LABEL: ${{ steps.size.outputs.result }}
         run: |
           mkdir -p pr-size
-          echo "${{ steps.size.outputs.result }}" > pr-size/label.txt
-          echo "${{ github.event.pull_request.number }}" > pr-size/pr-number.txt
+          echo "$SIZE_LABEL" > pr-size/label.txt
 
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -62,17 +62,24 @@ jobs:
             console.log(`PR size: ${total} lines -> ${sizeLabel}`);
             return sizeLabel;
 
-      # Only the label goes in the artifact. The PR number is derived by the
-      # consumer from its own trigger event: this workflow runs on
-      # `pull_request`, so a pull request from a fork supplies the definition
-      # that produces these files, and nothing in them can be trusted to say
-      # which pull request to act on.
+      # This workflow runs on `pull_request`, so a pull request — including one
+      # from a fork — supplies the definition that produces these files.
+      # Nothing in them can be trusted to say which pull request to act on, so
+      # the consumer derives the number from its own trigger event instead.
+      #
+      # pr-number.txt is still written even though the new consumer ignores it.
+      # `workflow_run` consumers always execute the copy on the default branch,
+      # so until this change merges the consumer reading it is the old one, and
+      # dropping the file here would break labelling for every open pull
+      # request. Removing the write is a follow-up once this has landed.
       - name: Save size label to artifact
         env:
           SIZE_LABEL: ${{ steps.size.outputs.result }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           mkdir -p pr-size
           echo "$SIZE_LABEL" > pr-size/label.txt
+          echo "$PR_NUMBER" > pr-size/pr-number.txt
 
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6


### PR DESCRIPTION
> **Stacked on #6259's base is now `main`** — #6258 has merged.

## Summary

- **The size labeler passed its target across a trust boundary in an artifact.** `pr-size-labeler.yml` runs on `pull_request`, which means the pull request supplies the workflow definition that produces the artifact. `pr-size-label-apply.yml` then consumed it on `workflow_run` — in the base repository, with `pull-requests: write` — and took **both** the pull request number and the label name from it verbatim, with no validation.
- **The number is now derived from the consumer's own trigger event**, and the label is checked against the five known `size/*` values. The artifact still carries a pull request number, but nothing reads it — see the rollout note below.

This is the standard `workflow_run` artifact-trust pattern: the producing workflow is attacker-influenced, the consuming workflow is privileged, and anything crossing between them is untrusted input.

## Why `workflow_run.pull_requests` isn't enough on its own

The obvious fix is `github.event.workflow_run.pull_requests[0].number`. That field is empty for pull requests from forks — which is the case that matters — so a naive swap would silently stop labelling exactly those pull requests.

Measured over the last 30 runs of this workflow:

| Head repository | Runs | `pull_requests` populated |
|---|---:|---:|
| forks | 9 | **0** |
| `stacklok/toolhive` | 21 | 6 |

So it's unreliable in general, not just for forks. It's kept as a fast path with a `listPullRequestsAssociatedWithCommit` lookup on `head_sha` behind it, and the job fails rather than guessing if that doesn't resolve to exactly one open pull request.

## Why the artifact still carries a PR number

`workflow_run` consumers **always execute the copy of the workflow on the default branch**, never the version in the pull request. So a pull request can change the producer — which does run from the pull request head — but cannot change the consumer reading its output until it merges.

Removing `pr-number.txt` here in the same change therefore broke the apply job for every open pull request: the producer stopped writing the file while the consumer still on `main` was reading it. This is a two-phase rollout instead:

1. **This PR** — land the consumer change. The producer keeps writing `pr-number.txt`, bound through `env:` so it is not interpolated into the shell, and the new consumer ignores it.
2. **Follow-up** — once this is on `main`, drop the write.

## Behaviour

No change for a normal pull request, fork or not — the same label lands on the same pull request. The differences are that an unrecognised label now fails the job instead of being applied, and the target is no longer something the artifact can influence.

Part of #6253

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- Queried the last 30 runs of `pr-size-labeler.yml` through the API to confirm the `pull_requests` behaviour above, rather than relying on the documented behaviour.
- Checked all three embedded `github-script` bodies with `node --check`.
- Both workflows parse as YAML; `actionlint` reports 12 findings before and after, all pre-existing.
- `zizmor` `template-injection` on `pr-size-labeler.yml` goes 1 → 0, as a side effect of no longer interpolating the label into the shell.
- This pull request exercises both workflows directly. The first push dropped `pr-number.txt` and the apply job failed for exactly the reason above; the current revision keeps it and the job passes.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- Worth confirming the label that lands on this pull request is correct, since that is the end-to-end test.
- `listPullRequestsAssociatedWithCommit` resolves fork pull requests because the head commit is reachable in the base repository via `refs/pull/N/head`. If it ever returns more or fewer than one open pull request the job fails loudly rather than labelling something arbitrary.
- The `size/*` allow-list is duplicated between the resolve step and the existing "Remove old size labels" step. Left as-is to keep the diff focused; worth hoisting if this file grows.

Generated with [Claude Code](https://claude.com/claude-code)
