### PR TITLE
Clear the remaining zizmor findings in helm-publish

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Neither job in this workflow declares contents: write, so no push is
+          # possible and the credential has no use.
+          persist-credentials: false
 
       - name: Verify tag matches VERSION file
         run: |
@@ -59,9 +63,19 @@ jobs:
             path: deploy/charts/operator
           - name: toolhive-operator-crds
             path: deploy/charts/operator-crds
+    # Matrix and repository values are bound once here. CHART_VERSION cannot
+    # join them: it comes from a step output, which job-level env: cannot see.
+    env:
+      CHART_NAME: ${{ matrix.chart.name }}
+      CHART_PATH: ${{ matrix.chart.path }}
+      REPOSITORY: ${{ github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Neither job in this workflow declares contents: write, so no push is
+          # possible and the credential has no use.
+          persist-credentials: false
 
       - name: Extract version
         id: version
@@ -103,8 +117,6 @@ jobs:
       # than pasted into the command unquoted.
       - name: Package Helm chart
         env:
-          CHART_PATH: ${{ matrix.chart.path }}
-          CHART_NAME: ${{ matrix.chart.name }}
           CHART_VERSION: ${{ steps.version.outputs.version }}
         run: |
           helm package "$CHART_PATH" \
@@ -114,68 +126,76 @@ jobs:
 
       - name: Push to GHCR
         id: push
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          OUTPUT=$(helm push ${{ matrix.chart.name }}-${{ steps.version.outputs.version }}.tgz \
-            oci://${{ env.REGISTRY }}/${REPO} 2>&1)
+          REPO=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          OUTPUT=$(helm push "${CHART_NAME}-${CHART_VERSION}.tgz" \
+            "oci://${REGISTRY}/${REPO}" 2>&1)
           echo "$OUTPUT"
 
           # Extract digest from helm push output (e.g., "Digest: sha256:abc123...")
           DIGEST=$(echo "$OUTPUT" | grep 'Digest:' | awk '{print $2}' || echo "")
           if [ -n "$DIGEST" ]; then
-            echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+            echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
             echo "Captured digest: $DIGEST"
           fi
 
-          echo "Pushed chart to: oci://${{ env.REGISTRY }}/${REPO}/${{ matrix.chart.name }}:${{ steps.version.outputs.version }}"
+          echo "Pushed chart to: oci://${REGISTRY}/${REPO}/${CHART_NAME}:${CHART_VERSION}"
 
       - name: Sign Helm chart with Cosign
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
+          CHART_DIGEST: ${{ steps.push.outputs.digest }}
         run: |
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          CHART_REF="${{ env.REGISTRY }}/${REPO}/${{ matrix.chart.name }}"
-          DIGEST="${{ steps.push.outputs.digest }}"
+          REPO=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          CHART_REF="${REGISTRY}/${REPO}/${CHART_NAME}"
 
-          if [ -n "$DIGEST" ]; then
-            echo "Signing Helm chart by digest: ${CHART_REF}@${DIGEST}"
-            cosign sign -y "${CHART_REF}@${DIGEST}"
+          if [ -n "$CHART_DIGEST" ]; then
+            echo "Signing Helm chart by digest: ${CHART_REF}@${CHART_DIGEST}"
+            cosign sign -y "${CHART_REF}@${CHART_DIGEST}"
           else
-            echo "Signing Helm chart by tag: ${CHART_REF}:${{ steps.version.outputs.version }}"
-            cosign sign -y "${CHART_REF}:${{ steps.version.outputs.version }}"
+            echo "Signing Helm chart by tag: ${CHART_REF}:${CHART_VERSION}"
+            cosign sign -y "${CHART_REF}:${CHART_VERSION}"
           fi
           echo "Helm chart signed successfully"
 
       - name: Verify published chart
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          helm show chart oci://${{ env.REGISTRY }}/${REPO}/${{ matrix.chart.name }} \
-            --version ${{ steps.version.outputs.version }}
+          REPO=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          helm show chart "oci://${REGISTRY}/${REPO}/${CHART_NAME}" \
+            --version "$CHART_VERSION"
 
       - name: Summary
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          echo "## Helm Chart Published: ${{ matrix.chart.name }}" >> $GITHUB_STEP_SUMMARY
+          REPO=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          echo "## Helm Chart Published: ${CHART_NAME}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Chart | \`${{ matrix.chart.name }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Version | \`${{ steps.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Registry | \`oci://${{ env.REGISTRY }}/${REPO}/${{ matrix.chart.name }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Chart | \`${CHART_NAME}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | \`${CHART_VERSION}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Registry | \`oci://${REGISTRY}/${REPO}/${CHART_NAME}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Signed | ✅ Yes (Cosign keyless) |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Installation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "helm install my-release oci://${{ env.REGISTRY }}/${REPO}/${{ matrix.chart.name }} --version ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "helm install my-release oci://${REGISTRY}/${REPO}/${CHART_NAME} --version ${CHART_VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Verify Signature" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "cosign verify ${{ env.REGISTRY }}/${REPO}/${{ matrix.chart.name }}:${{ steps.version.outputs.version }} \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "cosign verify ${REGISTRY}/${REPO}/${CHART_NAME}:${CHART_VERSION} \\\\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\\\" >> $GITHUB_STEP_SUMMARY
-          echo "  --certificate-identity-regexp https://github.com/${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+          echo "  --certificate-identity-regexp https://github.com/${REPOSITORY}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Logout from GHCR
         if: always()
-        run: helm registry logout ${{ env.REGISTRY }}
+        run: helm registry logout "$REGISTRY"


### PR DESCRIPTION
First of the follow-ups to #6274, which makes the zizmor check blocking at `medium`. This clears the low and informational findings in one of the four release workflows so the threshold can eventually go lower.

## Summary

- **All nine `template-injection` findings and both `artipacked` findings in `helm-publish.yml` are cleared** — 11 → 0. Every expression in a `run:` block is now bound through `env:`.
- **Be clear about what this is and is not.** None of these values can carry a shell metacharacter: the version derives from the tag, the rest are matrix entries and a repository name, which GitHub restricts to `[A-Za-z0-9._-]`. The genuinely reachable sinks in this file — the GHCR credentials and the unquoted `helm package --version` — were fixed in #6270. **This is consistency, not a fix.**

It is worth doing now because the file is otherwise clean, so keeping it that way is cheap; and because leaving nine findings in place is what stops the gate dropping below `medium` later.

## Shape

- Matrix and repository values move to a **job-level** `env:` — they are constant across the job, so binding them once beats repeating them in six steps.
- `CHART_VERSION` stays **per-step**, because job-level `env:` cannot read a step output. That is the one asymmetry and it is deliberate.
- `$REGISTRY` is referenced directly; it is already a workflow-level `env:` and so already in every step's shell.
- Both checkouts get `persist-credentials: false`.

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- **Checked every shell variable in every step resolves.** Wrote a check that collects each step's available names — workflow `env:`, job `env:`, step `env:`, locally assigned, and the GitHub-provided ones — against every `$VAR` it references. No step references anything undefined.
- **Checked the artifact name still lines up.** `helm package` writes `${CHART_NAME}-${CHART_VERSION}.tgz` and `helm push` reads exactly that string; both now resolve from the same two variables rather than from re-interpolated expressions.
- **Confirmed neither job can push** — `verify-tag` and `publish-helm` both declare `contents: read` — so `persist-credentials: false` cannot break anything.
- Workflow parses as YAML; `actionlint` clean; `zizmor` reports **no findings at all** for this file.

**This cannot be verified before merge.** `helm-publish.yml` is `workflow_call` only, invoked from `releaser.yml` on `release: published`, and it runs *after* the image push — a failure leaves images in GHCR and charts not. That risk has not changed; what has changed is that it is now being taken for tidiness rather than for a fix, which is worth weighing.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- **If you would rather not take release-workflow churn for findings that cannot be exploited, this is the PR to decline.** The alternative is leaving the gate at `medium` permanently, which is a perfectly good place for it. #6274 stands on its own either way.
- The `Package Helm chart` step keeps only `CHART_VERSION` in its `env:` — `CHART_PATH` and `CHART_NAME` now come from the job — so that step's diff looks like a deletion. It is not losing anything.
- Best merged just after a release rather than just before.

Generated with [Claude Code](https://claude.com/claude-code)