### PR TITLE
Suppress four zizmor findings that cannot be fixed

### DIFF
--- a/.github/workflows/api-compat.yml
+++ b/.github/workflows/api-compat.yml
@@ -49,8 +49,15 @@ jobs:
     # bound that protects against a hung go install or git fetch.
     timeout-minutes: 10
     steps:
+      # Left persisting credentials deliberately. This job cannot push — it has
+      # contents: read — so the exposure is limited, and it runs
+      # `git fetch origin refs/tags/...` below. That fetch succeeds
+      # unauthenticated only because this repository is public; dropping the
+      # credential would make it depend on that staying true. This job is also
+      # the repository's only required status check, so breaking it blocks
+      # every pull request. Not worth it to clear one low-severity finding.
       - name: Checkout PR HEAD
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6   # zizmor: ignore[artipacked]
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,8 +54,13 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      # Unlike every other checkout in this repository, this one keeps its
+      # credentials on purpose. The job holds contents: write precisely so
+      # Claude can push commits to a pull request, and that push uses the
+      # credential actions/checkout leaves in .git/config. Setting
+      # persist-credentials: false here would break the action.
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6   # zizmor: ignore[artipacked]
         with:
           fetch-depth: 1
 

--- a/.github/workflows/pr-size-label-apply.yml
+++ b/.github/workflows/pr-size-label-apply.yml
@@ -1,7 +1,17 @@
 name: PR Size Labeler - Apply
 
 on:
-  workflow_run:
+  # The `workflow_run` trigger is what makes this workflow privileged, and it
+  # cannot be removed — applying a label needs write access that the calculate
+  # workflow, running on `pull_request`, deliberately does not have.
+  #
+  # What made that dangerous was trusting the artifact: the pull request number
+  # and the label were both read out of it, and the artifact is produced by a
+  # workflow the pull request author controls, forks included. Neither is now.
+  # The number is derived from this workflow's own event and the label must
+  # match a fixed list of five values, so nothing crossing the boundary can
+  # decide which pull request is acted on or what is applied to it.
+  workflow_run:   # zizmor: ignore[dangerous-triggers]
     workflows: ["PR Size Labeler - Calculate"]
     types: [completed]
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -24,7 +24,14 @@
 name: Generate Release Notes
 
 on:
-  workflow_run:
+  # `workflow_run` is required here, not incidental: claude-code-action rejects
+  # the `release` event outright (see the note above), and this needs to run
+  # after the tag workflow completes.
+  #
+  # The risk this audit flags is a privileged workflow checking out an
+  # event-supplied ref. This one deliberately does not — it checks out the
+  # default branch, for the reasons set out on the checkout step below.
+  workflow_run:   # zizmor: ignore[dangerous-triggers]
     workflows: ["Create Release Tag"]
     types: [completed]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- **Four findings will never be cleared by a code change**, so they would block a gate forever. Two flag a trigger that cannot be dropped; two flag credentials that are deliberately kept. Suppressing them is the only way the gate can ever be turned on honestly.
- **Each suppression carries its reasoning inline**, next to the code. A future sweep will see why the line was left alone; nobody reads the tracking issue before editing a workflow.

This changes no behaviour whatsoever — the diff is comments only.

| File | Rule | Why it can't be fixed |
|---|---|---|
| `pr-size-label-apply.yml` | `dangerous-triggers` | Applying a label needs write access the calculating workflow deliberately lacks, so `workflow_run` is required. What made it dangerous — reading the target pull request number and the label out of an artifact a pull request author controls — was fixed in #6259; neither is read from the artifact now. |
| `release-notes.yml` | `dangerous-triggers` | `claude-code-action` rejects the `release` event outright, so `workflow_run` is the only option. The risk this audit describes is a privileged workflow checking out an event-supplied ref; this one deliberately checks out the default branch, with the reasoning already documented on the step. |
| `claude.yml` | `artipacked` | The job holds `contents: write` **specifically** so Claude can push commits to a pull request, and that push uses the credential `actions/checkout` leaves behind. `persist-credentials: false` would break the action. |
| `api-compat.yml` | `artipacked` | Cannot push (`contents: read`), so exposure is limited, and it runs `git fetch origin refs/tags/...` — which succeeds unauthenticated only because this repository is public. It is also the repository's **only required status check**, so breaking it blocks every pull request. Not worth it for one low-severity finding. |

## Effect

| | High | Medium | Low | Info | Total |
|---|---:|---:|---:|---:|---:|
| Before | 10 | 4 | 9 | 24 | 47 |
| After | **8** | 4 | **7** | 24 | **43** |

More useful than the count: **all 8 remaining High findings are now in the four release workflows** — `releaser.yml` (4), `helm-publish.yml` (2), `create-release-pr.yml` (1), `create-release-tag.yml` (1). Nothing High is left anywhere else, so what stands between here and a `--min-severity=high` gate is now a single, clearly bounded decision.

Part of #6253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): CI configuration — comments only

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- Verified the suppression syntax on throwaway copies before writing it into the workflows: each file went from reporting its finding to reporting none.
- Confirmed the comment placement, which is **not** where the finding is reported. `dangerous-triggers` is reported against `on:` but is only suppressed by a comment on the `workflow_run:` line beneath it.
- All workflows parse as YAML; `actionlint` reports 12 findings before and after, all pre-existing.
- Confirmed the counts above and that the 8 survivors are the release-workflow findings.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **The two `artipacked` suppressions are not strictly required** for a `--min-severity=high` gate, since they are Low. They are here because the reasoning is worth recording where it will actually be read — particularly `claude.yml`, where the obvious "fix" breaks the action.
- Worth scrutinising the two `dangerous-triggers` justifications specifically. A suppression is only as good as its argument, and if either reads as hand-waving it should be challenged rather than merged.

Generated with [Claude Code](https://claude.com/claude-code)