### PR TITLE
Intersect default scopes with scopes_supported when scope is omitted

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -372,7 +372,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "baseline_client_scopes": {
-                        "description": "BaselineClientScopes is a baseline set of OAuth 2.0 scopes unioned into every\nDCR registration. All values must appear in ScopesSupported; the auth server\nrejects this RunConfig at startup otherwise. Empty means current behavior is\npreserved (registered scope = client-requested, or DefaultScopes if empty).\nWhen ScopesSupported is empty, the subset check uses registration.DefaultScopes\n(the same set applyDefaults would substitute at startup) — so\nBaselineClientScopes containing standard OIDC scopes works without enumerating\nScopesSupported explicitly.",
+                        "description": "BaselineClientScopes is a baseline set of OAuth 2.0 scopes unioned into every\nDCR registration. All values must appear in ScopesSupported; the auth server\nrejects this RunConfig at startup otherwise. Empty means current behavior is\npreserved (registered scope = client-requested, or the intersection of\nDefaultScopes with ScopesSupported if the client requested none).\nWhen ScopesSupported is empty, the subset check uses registration.DefaultScopes\n(the same set applyDefaults would substitute at startup) — so\nBaselineClientScopes containing standard OIDC scopes works without enumerating\nScopesSupported explicitly.",
                         "items": {
                             "type": "string"
                         },

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -365,7 +365,7 @@
                         "type": "string"
                     },
                     "baseline_client_scopes": {
-                        "description": "BaselineClientScopes is a baseline set of OAuth 2.0 scopes unioned into every\nDCR registration. All values must appear in ScopesSupported; the auth server\nrejects this RunConfig at startup otherwise. Empty means current behavior is\npreserved (registered scope = client-requested, or DefaultScopes if empty).\nWhen ScopesSupported is empty, the subset check uses registration.DefaultScopes\n(the same set applyDefaults would substitute at startup) — so\nBaselineClientScopes containing standard OIDC scopes works without enumerating\nScopesSupported explicitly.",
+                        "description": "BaselineClientScopes is a baseline set of OAuth 2.0 scopes unioned into every\nDCR registration. All values must appear in ScopesSupported; the auth server\nrejects this RunConfig at startup otherwise. Empty means current behavior is\npreserved (registered scope = client-requested, or the intersection of\nDefaultScopes with ScopesSupported if the client requested none).\nWhen ScopesSupported is empty, the subset check uses registration.DefaultScopes\n(the same set applyDefaults would substitute at startup) — so\nBaselineClientScopes containing standard OIDC scopes works without enumerating\nScopesSupported explicitly.",
                         "items": {
                             "type": "string"
                         },

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -486,7 +486,8 @@ components:
             BaselineClientScopes is a baseline set of OAuth 2.0 scopes unioned into every
             DCR registration. All values must appear in ScopesSupported; the auth server
             rejects this RunConfig at startup otherwise. Empty means current behavior is
-            preserved (registered scope = client-requested, or DefaultScopes if empty).
+            preserved (registered scope = client-requested, or the intersection of
+            DefaultScopes with ScopesSupported if the client requested none).
             When ScopesSupported is empty, the subset check uses registration.DefaultScopes
             (the same set applyDefaults would substitute at startup) — so
             BaselineClientScopes containing standard OIDC scopes works without enumerating

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -86,7 +86,8 @@ type RunConfig struct {
 	// BaselineClientScopes is a baseline set of OAuth 2.0 scopes unioned into every
 	// DCR registration. All values must appear in ScopesSupported; the auth server
 	// rejects this RunConfig at startup otherwise. Empty means current behavior is
-	// preserved (registered scope = client-requested, or DefaultScopes if empty).
+	// preserved (registered scope = client-requested, or the intersection of
+	// DefaultScopes with ScopesSupported if the client requested none).
 	// When ScopesSupported is empty, the subset check uses registration.DefaultScopes
 	// (the same set applyDefaults would substitute at startup) — so
 	// BaselineClientScopes containing standard OIDC scopes works without enumerating
@@ -920,7 +921,8 @@ type Config struct {
 	// BaselineClientScopes is a baseline set of OAuth 2.0 scopes the embedded
 	// DCR handler unions into every newly registered client's scope set. Empty
 	// means current behavior is preserved (DCR registers exactly what the client
-	// requested, or registration.DefaultScopes if the client requested none).
+	// requested, or the intersection of registration.DefaultScopes with
+	// ScopesSupported if the client requested none).
 	// All entries must also be present in ScopesSupported. When ScopesSupported
 	// is empty, the validation gate uses registration.DefaultScopes as the
 	// superset — so standard OIDC scopes (e.g. "offline_access") work without
@@ -1502,6 +1504,22 @@ func (c *Config) applyDefaults() error {
 	if len(c.ScopesSupported) == 0 {
 		c.ScopesSupported = registration.DefaultScopes
 		slog.Debug("applied default scopes_supported", "scopes", c.ScopesSupported)
+	}
+	// One-time operator-facing signal for the omitted-scope registration
+	// behavior (see registration.ValidateScopes and issue #6186). The outcome
+	// is fully determined by ScopesSupported, so it is logged once here
+	// rather than on every unauthenticated /oauth/register call or CIMD
+	// resolution — those record it at Debug.
+	if intersection, dropped, dcrErr := registration.ValidateScopes(nil, c.ScopesSupported); dcrErr != nil {
+		slog.Warn("scopes_supported shares no scopes with the default set; "+
+			"clients that omit scope will be rejected and must declare scope explicitly",
+			"scopes_supported", c.ScopesSupported,
+			"default_scopes", registration.DefaultScopes)
+	} else if len(dropped) > 0 {
+		slog.Info("scopes_supported does not cover the default scope set; "+
+			"clients that omit scope will register with the intersection",
+			"intersection", intersection,
+			"dropped_defaults", dropped)
 	}
 	if c.CIMDEnabled && c.CIMDCacheMaxSize == 0 {
 		c.CIMDCacheMaxSize = 256

--- a/pkg/authserver/server/handlers/dcr.go
+++ b/pkg/authserver/server/handlers/dcr.go
@@ -75,10 +75,20 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 	}
 
 	// Validate requested scopes against server's supported scopes
-	scopes, dcrErr := registration.ValidateScopes(dcrReq.Scopes, h.config.ScopesSupported)
+	scopes, droppedDefaults, dcrErr := registration.ValidateScopes(dcrReq.Scopes, h.config.ScopesSupported)
 	if dcrErr != nil {
 		writeDCRError(w, http.StatusBadRequest, dcrErr)
 		return
+	}
+	if len(droppedDefaults) > 0 {
+		// The request omitted scope and scopes_supported does not carry the
+		// full default set: registration proceeds with the intersection.
+		// Warn so operators can see which defaults the client did not get.
+		slog.Warn("DCR request omitted scope; registering the intersection of default scopes with scopes_supported",
+			"client_name", validated.ClientName,
+			"granted", scopes,
+			"dropped_defaults", droppedDefaults,
+		)
 	}
 
 	// Union with the operator-configured scope baseline. RFC 7591 §3.2.1 permits

--- a/pkg/authserver/server/handlers/dcr.go
+++ b/pkg/authserver/server/handlers/dcr.go
@@ -80,16 +80,6 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		writeDCRError(w, http.StatusBadRequest, dcrErr)
 		return
 	}
-	if len(droppedDefaults) > 0 {
-		// The request omitted scope and scopes_supported does not carry the
-		// full default set: registration proceeds with the intersection.
-		// Warn so operators can see which defaults the client did not get.
-		slog.Warn("DCR request omitted scope; registering the intersection of default scopes with scopes_supported",
-			"client_name", validated.ClientName,
-			"granted", scopes,
-			"dropped_defaults", droppedDefaults,
-		)
-	}
 
 	// Union with the operator-configured scope baseline. RFC 7591 §3.2.1 permits
 	// the AS to replace requested client metadata values during registration; we
@@ -196,6 +186,16 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 		"software_id", validated.SoftwareID,
 		"token_endpoint_auth_method", effectiveAuthMethod,
 		"scopes", scopes,
+	}
+	// The request omitted scope and scopes_supported does not carry the full
+	// default set: registration proceeded with the intersection (see issue
+	// #6186). Recorded on this line — after the baseline union and the
+	// client_id mint — so "scopes" is the set the client actually holds and
+	// the drop correlates with the client's later log lines. The drop itself
+	// is fully determined by startup config; the one-time operator-facing
+	// signal lives in Config.applyDefaults.
+	if len(droppedDefaults) > 0 {
+		logAttrs = append(logAttrs, "dropped_defaults", droppedDefaults)
 	}
 	if issuer := h.issuer(); issuer != "" {
 		logAttrs = append(logAttrs, "issuer", issuer)

--- a/pkg/authserver/server/handlers/dcr.go
+++ b/pkg/authserver/server/handlers/dcr.go
@@ -181,27 +181,9 @@ func (h *Handler) RegisterClientHandler(w http.ResponseWriter, req *http.Request
 	// upstream AS. The two uses live at opposite ends of the DCR flow.
 	// No "upstream" attribute is emitted because the /oauth/register
 	// endpoint has no upstream concept.
-	logAttrs := []any{
-		"client_id", clientID,
-		"software_id", validated.SoftwareID,
-		"token_endpoint_auth_method", effectiveAuthMethod,
-		"scopes", scopes,
-	}
-	// The request omitted scope and scopes_supported does not carry the full
-	// default set: registration proceeded with the intersection (see issue
-	// #6186). Recorded on this line — after the baseline union and the
-	// client_id mint — so "scopes" is the set the client actually holds and
-	// the drop correlates with the client's later log lines. The drop itself
-	// is fully determined by startup config; the one-time operator-facing
-	// signal lives in Config.applyDefaults.
-	if len(droppedDefaults) > 0 {
-		logAttrs = append(logAttrs, "dropped_defaults", droppedDefaults)
-	}
-	if issuer := h.issuer(); issuer != "" {
-		logAttrs = append(logAttrs, "issuer", issuer)
-	}
 	//nolint:gosec // G706: client_id is public metadata per RFC 7591.
-	slog.Debug("registered new DCR client", logAttrs...)
+	slog.Debug("registered new DCR client",
+		h.dcrClientLogAttrs(clientID, validated.SoftwareID, effectiveAuthMethod, scopes, droppedDefaults)...)
 
 	// Build response per RFC 7591 Section 3.2.1.
 	// Scopes reflects the scopes actually granted to this client: the
@@ -266,6 +248,32 @@ func (h *Handler) validateDCRRequest(
 		Error:            registration.DCRErrorInvalidClientMetadata,
 		ErrorDescription: "token-only authorization servers only permit private_key_jwt token-exchange registrations",
 	}
+}
+
+// dcrClientLogAttrs builds the attribute list for the "registered new DCR
+// client" record. dropped_defaults is attached only when the request omitted
+// scope and scopes_supported did not carry the full default set (see issue
+// #6186): recording it here — after the baseline union and the client_id
+// mint upstream — means "scopes" is the set the client actually holds and
+// the drop correlates with the client's later log lines. The drop itself is
+// fully determined by startup config; the one-time operator-facing signal
+// lives in Config.applyDefaults.
+func (h *Handler) dcrClientLogAttrs(
+	clientID, softwareID, effectiveAuthMethod string, scopes, droppedDefaults []string,
+) []any {
+	attrs := []any{
+		"client_id", clientID,
+		"software_id", softwareID,
+		"token_endpoint_auth_method", effectiveAuthMethod,
+		"scopes", scopes,
+	}
+	if len(droppedDefaults) > 0 {
+		attrs = append(attrs, "dropped_defaults", droppedDefaults)
+	}
+	if issuer := h.issuer(); issuer != "" {
+		attrs = append(attrs, "issuer", issuer)
+	}
+	return attrs
 }
 
 // resolveForceConfidentialOverride checks whether validated's redirect_uris

--- a/pkg/authserver/server/handlers/dcr_test.go
+++ b/pkg/authserver/server/handlers/dcr_test.go
@@ -266,6 +266,43 @@ func TestRegisterClientHandler_ScopeInResponse(t *testing.T) {
 		"DCR response should include granted scopes per RFC 7591 Section 3.2.1")
 }
 
+// TestRegisterClientHandler_OmittedScopeGrantsIntersection pins the
+// default-scope fallback when scopes_supported does not carry the full
+// default set: the registration proceeds with the intersection of
+// DefaultScopes and ScopesSupported instead of rejecting (issue #6186).
+func TestRegisterClientHandler_OmittedScopeGrantsIntersection(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	stor := mocks.NewMockStorage(ctrl)
+	stor.EXPECT().RegisterClient(gomock.Any(), gomock.Any()).Return(nil)
+
+	handler := &Handler{
+		storage: stor,
+		config: &server.AuthorizationServerConfig{
+			Config:          &fosite.Config{AccessTokenIssuer: "https://test-authserver"},
+			ScopesSupported: []string{"openid", "email", "offline_access"}, // lacks "profile"
+		},
+	}
+
+	reqBody, err := json.Marshal(oauthproto.DynamicClientRegistrationRequest{
+		RedirectURIs: []string{"http://127.0.0.1:8080/callback"},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/register", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.RegisterClientHandler(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp oauthproto.DynamicClientRegistrationResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, []string{"openid", "email", "offline_access"}, []string(resp.Scopes),
+		"registration must proceed with the intersection of default scopes and scopes_supported")
+}
+
 func TestRegisterClientHandler_BaselineClientScopes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -544,6 +544,18 @@ func ValidateScopes(requestedScopes, allowedScopes []string) (scopes, droppedDef
 	// reject any client that omits scope against a server whose
 	// scopes_supported does not carry the full default set, even though a
 	// perfectly usable subset exists (see issue #6186).
+	//
+	// Known residual gap (#6186): this fallback draws from DefaultScopes
+	// only, never from the rest of allowedScopes. A scope-omitting client
+	// against a server whose scopes_supported carries entries outside the
+	// default set (e.g. mcp:tools) registers without them — and because
+	// protected-resource metadata advertises scopes_supported and MCP
+	// guidance tells clients to request all of it absent a narrower hint,
+	// such a client can then fail at /oauth/authorize with invalid_scope.
+	// Defaulting to allowedScopes itself would close that, but granting
+	// every anonymous registration the full advertised set is a policy
+	// decision; the explicit opt-in for it is
+	// baseline_client_scopes = scopes_supported.
 	for _, s := range DefaultScopes {
 		if allowed[s] {
 			scopes = append(scopes, s)

--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -20,6 +20,7 @@ package registration
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/go-jose/go-jose/v3"
 
@@ -499,13 +500,20 @@ func ValidateRedirectURI(uri string) *DCRError {
 // ValidateScopes validates a slice of already-parsed scope tokens against
 // the server's allowed set per RFC 7591 §2.
 //
-//   - Empty/nil input falls back to DefaultScopes (which must itself be a
-//     subset of allowedScopes; otherwise the call returns an error).
+//   - Empty/nil input falls back to the intersection of DefaultScopes with
+//     allowedScopes (RFC 7591 §2 permits the server to register a client
+//     with a default set of scopes). Defaults the server does not support
+//     are returned in droppedDefaults so callers can surface them; only an
+//     empty intersection is rejected, because no sensible default exists
+//     and the client must declare scope explicitly.
 //   - Each requested scope must appear in allowedScopes; otherwise returns
 //     invalid_client_metadata.
 //   - Duplicates in the input are tolerated and deduplicated per RFC 6749
 //     §3.3 (scope is a set of case-sensitive strings).
-func ValidateScopes(requestedScopes, allowedScopes []string) ([]string, *DCRError) {
+//
+// droppedDefaults is non-nil only on the default-fallback path; requested
+// scopes are validated strictly and never dropped.
+func ValidateScopes(requestedScopes, allowedScopes []string) (scopes, droppedDefaults []string, dcrErr *DCRError) {
 	// Build allowed scope set for O(1) lookup
 	allowed := make(map[string]bool, len(allowedScopes))
 	for _, s := range allowedScopes {
@@ -514,12 +522,11 @@ func ValidateScopes(requestedScopes, allowedScopes []string) ([]string, *DCRErro
 
 	// Deduplicate while validating each requested scope against the
 	// allowed set.
-	var scopes []string
 	if len(requestedScopes) > 0 {
 		seen := make(map[string]bool)
 		for _, s := range requestedScopes {
 			if !allowed[s] {
-				return nil, &DCRError{
+				return nil, nil, &DCRError{
 					Error:            DCRErrorInvalidClientMetadata,
 					ErrorDescription: "unsupported scope: " + s,
 				}
@@ -529,22 +536,29 @@ func ValidateScopes(requestedScopes, allowedScopes []string) ([]string, *DCRErro
 				scopes = append(scopes, s)
 			}
 		}
+		return scopes, nil, nil
 	}
 
-	// If no scopes requested, use defaults validated against allowed scopes
-	if len(scopes) == 0 {
-		for _, s := range DefaultScopes {
-			if !allowed[s] {
-				return nil, &DCRError{
-					Error:            DCRErrorInvalidClientMetadata,
-					ErrorDescription: "default scope not supported by server: " + s,
-				}
-			}
+	// No scopes requested: fall back to the intersection of DefaultScopes
+	// with the allowed set. Requiring every default to be supported would
+	// reject any client that omits scope against a server whose
+	// scopes_supported does not carry the full default set, even though a
+	// perfectly usable subset exists (see issue #6186).
+	for _, s := range DefaultScopes {
+		if allowed[s] {
+			scopes = append(scopes, s)
+		} else {
+			droppedDefaults = append(droppedDefaults, s)
 		}
-		return DefaultScopes, nil
 	}
-
-	return scopes, nil
+	if len(scopes) == 0 {
+		return nil, nil, &DCRError{
+			Error: DCRErrorInvalidClientMetadata,
+			ErrorDescription: "none of the default scopes (" + strings.Join(DefaultScopes, " ") +
+				") are supported by this server; the client must declare scope explicitly",
+		}
+	}
+	return scopes, droppedDefaults, nil
 }
 
 // UnionScopes returns the union of requested and baseline scopes, preserving

--- a/pkg/authserver/server/registration/dcr_test.go
+++ b/pkg/authserver/server/registration/dcr_test.go
@@ -690,6 +690,7 @@ func TestValidateScopes(t *testing.T) {
 		expectError     bool
 		errorCode       string
 		expectedScopes  []string
+		expectedDropped []string
 	}{
 		{
 			name:            "valid subset of allowed scopes",
@@ -737,7 +738,21 @@ func TestValidateScopes(t *testing.T) {
 			expectedScopes:  []string{"openid", "profile"},
 		},
 		{
-			name:            "empty input rejected when defaults not in allowed set",
+			name:            "empty input returns intersection when some defaults unsupported",
+			requestedScopes: nil,
+			allowedScopes:   []string{"openid", "email", "offline_access"},
+			expectedScopes:  []string{"openid", "email", "offline_access"},
+			expectedDropped: []string{"profile"},
+		},
+		{
+			name:            "empty input returns single-scope intersection",
+			requestedScopes: nil,
+			allowedScopes:   []string{"email", "custom_scope"},
+			expectedScopes:  []string{"email"},
+			expectedDropped: []string{"openid", "profile", "offline_access"},
+		},
+		{
+			name:            "empty input rejected when no default scope is in the allowed set",
 			requestedScopes: nil,
 			allowedScopes:   []string{"custom_scope"},
 			expectError:     true,
@@ -749,15 +764,17 @@ func TestValidateScopes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			scopes, dcrErr := ValidateScopes(tt.requestedScopes, tt.allowedScopes)
+			scopes, dropped, dcrErr := ValidateScopes(tt.requestedScopes, tt.allowedScopes)
 
 			if tt.expectError {
 				require.NotNil(t, dcrErr, "expected error")
 				assert.Equal(t, tt.errorCode, dcrErr.Error)
 				assert.Nil(t, scopes)
+				assert.Nil(t, dropped)
 			} else {
 				require.Nil(t, dcrErr, "unexpected error: %v", dcrErr)
 				assert.Equal(t, tt.expectedScopes, scopes)
+				assert.Equal(t, tt.expectedDropped, dropped)
 			}
 		})
 	}

--- a/pkg/authserver/storage/cimd_decorator.go
+++ b/pkg/authserver/storage/cimd_decorator.go
@@ -142,6 +142,13 @@ func (d *CIMDStorageDecorator) fetchOrCached(ctx context.Context, id string) (fo
 func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Client, error) {
 	doc, err := cimd.FetchClientMetadataDocument(ctx, id)
 	if err != nil {
+		// Log every rejection in fetch() at Warn: the errors returned here
+		// surface to the client as a generic invalid_client/invalid_request
+		// with the hint dropped by fosite's production error rendering, so
+		// without a server-side log line these failures are undiagnosable
+		// (see issue #6186).
+		slog.WarnContext(ctx, "CIMD document fetch failed",
+			"client_id", id, "error", err)
 		return nil, fmt.Errorf("%w: %w", fosite.ErrNotFound.WithHint("CIMD fetch failed"), err)
 	}
 
@@ -152,6 +159,8 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 	// be fetched at all).
 	authMethod, ok := negotiateTokenEndpointAuthMethod(doc)
 	if !ok {
+		slog.WarnContext(ctx, "CIMD client rejected: unsupported token_endpoint_auth_method",
+			"client_id", id, "token_endpoint_auth_method", doc.TokenEndpointAuthMethod)
 		return nil, fmt.Errorf("%w: CIMD document at %s claims token_endpoint_auth_method %q "+
 			"but this server only supports %q (token_endpoint_auth_methods_supported: %v)",
 			fosite.ErrInvalidClient.WithHint("unsupported token_endpoint_auth_method"),
@@ -174,6 +183,8 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 	// a client that resolves and then fails every token request.
 	grantTypes, dcrErr := registration.FilterPublicGrantTypes(doc.GrantTypes)
 	if dcrErr != nil {
+		slog.WarnContext(ctx, "CIMD client rejected: invalid grant_types",
+			"client_id", id, "error", dcrErr.ErrorDescription)
 		return nil, fmt.Errorf("%w: CIMD document at %s: %s",
 			fosite.ErrInvalidClient.WithHint(dcrErr.ErrorDescription), id, dcrErr.ErrorDescription)
 	}
@@ -183,6 +194,8 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 	}
 	responseTypes, dcrErr := registration.FilterPublicResponseTypes(doc.ResponseTypes)
 	if dcrErr != nil {
+		slog.WarnContext(ctx, "CIMD client rejected: invalid response_types",
+			"client_id", id, "error", dcrErr.ErrorDescription)
 		return nil, fmt.Errorf("%w: CIMD document at %s: %s",
 			fosite.ErrInvalidClient.WithHint(dcrErr.ErrorDescription), id, dcrErr.ErrorDescription)
 	}
@@ -194,11 +207,11 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 	// Compute and validate the client scope list consistent with DCR.
 	// When ScopesSupported is configured:
 	//   - Declared scopes are validated via registration.ValidateScopes (same
-	//     function as the DCR handler).
-	//   - Omitted scope uses ValidateScopes(nil, scopesSupported) which returns
-	//     DefaultScopes when DefaultScopes ⊆ ScopesSupported, matching DCR.
-	//     If DefaultScopes ⊄ ScopesSupported the document must declare scope
-	//     explicitly to avoid ambiguous privilege grant.
+	//     function as the DCR handler); an unsupported declared scope rejects.
+	//   - Omitted scope uses ValidateScopes(nil, scopesSupported), which grants
+	//     the intersection of DefaultScopes with ScopesSupported (matching DCR)
+	//     and reports the defaults it dropped; only an empty intersection is
+	//     rejected, in which case the document must declare scope explicitly.
 	// When ScopesSupported is not configured: no AS-level validation; declared
 	// scopes are used directly, or nil to let buildFositeClient apply DefaultScopes.
 	// In both cases BaselineClientScopes is unioned in after validation,
@@ -206,21 +219,30 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 	var resolvedScopes []string
 	if len(d.scopesSupported) > 0 {
 		if doc.Scope != "" {
-			computed, dcrErr := registration.ValidateScopes(strings.Fields(doc.Scope), d.scopesSupported)
+			computed, _, dcrErr := registration.ValidateScopes(strings.Fields(doc.Scope), d.scopesSupported)
 			if dcrErr != nil {
+				slog.WarnContext(ctx, "CIMD client rejected: invalid scope",
+					"client_id", id, "error", dcrErr.ErrorDescription)
 				return nil, fmt.Errorf("%w: CIMD document at %s: %s",
 					fosite.ErrInvalidClient.WithHint(dcrErr.ErrorDescription), id, dcrErr.ErrorDescription)
 			}
 			resolvedScopes = computed
 		} else {
-			// Omitted scope: match DCR — give DefaultScopes when they fit, else require explicit scope.
-			computed, dcrErr := registration.ValidateScopes(nil, d.scopesSupported)
+			// Omitted scope: match DCR — grant the intersection of DefaultScopes
+			// with scopes_supported; reject only when the intersection is empty.
+			computed, dropped, dcrErr := registration.ValidateScopes(nil, d.scopesSupported)
 			if dcrErr != nil {
-				return nil, fmt.Errorf("%w: CIMD document at %s omits scope but "+
-					"DefaultScopes are not a subset of this server's scopes_supported — "+
+				slog.WarnContext(ctx, "CIMD client rejected: no usable default scopes",
+					"client_id", id, "error", dcrErr.ErrorDescription)
+				return nil, fmt.Errorf("%w: CIMD document at %s omits scope and "+
+					"none of the default scopes are supported by this server — "+
 					"the document must explicitly declare its required scopes",
 					fosite.ErrInvalidClient.WithHint("scope field required"),
 					id)
+			}
+			if len(dropped) > 0 {
+				slog.WarnContext(ctx, "CIMD document omits scope; granting the intersection of default scopes with scopes_supported",
+					"client_id", id, "granted", computed, "dropped_defaults", dropped)
 			}
 			resolvedScopes = computed
 		}

--- a/pkg/authserver/storage/cimd_decorator.go
+++ b/pkg/authserver/storage/cimd_decorator.go
@@ -217,6 +217,7 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 	// In both cases BaselineClientScopes is unioned in after validation,
 	// matching the DCR handler's behaviour.
 	var resolvedScopes []string
+	var droppedDefaults []string
 	if len(d.scopesSupported) > 0 {
 		if doc.Scope != "" {
 			computed, _, dcrErr := registration.ValidateScopes(strings.Fields(doc.Scope), d.scopesSupported)
@@ -240,17 +241,24 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 					fosite.ErrInvalidClient.WithHint("scope field required"),
 					id)
 			}
-			if len(dropped) > 0 {
-				slog.WarnContext(ctx, "CIMD document omits scope; granting the intersection of default scopes with scopes_supported",
-					"client_id", id, "granted", computed, "dropped_defaults", dropped)
-			}
 			resolvedScopes = computed
+			droppedDefaults = dropped
 		}
 	} else if doc.Scope != "" {
 		resolvedScopes = strings.Fields(doc.Scope)
 	}
 	if len(d.baselineClientScopes) > 0 {
 		resolvedScopes = registration.UnionScopes(resolvedScopes, d.baselineClientScopes)
+	}
+	// The document omitted scope and scopes_supported does not carry the full
+	// default set: resolution proceeded with the intersection (see issue
+	// #6186). Recorded after the baseline union so "scopes" is the set the
+	// client actually receives; Debug because the drop is fully determined by
+	// startup config — the one-time operator-facing signal lives in
+	// Config.applyDefaults.
+	if len(droppedDefaults) > 0 {
+		slog.DebugContext(ctx, "CIMD document omits scope; granted the intersection of default scopes with scopes_supported",
+			"client_id", id, "scopes", resolvedScopes, "dropped_defaults", droppedDefaults)
 	}
 
 	client := buildFositeClient(doc, resolvedScopes, grantTypes, responseTypes, authMethod)

--- a/pkg/authserver/storage/cimd_decorator.go
+++ b/pkg/authserver/storage/cimd_decorator.go
@@ -204,18 +204,37 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 			"client_id", id, "declared", doc.ResponseTypes, "effective", responseTypes)
 	}
 
-	// Compute and validate the client scope list consistent with DCR.
-	// When ScopesSupported is configured:
-	//   - Declared scopes are validated via registration.ValidateScopes (same
-	//     function as the DCR handler); an unsupported declared scope rejects.
-	//   - Omitted scope uses ValidateScopes(nil, scopesSupported), which grants
-	//     the intersection of DefaultScopes with ScopesSupported (matching DCR)
-	//     and reports the defaults it dropped; only an empty intersection is
-	//     rejected, in which case the document must declare scope explicitly.
-	// When ScopesSupported is not configured: no AS-level validation; declared
-	// scopes are used directly, or nil to let buildFositeClient apply DefaultScopes.
-	// In both cases BaselineClientScopes is unioned in after validation,
-	// matching the DCR handler's behaviour.
+	resolvedScopes, err := d.resolveCIMDScopes(ctx, id, doc)
+	if err != nil {
+		return nil, err
+	}
+
+	client := buildFositeClient(doc, resolvedScopes, grantTypes, responseTypes, authMethod)
+
+	d.cache.Add(id, &cimdCacheEntry{
+		client:  client,
+		expires: time.Now().Add(d.ttl),
+	})
+
+	return client, nil
+}
+
+// resolveCIMDScopes computes and validates the client scope list consistent
+// with DCR. When d.scopesSupported is configured:
+//   - Declared scopes are validated via registration.ValidateScopes (same
+//     function as the DCR handler); an unsupported declared scope rejects.
+//   - Omitted scope uses ValidateScopes(nil, scopesSupported), which grants
+//     the intersection of DefaultScopes with ScopesSupported (matching DCR)
+//     and reports the defaults it dropped; only an empty intersection is
+//     rejected, in which case the document must declare scope explicitly.
+//
+// When d.scopesSupported is not configured: no AS-level validation; declared
+// scopes are used directly, or nil to let buildFositeClient apply
+// DefaultScopes. In both cases d.baselineClientScopes is unioned in after
+// validation, matching the DCR handler's behaviour.
+func (d *CIMDStorageDecorator) resolveCIMDScopes(
+	ctx context.Context, id string, doc *cimd.ClientMetadataDocument,
+) ([]string, error) {
 	var resolvedScopes []string
 	var droppedDefaults []string
 	if len(d.scopesSupported) > 0 {
@@ -260,15 +279,7 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 		slog.DebugContext(ctx, "CIMD document omits scope; granted the intersection of default scopes with scopes_supported",
 			"client_id", id, "scopes", resolvedScopes, "dropped_defaults", droppedDefaults)
 	}
-
-	client := buildFositeClient(doc, resolvedScopes, grantTypes, responseTypes, authMethod)
-
-	d.cache.Add(id, &cimdCacheEntry{
-		client:  client,
-		expires: time.Now().Add(d.ttl),
-	})
-
-	return client, nil
+	return resolvedScopes, nil
 }
 
 // defaultCIMDTokenEndpointAuthMethod is the token endpoint authentication

--- a/pkg/authserver/storage/cimd_decorator_test.go
+++ b/pkg/authserver/storage/cimd_decorator_test.go
@@ -715,9 +715,23 @@ func TestFetch_ScopeResolution(t *testing.T) {
 			wantScopes:      registration.DefaultScopes,
 		},
 		{
-			name:            "omitted scope with restrictive ScopesSupported requires explicit scope",
+			// The #6186 shape: the server's scopes_supported lacks one default
+			// (profile); the client must still register with the intersection.
+			name:            "omitted scope with reduced ScopesSupported grants the intersection",
+			docScope:        "",
+			scopesSupported: []string{"openid", "email", "offline_access"},
+			wantScopes:      []string{"openid", "email", "offline_access"},
+		},
+		{
+			name:            "omitted scope with restrictive ScopesSupported grants the single-scope intersection",
 			docScope:        "",
 			scopesSupported: []string{"openid"},
+			wantScopes:      []string{"openid"},
+		},
+		{
+			name:            "omitted scope with ScopesSupported disjoint from defaults rejected",
+			docScope:        "",
+			scopesSupported: []string{"custom_scope"},
 			wantErr:         true,
 		},
 		{


### PR DESCRIPTION
Closes #6186

## Problem

When a registration omits `scope`, `registration.ValidateScopes` required every entry of `DefaultScopes` to be present in the server's `scopes_supported` and rejected the client otherwise. Any server whose `scopes_supported` lacks even one default (e.g. `profile`) therefore rejected every scope-less registration — on both the DCR and the CIMD paths — and on the CIMD path the failure surfaced to the client as a generic `invalid_client` with no server-side log line at any level (see #6186 for the analysis and repro).

## Change

- The `ValidateScopes` empty-input fallback now returns the intersection of `DefaultScopes` with `allowedScopes`, plus the list of dropped defaults (RFC 7591 §2 permits the server to register a client with a default set of scopes). Only an empty intersection is rejected, with an error description that names the full default set. Explicit-scope validation is unchanged and strict.
- The dropped defaults are recorded per registration at Debug: on the DCR path as a `dropped_defaults` attribute of the existing `registered new DCR client` record (after the baseline union and the `client_id` mint, so `scopes` is the final set and the record correlates by `client_id`); on the CIMD path as a post-union Debug record keyed on the `client_id` URL. The operator-facing signal is a one-time startup log in `Config.applyDefaults` reusing `ValidateScopes(nil, ...)`: Info naming the intersection and the dropped defaults when `scopes_supported` does not cover the default set, Warn when the intersection is empty (scope-omitting clients will be rejected).
- Diagnosability: every rejection path in the CIMD decorator's `fetch()` (fetch failure, `token_endpoint_auth_method`, `grant_types`, `response_types`, scope) WARN-logs the `client_id` and the reason, since fosite's production error rendering drops the hint and these failures previously left no server-side trace.
- The stale `BaselineClientScopes` doc comments (the `RunConfig` swagger source and the server config struct) now describe the intersection fallback; `docs/server/` regenerated.

## Behavior

| Registration | Before | After |
| --- | --- | --- |
| omits scope, `scopes_supported` carries all defaults | defaults granted | unchanged |
| omits scope, `scopes_supported` lacks some defaults | rejected (`invalid_client`) | intersection granted (Debug record; one-time startup log) |
| omits scope, `scopes_supported` disjoint from defaults | rejected | still rejected, clearer message |
| declares scope | strict validation | unchanged |
| `baseline_client_scopes` union | after validation | unchanged |

## User-facing change

A registration that omits `scope` against a server whose `scopes_supported` lacks part of the default set previously failed with HTTP 400 (`invalid_client_metadata` on DCR, `invalid_client` on CIMD); it now succeeds and registers the intersection. The DCR response's `scope` field reflects the granted set.

## Known residual gap (deliberately out of scope)

The omitted-scope fallback draws from `DefaultScopes` only, never from the rest of `scopes_supported`. A scope-omitting client against a server advertising non-default entries (e.g. `mcp:tools`) registers without them — and since protected-resource metadata advertises `scopes_supported` and MCP guidance tells clients to request all of it absent a narrower hint, such a client can still fail at `/oauth/authorize` with `invalid_scope`. Defaulting to `allowedScopes` itself would close that case but hands every anonymous registration the full advertised set — a policy change with an existing explicit opt-in (`baseline_client_scopes = scopes_supported`). The gap is also named in a code comment at the fallback site.

## Tests

- `ValidateScopes` table extended: intersection with one dropped default (the exact #6186 shape), single-scope intersection, disjoint-set rejection.
- CIMD decorator `TestFetch_ScopeResolution`: the previous "restrictive ScopesSupported requires explicit scope" case now pins the intersection grant; a disjoint case pins the remaining rejection.
- DCR handler: a scope-less registration against a `scopes_supported` lacking `profile` returns 201 with the intersection in the response.

As proposed in https://github.com/stacklok/toolhive/issues/6186#issuecomment-5255721255. Happy to split the diagnosability WARNs into a separate PR if preferred.
