### PR TITLE
Pass only the secret the test workflow needs

### DIFF
--- a/.github/workflows/run-on-main.yml
+++ b/.github/workflows/run-on-main.yml
@@ -22,7 +22,11 @@ jobs:
   tests:
     name: Tests
     uses: ./.github/workflows/test.yml
-    secrets: inherit
+    # Named rather than inherited: this job runs the Go test suite, and so
+    # executes repository code and its dependency tree. It has no business
+    # holding the release signing keys.
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   codegen:
     name: Codegen
     uses: ./.github/workflows/verify-gen.yml
@@ -30,7 +34,6 @@ jobs:
   helm-charts:
     name: Helm Charts
     uses: ./.github/workflows/helm-charts-test.yml
-    secrets: inherit
   e2e-tests:
     name: E2E Tests
     needs: [linting, tests, codegen]

--- a/.github/workflows/run-on-pr.yml
+++ b/.github/workflows/run-on-pr.yml
@@ -23,7 +23,11 @@ jobs:
   tests:
     name: Tests
     uses: ./.github/workflows/test.yml
-    secrets: inherit
+    # Named rather than inherited: this job runs the Go test suite, and so
+    # executes repository code and its dependency tree. It has no business
+    # holding the release signing keys.
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Docs
     uses: ./.github/workflows/verify-docgen.yml
@@ -34,7 +38,6 @@ jobs:
   helm-charts:
     name: Helm Charts
     uses: ./.github/workflows/helm-charts-test.yml
-    secrets: inherit
   e2e-tests:
     name: E2E Tests
     needs: [linting, tests, docs, codegen]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,13 @@ name: Tests
 
 on:
   workflow_call:
+    secrets:
+      # Declared so callers can pass this one secret explicitly instead of
+      # `secrets: inherit`. Optional: pull requests from forks receive no
+      # secrets at all, and codecov accepts tokenless uploads for public
+      # repositories, so an empty value degrades rather than fails.
+      CODECOV_TOKEN:
+        required: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- **`secrets: inherit` handed every repository secret to the test workflows.** `run-on-pr.yml` and `run-on-main.yml` called `test.yml` and `helm-charts-test.yml` that way. Between them, those two workflows reference exactly one secret that is not `GITHUB_TOKEN`.
- **`test.yml` runs the Go test suite** — repository code and its whole dependency tree — in a job whose `secrets` context also carried the release signing keys.

Between them, those two workflows reference exactly one secret that is not `GITHUB_TOKEN`. Every other secret configured on the repository — the large majority of them release-time credentials with no bearing on running tests — was being handed over as well.

Pull requests from forks receive no secrets at all, so forks were never the exposure. A pull request from a branch **in this repository** does receive them, and the workflow definition that runs comes from the pull request head — so this narrows what a compromised dependency or a malicious same-repo branch can reach.

## What changed

- `test.yml` declares `CODECOV_TOKEN` as an optional `workflow_call` secret, so callers can name it. Optional rather than required because fork pull requests pass an empty value, and codecov accepts tokenless uploads for public repositories — an empty token degrades rather than fails.
- Both callers pass `CODECOV_TOKEN` and nothing else to `test.yml`.
- Both callers drop the `secrets:` block for `helm-charts-test.yml` entirely — it references only `GITHUB_TOKEN`, which is always available to a called workflow and is never passed explicitly.

`secrets-inherit` goes 4 → 0; repo-wide 36 → 32. There is no `secrets: inherit` left in the repository.

Part of #6253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): CI configuration

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- Cross-checked every reusable workflow called by the two entry points: for each, the secrets it *references*, the secrets it *declares* under `on.workflow_call.secrets`, and the secrets each caller *passes*. `test.yml` is the only one with any, and all three sets agree on `CODECOV_TOKEN`.
- Confirmed the other called workflows reference no secrets beyond `GITHUB_TOKEN`, so dropping their `secrets:` blocks changes nothing.
- All workflows parse as YAML; `actionlint` reports 12 findings before and after, all pre-existing.
- **This pull request exercises the change directly** — `run-on-pr.yml` runs on it, so the Tests and Helm Charts jobs here are running under the narrowed secrets.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **The coverage upload is the thing to watch.** If `CODECOV_TOKEN` were not reaching `test.yml`, the codecov step is where it would show. Worth a glance at this pull request's own Tests job before merging.
- A called workflow can only receive a secret it declares, which is why the declaration in `test.yml` is part of this change rather than caller-side only. Anything added to `test.yml` later that needs a new secret must declare it *and* be passed it — that is the intended friction.

Generated with [Claude Code](https://claude.com/claude-code)
