### PR TITLE
Rate limiting observability (metrics and tracing) PR C

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -284,6 +284,21 @@ Total number of Redis errors encountered while checking rate limits.
 | `server` | string | MCPServer or VirtualMCPServer name |
 | `error_type` | string | `"timeout"`, `"connection"`, `"auth"`, or `"other"` |
 
+#### `toolhive_rate_limit_fail_open` (Counter)
+
+Total number of rate limit checks allowed after an enforcement error. Prometheus
+exports this counter as `toolhive_rate_limit_fail_open_total`.
+
+This counter records the application of fail-open policy, while
+`toolhive_rate_limit_redis_errors` records the underlying Redis failure. A
+failed check does not increment `toolhive_rate_limit_decisions` because Redis
+did not produce a rate limit decision.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `namespace` | string | Kubernetes namespace associated with the server |
+| `server` | string | MCPServer or VirtualMCPServer name |
+
 #### `toolhive_rate_limit_check_latency` (Histogram, seconds)
 
 Duration of each attempted atomic Redis Lua rate limit check, including failed
@@ -350,7 +365,7 @@ attributes below.
 |-----------|------|-------------|
 | `rate_limit.decision` | string | `"allowed"` or `"rejected"` |
 | `rate_limit.rejected_by` | string | `"none"` for allowed requests, otherwise the bucket that rejected the request |
-| `rate_limit.fail_open` | bool | `false` for normal allowed and rejected outcomes |
+| `rate_limit.fail_open` | bool | `true` when an enforcement error is allowed to fail open; otherwise `false` |
 
 The bounded `rate_limit.rejected_by` values are:
 
@@ -363,9 +378,12 @@ The bounded `rate_limit.rejected_by` values are:
 
 When no configured bucket applies to a tool call, the span records
 `rate_limit.decision="allowed"`, `rate_limit.rejected_by="none"`, and
-`rate_limit.fail_open=false`. Redis check failures do not receive these normal
-outcome attributes. If multiple rate limit checks use the same request span,
-the latest normal outcome replaces earlier values.
+`rate_limit.fail_open=false`. When a Redis check fails and enforcement fails
+open, the span records `rate_limit.decision="allowed"`,
+`rate_limit.rejected_by="none"`, and `rate_limit.fail_open=true`. These
+attributes describe the rate limit outcome only; the eventual request result
+determines the span status. If multiple rate limit checks use the same request
+span, the latest outcome replaces earlier values (last write wins).
 
 ### Tool, Prompt, and Resource Attributes
 

--- a/pkg/ratelimit/limiter.go
+++ b/pkg/ratelimit/limiter.go
@@ -29,6 +29,12 @@ type Limiter interface {
 	Allow(ctx context.Context, toolName, userID string) (*Decision, error)
 }
 
+// failOpenObserver records the policy decision made by production enforcement
+// adapters after the built-in limiter returns an infrastructure error.
+type failOpenObserver interface {
+	recordFailOpen(context.Context)
+}
+
 // Decision holds the result of a rate limit check.
 type Decision struct {
 	// Allowed is true when the request may proceed.
@@ -39,7 +45,10 @@ type Decision struct {
 	RetryAfter time.Duration
 }
 
-// Allow checks whether identity may call toolName through limiter.
+// Allow checks whether identity may call toolName through limiter. When the
+// built-in limiter returns an infrastructure error, Allow records fail-open
+// observability before preserving the error for the HTTP or vMCP adapter to log
+// and apply its existing fail-open behavior.
 func Allow(ctx context.Context, limiter Limiter, identity *auth.Identity, toolName string) error {
 	if limiter == nil {
 		return nil
@@ -55,6 +64,9 @@ func Allow(ctx context.Context, limiter Limiter, identity *auth.Identity, toolNa
 
 	decision, err := limiter.Allow(ctx, toolName, userID)
 	if err != nil {
+		if observer, ok := limiter.(failOpenObserver); ok {
+			observer.recordFailOpen(ctx)
+		}
 		return err
 	}
 	if !decision.Allowed {
@@ -163,6 +175,13 @@ type limiter struct {
 	perUserTools map[string]bucketSpec          // tool name -> per-user bucket spec; nil when none
 }
 
+var _ failOpenObserver = (*limiter)(nil)
+
+func (l *limiter) recordFailOpen(ctx context.Context) {
+	l.telemetry.recordFailOpen(ctx)
+	recordRateLimitSpanOutcome(ctx, rateLimitDecisionAllowed, rateLimitRejectedByNone, true)
+}
+
 // Allow atomically checks all applicable rate limit buckets for the request.
 // Tokens are only consumed if ALL buckets have sufficient capacity, preventing
 // a rejected per-tool or per-user call from draining other budgets.
@@ -225,7 +244,7 @@ func (l *limiter) Allow(ctx context.Context, toolName, userID string) (*Decision
 	}
 
 	if len(checks) == 0 {
-		recordRateLimitSpanOutcome(ctx, rateLimitDecisionAllowed, rateLimitRejectedByNone)
+		recordRateLimitSpanOutcome(ctx, rateLimitDecisionAllowed, rateLimitRejectedByNone, false)
 		return &Decision{Allowed: true}, nil
 	}
 
@@ -243,7 +262,7 @@ func (l *limiter) Allow(ctx context.Context, toolName, userID string) (*Decision
 	}
 	if rejectedIdx >= 0 {
 		l.telemetry.recordRejected(ctx, checks[rejectedIdx])
-		recordRateLimitSpanOutcome(ctx, rateLimitDecisionRejected, checks[rejectedIdx].rejectionIdentifier())
+		recordRateLimitSpanOutcome(ctx, rateLimitDecisionRejected, checks[rejectedIdx].rejectionIdentifier(), false)
 		return &Decision{
 			Allowed:    false,
 			RetryAfter: buckets[rejectedIdx].RetryAfter(),
@@ -251,7 +270,7 @@ func (l *limiter) Allow(ctx context.Context, toolName, userID string) (*Decision
 	}
 
 	l.telemetry.recordAllowed(ctx, checks)
-	recordRateLimitSpanOutcome(ctx, rateLimitDecisionAllowed, rateLimitRejectedByNone)
+	recordRateLimitSpanOutcome(ctx, rateLimitDecisionAllowed, rateLimitRejectedByNone, false)
 	return &Decision{Allowed: true}, nil
 }
 

--- a/pkg/ratelimit/middleware_test.go
+++ b/pkg/ratelimit/middleware_test.go
@@ -6,7 +6,6 @@ package ratelimit
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +16,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -262,22 +262,55 @@ func TestRateLimitHandler_AnnotatesTelemetryRequestSpan(t *testing.T) {
 
 func TestRateLimitHandler_RedisErrorFailOpen(t *testing.T) {
 	t.Parallel()
+	client, redisServer := newTestClient(t)
+	limiter, err := newLimiter(
+		client,
+		"test-ns",
+		"test-server",
+		newSpanTestRateLimitConfig(t, rateLimitScopeShared, rateLimitOperationTool),
+		nil,
+	)
+	require.NoError(t, err)
+	redisServer.Close()
 
-	limiter := &dummyLimiter{err: errors.New("redis connection refused")}
+	tracerProvider, recorder := newRateLimitTracerProvider(t)
+	meterProvider := sdkmetric.NewMeterProvider()
+	t.Cleanup(func() {
+		require.NoError(t, meterProvider.Shutdown(context.Background()))
+	})
+	telemetryMiddleware := telemetry.NewHTTPMiddleware(
+		telemetry.Config{},
+		tracerProvider,
+		meterProvider,
+		"test-server",
+		"streamable-http",
+	)
 	nextCalled := false
-	handler := rateLimitHandler(limiter)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		nextCalled = true
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
-	req = withParsedMCPRequest(req, "tools/call", "echo", 1)
+	handler := mcp.ParsingMiddleware(telemetryMiddleware(rateLimitHandler(limiter)(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+			w.WriteHeader(http.StatusOK)
+		},
+	))))
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search"}}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
 
 	assert.True(t, nextCalled, "should fail open and call next handler")
 	assert.Equal(t, http.StatusOK, w.Code)
+	spans := recorder.Ended()
+	require.Len(t, spans, 1, "fail-open must preserve the telemetry request span without creating another span")
+	attributes := spanAttributeMap(spans[0])
+	assert.Equal(t, "allowed", attributes["rate_limit.decision"])
+	assert.Equal(t, "none", attributes["rate_limit.rejected_by"])
+	assert.Equal(t, true, attributes["rate_limit.fail_open"])
+	assert.Equal(t, codes.Ok, spans[0].Status().Code)
 }
 
 func TestRateLimitHandler_NoParsedMCPRequest_PassesThrough(t *testing.T) {

--- a/pkg/ratelimit/observability.go
+++ b/pkg/ratelimit/observability.go
@@ -45,6 +45,7 @@ type rateLimitTelemetry struct {
 
 	decisions    metric.Int64Counter
 	redisErrors  metric.Int64Counter
+	failOpen     metric.Int64Counter
 	checkLatency metric.Float64Histogram
 }
 
@@ -75,6 +76,14 @@ func newRateLimitTelemetry(
 		return nil, fmt.Errorf("create Redis error counter: %w", err)
 	}
 
+	failOpen, err := meter.Int64Counter(
+		"toolhive_rate_limit_fail_open",
+		metric.WithDescription("Total number of rate limit checks allowed after an enforcement error"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create fail-open counter: %w", err)
+	}
+
 	checkLatency, err := meter.Float64Histogram(
 		"toolhive_rate_limit_check_latency",
 		metric.WithDescription("Duration of Redis Lua rate limit checks in seconds"),
@@ -90,6 +99,7 @@ func newRateLimitTelemetry(
 		serverName:   serverName,
 		decisions:    decisions,
 		redisErrors:  redisErrors,
+		failOpen:     failOpen,
 		checkLatency: checkLatency,
 	}, nil
 }
@@ -131,6 +141,16 @@ func (t *rateLimitTelemetry) recordRedisError(ctx context.Context, err error) {
 	))
 }
 
+func (t *rateLimitTelemetry) recordFailOpen(ctx context.Context) {
+	if t == nil {
+		return
+	}
+	t.failOpen.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("namespace", t.namespace),
+		attribute.String("server", t.serverName),
+	))
+}
+
 func (t *rateLimitTelemetry) recordCheckLatency(ctx context.Context, duration time.Duration) {
 	if t == nil {
 		return
@@ -141,11 +161,11 @@ func (t *rateLimitTelemetry) recordCheckLatency(ctx context.Context, duration ti
 	))
 }
 
-func recordRateLimitSpanOutcome(ctx context.Context, decision, rejectedBy string) {
+func recordRateLimitSpanOutcome(ctx context.Context, decision, rejectedBy string, failOpen bool) {
 	trace.SpanFromContext(ctx).SetAttributes(
 		attribute.String("rate_limit.decision", decision),
 		attribute.String("rate_limit.rejected_by", rejectedBy),
-		attribute.Bool("rate_limit.fail_open", false),
+		attribute.Bool("rate_limit.fail_open", failOpen),
 	)
 }
 

--- a/pkg/ratelimit/observability_test.go
+++ b/pkg/ratelimit/observability_test.go
@@ -169,6 +169,142 @@ func TestRateLimitMetrics_RedisErrorAndFailedLatency(t *testing.T) {
 		"server":    "test-server",
 	}))
 	assert.Nil(t, findRateLimitMetric(metrics, "toolhive_rate_limit_decisions"))
+	assert.Nil(t, findRateLimitMetric(metrics, "toolhive_rate_limit_fail_open"))
+}
+
+func TestRateLimitMetrics_SharedAdapterRecordsFailOpenPerInvocation(t *testing.T) {
+	t.Parallel()
+	client, redisServer := newTestClient(t)
+	reader, meterProvider := newRateLimitMeterProvider()
+	t.Cleanup(func() {
+		require.NoError(t, meterProvider.Shutdown(context.Background()))
+	})
+
+	limiter, err := newLimiter(client, "test-ns", "test-server", &v1beta1.RateLimitConfig{
+		Shared: &v1beta1.RateLimitBucket{
+			MaxTokens:    1,
+			RefillPeriod: metav1.Duration{Duration: time.Minute},
+		},
+	}, meterProvider)
+	require.NoError(t, err)
+	redisServer.Close()
+
+	tracerProvider, recorder := newRateLimitTracerProvider(t)
+	tracer := tracerProvider.Tracer("rate-limit-test")
+	for range 2 {
+		ctx, span := tracer.Start(t.Context(), "request")
+		err := Allow(ctx, limiter, nil, "")
+		require.Error(t, err)
+		span.End()
+	}
+
+	metrics := collectRateLimitMetrics(t, reader)
+	failOpen := requireRateLimitMetric(t, metrics, "toolhive_rate_limit_fail_open")
+	sum, ok := failOpen.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "metric %q is not an int64 sum", failOpen.Name)
+	require.Len(t, sum.DataPoints, 1)
+	assert.Equal(t, int64(2), sum.DataPoints[0].Value)
+	assert.Equal(t, map[string]string{
+		"namespace": "test-ns",
+		"server":    "test-server",
+	}, stringAttributeMap(sum.DataPoints[0].Attributes))
+
+	redisErrors := requireRateLimitMetric(t, metrics, "toolhive_rate_limit_redis_errors")
+	assert.Equal(t, int64(2), counterValueWithAttributes(t, redisErrors, map[string]string{
+		"namespace":  "test-ns",
+		"server":     "test-server",
+		"error_type": redisErrorTypeConnection,
+	}))
+	assert.Nil(t, findRateLimitMetric(metrics, "toolhive_rate_limit_decisions"))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 2, "fail-open must annotate ambient spans without creating child spans")
+	for _, span := range spans {
+		attributes := spanAttributeMap(span)
+		assert.Equal(t, "allowed", attributes["rate_limit.decision"])
+		assert.Equal(t, "none", attributes["rate_limit.rejected_by"])
+		assert.Equal(t, true, attributes["rate_limit.fail_open"])
+	}
+}
+
+func TestRateLimitMetrics_NormalAdapterOutcomesDoNotRecordFailOpen(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		config     *v1beta1.RateLimitConfig
+		toolName   string
+		preconsume bool
+		nilLimiter bool
+		wantErr    bool
+	}{
+		{
+			name: "allowed",
+			config: &v1beta1.RateLimitConfig{Shared: &v1beta1.RateLimitBucket{
+				MaxTokens: 1, RefillPeriod: metav1.Duration{Duration: time.Minute},
+			}},
+		},
+		{
+			name: "rejected",
+			config: &v1beta1.RateLimitConfig{Shared: &v1beta1.RateLimitBucket{
+				MaxTokens: 1, RefillPeriod: metav1.Duration{Duration: time.Minute},
+			}},
+			preconsume: true,
+			wantErr:    true,
+		},
+		{
+			name: "no applicable bucket",
+			config: &v1beta1.RateLimitConfig{Tools: []v1beta1.ToolRateLimitConfig{{
+				Name: "search",
+				Shared: &v1beta1.RateLimitBucket{
+					MaxTokens: 1, RefillPeriod: metav1.Duration{Duration: time.Minute},
+				},
+			}}},
+			toolName: "other-tool",
+		},
+		{
+			name:   "no-op limiter",
+			config: nil,
+		},
+		{
+			name:       "nil limiter",
+			nilLimiter: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client, _ := newTestClient(t)
+			reader, meterProvider := newRateLimitMeterProvider()
+			t.Cleanup(func() {
+				require.NoError(t, meterProvider.Shutdown(context.Background()))
+			})
+
+			var limiter Limiter
+			if !tt.nilLimiter {
+				var err error
+				limiter, err = newLimiter(client, "test-ns", "test-server", tt.config, meterProvider)
+				require.NoError(t, err)
+			}
+			if tt.preconsume {
+				decision, err := limiter.Allow(t.Context(), tt.toolName, "")
+				require.NoError(t, err)
+				require.True(t, decision.Allowed)
+			}
+
+			err := Allow(t.Context(), limiter, nil, tt.toolName)
+			if tt.wantErr {
+				var limited *RateLimitedError
+				require.ErrorAs(t, err, &limited)
+			} else {
+				require.NoError(t, err)
+			}
+
+			metrics := collectRateLimitMetrics(t, reader)
+			assert.Nil(t, findRateLimitMetric(metrics, "toolhive_rate_limit_fail_open"))
+		})
+	}
 }
 
 func TestRateLimitMetrics_NoApplicableBucketRecordsNothing(t *testing.T) {
@@ -342,6 +478,33 @@ func TestRateLimitSpanAttributes_RedisErrorLeavesOutcomeUnset(t *testing.T) {
 	assert.NotContains(t, attributes, "rate_limit.fail_open")
 }
 
+func TestRateLimitSpanAttributes_FailOpenWithNilMeterProvider(t *testing.T) {
+	t.Parallel()
+	client, redisServer := newTestClient(t)
+	limiter, err := newLimiter(
+		client,
+		"test-ns",
+		"test-server",
+		newSpanTestRateLimitConfig(t, rateLimitScopeShared, rateLimitOperationServer),
+		nil,
+	)
+	require.NoError(t, err)
+	redisServer.Close()
+
+	tracerProvider, recorder := newRateLimitTracerProvider(t)
+	ctx, span := tracerProvider.Tracer("rate-limit-test").Start(t.Context(), "request")
+	err = Allow(ctx, limiter, nil, "")
+	require.Error(t, err)
+	span.End()
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	attributes := spanAttributeMap(spans[0])
+	assert.Equal(t, "allowed", attributes["rate_limit.decision"])
+	assert.Equal(t, "none", attributes["rate_limit.rejected_by"])
+	assert.Equal(t, true, attributes["rate_limit.fail_open"])
+}
+
 func TestClassifyRedisError(t *testing.T) {
 	t.Parallel()
 
@@ -391,6 +554,7 @@ func TestRateLimitMetricNamesUseToolHivePrefix(t *testing.T) {
 		operationType: rateLimitOperationServer,
 	})
 	telemetry.recordRedisError(t.Context(), errors.New("ERR script failed"))
+	telemetry.recordFailOpen(t.Context())
 	telemetry.recordCheckLatency(t.Context(), time.Millisecond)
 
 	metrics := collectRateLimitMetrics(t, reader)
@@ -536,4 +700,12 @@ func attributesMatch(attributes attribute.Set, want map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func stringAttributeMap(attributes attribute.Set) map[string]string {
+	result := make(map[string]string, attributes.Len())
+	for _, attr := range attributes.ToSlice() {
+		result[string(attr.Key)] = attr.Value.AsString()
+	}
+	return result
 }

--- a/pkg/vmcp/ratelimit/decorator_test.go
+++ b/pkg/vmcp/ratelimit/decorator_test.go
@@ -5,7 +5,6 @@ package ratelimit
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,17 +198,54 @@ func TestCallToolRateLimitedAnnotatesAmbientSpan(t *testing.T) {
 
 func TestCallToolLimiterErrorFailsOpen(t *testing.T) {
 	t.Parallel()
+	redisServer := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+	limiter, err := baseratelimit.NewLimiter(client, "test-ns", "test-vmcp", &v1beta1.RateLimitConfig{
+		Tools: []v1beta1.ToolRateLimitConfig{
+			{
+				Name: "backend_a_echo",
+				Shared: &v1beta1.RateLimitBucket{
+					MaxTokens:    1,
+					RefillPeriod: metav1.Duration{Duration: time.Minute},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	redisServer.Close()
 
-	expected := errors.New("redis unavailable")
-	limiter := &recordingLimiter{err: expected}
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(recorder),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	t.Cleanup(func() {
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+	ctx, span := tracerProvider.Tracer("vmcp-rate-limit-test").Start(t.Context(), "request")
 	inner := &recordingCore{}
 	decorated := NewDecorator(inner, limiter)
 
-	result, err := decorated.CallTool(t.Context(), nil, "backend_a_echo", nil, nil)
+	result, err := decorated.CallTool(ctx, nil, "backend_a_echo", nil, nil)
+	span.End()
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, inner.called)
+	spans := recorder.Ended()
+	require.Len(t, spans, 1, "the decorator must preserve the ambient span without creating another span")
+	attributes := make(map[string]any, len(spans[0].Attributes()))
+	for _, attr := range spans[0].Attributes() {
+		attributes[string(attr.Key)] = attr.Value.AsInterface()
+	}
+	assert.Equal(t, "allowed", attributes["rate_limit.decision"])
+	assert.Equal(t, "none", attributes["rate_limit.rejected_by"])
+	assert.Equal(t, true, attributes["rate_limit.fail_open"])
+	assert.Equal(t, codes.Unset, spans[0].Status().Code)
+	assert.Empty(t, spans[0].Events(), "handled fail-open must not be recorded as a span error")
 }
 
 func TestCallToolNilIdentityUsesEmptyUserID(t *testing.T) {


### PR DESCRIPTION
## Summary

Redis error metrics show that a rate-limit check failed, but they do not show
whether ToolHive applied its fail-open policy and allowed the operation to
continue. This leaves operators unable to distinguish an observed dependency
failure from an enforcement outcome for an individual request.

- Add `toolhive_rate_limit_fail_open`, a counter with bounded `namespace` and
  `server` attributes, emitted once per failed shared enforcement check.
- Record fail-open at the shared `ratelimit.Allow` adapter used by MCPServer and
  VirtualMCPServer, without expanding the public limiter interface or
  duplicating transport-specific instrumentation.
- Annotate the existing request span with `decision=allowed`,
  `rejected_by=none`, and `fail_open=true` when enforcement proceeds after a
  Redis error.
- Preserve Redis error metrics, decision-counter semantics, warning logs,
  retry behavior, and the existing mandatory fail-open policy.

Part of #4553

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Additional verification:

- `git diff --check`
- Concrete closed-Redis coverage for the shared adapter, MCPServer middleware,
  and VirtualMCPServer decorator
- Repeated-failure coverage proving one fail-open increment per adapter call
- Normal allowed, rejected, no-applicable-bucket, no-op, and nil-limiter
  coverage proving no fail-open increment

## Changes

| File | Change |
|------|--------|
| `pkg/ratelimit/limiter.go` | Observes fail-open once at the shared enforcement adapter while preserving the original error. |
| `pkg/ratelimit/observability.go` | Adds the fail-open counter and fail-open request-span outcome. |
| `pkg/ratelimit/observability_test.go` | Verifies raw Redis errors, exact counter values and labels, repeated failures, normal outcomes, and nil-meter span behavior. |
| `pkg/ratelimit/middleware_test.go` | Proves MCPServer delegates after Redis failure and preserves its successful request span. |
| `pkg/vmcp/ratelimit/decorator_test.go` | Proves VirtualMCPServer delegates after Redis failure without creating another span. |
| `docs/observability.md` | Documents the new counter and fail-open span semantics. |

## Does this introduce a user-facing change?

Yes. OpenTelemetry and Prometheus users can now identify rate-limit checks that
failed open. Prometheus exports the counter as
`toolhive_rate_limit_fail_open_total`.

Request admission behavior and client responses are unchanged.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

1. Keep raw Redis error and latency telemetry in the concrete limiter, where
   the Redis result is known, without claiming that fail-open has occurred.
2. Add a private observer capability implemented by the built-in limiter; do
   not add a method to the exported `Limiter` interface.
3. Invoke that observer once when the shared `ratelimit.Allow` enforcement
   adapter receives an infrastructure error, then return the original error so
   MCPServer and VirtualMCPServer retain their existing logging and delegation.
4. Increment `toolhive_rate_limit_fail_open` with only `namespace` and `server`
   attributes and annotate the ambient request span as allowed through
   fail-open.
5. Do not increment `toolhive_rate_limit_decisions` for an errored Redis check,
   because Redis did not produce a bucket decision.
6. Verify the raw-error boundary, exact-once adapter emission, normal outcomes,
   and both production enforcement paths with concrete closed-Redis tests.
7. Update the observability reference without adding a disruptive Redis-outage
   Kubernetes E2E.

</details>

## Special notes for reviewers

The package-level `ratelimit.Allow` helper records fail-open observability but
still returns the original limiter error. This deliberately preserves the
existing HTTP and VirtualMCPServer warning logs and their established behavior
of continuing the request after infrastructure failure.

The fail-open counter describes applied enforcement policy, while
`toolhive_rate_limit_redis_errors` describes the underlying dependency failure.
It intentionally has no tool, user, request, error, scope, or operation labels.