### PR TITLE
Drop build fingerprint from proxy /health response

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -11,8 +11,6 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
-
-	"github.com/stacklok/toolhive/pkg/versions"
 )
 
 // HealthStatus represents the overall health status
@@ -39,14 +37,19 @@ type MCPStatus struct {
 	LastChecked time.Time `json:"last_checked"`
 }
 
-// HealthResponse represents the standardized health check response
+// HealthResponse represents the standardized health check response.
+//
+// This endpoint is unauthenticated (it must stay reachable for Kubernetes
+// liveness and readiness probes), so it deliberately exposes no build
+// fingerprint — version, commit, build date, Go version, or platform. This
+// matches the minimal shape already used by the vMCP server and the v1 API,
+// which redact the same information to avoid disclosure on an unauthenticated
+// path.
 type HealthResponse struct {
 	// Status is the overall health status
 	Status HealthStatus `json:"status"`
 	// Timestamp is when the health check was performed
 	Timestamp time.Time `json:"timestamp"`
-	// Version contains ToolHive version information
-	Version versions.VersionInfo `json:"version"`
 	// Transport indicates the type of transport used by the MCP server (stdio, sse)
 	Transport string `json:"transport"`
 	// MCP contains MCP server status information
@@ -82,7 +85,6 @@ func (hc *HealthChecker) CheckHealth(ctx context.Context) *HealthResponse {
 	response := &HealthResponse{
 		Status:    StatusHealthy,
 		Timestamp: time.Now(),
-		Version:   versions.GetVersionInfo(),
 		Transport: hc.transport,
 	}
 

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -13,9 +13,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stacklok/toolhive/pkg/versions"
 )
+
+// fingerprintKeys are the JSON keys a build fingerprint would serialize under.
+// The unauthenticated /health response must not expose any of them.
+var fingerprintKeys = []string{"version", "commit", "build_date", "go_version", "platform"}
+
+func assertNoFingerprint(t *testing.T, body []byte) {
+	t.Helper()
+	for _, key := range fingerprintKeys {
+		assert.NotContains(t, string(body), key,
+			"unauthenticated /health body must not expose %q", key)
+	}
+}
 
 // mockMCPPinger implements MCPPinger for testing
 type mockMCPPinger struct {
@@ -74,7 +84,6 @@ func TestHealthChecker_CheckHealth(t *testing.T) {
 
 			assert.Equal(t, tt.expectedStatus, health.Status)
 			assert.Equal(t, tt.transport, health.Transport)
-			assert.NotEmpty(t, health.Version.Version)
 			assert.WithinDuration(t, time.Now(), health.Timestamp, 1*time.Second)
 
 			if tt.pinger != nil {
@@ -118,9 +127,9 @@ func TestHealthChecker_ServeHTTP(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, StatusHealthy, response.Status)
 				assert.Equal(t, "stdio", response.Transport)
-				assert.NotEmpty(t, response.Version.Version)
 				assert.NotNil(t, response.MCP)
 				assert.True(t, response.MCP.Available)
+				assertNoFingerprint(t, body)
 			},
 		},
 		{
@@ -134,9 +143,9 @@ func TestHealthChecker_ServeHTTP(t *testing.T) {
 				err := json.Unmarshal(body, &response)
 				require.NoError(t, err)
 				assert.Equal(t, StatusDegraded, response.Status)
-				assert.NotEmpty(t, response.Version.Version)
 				assert.NotNil(t, response.MCP)
 				assert.False(t, response.MCP.Available)
+				assertNoFingerprint(t, body)
 			},
 		},
 		{
@@ -181,7 +190,6 @@ func TestHealthResponse_JSON(t *testing.T) {
 	response := &HealthResponse{
 		Status:    StatusHealthy,
 		Timestamp: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
-		Version:   versions.GetVersionInfo(),
 		Transport: "stdio",
 		MCP: &MCPStatus{
 			Available:    true,
@@ -199,8 +207,8 @@ func TestHealthResponse_JSON(t *testing.T) {
 
 	assert.Equal(t, response.Status, unmarshaled.Status)
 	assert.Equal(t, response.Transport, unmarshaled.Transport)
-	assert.Equal(t, response.Version.Version, unmarshaled.Version.Version)
 	assert.True(t, response.Timestamp.Equal(unmarshaled.Timestamp))
+	assertNoFingerprint(t, data)
 
 	require.NotNil(t, unmarshaled.MCP)
 	assert.Equal(t, response.MCP.Available, unmarshaled.MCP.Available)


### PR DESCRIPTION
## Summary

The proxy `/health` endpoint (`pkg/healthcheck/healthcheck.go`) set `Version: versions.GetVersionInfo()` on its response unconditionally — no flag, no redaction — exposing version, commit, build date, `runtime.Version()`, and `GOOS/GOARCH`. The endpoint must stay **unauthenticated** so Kubernetes liveness/readiness probes can reach it, so the fix is not "put `/health` behind auth" — it is to stop disclosing the build fingerprint.

ToolHive already made this call twice, and the proxies simply did not follow it:
- `pkg/vmcp/server/server.go` returns only `{"status":"ok"}`, with a security comment that it exposes no version information to prevent disclosure.
- `pkg/api/v1/healthcheck.go` returns `204 No Content`.

This is Finding F of #6271.

- Remove the `Version` field from `HealthResponse` and stop calling `versions.GetVersionInfo()`, so the unauthenticated body carries no version, commit, build date, Go version, or platform.
- Keep `status`, `transport`, and MCP backend status so probes retain the degraded-state signal (`/health` still returns 503 when unhealthy).
- Aligns the proxies with the minimal shape already used by vMCP and the v1 API.

Part of #6271

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Updated `pkg/healthcheck/healthcheck_test.go`: dropped the `Version` assertions and added `assertNoFingerprint`, which asserts the serialized `/health` body contains none of `version`, `commit`, `build_date`, `go_version`, `platform`.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes. The proxy `/health` JSON response no longer includes a `version` object (version/commit/build date/Go version/platform). Anyone parsing that field from `/health` should read version information from an authenticated source instead.

Generated with [Claude Code](https://claude.com/claude-code)