### PR TITLE
Gate the Claude workflow on write access, not contribution history

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,27 +13,36 @@ on:
 jobs:
   claude:
     name: Claude Code Action
-    # Security: Only allow invocation by trusted contributors.
-    # Blocks NONE (anonymous), FIRST_TIMER, and FIRST_TIME_CONTRIBUTOR to
-    # prevent prompt-injection attacks from untrusted GitHub users.
+    # Security: only allow invocation by trusted contributors.
+    #
+    # This is an allow-list rather than a deny-list. Denying NONE, FIRST_TIMER
+    # and FIRST_TIME_CONTRIBUTOR still admitted CONTRIBUTOR — which anyone
+    # earns permanently by getting a single pull request merged — and
+    # MANNEQUIN. This job holds contents: write and ANTHROPIC_API_KEY and
+    # allows Bash(git *), so the bar needs to be write access to the
+    # repository, not a history of contributing to it.
+    #
+    # Same pattern as the /retest gate in retest.yaml.
     # See: https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
-       github.event.comment.author_association != 'NONE' &&
-       github.event.comment.author_association != 'FIRST_TIMER' &&
-       github.event.comment.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
-       github.event.comment.author_association != 'NONE' &&
-       github.event.comment.author_association != 'FIRST_TIMER' &&
-       github.event.comment.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
-       github.event.review.author_association != 'NONE' &&
-       github.event.review.author_association != 'FIRST_TIMER' &&
-       github.event.review.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude') &&
-       github.event.issue.author_association != 'NONE' &&
-       github.event.issue.author_association != 'FIRST_TIMER' &&
-       github.event.issue.author_association != 'FIRST_TIME_CONTRIBUTOR')
+    if: >-
+      ${{
+        (github.event_name == 'issue_comment'
+          && contains(github.event.comment.body, '@claude')
+          && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                      github.event.comment.author_association))
+        || (github.event_name == 'pull_request_review_comment'
+          && contains(github.event.comment.body, '@claude')
+          && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                      github.event.comment.author_association))
+        || (github.event_name == 'pull_request_review'
+          && contains(github.event.review.body, '@claude')
+          && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                      github.event.review.author_association))
+        || (github.event_name == 'issues'
+          && contains(github.event.issue.body, '@claude')
+          && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                      github.event.issue.author_association))
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Least-privilege permissions for the AI agent workflow.


### PR DESCRIPTION
> **Stacked on #6259**, which is stacked on #6258. Merge in order, or rebase once those land.

## Summary

- **The trigger used a deny-list, and the gap was `CONTRIBUTOR`.** It denied `NONE`, `FIRST_TIMER` and `FIRST_TIME_CONTRIBUTOR` — but `CONTRIBUTOR` is earned *permanently* by getting a single pull request merged, and it admitted `MANNEQUIN` as well. Any outside account that has landed one change could invoke the job from then on.
- **The job it guards is not a low-privilege one.** It holds `contents: write` and `ANTHROPIC_API_KEY`, and allows `Bash(git *)`, driven by the text of an issue or comment. The right bar is write access to the repository, not a history of contributing to it.
- **Replaced with the `OWNER`/`MEMBER`/`COLLABORATOR` allow-list** already used by the `/retest` gate in `retest.yaml`, so there is now one idiom for "trusted enough to trigger privileged automation" rather than two.

| | Allowed |
|---|---|
| Before | `OWNER`, `MEMBER`, `COLLABORATOR`, **`CONTRIBUTOR`**, **`MANNEQUIN`** |
| After | `OWNER`, `MEMBER`, `COLLABORATOR` |

An allow-list is also the more durable shape: GitHub can add association values, and a deny-list silently admits anything new.

Part of #6253

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- Enumerated every value of `CommentAuthorAssociation` against both the old and new conditions to confirm exactly which lose access: `CONTRIBUTOR` and `MANNEQUIN`, and nothing else.
- All four event branches (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`) keep their existing `@claude` body check and their existing association source — only the association test changed.
- `actionlint` is clean on the file and the workflow parses.

## Does this introduce a user-facing change?

Yes, for maintainers: **`@claude` no longer responds to people without write access to the repository.** Anyone who is `OWNER`, `MEMBER` or `COLLABORATOR` is unaffected. If an outside contributor should keep access, the fix is to add them as a repository collaborator rather than to widen this condition.

## Special notes for reviewers

- Worth confirming nobody currently relies on `@claude` as a non-collaborator — that is the one behavioural risk here, and it fails closed (the job simply does not run) rather than erroring.
- The checkout in this workflow still persists its credentials, unlike the ones cleaned up in #6255 and #6258. That is deliberate: this job has `contents: write` specifically so Claude can push commits to pull requests, so the credential is in use. Left alone.

Generated with [Claude Code](https://claude.com/claude-code)