### PR TITLE
Bind the GHCR credentials and chart version in helm-publish

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -81,23 +81,36 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Login to GHCR (Helm)
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USERNAME: ${{ github.actor }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} \
-            --username ${{ github.actor }} \
+          echo "$GHCR_TOKEN" | helm registry login "$REGISTRY" \
+            --username "$GHCR_USERNAME" \
             --password-stdin
 
       - name: Login to GHCR (Cosign)
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USERNAME: ${{ github.actor }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | cosign login ${{ env.REGISTRY }} \
-            --username ${{ github.actor }} \
+          echo "$GHCR_TOKEN" | cosign login "$REGISTRY" \
+            --username "$GHCR_USERNAME" \
             --password-stdin
 
+      # CHART_VERSION derives from GITHUB_REF_NAME, and git ref names may
+      # contain ';', '$', backticks and '|' — so it is bound and quoted rather
+      # than pasted into the command unquoted.
       - name: Package Helm chart
+        env:
+          CHART_PATH: ${{ matrix.chart.path }}
+          CHART_NAME: ${{ matrix.chart.name }}
+          CHART_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          helm package ${{ matrix.chart.path }} \
-            --version ${{ steps.version.outputs.version }} \
-            --app-version ${{ steps.version.outputs.version }}
-          echo "Packaged chart: ${{ matrix.chart.name }}-${{ steps.version.outputs.version }}.tgz"
+          helm package "$CHART_PATH" \
+            --version "$CHART_VERSION" \
+            --app-version "$CHART_VERSION"
+          echo "Packaged chart: ${CHART_NAME}-${CHART_VERSION}.tgz"
 
       - name: Push to GHCR
         id: push


### PR DESCRIPTION
Fourth of the release-workflow changes tracked in #6253, after #6263 and #6266. **Deliberately narrow** — see the scope note.

## Summary

- **Both GHCR logins put a secret and `github.actor` into the script text.** `${{ }}` is substituted before the shell parses the block, so `secrets.GITHUB_TOKEN` was written into the run script on disk rather than arriving through the environment. Both are now bound via `env:`. These are the two High findings.
- **The packaging step passed the chart version unquoted.** That value derives from `GITHUB_REF_NAME`, and git ref names may contain `;`, `$`, backticks and `|` — unlike a repository name. It is the one value in this file that could plausibly carry a metacharacter, so it is now bound and quoted.

`helm-publish.yml` goes from 14 `template-injection` findings to 9, clearing **both** High ones. Repo-wide High goes **4 → 2**; the two left are the app tokens in `create-release-tag.yml` and `releaser.yml`.

## Scope — why only three steps

The other nine findings in this file are `github.repository` and `matrix.chart.*`, neither of which can hold a shell metacharacter. Converting them would touch the push, sign, verify and summary steps for no security benefit.

This workflow runs **only** during a release, cannot be exercised by any pull request, and runs *after* `image-build-and-push` — so a failure leaves images in GHCR, charts not, with the tag already cut. Changes here have to earn their risk, and a stylistic sweep does not. That is also why the two `artipacked` findings are untouched.

An earlier draft of this work converted the whole file, including moving the version from a step output to `$GITHUB_ENV`. That was correctly pushed back on as a refactor of value plumbing in an untestable path, and it is not repeated here.

Part of #6253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): CI configuration

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- Confirmed `REGISTRY` is a workflow-level `env:` and so is already present in every step's shell environment — the logins now reference `"$REGISTRY"` directly rather than re-interpolating `${{ env.REGISTRY }}`.
- Confirmed the three touched steps are self-contained: no step output, artifact or later step depends on anything the change alters. `steps.version.outputs.version` is still produced and still consumed by the untouched steps exactly as before.
- Workflow parses as YAML; `actionlint` clean.
- `zizmor` on this file: `template-injection` High 2 → 0, total 14 → 9.

**This cannot be verified before merge** — `helm-publish.yml` is `workflow_call` only, invoked from `releaser.yml` on `release: published`. The first real exercise is the next release.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **The value to check is `CHART_VERSION`.** `helm package --version "$CHART_VERSION"` must produce the same `.tgz` name the later push and sign steps expect — those steps still build that name from `${{ steps.version.outputs.version }}`, and both now resolve from the same step output. Worth reading the packaging, push and sign steps together to confirm the names still line up.
- Best merged just after a release rather than just before, to maximise the window for noticing anything wrong.
- The remaining nine `template-injection` findings and two `artipacked` findings in this file are intentional and recorded in #6253, not oversights.

Generated with [Claude Code](https://claude.com/claude-code)