### PR TITLE
Deflake the initialize dial-error proxy test

### DIFF
--- a/pkg/transport/proxy/transparent/backend_routing_test.go
+++ b/pkg/transport/proxy/transparent/backend_routing_test.go
@@ -820,9 +820,17 @@ func TestRoundTripDoesNotReplayInitializeOnDialError(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Mcp-Session-Id", clientSessionID)
 
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	_ = resp.Body.Close()
+	// A dedicated client, not http.DefaultClient: the shared transport pools
+	// keep-alive connections across the package's parallel tests, and reusing
+	// one whose proxy has since been closed surfaces here as a transport error.
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	resp, err := client.Do(req)
+	// Either outcome is legitimate for a dial failure -- the reverse proxy may
+	// synthesize a 502, or the connection may fail outright. Neither is what
+	// this test is about; the assertions below are.
+	if err == nil {
+		_ = resp.Body.Close()
+	}
 
 	assert.Zero(t, targetHits.Load(),
 		"the proxy must not send its own initialize to the target service for an initialize dial error")


### PR DESCRIPTION
## Summary

`TestRoundTripDoesNotReplayInitializeOnDialError` fails intermittently in a full-suite run with `Received unexpected error` on the HTTP call, while passing every time in isolation (6/6 plain, 4/4 with `-race`).

It used `http.DefaultClient`, whose shared transport pools keep-alive connections across this package's parallel tests. Reusing one whose proxy has since been closed surfaces as a transport error before the request is even made.

- Use a dedicated client with `DisableKeepAlives`.
- Stop requiring `NoError` on the request itself. For a dial failure either outcome is legitimate — the reverse proxy may synthesize a 502, or the connection may fail outright — so that assertion pinned an incidental detail rather than the behaviour under test.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Package green with `-race`, and the test still fails when the production guard it covers is removed:

```
--- FAIL: TestRoundTripDoesNotReplayInitializeOnDialError
    the proxy must not send its own initialize to the target service for an initialize dial error
```

So the relaxed HTTP assertion did not weaken what the test actually guards.

## Does this introduce a user-facing change?

No. Test-only.

## Special notes for reviewers

Mine from #6152, surfaced in a full-suite run rather than CI. Other tests in this file use `http.DefaultClient` too and are presumably exposed to the same reuse hazard; I have left them alone rather than widen this beyond the test that actually failed.

Generated with [Claude Code](https://claude.com/claude-code)