### PR TITLE
fix(telemetry): bound mcp method metric label cardinality

### DIFF
--- a/pkg/telemetry/method_allowlist.go
+++ b/pkg/telemetry/method_allowlist.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import "github.com/stacklok/toolhive-core/mcpcompat/mcp"
+
+const (
+	// methodLabelUnknown marks a request whose MCP method could not be parsed.
+	// A GET (SSE stream open) or DELETE (session end) carries no JSON-RPC body,
+	// so it has no method to record.
+	methodLabelUnknown = "unknown"
+
+	// methodLabelOther marks a parsed method outside the known set. It keeps the
+	// signal that an unregistered method was attempted. It drops the value.
+	methodLabelOther = "other"
+)
+
+// knownMCPMethods is the bounded set of MCP method names recorded verbatim as a
+// metric label value. A method outside this set collapses to methodLabelOther.
+//
+// The JSON-RPC method field comes from the raw request body before validation.
+// An unauthenticated caller controls it. A label built from that field grows the
+// metric registry without limit as new values arrive (CWE-770, CWE-400). The
+// allowlist bounds the label cardinality regardless of input.
+//
+// The set covers the MCP specification method names, both requests and
+// notifications. Keep it in sync with the MCP spec when methods are added.
+var knownMCPMethods = func() map[string]struct{} {
+	methods := []string{
+		// Request and response methods defined as constants in toolhive-core.
+		string(mcp.MethodInitialize),
+		string(mcp.MethodPing),
+		string(mcp.MethodResourcesList),
+		string(mcp.MethodResourcesTemplatesList),
+		string(mcp.MethodResourcesRead),
+		string(mcp.MethodPromptsList),
+		string(mcp.MethodPromptsGet),
+		string(mcp.MethodToolsList),
+		string(mcp.MethodToolsCall),
+		string(mcp.MethodSetLogLevel),
+		string(mcp.MethodElicitationCreate),
+		string(mcp.MethodComplete),
+		string(mcp.MethodListRoots),
+		string(mcp.MethodNotificationInitialized),
+
+		// Spec methods not yet defined as constants in toolhive-core. Keep as
+		// literals until the upstream constants exist.
+		"resources/subscribe",
+		"resources/unsubscribe",
+		"sampling/createMessage",
+		"notifications/cancelled",
+		"notifications/progress",
+		"notifications/message",
+		"notifications/resources/updated",
+		"notifications/resources/list_changed",
+		"notifications/tools/list_changed",
+		"notifications/prompts/list_changed",
+		"notifications/roots/list_changed",
+	}
+	set := make(map[string]struct{}, len(methods))
+	for _, method := range methods {
+		set[method] = struct{}{}
+	}
+	return set
+}()
+
+// sanitizeMCPMethod maps a parsed MCP method to a bounded metric label value.
+// It returns the method verbatim when the method is in the known set. It returns
+// methodLabelUnknown for an empty or unparsed method. It returns methodLabelOther
+// for any other value. This bounds metric label cardinality.
+func sanitizeMCPMethod(method string) string {
+	if method == "" || method == methodLabelUnknown {
+		return methodLabelUnknown
+	}
+	if _, ok := knownMCPMethods[method]; ok {
+		return method
+	}
+	return methodLabelOther
+}

--- a/pkg/telemetry/method_allowlist_test.go
+++ b/pkg/telemetry/method_allowlist_test.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
+)
+
+func TestSanitizeMCPMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		want   string
+	}{
+		{"empty is unknown", "", methodLabelUnknown},
+		{"unknown stays unknown", methodLabelUnknown, methodLabelUnknown},
+
+		// Known methods pass through verbatim.
+		{"initialize", string(mcp.MethodInitialize), "initialize"},
+		{"tools/call", string(mcp.MethodToolsCall), "tools/call"},
+		{"tools/list", string(mcp.MethodToolsList), "tools/list"},
+		{"prompts/get", string(mcp.MethodPromptsGet), "prompts/get"},
+		{"resources/read", string(mcp.MethodResourcesRead), "resources/read"},
+		{"ping", string(mcp.MethodPing), "ping"},
+		{"notifications/initialized", "notifications/initialized", "notifications/initialized"},
+		{"sampling/createMessage", "sampling/createMessage", "sampling/createMessage"},
+		{"resources/subscribe", "resources/subscribe", "resources/subscribe"},
+
+		// Scanner-supplied values from the report collapse to the sentinel.
+		// None is a registered MCP method or ToolHive tool.
+		{"eth debug_traceTransaction", "debug_traceTransaction", methodLabelOther},
+		{"eth txpool_content", "txpool_content", methodLabelOther},
+		{"cms User.filter", "User.filter", methodLabelOther},
+		{"cms web.Login", "web.Login", methodLabelOther},
+
+		// Near-miss and injection-shaped inputs collapse to the sentinel.
+		{"case mismatch", "Tools/Call", methodLabelOther},
+		{"trailing space", "tools/call ", methodLabelOther},
+		{"arbitrary", "../../etc/passwd", methodLabelOther},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, sanitizeMCPMethod(tt.method))
+		})
+	}
+}
+
+// TestSanitizeMCPMethodBoundsCardinality confirms that a set of distinct
+// attacker-controlled method values maps to a single label value.
+func TestSanitizeMCPMethodBoundsCardinality(t *testing.T) {
+	t.Parallel()
+
+	attackerMethods := []string{
+		"debug_traceTransaction",
+		"txpool_content",
+		"User.filter",
+		"web.Login",
+		"eth_getBalance",
+		"admin_peers",
+	}
+
+	labels := make(map[string]struct{})
+	for _, method := range attackerMethods {
+		labels[sanitizeMCPMethod(method)] = struct{}{}
+	}
+
+	assert.Len(t, labels, 1, "distinct unknown methods must collapse to one label")
+	_, ok := labels[methodLabelOther]
+	assert.True(t, ok, "the single label must be the other sentinel")
+}

--- a/pkg/telemetry/middleware.go
+++ b/pkg/telemetry/middleware.go
@@ -689,12 +689,15 @@ func (m *HTTPMiddleware) recordMetrics(ctx context.Context, r *http.Request, rw 
 		mcpResourceID = parsedMCP.ResourceID
 	}
 
-	// Common attributes for all metrics
+	// Common attributes for all metrics.
+	// Sanitize mcp_method to a bounded set. An unauthenticated caller controls
+	// the JSON-RPC method field, so the raw value would grow the registry without
+	// limit. See sanitizeMCPMethod and knownMCPMethods.
 	attrs := metric.WithAttributes(
 		attribute.String("method", r.Method),
 		attribute.String("status_code", strconv.Itoa(rw.statusCode)),
 		attribute.String("status", status),
-		attribute.String("mcp_method", mcpMethod),
+		attribute.String("mcp_method", sanitizeMCPMethod(mcpMethod)),
 		attribute.String("mcp_resource_id", mcpResourceID),
 		attribute.String("server", m.serverName),
 		attribute.String("transport", m.transport),
@@ -740,7 +743,8 @@ func (m *HTTPMiddleware) recordOperationDuration(
 	networkTransport, protocolName, _ := mapTransport(m.transport)
 
 	specAttrs := []attribute.KeyValue{
-		attribute.String("mcp.method.name", mcpMethod),
+		// Sanitize to a bounded set. The caller controls the raw method value.
+		attribute.String("mcp.method.name", sanitizeMCPMethod(mcpMethod)),
 		attribute.String("jsonrpc.protocol.version", "2.0"),
 		attribute.String("network.transport", networkTransport),
 	}

--- a/pkg/telemetry/middleware_test.go
+++ b/pkg/telemetry/middleware_test.go
@@ -2204,6 +2204,51 @@ func TestHTTPMiddleware_OperationDuration(t *testing.T) {
 			shouldHaveData: true,
 		},
 		{
+			name: "unregistered method collapses to the other sentinel",
+			setupRequest: func(t *testing.T) (*http.Request, context.Context) {
+				t.Helper()
+				// An unauthenticated scanner controls the JSON-RPC method field.
+				// debug_traceTransaction is an Ethereum RPC method, not an MCP
+				// method. The parser leaves ResourceID empty for it.
+				mcpRequest := &mcpparser.ParsedMCPRequest{
+					Method:    "debug_traceTransaction",
+					ID:        "test-789",
+					IsRequest: true,
+				}
+				req := httptest.NewRequest("POST", "/messages", nil)
+				ctx := context.WithValue(req.Context(), mcpparser.MCPRequestContextKey, mcpRequest)
+				return req, ctx
+			},
+			verifyMetric: func(t *testing.T, rm metricdata.ResourceMetrics) {
+				t.Helper()
+				var foundMetric bool
+				for _, sm := range rm.ScopeMetrics {
+					for _, m := range sm.Metrics {
+						if m.Name == metricOperationDuration {
+							foundMetric = true
+							histData, ok := m.Data.(metricdata.Histogram[float64])
+							require.True(t, ok)
+							require.NotEmpty(t, histData.DataPoints)
+
+							dp := histData.DataPoints[0]
+							attrMap := make(map[string]interface{})
+							for _, attr := range dp.Attributes.ToSlice() {
+								attrMap[string(attr.Key)] = attr.Value.AsInterface()
+							}
+
+							// The raw method never reaches the label.
+							assert.Equal(t, "other", attrMap["mcp.method.name"])
+							assert.NotEqual(t, "debug_traceTransaction", attrMap["mcp.method.name"])
+							_, hasTool := attrMap["gen_ai.tool.name"]
+							assert.False(t, hasTool, "no tool label for a non-tools/call method")
+						}
+					}
+				}
+				assert.True(t, foundMetric, "operation duration still records, with a bounded label")
+			},
+			shouldHaveData: true,
+		},
+		{
 			name: "non-MCP request does not record operation duration",
 			setupRequest: func(t *testing.T) (*http.Request, context.Context) {
 				t.Helper()


### PR DESCRIPTION
## Summary

The telemetry middleware writes the JSON-RPC `method` field into metric label values before validation. The field is parsed from the raw request body, so an unauthenticated caller controls it. The in-process metric registry grows without limit as new values arrive (CWE-770 / CWE-400).

This is observable in production: a public docs-MCP endpoint already carries labels from internet scanners that map to no MCP method - `debug_traceTransaction`, `txpool_content`, `User.filter`, `web.Login`. Each distinct value creates 17 time series (a 15-bucket histogram plus `_sum` and `_count`).

Reported against `toolhive-doc-mcp.stacklok.com` (2026-08-08), good-faith testing.

## Change

- Add `pkg/telemetry/method_allowlist.go`: a bounded allowlist of MCP method names and a `sanitizeMCPMethod` helper.
  - Known method -> recorded verbatim.
  - Any other parsed method -> `other` sentinel (keeps the "an unregistered method was attempted" signal without recording its value).
  - Empty/unparsed method -> `unknown` (existing behavior).
- Apply the sanitizer to the two metric label sites in `middleware.go`: `mcp_method` (request counter and duration) and `mcp.method.name` (operation duration).

## What is intentionally not changed

- **Span attributes keep the raw method.** Traces are sampled and ephemeral. They do not aggregate into a registry, and the OTEL MCP semantic conventions want the real method name on the span.
- **Control flow keeps the real method.** The `tools/call` and `prompts/get` branches and the "method could not be determined" warning still switch on the parsed value. Both methods are in the allowlist, so labels stay consistent.

## Known follow-up

Tool-name labels (`gen_ai.tool.name`, `mcp_resource_id`) remain unbounded for a *valid* `tools/call` carrying an arbitrary tool name. The parser leaves `ResourceID` empty for unregistered methods, so the observed scanner traffic does not reach those labels. Bounding tool names needs the registered tool set at middleware time and is left as follow-up.

## Testing

- `pkg/telemetry/method_allowlist_test.go` - table tests for the sanitizer, including the four scanner method names from the report and a cardinality-collapse assertion.
- `pkg/telemetry/middleware_test.go` - end-to-end case: a bogus method through the middleware surfaces `mcp.method.name="other"` with no tool label leak.
- `go test ./pkg/telemetry/`, `go vet`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)