### PR TITLE
Bound client-controlled metric label length

### DIFF
--- a/pkg/telemetry/middleware.go
+++ b/pkg/telemetry/middleware.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -37,6 +38,18 @@ const (
 	networkTransportTCP = "tcp"
 	// networkProtocolHTTP is the OTEL value for HTTP protocol
 	networkProtocolHTTP = "http"
+	// maxLabelValueBytes bounds the length of client-controlled metric label
+	// values. Cumulative metric readers (Prometheus, OTLP PeriodicReader) keep
+	// every distinct attribute set resident for the process lifetime, so an
+	// unbounded label value (e.g. an 8 MB MCP method name) stays in memory
+	// permanently and can exhaust the pod. This caps the byte length; the OTEL
+	// SDK's 2000-series limit caps the count. Spans are left untruncated on
+	// purpose — they are sampled and ephemeral, and the OTEL MCP semconv wants
+	// the real value.
+	maxLabelValueBytes = 128
+	// labelTruncationMarker is appended to truncated label values so consumers
+	// can tell a value was clamped.
+	labelTruncationMarker = "..."
 )
 
 // MCPHistogramBuckets are the bucket boundaries defined by the MCP OTEL semantic conventions
@@ -697,6 +710,24 @@ func (rw *responseWriter) Flush() {
 	}
 }
 
+// truncateLabelValue bounds a client-controlled metric label value to
+// maxLabelValueBytes, clamping on a UTF-8 rune boundary so the result is never
+// invalid UTF-8, and appending labelTruncationMarker to signal truncation.
+// Values within the cap are returned unchanged. Use this only for metric
+// labels; span attributes keep the full value.
+func truncateLabelValue(s string) string {
+	if len(s) <= maxLabelValueBytes {
+		return s
+	}
+	// Reserve room for the marker so the returned value stays within the cap.
+	limit := maxLabelValueBytes - len(labelTruncationMarker)
+	// Back up to a rune boundary so we never split a multi-byte character.
+	for limit > 0 && !utf8.RuneStart(s[limit]) {
+		limit--
+	}
+	return s[:limit] + labelTruncationMarker
+}
+
 // recordMetrics records request metrics.
 func (m *HTTPMiddleware) recordMetrics(ctx context.Context, r *http.Request, rw *responseWriter, duration time.Duration) {
 	// Get MCP method from context if available
@@ -724,8 +755,8 @@ func (m *HTTPMiddleware) recordMetrics(ctx context.Context, r *http.Request, rw 
 		attribute.String("method", r.Method),
 		attribute.String("status_code", strconv.Itoa(rw.statusCode)),
 		attribute.String("status", status),
-		attribute.String("mcp_method", mcpMethod),
-		attribute.String("mcp_resource_id", mcpResourceID),
+		attribute.String("mcp_method", truncateLabelValue(mcpMethod)),
+		attribute.String("mcp_resource_id", truncateLabelValue(mcpResourceID)),
 		attribute.String("server", m.serverName),
 		attribute.String("transport", m.transport),
 	)
@@ -754,7 +785,7 @@ func (m *HTTPMiddleware) recordMetrics(ctx context.Context, r *http.Request, rw 
 		if parsedMCP := mcpparser.GetParsedMCPRequest(ctx); parsedMCP != nil && parsedMCP.ResourceID != "" {
 			toolAttrs := metric.WithAttributes(
 				attribute.String("server", m.serverName),
-				attribute.String("tool", parsedMCP.ResourceID),
+				attribute.String("tool", truncateLabelValue(parsedMCP.ResourceID)),
 				attribute.String("status", status),
 			)
 			m.toolCallCounter.Add(ctx, 1, toolAttrs)
@@ -770,7 +801,7 @@ func (m *HTTPMiddleware) recordOperationDuration(
 	networkTransport, protocolName, _ := mapTransport(m.transport)
 
 	specAttrs := []attribute.KeyValue{
-		attribute.String("mcp.method.name", mcpMethod),
+		attribute.String("mcp.method.name", truncateLabelValue(mcpMethod)),
 		attribute.String("jsonrpc.protocol.version", "2.0"),
 		attribute.String("network.transport", networkTransport),
 	}
@@ -795,11 +826,11 @@ func (m *HTTPMiddleware) recordOperationDuration(
 	case string(mcp.MethodToolsCall):
 		specAttrs = append(specAttrs, attribute.String("gen_ai.operation.name", "execute_tool"))
 		if resourceID != "" {
-			specAttrs = append(specAttrs, attribute.String("gen_ai.tool.name", resourceID))
+			specAttrs = append(specAttrs, attribute.String("gen_ai.tool.name", truncateLabelValue(resourceID)))
 		}
 	case methodPromptsGet:
 		if resourceID != "" {
-			specAttrs = append(specAttrs, attribute.String("gen_ai.prompt.name", resourceID))
+			specAttrs = append(specAttrs, attribute.String("gen_ai.prompt.name", truncateLabelValue(resourceID)))
 		}
 	}
 

--- a/pkg/telemetry/middleware_test.go
+++ b/pkg/telemetry/middleware_test.go
@@ -2599,6 +2599,7 @@ func TestHTTPMiddleware_TruncatesMetricLabelsKeepsSpanFull(t *testing.T) {
 	}
 	assert.Contains(t, checked, "gen_ai.tool.name", "operation duration tool label should have been asserted")
 	assert.Contains(t, checked, "tool", "tool call counter label should have been asserted")
+	assert.Contains(t, checked, "mcp_resource_id", "request metric mcp_resource_id label should have been asserted")
 
 	// The span keeps the full, untruncated value.
 	spans := recorder.Ended()

--- a/pkg/telemetry/middleware_test.go
+++ b/pkg/telemetry/middleware_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,8 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/mock/gomock"
@@ -2460,4 +2463,178 @@ func TestRecordSSEConnection_DualEmission(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTruncateLabelValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		check func(t *testing.T, got string)
+	}{
+		{
+			name:  "empty string is unchanged",
+			input: "",
+			check: func(t *testing.T, got string) {
+				t.Helper()
+				assert.Equal(t, "", got)
+			},
+		},
+		{
+			name:  "value within the cap is unchanged",
+			input: "tools/call",
+			check: func(t *testing.T, got string) {
+				t.Helper()
+				assert.Equal(t, "tools/call", got)
+			},
+		},
+		{
+			name:  "value exactly at the cap is unchanged",
+			input: strings.Repeat("a", maxLabelValueBytes),
+			check: func(t *testing.T, got string) {
+				t.Helper()
+				assert.Equal(t, strings.Repeat("a", maxLabelValueBytes), got)
+			},
+		},
+		{
+			name:  "value over the cap is truncated within the cap and marked",
+			input: strings.Repeat("a", 8*1024*1024),
+			check: func(t *testing.T, got string) {
+				t.Helper()
+				assert.LessOrEqual(t, len(got), maxLabelValueBytes,
+					"truncated value (including marker) must not exceed the cap")
+				assert.True(t, strings.HasSuffix(got, labelTruncationMarker),
+					"truncated value must carry the truncation marker")
+			},
+		},
+		{
+			name: "multi-byte value clamps on a rune boundary",
+			// Each '世' is 3 bytes; a run well over the cap forces truncation
+			// mid-rune unless we clamp to a boundary.
+			input: strings.Repeat("世", maxLabelValueBytes),
+			check: func(t *testing.T, got string) {
+				t.Helper()
+				assert.LessOrEqual(t, len(got), maxLabelValueBytes)
+				assert.True(t, utf8.ValidString(got),
+					"truncation must not split a multi-byte rune")
+				assert.True(t, strings.HasSuffix(got, labelTruncationMarker))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.check(t, truncateLabelValue(tt.input))
+		})
+	}
+}
+
+// TestHTTPMiddleware_TruncatesMetricLabelsKeepsSpanFull is the finding B
+// regression guard: a client-controlled label value (here a tool name) that
+// exceeds the cap must be truncated on every metric it reaches, while the span
+// retains the full value. Cumulative metric readers keep each distinct
+// attribute set resident for the process lifetime, so an unbounded label value
+// is a memory-exhaustion vector; spans are sampled and ephemeral, and the OTEL
+// MCP semconv wants the real value.
+func TestHTTPMiddleware_TruncatesMetricLabelsKeepsSpanFull(t *testing.T) {
+	t.Parallel()
+
+	hugeToolName := strings.Repeat("a", 8*1024*1024)
+
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(recorder),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	t.Cleanup(func() { require.NoError(t, tracerProvider.Shutdown(context.Background())) })
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, meterProvider.Shutdown(context.Background())) })
+
+	middleware := NewHTTPMiddleware(
+		Config{ServiceName: "test-service", ServiceVersion: "1.0.0"},
+		tracerProvider,
+		meterProvider,
+		"github",
+		"streamable-http",
+	)
+
+	wrapped := middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	mcpRequest := &mcpparser.ParsedMCPRequest{
+		Method:     "tools/call",
+		ID:         "1",
+		ResourceID: hugeToolName,
+		IsRequest:  true,
+	}
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req = req.WithContext(context.WithValue(req.Context(), mcpparser.MCPRequestContextKey, mcpRequest))
+	wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Every metric label carrying the tool name must be bounded.
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	checked := map[string]bool{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			for _, attrs := range dataPointAttributes(m) {
+				for _, key := range []string{"mcp_resource_id", "tool", "gen_ai.tool.name"} {
+					if v, ok := attrs[key]; ok {
+						s, _ := v.(string)
+						assert.LessOrEqual(t, len(s), maxLabelValueBytes,
+							"metric %q label %q must be truncated", m.Name, key)
+						assert.True(t, strings.HasSuffix(s, labelTruncationMarker),
+							"metric %q label %q must carry the truncation marker", m.Name, key)
+						checked[key] = true
+					}
+				}
+			}
+		}
+	}
+	assert.Contains(t, checked, "gen_ai.tool.name", "operation duration tool label should have been asserted")
+	assert.Contains(t, checked, "tool", "tool call counter label should have been asserted")
+
+	// The span keeps the full, untruncated value.
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	spanAttrs := make(map[string]any, len(spans[0].Attributes()))
+	for _, attr := range spans[0].Attributes() {
+		spanAttrs[string(attr.Key)] = attr.Value.AsInterface()
+	}
+	assert.Equal(t, hugeToolName, spanAttrs["gen_ai.tool.name"],
+		"span must retain the full tool name")
+}
+
+// dataPointAttributes flattens the attribute sets of every data point on a
+// metric into string-keyed maps, regardless of the underlying aggregation.
+func dataPointAttributes(m metricdata.Metrics) []map[string]any {
+	var out []map[string]any
+	collect := func(set attribute.Set) {
+		attrs := make(map[string]any, set.Len())
+		for _, kv := range set.ToSlice() {
+			attrs[string(kv.Key)] = kv.Value.AsInterface()
+		}
+		out = append(out, attrs)
+	}
+	switch data := m.Data.(type) {
+	case metricdata.Sum[int64]:
+		for _, dp := range data.DataPoints {
+			collect(dp.Attributes)
+		}
+	case metricdata.Sum[float64]:
+		for _, dp := range data.DataPoints {
+			collect(dp.Attributes)
+		}
+	case metricdata.Histogram[float64]:
+		for _, dp := range data.DataPoints {
+			collect(dp.Attributes)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

Cumulative metric readers (Prometheus reader, OTLP `PeriodicReader`) keep every distinct attribute set resident for the process lifetime — there is no TTL, LRU, or scrape-driven reset. The OpenTelemetry Go SDK caps attribute **sets** at 2000 per instrument, which bounds series *count*, but nothing bounds the byte *length* of any single label value.

The parsed MCP method, tool, and prompt names are taken verbatim from the client request (`pkg/mcp/parser.go`, `Method: req.Method`), bounded only by the 8 MB request body cap. So a single metric label value can approach 8 MB and stay resident until the process exits. Roughly 64 such requests retain ~512 MB permanently — enough to OOM a typical pod, and it OOM-loops if the attack repeats after restart. The metric is recorded after the response, so a backend 404/500 or a Cedar 403 still records; only an auth 401 short-circuits, so this is reachable on intentionally-unauthenticated deployments (e.g. a public docs server).

This is Finding B of #6271.

- Add `truncateLabelValue`, capping a client-controlled metric label value at 128 bytes, clamped on a UTF-8 rune boundary (never emits invalid UTF-8) with a trailing `...` marker.
- Apply it to every client-controlled metric label site in `pkg/telemetry/middleware.go`: `mcp_method`, `mcp_resource_id`, `tool`, `mcp.method.name`, `gen_ai.tool.name`, `gen_ai.prompt.name`. Hardcoded values (transport, `jsonrpc.protocol.version`) are left alone.
- Span attributes keep the **full** value on purpose — spans are sampled and ephemeral, and the OTEL MCP semconv wants the real value.

Part of #6271

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New tests in `pkg/telemetry/middleware_test.go`:
- `TestTruncateLabelValue` — under/at/over the cap, empty string, and multi-byte rune-boundary clamping.
- `TestHTTPMiddleware_TruncatesMetricLabelsKeepsSpanFull` — an oversized tool name is truncated on every metric label it reaches, while the span retains the full value.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Metric label values for client-controlled MCP method, tool, and prompt names are now truncated to 128 bytes (with a trailing `...`) on metrics. Traces are unaffected and retain the full value.

## Special notes for reviewers

- The 2000-series cap that makes this a length-only (not count) problem is an inherited transitive default; Finding C (#6271) tracks a regression test that junk cannot exhaust the series budget, and depends on this PR plus Finding D landing first.

Generated with [Claude Code](https://claude.com/claude-code)