### PR TITLE
Make the zizmor check blocking

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -52,9 +52,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    # --no-exit-codes stops *findings* failing the job; this stops a tool or
-    # network failure doing so. Both come off when the gate goes blocking.
-    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -62,9 +59,10 @@ jobs:
           # This job only reads the workflow files; it never pushes.
           persist-credentials: false
 
-      # Advisory only for now: --no-exit-codes keeps the job green while the
-      # existing backlog is worked through, so this reports without blocking.
-      # Remove it (and add --min-severity) once the backlog is clear.
+      # Reported at every severity so the Security tab keeps the full picture,
+      # including the low and informational findings this job does not block
+      # on. --no-exit-codes because the gate below decides pass or fail, not
+      # this step.
       #
       # Results are written straight to SARIF and never echoed. Workflow logs
       # and job summaries are world-readable on a public repository, so
@@ -83,12 +81,34 @@ jobs:
 
       # Pull requests from forks get a read-only token, so the upload is
       # skipped there; those workflows are still scanned on push to main.
+      # Runs before the gate so findings reach the Security tab either way.
       - name: Upload zizmor results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         if: always() && !github.event.pull_request.head.repo.fork
         with:
           sarif_file: zizmor.sarif
           category: "zizmor"
+
+      # The gate. `main` is clear of medium-and-above findings, so anything
+      # this reports was introduced by the change under review — which is why
+      # this step, unlike the one above, prints. The full inventory stays out
+      # of the public log; a finding in the diff under review does not, and a
+      # gate that fails without saying why is not worth having.
+      #
+      # The remaining low and informational findings are deliberate and are
+      # documented where they sit: checkouts whose credentials are in use, and
+      # expressions carrying values GitHub constrains to characters that cannot
+      # reach a shell. Lowering this threshold means dealing with those first.
+      - name: Fail on new findings
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pipx run zizmor==1.29.0 \
+            --persona=regular \
+            --min-severity=medium \
+            --no-progress \
+            --format=plain \
+            .github/
 
   govulncheck:
     name: Go Vulnerability Check

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -52,12 +52,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    env:
-      # Pinned by digest, not just by version: a tag can be repointed, a digest
-      # cannot. This is the same image and digest that zizmorcore/zizmor-action
-      # resolves 1.29.0 to, so it is the artifact upstream publishes and vets.
-      # Renovate updates digest pins; bump the tag and the digest together.
-      ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -65,64 +59,37 @@ jobs:
           # This job only reads the workflow files; it never pushes.
           persist-credentials: false
 
-      # Reported at every severity so the Security tab keeps the full picture,
-      # including the low and informational findings this job does not block
-      # on. --no-exit-codes because the gate below decides pass or fail, not
-      # this step.
-      #
-      # Results are written straight to SARIF and never echoed. Workflow logs
-      # and job summaries are world-readable on a public repository, so
-      # printing findings would publish them; the SARIF upload keeps them in
-      # the Security tab, which requires write access to read.
-      - name: Run zizmor
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker run --rm \
-            --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
-            --workdir /workspace \
-            --env GH_TOKEN \
-            "${ZIZMOR_IMAGE}" \
-            --persona=regular \
-            --format=sarif \
-            --no-exit-codes \
-            --no-progress \
-            -- .github/ > zizmor.sarif
-
-      # Pull requests from forks get a read-only token, so the upload is
-      # skipped there; those workflows are still scanned on push to main.
-      # Runs before the gate so findings reach the Security tab either way.
-      - name: Upload zizmor results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
-        if: always() && !github.event.pull_request.head.repo.fork
+      # Reports at every severity, including the low and informational findings
+      # the gate below does not block on, so the Security tab keeps the full
+      # picture. This step does not gate: zizmor suppresses its findings exit
+      # code when the output format is SARIF, which is what advanced-security
+      # selects. The upload happens inside the action.
+      - name: Report findings
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
-          sarif_file: zizmor.sarif
-          category: "zizmor"
+          version: "1.29.0"
+          inputs: .github/
+          persona: regular
 
       # The gate. `main` is clear of medium-and-above findings, so anything
-      # this reports was introduced by the change under review — which is why
-      # this step, unlike the one above, prints. The full inventory stays out
-      # of the public log; a finding in the diff under review does not, and a
-      # gate that fails without saying why is not worth having.
+      # this reports was introduced by the change under review.
+      #
+      # advanced-security: false is what makes this block — it swaps SARIF for
+      # human-readable output, which restores the findings exit code, and
+      # avoids uploading a second, severity-filtered SARIF over the first.
       #
       # The remaining low and informational findings are deliberate and are
       # documented where they sit: checkouts whose credentials are in use, and
       # expressions carrying values GitHub constrains to characters that cannot
       # reach a shell. Lowering this threshold means dealing with those first.
       - name: Fail on new findings
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker run --rm \
-            --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
-            --workdir /workspace \
-            --env GH_TOKEN \
-            "${ZIZMOR_IMAGE}" \
-            --persona=regular \
-            --min-severity=medium \
-            --no-progress \
-            --format=plain \
-            -- .github/
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          version: "1.29.0"
+          inputs: .github/
+          persona: regular
+          min-severity: medium
+          advanced-security: false
 
   govulncheck:
     name: Go Vulnerability Check

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -52,6 +52,12 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    env:
+      # Pinned by digest, not just by version: a tag can be repointed, a digest
+      # cannot. This is the same image and digest that zizmorcore/zizmor-action
+      # resolves 1.29.0 to, so it is the artifact upstream publishes and vets.
+      # Renovate updates digest pins; bump the tag and the digest together.
+      ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.29.0@sha256:863026d54f91271b10b60b67ad8054cb37120167e162482597db102b3026a284
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -72,12 +78,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pipx run zizmor==1.29.0 \
+          docker run --rm \
+            --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
+            --workdir /workspace \
+            --env GH_TOKEN \
+            "${ZIZMOR_IMAGE}" \
             --persona=regular \
             --format=sarif \
             --no-exit-codes \
             --no-progress \
-            .github/ > zizmor.sarif
+            -- .github/ > zizmor.sarif
 
       # Pull requests from forks get a read-only token, so the upload is
       # skipped there; those workflows are still scanned on push to main.
@@ -103,12 +113,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pipx run zizmor==1.29.0 \
+          docker run --rm \
+            --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
+            --workdir /workspace \
+            --env GH_TOKEN \
+            "${ZIZMOR_IMAGE}" \
             --persona=regular \
             --min-severity=medium \
             --no-progress \
             --format=plain \
-            .github/
+            -- .github/
 
   govulncheck:
     name: Go Vulnerability Check


### PR DESCRIPTION
The last item in #6253. `main` is clear of medium-and-above findings, so the advisory mode can come off.

## Summary

- **`main` has zero findings at medium or above** — down from 111 findings overall, of which 33 were high or medium. `--no-exit-codes` and the job's `continue-on-error` were there to keep the job green while that backlog was worked through. Both are gone, and the check now fails on anything at medium or higher.
- **Switched to the official [`zizmorcore/zizmor-action`](https://github.com/zizmorcore/zizmor-action)**, replacing a hand-rolled `pipx run`. The action resolves zizmor to a digest-pinned container image, so the artifact is pinned rather than just the version number — worth having for a check that is about to start blocking merges.
- **Gated at `medium`, not `high`.** The plan said `high`, but medium is also at zero, so the stricter threshold is free. The three medium rules — `secrets-inherit`, `ref-version-mismatch` and `excessive-permissions` — are all worth blocking on. Dropping to `high` is a one-word change if it proves too tight.

## Why two calls to the action rather than one

They cannot be combined, for a reason that is not obvious:

**zizmor suppresses its findings exit code when the output format is SARIF** — and SARIF is what `advanced-security: true` selects. Measured against a checkout of `main` with one medium finding injected, repeated three times each:

| flags | exit code |
|---|---|
| `--format=sarif --min-severity=medium` | **0** |
| `--format=plain --min-severity=medium` | 13 |
| `--format=github --min-severity=medium` | 13 |

So the action's documented Advanced Security usage **reports without gating**. That is a sensible default for a scanner, but it means a single call cannot both upload SARIF and fail the build.

Hence:

| Step | `advanced-security` | Severity | Effect |
|---|---|---|---|
| Report findings | `true` (default) | all | SARIF to the Security tab, cannot fail |
| Fail on new findings | `false` | medium and above | human-readable output, **gates** |

The first call reporting at every severity is deliberate: it keeps the low and informational findings visible in the Security tab even though the gate ignores them. The second sets `advanced-security: false` both to restore the exit code and to avoid uploading a second, severity-filtered SARIF over the first.

## What is deliberately not blocked

24 findings remain, all low or informational, all in the four release workflows:

- `artipacked` ×7 — checkouts in release jobs, in workflows no pull request can exercise.
- `template-injection` ×17 — `github.repository` and a semver-validated version, neither of which can carry a shell metacharacter.

Lowering the threshold further means dealing with those first — #6275 makes a start. The trade is recorded in the job's comments, not just here.

Closes #6253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [x] Other (describe): CI configuration

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- **Established the SARIF exit-code behaviour by measurement**, not from documentation — three repeats of each format against a real checkout, as tabled above. It is the reason this is two steps, so it seemed worth being sure of.
- **Verified the gate actually bites.** Injected a real regression — a pin with a mismatched version comment, a medium `ref-version-mismatch` — and confirmed zizmor reports it with file, line, the offending text and a fix hint, and exits 13. Reverted afterwards. A gate that has never been seen to fail is not a gate.
- Confirmed the reporting run produces valid SARIF containing all 24 findings, so nothing disappears from the Security tab.
- Confirmed the action pin `3dc1ecc9…` is the commit `v0.6.2` points to.
- Confirmed the job no longer carries `continue-on-error`, and that the steps are ordered checkout → report → gate.
- Workflow parses as YAML; `actionlint` clean.
- **This pull request exercises the change on itself** — `security-scan.yml` runs on every pull request, so the gate is running here.

## Does this introduce a user-facing change?

Yes, for contributors: a pull request that introduces a medium-or-higher workflow finding will now fail CI rather than reporting quietly. That is the intent.

## Special notes for reviewers

- **The threshold is the decision worth making here**, not the mechanics. `medium` costs nothing today; `high` is more forgiving of future churn. I would rather start strict and relax if it annoys, but it is a team call.
- The action pulls its zizmor image by digest from a version map inside the action repo, so pinning the action pins the scanner too. Bumping `version:` is only safe to a version that map knows; the action fails loudly on an unknown one.
- If the gate ever fires on something that genuinely cannot be fixed, the established pattern is a `# zizmor: ignore[rule]` comment carrying the reasoning — see `claude.yml` and `api-compat.yml` for existing examples.

Generated with [Claude Code](https://claude.com/claude-code)
