### PR TITLE
Scope releaser permissions and bind the tag expression

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -25,14 +25,19 @@ on:
   release:
     types: [published]
 
+# Read-only by default. The jobs that need to write — release-binaries and the
+# reusable workflows this calls — already declare their own permissions, which
+# replace this rather than extend it, so they are unaffected.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
 
   verify-release:
     name: Verify Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -67,6 +72,8 @@ jobs:
   compute-build-flags:
     name: Compute Build Flags
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
     outputs:
       commit-date: ${{ steps.ldflags.outputs.commit-date }}
       commit: ${{ steps.ldflags.outputs.commit }}
@@ -176,11 +183,15 @@ jobs:
       - name: Remove existing release assets (allows re-runs)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Bound to the environment rather than interpolated: a git ref name
+          # may contain ';', '$', backticks and '|', and this is a command
+          # substitution.
+          TAG: ${{ github.ref_name }}
         run: |
           # Delete existing assets so GoReleaser can re-upload when re-running a failed job
           set +e
-          for name in $(gh release view "${{ github.ref_name }}" --json assets --jq '.assets[].name' 2>/dev/null); do
-            gh release delete-asset "${{ github.ref_name }}" "$name" -y 2>/dev/null || true
+          for name in $(gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null); do
+            gh release delete-asset "$TAG" "$name" -y 2>/dev/null || true
           done
           set -e
 


### PR DESCRIPTION
First of the release-workflow changes tracked in #6253. Deliberately the smallest and most contained one, because **nothing here can be exercised by a pull request** — `releaser.yml` runs only on `release: published`.

## Summary

- **The workflow handed `contents: write` to jobs that only read.** It was declared at workflow level, so every job that did not declare its own inherited it — `verify-release` and `compute-build-flags`, both of which just check out and read git locally. The default is now `contents: read` and those two declare it explicitly, so nothing inherits.
- **A tag name was interpolated into a command substitution.** `gh release view "${{ github.ref_name }}"` inside `$( )`. Git ref names may contain `;`, `$`, backticks and `|` — unlike, say, a repository name — so this one is a real sink rather than a stylistic nit. It is still gated behind repo write access, since creating a release requires it.

## Why the permission change is safe

A job-level `permissions:` block **replaces** the workflow default rather than extending it, so the jobs that write were never relying on the workflow-level grant:

| Job | Permissions | Effect |
|---|---|---|
| `verify-release` | inherited → now explicit `contents: read` | only reads |
| `compute-build-flags` | inherited → now explicit `contents: read` | only reads |
| `release-binaries` | declares `contents: write`, `id-token: write` | unchanged |
| `image-build-and-push` | declares its own | unchanged |
| `skills-build-and-push` | declares its own | unchanged |
| `publish-helm` | declares its own | unchanged |
| `notify-release-failure` | declares `{}` | unchanged |

Every job in the file now states its own permissions, so this cannot drift back by someone adding a job that quietly inherits write.

## Effect

`releaser.yml` goes from 4 High findings to 1; repo-wide High goes **10 → 7**. The remaining one is `github-app` — the Homebrew tap token inheriting blanket installation permissions — which is deliberately left for a later change, because scoping app tokens is the part most likely to break a release and wants the App's actual installation permissions checked first.

Part of #6253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): CI configuration

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- Enumerated every job in the file and confirmed which inherited the workflow-level permission, rather than assuming — only the two read-only jobs did.
- Asserted programmatically that no job inherits any more.
- Workflow parses as YAML; `actionlint` reports nothing new.
- `zizmor` on this file: `excessive-permissions` 1 → 0 and `template-injection` 2 → 0.

**This cannot be verified before merge.** `releaser.yml` runs only on `release: published`, so the first real exercise is the next release. That is why this change is limited to a permissions default and a quoting fix, and why the app-token work is not in it.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **Best merged just after a release rather than just before**, to maximise the window for noticing anything wrong.
- The `--json assets` cleanup step is a re-run convenience; if the quoting change were wrong it would fail that step rather than corrupt a release, which is part of why it was chosen to go first.
- **Unrelated pre-existing bug spotted while here, not fixed:** line 354 references `needs.extract-release-actor.outputs.triggered_by`, but no `extract-release-actor` job exists in this workflow. The expression resolves to null and falls through to `|| github.actor`, so the failure-notification "Triggered by" line silently never shows the preserved release triggerer that `create-release-tag.yml` goes to the trouble of extracting. Worth its own issue; changing it here would mean altering release behaviour in a pull request that cannot test it.

Generated with [Claude Code](https://claude.com/claude-code)