### PR TITLE
Stop writing the PR number into the size label artifact

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -65,21 +65,14 @@ jobs:
       # This workflow runs on `pull_request`, so a pull request — including one
       # from a fork — supplies the definition that produces these files.
       # Nothing in them can be trusted to say which pull request to act on, so
-      # the consumer derives the number from its own trigger event instead.
-      #
-      # pr-number.txt is still written even though the new consumer ignores it.
-      # `workflow_run` consumers always execute the copy on the default branch,
-      # so until this change merges the consumer reading it is the old one, and
-      # dropping the file here would break labelling for every open pull
-      # request. Removing the write is a follow-up once this has landed.
+      # the consumer derives the number from its own trigger event instead, so
+      # the label is the only thing that needs to cross the boundary.
       - name: Save size label to artifact
         env:
           SIZE_LABEL: ${{ steps.size.outputs.result }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           mkdir -p pr-size
           echo "$SIZE_LABEL" > pr-size/label.txt
-          echo "$PR_NUMBER" > pr-size/pr-number.txt
 
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6


### PR DESCRIPTION
> **#6259 and #6260 have merged**, so this is now a single commit against `main` and the blocker below no longer applies.

## Summary

- **Nothing reads `pr-number.txt` any more.** #6259 changed the apply workflow to derive the pull request number from its own `workflow_run` event instead of from the artifact, because the artifact is produced by a `pull_request` workflow and is therefore attacker-influenced. This removes the now-unused write.
- **It could not be done in #6259 itself.** `workflow_run` consumers always execute the copy of the workflow on the **default branch**, never the version in the pull request. A pull request can change the producer — which does run from the pull request head — but cannot change the consumer reading its output until it merges. Dropping the write alongside the consumer change failed the apply job on every open pull request, because the producer stopped writing the file while `main`'s consumer was still reading it.

So this is phase two of a two-phase rollout:

| Phase | Change | Effect |
|---|---|---|
| #6259 | Consumer stops reading `pr-number.txt`; producer keeps writing it | Old consumer on `main` still works throughout |
| **This PR** | Producer stops writing it | Safe once the new consumer is on `main` |

## CI state

#6259 is on `main`, so the consumer running against this pull request is the new one that ignores `pr-number.txt`. The apply job passes here — the ordering hazard described above is resolved, not merely tolerated.

Part of #6253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- `grep -rn "pr-number.txt" .github/` returns nothing across the whole directory, so producer and consumer agree.
- The workflow parses as YAML and `actionlint` is clean on it.
- The end-to-end behaviour was already proven on #6259: after the fix, its apply runs succeeded and both #6259 and #6260 received `size/XS` through the new resolve-from-event path.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- The artifact now carries a single file whose only permitted values are the five `size/*` labels, checked by the consumer. There is nothing left in it that can influence which pull request is acted on.

Generated with [Claude Code](https://claude.com/claude-code)
