### PR TITLE
fix(operator): apply deprecated VirtualMCPServer inline telemetry

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -685,6 +685,27 @@ func (r *VirtualMCPServerReconciler) emitPrimaryUpstreamProviderDeprecatedEvent(
 			"move the value to spec.authServerConfig.primaryUpstreamProvider")
 }
 
+// emitInlineTelemetryDeprecatedEvent emits a Warning event when the VirtualMCPServer
+// uses the deprecated spec.config.telemetry field instead of spec.telemetryConfigRef.
+// Only emits when the spec has changed since the last observed generation, so the event
+// fires once per spec change instead of on every reconcile.
+func (r *VirtualMCPServerReconciler) emitInlineTelemetryDeprecatedEvent(
+	vmcp *mcpv1beta1.VirtualMCPServer,
+	usesInlineTelemetry bool,
+) {
+	if !usesInlineTelemetry || r.Recorder == nil {
+		return
+	}
+	if vmcp.Generation == vmcp.Status.ObservedGeneration {
+		return
+	}
+	r.Recorder.Eventf(vmcp, nil, corev1.EventTypeWarning,
+		"InlineTelemetryDeprecated", "ConvertTelemetry",
+		"spec.config.telemetry is deprecated for operator deployments; "+
+			"migrate to spec.telemetryConfigRef referencing an MCPTelemetryConfig. "+
+			"Inline telemetry is still applied for compatibility.")
+}
+
 func (r *VirtualMCPServerReconciler) validateAuthzUpstreamAvailable(
 	ctx context.Context,
 	vmcp *mcpv1beta1.VirtualMCPServer,

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
@@ -50,6 +50,10 @@ func (r *VirtualMCPServerReconciler) ensureVmcpConfigConfigMap(
 		return fmt.Errorf("failed to create vmcp Config from VirtualMCPServer: %w", err)
 	}
 
+	// Emit deprecation event if inline telemetry is used instead of telemetryConfigRef
+	usesInlineTelemetry := vmcp.Spec.Config.Telemetry != nil && vmcp.Spec.TelemetryConfigRef == nil
+	r.emitInlineTelemetryDeprecatedEvent(vmcp, usesInlineTelemetry)
+
 	// Process outgoing auth configuration for both inline and discovered modes
 	if err := r.processOutgoingAuth(ctx, vmcp, config, typedWorkloads, statusManager); err != nil {
 		return err

--- a/cmd/thv-operator/pkg/spectoconfig/telemetry.go
+++ b/cmd/thv-operator/pkg/spectoconfig/telemetry.go
@@ -72,8 +72,9 @@ func NormalizeMCPTelemetryConfig(
 // runtime in telemetry.NewProvider() to always reflect the running binary version,
 // avoiding stale versions persisted in configs. See #2296.
 //
-// This function is used by both the VirtualMCPServer converter (for spec.config.telemetry)
-// and indirectly by NormalizeMCPTelemetryConfig (for MCPTelemetryConfig-based configs).
+// This function is used by the VirtualMCPServer converter for deprecated
+// inline spec.config.telemetry and by NormalizeMCPTelemetryConfig for
+// MCPTelemetryConfig-based configs.
 func NormalizeTelemetryConfig(config *telemetry.Config, defaultServiceName string) *telemetry.Config {
 	if config == nil {
 		return nil

--- a/cmd/thv-operator/pkg/vmcpconfig/converter.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter.go
@@ -136,8 +136,9 @@ func (c *Converter) Convert(
 	// Use Operational from spec.config directly
 	config.Operational = vmcp.Spec.Config.Operational
 
-	// Normalize telemetry config: prefer TelemetryConfigRef (shared MCPTelemetryConfig resource),
-	// The inline config.telemetry field is no longer read by the operator.
+	// Normalize telemetry config: prefer TelemetryConfigRef (shared MCPTelemetryConfig).
+	// Inline config.telemetry remains as a deprecated operator fallback for compatibility
+	// with docs and existing CRs; TelemetryConfigRef always wins when both are present.
 	normalizedTelemetry := c.normalizeTelemetry(ctx, vmcp, telemetryCfg)
 	config.Telemetry = normalizedTelemetry
 
@@ -482,12 +483,17 @@ func mapResolvedOIDCToVmcpConfigFromRef(
 	return config
 }
 
-// normalizeTelemetry resolves and normalizes the telemetry config from a
-// pre-fetched MCPTelemetryConfig. Returns nil when TelemetryConfigRef is not set.
-// The Config.Telemetry field is still valid for standalone CLI deployments but is
-// no longer read by the operator — use TelemetryConfigRef instead.
+// normalizeTelemetry resolves and normalizes the telemetry config.
+// Preference order:
+//  1. TelemetryConfigRef → shared MCPTelemetryConfig (preferred for operator deployments)
+//  2. Inline spec.config.telemetry (deprecated for operator; still applied for compatibility)
+//
+// Returning nil disables telemetry (no OTLP, no Prometheus /metrics handler).
+// When /metrics is not registered, GET /metrics falls through to the MCP streamable
+// HTTP handler and returns HTTP 406 JSON-RPC ("Client must accept text/event-stream"),
+// which looks like a broken Prometheus scrape rather than a missing feature.
 func (*Converter) normalizeTelemetry(
-	_ context.Context,
+	ctx context.Context,
 	vmcp *mcpv1beta1.VirtualMCPServer,
 	telemetryCfg *mcpv1beta1.MCPTelemetryConfig,
 ) *telemetry.Config {
@@ -495,6 +501,19 @@ func (*Converter) normalizeTelemetry(
 		return spectoconfig.NormalizeMCPTelemetryConfig(
 			&telemetryCfg.Spec, vmcp.Spec.TelemetryConfigRef.ServiceName, vmcp.Name)
 	}
+
+	if vmcp.Spec.Config.Telemetry != nil {
+		ctxLogger := log.FromContext(ctx)
+		ctxLogger.Info(
+			"VirtualMCPServer.spec.config.telemetry is deprecated for operator deployments; "+
+				"migrate to spec.telemetryConfigRef referencing an MCPTelemetryConfig. "+
+				"Inline telemetry is still applied for compatibility.",
+			"name", vmcp.Name,
+			"namespace", vmcp.Namespace,
+		)
+		return spectoconfig.NormalizeTelemetryConfig(vmcp.Spec.Config.Telemetry, vmcp.Name)
+	}
+
 	return nil
 }
 

--- a/cmd/thv-operator/pkg/vmcpconfig/converter.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter.go
@@ -503,14 +503,6 @@ func (*Converter) normalizeTelemetry(
 	}
 
 	if vmcp.Spec.Config.Telemetry != nil {
-		ctxLogger := log.FromContext(ctx)
-		ctxLogger.Info(
-			"VirtualMCPServer.spec.config.telemetry is deprecated for operator deployments; "+
-				"migrate to spec.telemetryConfigRef referencing an MCPTelemetryConfig. "+
-				"Inline telemetry is still applied for compatibility.",
-			"name", vmcp.Name,
-			"namespace", vmcp.Namespace,
-		)
 		return spectoconfig.NormalizeTelemetryConfig(vmcp.Spec.Config.Telemetry, vmcp.Name)
 	}
 

--- a/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
+++ b/cmd/thv-operator/pkg/vmcpconfig/converter_test.go
@@ -1474,9 +1474,11 @@ func TestConvert_DefaultToolVisibilityPreserved(t *testing.T) {
 	}
 }
 
-// TestConverter_InlineTelemetryIgnored verifies that the operator-side converter
-// ignores Config.Telemetry (the standalone CLI field) and only uses TelemetryConfigRef.
-func TestConverter_InlineTelemetryIgnored(t *testing.T) {
+// TestConverter_InlineTelemetryApplied verifies that the operator-side converter
+// still applies deprecated Config.Telemetry when TelemetryConfigRef is unset.
+// Without this fallback, enablePrometheusMetricsPath on the CR is a silent no-op
+// and GET /metrics returns MCP 406 instead of Prometheus text.
+func TestConverter_InlineTelemetryApplied(t *testing.T) {
 	t.Parallel()
 
 	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
@@ -1486,8 +1488,9 @@ func TestConverter_InlineTelemetryIgnored(t *testing.T) {
 		}),
 		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
 			Telemetry: &telemetry.Config{
-				Endpoint:    "otlp-collector:4317",
-				ServiceName: "should-be-ignored",
+				Endpoint:                    "otlp-collector:4317",
+				ServiceName:                 "inline-vmcp",
+				EnablePrometheusMetricsPath: true,
 			},
 		}),
 	)
@@ -1498,7 +1501,56 @@ func TestConverter_InlineTelemetryIgnored(t *testing.T) {
 	config, _, err := converter.Convert(ctx, vmcp, nil)
 	require.NoError(t, err)
 	require.NotNil(t, config)
-	assert.Nil(t, config.Telemetry, "Config.Telemetry should be ignored by the operator; use TelemetryConfigRef")
+	require.NotNil(t, config.Telemetry, "inline Config.Telemetry must be applied when TelemetryConfigRef is unset")
+	assert.Equal(t, "otlp-collector:4317", config.Telemetry.Endpoint)
+	assert.Equal(t, "inline-vmcp", config.Telemetry.ServiceName)
+	assert.True(t, config.Telemetry.EnablePrometheusMetricsPath)
+}
+
+// TestConverter_TelemetryConfigRefWinsOverInline verifies TelemetryConfigRef
+// takes precedence when both the shared ref and deprecated inline telemetry are set.
+func TestConverter_TelemetryConfigRefWinsOverInline(t *testing.T) {
+	t.Parallel()
+
+	refCfg := &mcpv1beta1.MCPTelemetryConfig{
+		Spec: mcpv1beta1.MCPTelemetryConfigSpec{
+			Prometheus: &mcpv1beta1.PrometheusConfig{
+				Enabled: true,
+			},
+			OpenTelemetry: &mcpv1beta1.MCPTelemetryOTelConfig{
+				Enabled:  true,
+				Endpoint: "from-ref:4318",
+				Insecure: true,
+			},
+		},
+	}
+
+	vmcp := v1beta1test.NewVirtualMCPServer("test-vmcp", "default",
+		v1beta1test.WithVMCPGroupRef("test-group"),
+		v1beta1test.WithVMCPIncomingAuth(&mcpv1beta1.IncomingAuthConfig{
+			Type: "anonymous",
+		}),
+		v1beta1test.WithVMCPTelemetryConfigRef("shared-otel"),
+		v1beta1test.WithVMCPConfig(vmcpconfig.Config{
+			Telemetry: &telemetry.Config{
+				Endpoint:    "from-inline:4317",
+				ServiceName: "should-not-win",
+			},
+		}),
+	)
+	// ServiceName override on the ref
+	vmcp.Spec.TelemetryConfigRef.ServiceName = "from-ref-service"
+
+	converter := newTestConverter(t, newNoOpMockResolver(t))
+	ctx := log.IntoContext(context.Background(), logr.Discard())
+
+	config, _, err := converter.Convert(ctx, vmcp, refCfg)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	require.NotNil(t, config.Telemetry)
+	assert.Equal(t, "from-ref:4318", config.Telemetry.Endpoint)
+	assert.Equal(t, "from-ref-service", config.Telemetry.ServiceName)
+	assert.True(t, config.Telemetry.EnablePrometheusMetricsPath)
 }
 
 // TestConverter_TelemetryNil tests that nil telemetry config is handled correctly.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -166,11 +166,12 @@ spec:
 See [`examples/operator/mcp-servers/mcpserver_fetch_otel.yaml`](../examples/operator/mcp-servers/mcpserver_fetch_otel.yaml)
 for a complete example.
 
-**Inline (deprecated)**: The inline `spec.telemetry` (MCPServer, MCPRemoteProxy)
-and `spec.config.telemetry` (VirtualMCPServer) fields still work but are
-deprecated and will be removed in a future API version. They are mutually exclusive with
-`telemetryConfigRef` (CEL enforced). All three resource types now support
-`spec.telemetryConfigRef`.
+**Inline (deprecated)**: For VirtualMCPServer, inline `spec.config.telemetry`
+is still applied by the operator when `spec.telemetryConfigRef` is unset
+(deprecated; controller logs a migration warning). Prefer
+`MCPTelemetryConfig` + `telemetryConfigRef` for MCPServer, MCPRemoteProxy, and
+VirtualMCPServer. Without either path, Prometheus `/metrics` is not registered
+on VirtualMCPServer and scrapes receive MCP protocol 406 responses.
 
 For VirtualMCPServer telemetry, see the
 [vMCP observability docs](./operator/virtualmcpserver-observability.md).

--- a/docs/operator/virtualmcpserver-observability.md
+++ b/docs/operator/virtualmcpserver-observability.md
@@ -197,10 +197,13 @@ spec:
 See [`examples/operator/virtual-mcps/vmcp_with_telemetry_ref.yaml`](../../examples/operator/virtual-mcps/vmcp_with_telemetry_ref.yaml)
 for a complete example with an MCPGroup and backend MCPServer.
 
-**Inline (deprecated)**: The inline `spec.config.telemetry` field still works
-but is deprecated and will be removed in a future API version. It is mutually exclusive with
-`telemetryConfigRef` (CEL enforced). Migrate to `telemetryConfigRef` to use the
-shared MCPTelemetryConfig pattern.
+**Inline (deprecated)**: The inline `spec.config.telemetry` field is still
+applied by the operator when `spec.telemetryConfigRef` is unset (with a
+controller log warning). Prefer `telemetryConfigRef` / `MCPTelemetryConfig`.
+If neither is set, telemetry is disabled: the Prometheus `/metrics` route is
+not registered, and `GET /metrics` falls through to the MCP streamable-HTTP
+handler (HTTP 406 JSON-RPC requiring `text/event-stream`).
+`telemetryConfigRef` always wins when both are present.
 
 ```yaml
 # Deprecated — use telemetryConfigRef instead


### PR DESCRIPTION
## Summary

Fixes **#6276**: operator-managed VirtualMCPServer silently ignored
`spec.config.telemetry` after #4819, so
`enablePrometheusMetricsPath: true` never registered `/metrics`. Prometheus
scrapes then hit the MCP streamable-HTTP handler and got **HTTP 406** JSON-RPC
(`Client must accept text/event-stream`) instead of Prometheus text.

This also unblocked collecting Go runtime series for **#5860**.

### Changes
- Restore deprecated inline `config.telemetry` fallback when
  `telemetryConfigRef` is unset (TelemetryConfigRef still wins when both set)
- Log a migration warning pointing operators at `MCPTelemetryConfig`
- Unit tests for inline apply + ref precedence
- Docs: remove false “CEL mutual exclusion” claim; document 406 failure mode
  when telemetry is not configured

### Preferred long-term path (unchanged)
```yaml
apiVersion: toolhive.stacklok.dev/v1beta1
kind: MCPTelemetryConfig
metadata:
  name: vmcp-prometheus
spec:
  prometheus:
    enabled: true
```
with `spec.telemetryConfigRef` on VirtualMCPServer.

## Test plan
- [x] `go test ./cmd/thv-operator/pkg/vmcpconfig/ -run 'TestConverter_InlineTelemetry|TestConverter_TelemetryConfigRefWins|TestConverter_TelemetryNil'`
- [ ] CI unit / operator tests
- [ ] After merge: operator with only inline `enablePrometheusMetricsPath: true`
      should render `telemetry` into the vmcp ConfigMap and serve HTTP 200 on
      `GET /metrics` with `Accept: text/plain`

## Security
No secrets, private hostnames, or customer data in this PR or linked issues.