### PR TITLE
Clear the last zizmor findings in the release workflows

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -44,6 +44,10 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # releaseo pushes the release branch with the app token it is given
+          # explicitly, not with the credential actions/checkout persists.
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -35,6 +35,9 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          # The one push in this job supplies its token in the remote URL, so
+          # the credential actions/checkout persists is never used.
+          persist-credentials: false
 
       - name: Read version
         id: version
@@ -49,8 +52,9 @@ jobs:
 
       - name: Verify release PR
         id: verify
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
 
           # Get commit details
           COMMIT_MSG=$(git log -1 --pretty=%s)
@@ -124,8 +128,10 @@ jobs:
 
       - name: Check if tag exists
         id: check-tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists"
             echo "exists=true" >> $GITHUB_OUTPUT
@@ -136,21 +142,28 @@ jobs:
 
       - name: Create tag
         if: steps.check-tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
-          git push https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git "$TAG"
+          # The token is supplied in the URL, so this push does not use the
+          # credential actions/checkout would otherwise leave in .git/config.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git" "$TAG"
           echo "Created and pushed tag: $TAG"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Check if GitHub Release exists
         id: check-release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub Release $TAG already exists"
             echo "exists=true" >> $GITHUB_OUTPUT
@@ -158,13 +171,11 @@ jobs:
             echo "GitHub Release $TAG does not exist"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create GitHub Release
         if: steps.check-release.outputs.exists == 'false'
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
 
           # Create GitHub Release (triggers releaser.yml via release event)
           # Note: Uses a GitHub App installation token rather than GITHUB_TOKEN,
@@ -183,16 +194,19 @@ jobs:
           echo "Created GitHub Release: $TAG"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.version }}
           # Read out of a git commit trailer, so unlike the version — which is
           # checked against a semver pattern before use — this one is not
           # constrained by anything. Bound rather than interpolated.
           TRIGGERED_BY: ${{ steps.actor.outputs.triggered_by }}
 
       - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG_EXISTED: ${{ steps.check-tag.outputs.exists }}
+          RELEASE_EXISTED: ${{ steps.check-release.outputs.exists }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
-          TAG_EXISTED="${{ steps.check-tag.outputs.exists }}"
-          RELEASE_EXISTED="${{ steps.check-release.outputs.exists }}"
+          TAG="v${VERSION}"
 
           echo "## Release Summary for \`$TAG\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Verify tag matches VERSION file
         run: |
@@ -84,6 +86,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - id: ldflags
         run: |
           echo "commit=$GITHUB_SHA" >> $GITHUB_OUTPUT
@@ -105,6 +108,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6


### PR DESCRIPTION
Follows #6275, which did the same for `helm-publish.yml`. **This clears the last of them: `zizmor` now reports no findings at all across `.github/`.**

## Summary

- **`create-release-tag.yml` — 9 findings → 0.** Every expression in a `run:` block is bound through `env:`, and the checkout stops persisting credentials.
- **`releaser.yml` ×3 and `create-release-pr.yml` ×1 — the remaining `artipacked` findings.** Checkouts that kept a credential none of them uses.

Repository total: **13 → 0**. The starting point was 111.

## This is consistency, not a fix

Seven of the eight `template-injection` findings are the same value — `steps.version.outputs.version` — which the job checks against `^[0-9]+\.[0-9]+\.[0-9]+$` before any of these steps run. The eighth pair are `steps.check-*.outputs.exists`, which the workflow sets itself to the literal `true` or `false`. None could carry a shell metacharacter. The genuinely unconstrained value in this file, the `Release-Triggered-By` commit trailer, was bound in #6272.

## Why the checkout changes are safe

None of these three workflows uses the persisted credential:

| Workflow | Evidence |
|---|---|
| `create-release-tag.yml` | Performs the repository's only `git push` — but as `git push "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"`. The token is in the remote URL, so `.git/config` is never consulted. |
| `releaser.yml` | Contains no `git push`, `commit` or `tag`. GoReleaser uploads assets through the API with the token it is given, and pushes the Homebrew formula with a separate app token. Two of its three checkouts are in jobs declaring `contents: read` and could not push regardless. |
| `create-release-pr.yml` | Contains no git write either. `releaseo` is handed the release app token explicitly as an input. |

Each change carries a comment recording this, so the next reader does not have to re-derive it.

## Deliberately not restructured

The version is bound per-step rather than exported once via `$GITHUB_ENV`. Six `env:` blocks repeating one line is more verbose, but moving a value from a step output into the job environment changes how it flows between steps — a refactor of plumbing in workflows no pull request can exercise. An earlier attempt at this file did exactly that and was correctly pushed back on. The verbose version is the safe one.

Part of #6253

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

- **Checked every shell variable in every step resolves.** Collected each step's available names — workflow `env:`, job `env:`, step `env:`, locally assigned, and GitHub-provided — and compared against every `$VAR` referenced. Nothing undefined.
- **Confirmed no `run:` block contains an expression any more**, by walking the block structure rather than grepping for a pattern.
- **Confirmed how each workflow authenticates**, as tabled above, rather than assuming the credential was unused.
- All workflows parse as YAML; `actionlint` reports 12 findings before and after, all pre-existing.
- `zizmor` across `.github/`: **no findings to report**.

**None of this can be verified before merge.** All three workflows run only on release events. `create-release-tag.yml` failing would stop the run after the release pull request merges but before the tag exists, so nothing would be half-published; recovery is re-running it or tagging by hand.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- Best merged just after a release rather than just before.
- With this and #6274, the gate could drop from `medium` to `low` or lower, since there is nothing left for it to catch. Worth doing as a follow-up once a release has passed through these workflows unchanged — tightening the threshold before the first real exercise would mean two untested changes at once.

Generated with [Claude Code](https://claude.com/claude-code)
