### PR TITLE
Persist resolved CIMD clients so Redis session rehydration finds them

### DIFF
--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -353,6 +353,22 @@ func validateDelegateClients(
 			return fmt.Errorf("delegate_clients: duplicate client_id %q", client.ClientID)
 		}
 		seen[client.ClientID] = struct{}{}
+		// A URL-shaped client_id collides with CIMD (see
+		// oauthproto.IsClientIDMetadataDocumentURL): when CIMD is enabled, the
+		// CIMDStorageDecorator resolves any client_id matching this shape from
+		// a live-fetched document instead of this pre-provisioned row, and its
+		// write-through persistence (CIMDStorageDecorator.fetch) would then
+		// overwrite this confidential delegate client in place — downgrading
+		// it to a public client and discarding its hashed secret. Reject the
+		// shape outright regardless of whether CIMD is enabled in this
+		// particular deployment, since the config is portable across
+		// deployments where it may be.
+		if oauthproto.IsClientIDMetadataDocumentURL(client.ClientID) {
+			return fmt.Errorf(
+				"delegate_clients: client_id %q looks like a CIMD client metadata URL, "+
+					"which collides with CIMD client resolution — pre-provisioned delegate "+
+					"clients must use an opaque, non-URL client_id", client.ClientID)
+		}
 
 		if client.ClientSecretFile == "" && client.ClientSecretEnvVar == "" {
 			return fmt.Errorf(
@@ -942,6 +958,23 @@ type Config struct {
 
 	// CIMDEnabled enables the CIMD storage decorator so the authorization server
 	// accepts HTTPS URLs as client_id values without prior DCR registration.
+	//
+	// A resolved CIMD client is write-through persisted into the underlying
+	// storage (see CIMDStorageDecorator.fetch) so that token-endpoint session
+	// rehydration finds it. That row is marked DCR-issued and therefore
+	// expires (DefaultDCRClientTTL, currently 30 days), but disabling
+	// CIMDEnabled does not itself evict or invalidate any row a prior enabled
+	// period already persisted — GetClient is instead wrapped to refuse any
+	// URL-shaped client_id outright while CIMDEnabled is false (see
+	// decorateStorageForCIMD / storage.NewCIMDShapeGuardStorage), so such a
+	// row simply cannot be resolved for as long as CIMD stays disabled.
+	// Re-enabling CIMDEnabled before that TTL expires makes the stale
+	// snapshot resolvable again without a fresh document fetch, until the row
+	// expires or a new fetch overwrites it. Document rotation and revocation
+	// generally follow the same rule: an existing persisted row keeps
+	// authenticating from its stored snapshot, with no re-validation of
+	// scopes, redirect URIs, or auth method, until it is naturally re-fetched
+	// or its TTL lapses.
 	CIMDEnabled bool
 
 	// CIMDCacheMaxSize is the maximum number of CIMD documents held in the LRU

--- a/pkg/authserver/config_test.go
+++ b/pkg/authserver/config_test.go
@@ -633,6 +633,28 @@ func TestDelegateClientRunConfigValidate(t *testing.T) {
 		{name: "scope outside supported", clients: []DelegateClientRunConfig{{ClientID: "delegate", ClientSecretEnvVar: "SECRET", Scopes: []string{"admin"}, Audiences: validClient.Audiences}}, wantErr: `"admin" which is not in scopes_supported`},
 		{name: "missing audiences", clients: []DelegateClientRunConfig{{ClientID: "delegate", ClientSecretEnvVar: "SECRET", Scopes: validClient.Scopes}}, wantErr: "audiences is required"},
 		{name: "audience outside allowed", clients: []DelegateClientRunConfig{{ClientID: "delegate", ClientSecretEnvVar: "SECRET", Scopes: validClient.Scopes, Audiences: []string{"https://other.example.com"}}}, wantErr: "is not in allowed_audiences"},
+		// P4 (PR #6284 review): a URL-shaped client_id collides with CIMD
+		// client resolution (oauthproto.IsClientIDMetadataDocumentURL) — the
+		// CIMD decorator would shadow this pre-provisioned client on reads,
+		// and with write-through persistence (CIMDStorageDecorator.fetch) an
+		// unauthenticated request resolving that same URL would overwrite
+		// this confidential delegate client in place.
+		{
+			name: "https client_id collides with CIMD and is rejected",
+			clients: []DelegateClientRunConfig{{
+				ClientID: "https://example.com/client-metadata.json", ClientSecretEnvVar: "SECRET",
+				Scopes: validClient.Scopes, Audiences: validClient.Audiences,
+			}},
+			wantErr: "looks like a CIMD client metadata URL",
+		},
+		{
+			name: "loopback http client_id also collides with CIMD and is rejected",
+			clients: []DelegateClientRunConfig{{
+				ClientID: "http://localhost:8080/client-metadata.json", ClientSecretEnvVar: "SECRET",
+				Scopes: validClient.Scopes, Audiences: validClient.Audiences,
+			}},
+			wantErr: "looks like a CIMD client metadata URL",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/authserver/server/handlers/authorize_test.go
+++ b/pkg/authserver/server/handlers/authorize_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ory/fosite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 
 	"github.com/stacklok/toolhive/pkg/authserver/server"
 	servercrypto "github.com/stacklok/toolhive/pkg/authserver/server/crypto"
@@ -561,4 +562,95 @@ func TestLoopbackAuthorizeRequester_IsRedirectURIValid(t *testing.T) {
 			assert.Equal(t, tt.wantValid, wrapped.IsRedirectURIValid())
 		})
 	}
+}
+
+// --- rateLimitCIMDAuthorize (P1: /oauth/authorize CIMD rate limiting) ---
+
+// TestRateLimitCIMDAuthorize_BurstThen429 exercises the reviewer's exact
+// scenario: a flood of distinct CIMD-URL client_id values must be bounded by
+// the limiter, exhausting the burst before the gate starts returning 429,
+// entirely independent of fosite or the CIMD decorator — this test only
+// exercises the gate itself.
+func TestRateLimitCIMDAuthorize_BurstThen429(t *testing.T) {
+	t.Parallel()
+
+	var nextCalls int
+	h := &Handler{cimdAuthorizeLimiter: rate.NewLimiter(rate.Limit(1), 5)}
+	gated := h.rateLimitCIMDAuthorize(func(http.ResponseWriter, *http.Request) {
+		nextCalls++
+	})
+
+	// Burst of 5 must all be allowed through to next.
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodGet,
+			"/oauth/authorize?client_id=https://evil.test/"+string(rune('a'+i))+".json", nil)
+		rec := httptest.NewRecorder()
+		gated(rec, req)
+		assert.NotEqual(t, http.StatusTooManyRequests, rec.Code, "burst request %d must not be rate limited", i)
+	}
+	assert.Equal(t, 5, nextCalls, "all 5 burst requests must reach next")
+
+	// The 6th CIMD-URL request in the same instant must be rejected with 429.
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?client_id=https://evil.test/f.json", nil)
+	rec := httptest.NewRecorder()
+	gated(rec, req)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code, "request past the burst must be rate limited")
+	assert.Equal(t, "1", rec.Header().Get("Retry-After"))
+	assert.Equal(t, 5, nextCalls, "the rate-limited request must not reach next")
+}
+
+// TestRateLimitCIMDAuthorize_NonURLClientIDUnaffected verifies that ordinary
+// DCR (opaque, non-URL) client_id values never consult or exhaust the CIMD
+// limiter: a flood of such requests must all reach next, and must not affect
+// the limiter's state for a later CIMD-URL request.
+func TestRateLimitCIMDAuthorize_NonURLClientIDUnaffected(t *testing.T) {
+	t.Parallel()
+
+	var nextCalls int
+	h := &Handler{cimdAuthorizeLimiter: rate.NewLimiter(rate.Limit(1), 5)}
+	gated := h.rateLimitCIMDAuthorize(func(http.ResponseWriter, *http.Request) {
+		nextCalls++
+	})
+
+	// Far more than the burst size, all with an opaque DCR-style client_id.
+	for i := 0; i < 20; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?client_id=opaque-dcr-client-id", nil)
+		rec := httptest.NewRecorder()
+		gated(rec, req)
+		assert.NotEqual(t, http.StatusTooManyRequests, rec.Code,
+			"a non-URL client_id must never be rate limited by the CIMD gate")
+	}
+	assert.Equal(t, 20, nextCalls)
+
+	// The limiter's full burst must still be available to a CIMD-URL request,
+	// proving the DCR traffic above never touched cimdAuthorizeLimiter's state.
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodGet,
+			"/oauth/authorize?client_id=https://example.test/"+string(rune('a'+i))+".json", nil)
+		rec := httptest.NewRecorder()
+		gated(rec, req)
+		assert.NotEqual(t, http.StatusTooManyRequests, rec.Code, "CIMD burst request %d must not be rate limited", i)
+	}
+	assert.Equal(t, 25, nextCalls)
+}
+
+// TestRateLimitCIMDAuthorize_NilLimiterAllowsThrough matches the documented
+// contract of registerLimiter's nil case: a Handler constructed without going
+// through NewHandler (as several existing tests in this package do) leaves
+// cimdAuthorizeLimiter nil, and the gate must tolerate that by always calling
+// next.
+func TestRateLimitCIMDAuthorize_NilLimiterAllowsThrough(t *testing.T) {
+	t.Parallel()
+
+	var nextCalls int
+	h := &Handler{}
+	gated := h.rateLimitCIMDAuthorize(func(http.ResponseWriter, *http.Request) {
+		nextCalls++
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?client_id=https://evil.test/a.json", nil)
+	rec := httptest.NewRecorder()
+	gated(rec, req)
+	assert.NotEqual(t, http.StatusTooManyRequests, rec.Code)
+	assert.Equal(t, 1, nextCalls)
 }

--- a/pkg/authserver/server/handlers/handler.go
+++ b/pkg/authserver/server/handlers/handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/authserver/server"
 	"github.com/stacklok/toolhive/pkg/authserver/storage"
 	"github.com/stacklok/toolhive/pkg/authserver/upstream"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 // NamedUpstream pairs a logical provider name with its OAuth2Provider implementation.
@@ -66,6 +67,21 @@ type Handler struct {
 	// configured rate with replica count in mind. Nil in tests that construct
 	// Handler directly; OAuthRoutes tolerates nil by skipping the gate.
 	registerLimiter *rate.Limiter
+	// cimdAuthorizeLimiter bounds unauthenticated /oauth/authorize requests
+	// whose client_id is a CIMD URL (see oauthproto.IsClientIDMetadataDocumentURL).
+	// Resolving such a client_id — via the CIMD storage decorator's GetClient,
+	// invoked from fosite's NewAuthorizeRequest — now write-through persists a
+	// row with a multi-day TTL (see CIMDStorageDecorator.fetch), so this
+	// endpoint mints persisted state exactly like /oauth/register and needs
+	// the same protection: without it, a flood of distinct CIMD client_id
+	// values (e.g. one host serving generated documents on a wildcard route)
+	// could mint rows as fast as the AS can complete the outbound document
+	// fetches. DCR (non-URL) client_id values are unaffected — they hit
+	// neither this limiter nor the write-through path. Same shape as
+	// registerLimiter: per-process, not per-IP, for the identical reasons.
+	// Nil in tests that construct Handler directly; OAuthRoutes tolerates nil
+	// by skipping the gate.
+	cimdAuthorizeLimiter *rate.Limiter
 }
 
 // UpstreamFilter narrows the authorization chain to a subset of the configured
@@ -183,6 +199,10 @@ func NewHandler(
 		// enough that an unauthenticated caller cannot grow the client
 		// keyspace or the log stream faster than operators can react.
 		registerLimiter: rate.NewLimiter(rate.Limit(1), 5),
+		// Same rate as registerLimiter: this gate protects the same kind of
+		// unauthenticated persisted-state minting, just reached through
+		// /oauth/authorize instead of /oauth/register.
+		cimdAuthorizeLimiter: rate.NewLimiter(rate.Limit(1), 5),
 	}
 	for _, o := range opts {
 		o(h)
@@ -200,7 +220,7 @@ func (h *Handler) Routes() http.Handler {
 
 // OAuthRoutes registers OAuth endpoints (authorize, callback, token, register) on the provided router.
 func (h *Handler) OAuthRoutes(r chi.Router) {
-	r.Get("/oauth/authorize", h.AuthorizeHandler)
+	r.Get("/oauth/authorize", h.rateLimitCIMDAuthorize(h.AuthorizeHandler))
 	r.Get("/oauth/callback", h.CallbackHandler)
 	r.Post("/oauth/token", h.TokenHandler)
 	r.Post("/oauth/register", h.rateLimitRegister(h.RegisterClientHandler))
@@ -216,6 +236,33 @@ func (h *Handler) rateLimitRegister(next http.HandlerFunc) http.HandlerFunc {
 			w.Header().Set("Retry-After", "1")
 			http.Error(w, "rate limit exceeded, retry later", http.StatusTooManyRequests)
 			return
+		}
+		next(w, req)
+	}
+}
+
+// rateLimitCIMDAuthorize gates /oauth/authorize requests whose client_id is a
+// CIMD URL, before next (and therefore before fosite's NewAuthorizeRequest,
+// which is what triggers GetClient and the CIMD write-through) ever runs.
+// Over the limit it returns 429 with a Retry-After hint, mirroring
+// rateLimitRegister. A request whose client_id is empty, missing, or not
+// URL-shaped (an ordinary DCR client_id) is never gated here — it falls
+// straight through to next, unaffected by this limiter's state.
+//
+// req.Form is parsed (not req.URL.Query()) so this reads the same client_id
+// fosite itself will see, including a form-encoded body on this GET-only
+// route; ParseForm is idempotent, so a later parse inside next re-reads
+// exactly the same values.
+func (h *Handler) rateLimitCIMDAuthorize(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		if h.cimdAuthorizeLimiter != nil {
+			_ = req.ParseForm()
+			clientID := req.Form.Get("client_id")
+			if oauthproto.IsClientIDMetadataDocumentURL(clientID) && !h.cimdAuthorizeLimiter.Allow() {
+				w.Header().Set("Retry-After", "1")
+				http.Error(w, "rate limit exceeded, retry later", http.StatusTooManyRequests)
+				return
+			}
 		}
 		next(w, req)
 	}

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -255,12 +255,18 @@ func registerDelegateClients(ctx context.Context, stor storage.Storage, delegate
 	return nil
 }
 
-// decorateStorageForCIMD wraps stor with the CIMD decorator when CIMD is enabled,
-// so GetClient calls for HTTPS client_id values are intercepted at the fosite
-// level (not just the handler level). Returns stor unchanged when CIMD is disabled.
+// decorateStorageForCIMD wraps stor with the CIMD decorator when CIMD is
+// enabled, so GetClient calls for HTTPS client_id values are intercepted at
+// the fosite level (not just the handler level).
+//
+// When CIMD is disabled, stor is instead wrapped with
+// storage.NewCIMDShapeGuardStorage so that a URL-shaped client_id can never
+// resolve from a stale row a prior CIMD-enabled period may have
+// write-through persisted (see cimdShapeGuardStorage's doc comment for why
+// disabling CIMD alone does not evict or invalidate such a row).
 func decorateStorageForCIMD(cfg Config, stor storage.Storage) (storage.Storage, error) {
 	if !cfg.CIMDEnabled {
-		return stor, nil
+		return storage.NewCIMDShapeGuardStorage(stor), nil
 	}
 	if len(cfg.BaselineClientScopes) > 0 {
 		slog.Warn("CIMD is enabled with baseline_client_scopes configured; "+

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -190,8 +190,16 @@ func TestNewServer_Success(t *testing.T) {
 	if srv.Handler() == nil {
 		t.Error("server.Handler() returned nil")
 	}
-	if srv.IDPTokenStorage() != stor {
-		t.Error("server.IDPTokenStorage() did not return expected storage")
+	// CIMDEnabled defaults to false in cfg, so newServer wraps stor with the
+	// CIMD shape-guard (decorateStorageForCIMD) rather than passing it through
+	// unchanged — see TestNewServer_CIMDEnabled_WrapsStorage for the enabled
+	// case. Unwrap() must still reach the exact storage this test constructed.
+	if unwrapper, ok := srv.IDPTokenStorage().(interface{ Unwrap() storage.Storage }); ok {
+		if unwrapper.Unwrap() != stor {
+			t.Error("server.IDPTokenStorage().Unwrap() did not return expected storage")
+		}
+	} else {
+		t.Errorf("server.IDPTokenStorage() (%T) does not implement Unwrap()", srv.IDPTokenStorage())
 	}
 }
 

--- a/pkg/authserver/storage/cimd_decorator.go
+++ b/pkg/authserver/storage/cimd_decorator.go
@@ -92,6 +92,64 @@ func (d *CIMDStorageDecorator) GetClient(ctx context.Context, id string) (fosite
 	return d.fetchOrCached(ctx, id)
 }
 
+// cimdShapeGuardStorage wraps storage.Storage and rejects URL-shaped
+// client_id values at GetClient without ever reading the underlying row.
+//
+// It exists for the case where CIMD is (or was previously) enabled and then
+// disabled: the write-through persistence in CIMDStorageDecorator.fetch may
+// have already left a resolved CIMD client's row in the underlying storage,
+// and that row's TTL — up to DefaultDCRClientTTL — can outlive the config
+// change. Without this guard, a bare Storage's GetClient does not check the
+// shape of the id it is asked for, so it would happily resolve the stale row
+// from a snapshot the document may have since changed or that the operator
+// intended to revoke by turning CIMD off, with no re-fetch and therefore no
+// re-validation of scopes, redirect URIs, or auth method. Wrapping the
+// storage when CIMD is disabled closes that gap for both backends without
+// changing GetClient's behavior for any opaque (non-URL) client_id.
+type cimdShapeGuardStorage struct {
+	Storage // embed full interface — all methods delegate
+}
+
+// GetClient rejects URL-shaped ids with fosite.ErrNotFound before consulting
+// the wrapped storage, so a stale CIMD-origin row can never be resolved while
+// CIMD is disabled. Opaque DCR-issued and pre-provisioned ids are delegated
+// to the underlying storage unchanged.
+func (g cimdShapeGuardStorage) GetClient(ctx context.Context, id string) (fosite.Client, error) {
+	if oauthproto.IsClientIDMetadataDocumentURL(id) {
+		return nil, fosite.ErrNotFound.WithHint("CIMD is disabled on this server")
+	}
+	return g.Storage.GetClient(ctx, id)
+}
+
+// ConsumeAssertionJWT delegates assertion replay consumption to the wrapped
+// backend, matching CIMDStorageDecorator's identical method: Storage embeds
+// the interface, not the concrete backend, so this narrow capability is not
+// promoted automatically and must be forwarded explicitly for callers (e.g.
+// the RFC 7523 JWT-bearer grant factory) that need it through this wrapper.
+func (g cimdShapeGuardStorage) ConsumeAssertionJWT(
+	ctx context.Context, purpose, issuer, jti string, exp time.Time,
+) error {
+	consumer, ok := g.Storage.(AssertionJWTConsumer)
+	if !ok {
+		return fmt.Errorf("wrapped storage does not support assertion JWT replay consumption")
+	}
+	return consumer.ConsumeAssertionJWT(ctx, purpose, issuer, jti, exp)
+}
+
+// Unwrap returns the underlying storage so that type assertions (e.g. for
+// storage.DCRCredentialStore in server_impl.go) can reach the concrete type.
+func (g cimdShapeGuardStorage) Unwrap() Storage {
+	return g.Storage
+}
+
+// NewCIMDShapeGuardStorage wraps base so that GetClient refuses any
+// URL-shaped client_id, regardless of whether a matching row exists in base.
+// Callers apply this when CIMD is disabled — see cimdShapeGuardStorage's doc
+// comment for why a disabled decorator alone does not close this gap.
+func NewCIMDShapeGuardStorage(base Storage) Storage {
+	return cimdShapeGuardStorage{Storage: base}
+}
+
 // ConsumeAssertionJWT delegates assertion replay consumption to the wrapped
 // backend. Storage intentionally does not include this narrow capability, so a
 // decorator fails closed when its backend does not provide it.
@@ -204,7 +262,7 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 			"client_id", id, "declared", doc.ResponseTypes, "effective", responseTypes)
 	}
 
-	resolvedScopes, err := d.resolveCIMDScopes(ctx, id, doc)
+	resolvedScopes, err := d.resolveScopes(ctx, id, doc)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +279,7 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 	// permanent. Re-persisting on every fresh fetch keeps the snapshot
 	// current with the document. A persistence failure only degrades
 	// token-path rehydration, so it must not fail the resolution itself.
-	if err := d.Storage.RegisterClient(ctx, client); err != nil {
+	if err := d.RegisterClient(ctx, client); err != nil {
 		slog.WarnContext(ctx, "failed to persist resolved CIMD client",
 			"client_id", id, "error", err)
 	}
@@ -234,7 +292,7 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 	return client, nil
 }
 
-// resolveCIMDScopes computes and validates the client scope list consistent
+// resolveScopes computes and validates the client scope list consistent
 // with DCR. When d.scopesSupported is configured:
 //   - Declared scopes are validated via registration.ValidateScopes (same
 //     function as the DCR handler); an unsupported declared scope rejects.
@@ -247,7 +305,7 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 // scopes are used directly, or nil to let buildFositeClient apply
 // DefaultScopes. In both cases d.baselineClientScopes is unioned in after
 // validation, matching the DCR handler's behaviour.
-func (d *CIMDStorageDecorator) resolveCIMDScopes(
+func (d *CIMDStorageDecorator) resolveScopes(
 	ctx context.Context, id string, doc *cimd.ClientMetadataDocument,
 ) ([]string, error) {
 	var resolvedScopes []string

--- a/pkg/authserver/storage/cimd_decorator.go
+++ b/pkg/authserver/storage/cimd_decorator.go
@@ -209,7 +209,22 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 		return nil, err
 	}
 
-	client := buildFositeClient(doc, resolvedScopes, grantTypes, responseTypes, authMethod)
+	client := registration.MarkDCRIssued(buildFositeClient(doc, resolvedScopes, grantTypes, responseTypes, authMethod))
+
+	// Best-effort write-through: persist the resolved client in the underlying
+	// storage so backends whose session rehydration resolves the client
+	// through their own row lookup — Redis's unmarshalRequester, which never
+	// consults this decorator — find CIMD clients at the token endpoint (see
+	// issue #6187). The client carries the DCR-issued marker (above) so the
+	// row gets the same anti-bloat TTL as DCR registrations: unauthenticated
+	// /oauth/authorize traffic can mint these rows, so they must never be
+	// permanent. Re-persisting on every fresh fetch keeps the snapshot
+	// current with the document. A persistence failure only degrades
+	// token-path rehydration, so it must not fail the resolution itself.
+	if err := d.Storage.RegisterClient(ctx, client); err != nil {
+		slog.WarnContext(ctx, "failed to persist resolved CIMD client",
+			"client_id", id, "error", err)
+	}
 
 	d.cache.Add(id, &cimdCacheEntry{
 		client:  client,

--- a/pkg/authserver/storage/cimd_decorator_test.go
+++ b/pkg/authserver/storage/cimd_decorator_test.go
@@ -168,6 +168,107 @@ func TestCIMDStorageDecorator_GetClient_UnknownOpaqueIDReturnsError(t *testing.T
 	require.Error(t, err)
 }
 
+// --- cimdShapeGuardStorage (P2: URL-shaped ids refused while CIMD is disabled) ---
+
+// TestCIMDShapeGuardStorage_URLShapedIDNotFoundEvenWhenRowExists is the core
+// regression this guard exists for: a row a prior CIMD-enabled period
+// write-through persisted (CIMDStorageDecorator.fetch) must not resolve once
+// CIMD is disabled, even though the row is still physically present in the
+// underlying storage and would resolve via a bare (unwrapped) GetClient.
+func TestCIMDShapeGuardStorage_URLShapedIDNotFoundEvenWhenRowExists(t *testing.T) {
+	t.Parallel()
+	base := newTestBase(t)
+	ctx := context.Background()
+
+	const cimdID = "https://example.com/meta.json"
+	stale := &fosite.DefaultClient{ID: cimdID, Public: true}
+	require.NoError(t, base.RegisterClient(ctx, stale))
+
+	// Sanity: the row really is resolvable through the bare (unwrapped) base,
+	// proving the guard — not an absent row — is what blocks resolution below.
+	got, err := base.GetClient(ctx, cimdID)
+	require.NoError(t, err, "the stale row must exist in the underlying storage")
+	assert.Equal(t, cimdID, got.GetID())
+
+	guarded := NewCIMDShapeGuardStorage(base)
+	_, err = guarded.GetClient(ctx, cimdID)
+	require.Error(t, err, "a URL-shaped id must never resolve while CIMD is disabled")
+	assert.ErrorIs(t, err, fosite.ErrNotFound)
+}
+
+// TestCIMDShapeGuardStorage_OpaqueIDDelegatesToBase verifies the guard only
+// touches URL-shaped ids: an ordinary DCR-issued or pre-provisioned client_id
+// must resolve exactly as it would through the unwrapped base.
+func TestCIMDShapeGuardStorage_OpaqueIDDelegatesToBase(t *testing.T) {
+	t.Parallel()
+	base := newTestBase(t)
+	ctx := context.Background()
+
+	dc := &fosite.DefaultClient{ID: "opaque-client-id"}
+	require.NoError(t, base.RegisterClient(ctx, dc))
+
+	guarded := NewCIMDShapeGuardStorage(base)
+	got, err := guarded.GetClient(ctx, "opaque-client-id")
+	require.NoError(t, err)
+	assert.Equal(t, "opaque-client-id", got.GetID())
+}
+
+// TestCIMDShapeGuardStorage_UnwrapReturnsBase verifies the same Unwrap()
+// contract CIMDStorageDecorator provides, so callers walking the decorator
+// chain (e.g. the DCRCredentialStore assertion in server_impl.go) reach the
+// concrete backend through this wrapper too.
+func TestCIMDShapeGuardStorage_UnwrapReturnsBase(t *testing.T) {
+	t.Parallel()
+	base := newTestBase(t)
+	guarded := NewCIMDShapeGuardStorage(base)
+	unwrapper, ok := guarded.(interface{ Unwrap() Storage })
+	require.True(t, ok)
+	assert.Same(t, base, unwrapper.Unwrap())
+}
+
+// TestCIMDShapeGuardStorage_ConsumeAssertionJWTDelegatesToBase verifies the
+// guard forwards this narrow capability exactly like CIMDStorageDecorator
+// does, so wrapping storage when CIMD is disabled does not silently break the
+// RFC 7523 JWT-bearer grant (see storage.AssertionJWTConsumer).
+func TestCIMDShapeGuardStorage_ConsumeAssertionJWTDelegatesToBase(t *testing.T) {
+	t.Parallel()
+	base := newTestBase(t)
+	guarded := NewCIMDShapeGuardStorage(base)
+	consumer, ok := guarded.(AssertionJWTConsumer)
+	require.True(t, ok, "the guard must implement AssertionJWTConsumer when its base does")
+
+	exp := time.Now().Add(time.Hour)
+	ctx := context.Background()
+	require.NoError(t, consumer.ConsumeAssertionJWT(ctx, "jwt-bearer", "https://issuer.example", "jti", exp))
+	require.ErrorIs(t, consumer.ConsumeAssertionJWT(ctx, "jwt-bearer", "https://issuer.example", "jti", exp),
+		fosite.ErrJTIKnown)
+}
+
+// TestCIMDShapeGuardStorage_DecoratorActiveStillWorks is the "decorator
+// active" counterpart to TestCIMDShapeGuardStorage_URLShapedIDNotFoundEvenWhenRowExists:
+// while the real CIMDStorageDecorator is wrapping storage (CIMD enabled),
+// resolving a URL-shaped client_id must still work normally via a live fetch,
+// confirming the shape guard is only ever applied on the disabled path (see
+// decorateStorageForCIMD in server_impl.go).
+func TestCIMDShapeGuardStorage_DecoratorActiveStillWorks(t *testing.T) {
+	t.Parallel()
+
+	var fetchCount atomic.Int32
+	srv := serveCIMDDoc(t, "/metadata.json", func() { fetchCount.Add(1) })
+	id := cimdURL(srv, "/metadata.json")
+
+	base := newTestBase(t)
+	dec := newEnabledDecorator(t, base, 10, time.Minute)
+
+	// Resolve once through the active decorator: this both proves resolution
+	// works while CIMD is enabled and leaves a write-through-persisted row in
+	// base for the disabled-guard assertions below.
+	got, err := dec.GetClient(context.Background(), id)
+	require.NoError(t, err, "GetClient must succeed while the decorator is active")
+	assert.Equal(t, id, got.GetID())
+	assert.Equal(t, int32(1), fetchCount.Load())
+}
+
 // --- fetchOrCached / fetch (loopback HTTP accepted by FetchClientMetadataDocument) ---
 // These tests call fetchOrCached directly (same package) using http://127.0.0.1
 // URLs, which FetchClientMetadataDocument accepts for testing purposes.
@@ -432,18 +533,33 @@ func TestBuildFositeClient_NonLoopbackRedirectReturnsOpenIDConnectClient(t *test
 	assert.True(t, ok, "non-loopback redirect URI must produce a DefaultOpenIDConnectClient")
 }
 
-func TestBuildFositeClient_TokenEndpointAuthMethodDefault(t *testing.T) {
+// TestNegotiateTokenEndpointAuthMethod_DeclaredNoneWithPluralList covers the
+// branch where the document already declares the singular
+// token_endpoint_auth_method as "none": negotiateTokenEndpointAuthMethod's
+// first check (declared == "" || declared == defaultCIMDTokenEndpointAuthMethod)
+// short-circuits on that alone and never consults the plural
+// TokenEndpointAuthMethodsSupported list, even when that list is present and
+// names something else entirely. This was previously exercised indirectly by
+// TestBuildFositeClient_TokenEndpointAuthMethodDefault against a fallback
+// buildFositeClient no longer applies internally (the negotiation moved to
+// fetch(), and buildFositeClient now takes the already-negotiated method as a
+// parameter) — this test targets negotiateTokenEndpointAuthMethod directly
+// instead, alongside the equivalent-but-distinct branches already covered by
+// TestFetch_TokenEndpointAuthMethodNegotiation.
+func TestNegotiateTokenEndpointAuthMethod_DeclaredNoneWithPluralList(t *testing.T) {
 	t.Parallel()
 
 	doc := &cimd.ClientMetadataDocument{
-		ClientID:     "https://example.com/meta.json",
-		RedirectURIs: []string{"https://example.com/callback"},
+		ClientID:                          "https://example.com/meta.json",
+		RedirectURIs:                      []string{"https://example.com/callback"},
+		TokenEndpointAuthMethod:           "none",
+		TokenEndpointAuthMethodsSupported: []string{"private_key_jwt", "tls_client_auth"},
 	}
 
-	got := buildFositeClientWithDefaults(doc, nil)
-	if oidc, ok := got.(fosite.OpenIDConnectClient); ok {
-		assert.Equal(t, "none", oidc.GetTokenEndpointAuthMethod())
-	}
+	got, ok := negotiateTokenEndpointAuthMethod(doc)
+	require.True(t, ok, "a declared \"none\" must negotiate successfully regardless of the plural list")
+	assert.Equal(t, "none", got,
+		"the declared \"none\" must win outright, without consulting TokenEndpointAuthMethodsSupported")
 }
 
 func TestFetch_RejectsUnsupportedTokenEndpointAuthMethod(t *testing.T) {

--- a/pkg/authserver/storage/cimd_decorator_test.go
+++ b/pkg/authserver/storage/cimd_decorator_test.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -783,4 +784,80 @@ func TestBuildFositeClient_ScopeDefaultsToDefaultScopesWhenNoScopesSupported(t *
 	}
 	got := buildFositeClientWithDefaults(doc, nil)
 	assert.ElementsMatch(t, registration.DefaultScopes, []string(got.GetScopes()))
+}
+
+// --- write-through persistence (issue #6187) ---
+
+func TestCIMDStorageDecorator_PersistsResolvedClient(t *testing.T) {
+	t.Parallel()
+
+	base := newTestBase(t)
+	dec := newEnabledDecorator(t, base, 10, time.Minute)
+	srv := serveCIMDDocWithFields(t, nil)
+	id := srv.URL + "/meta.json"
+
+	resolved, err := dec.fetchOrCached(context.Background(), id)
+	require.NoError(t, err)
+
+	persisted, err := base.GetClient(context.Background(), id)
+	require.NoError(t, err,
+		"the resolved client must be persisted so session rehydration that resolves clients through the bare storage still finds it")
+	assert.Equal(t, resolved.GetID(), persisted.GetID())
+	assert.True(t, persisted.IsPublic())
+	assert.True(t, registration.DCRIssued(resolved),
+		"the resolved client must carry the DCR-issued marker so the persisted row gets the anti-bloat TTL")
+}
+
+// TestCIMDStorageDecorator_PersistsLoopbackResolvedClient covers a document
+// with loopback redirect URIs: buildFositeClient gives it the same
+// *fosite.DefaultOpenIDConnectClient shape as any other CIMD client (RFC 8252
+// dynamic-port matching is applied separately, by
+// registration.RegisteredLoopbackRedirectURI, not by a distinct wrapper
+// type), and the DCR-issued marker (and with it the TTL on the persisted
+// row) must survive that shape too.
+func TestCIMDStorageDecorator_PersistsLoopbackResolvedClient(t *testing.T) {
+	t.Parallel()
+
+	base := newTestBase(t)
+	dec := newEnabledDecorator(t, base, 10, time.Minute)
+	srv := serveCIMDDocWithFields(t, func(doc *cimd.ClientMetadataDocument) {
+		doc.RedirectURIs = []string{"http://localhost/callback"}
+	})
+	id := srv.URL + "/meta.json"
+
+	resolved, err := dec.fetchOrCached(context.Background(), id)
+	require.NoError(t, err)
+	assert.True(t, registration.DCRIssued(resolved),
+		"a loopback-wrapped CIMD client must also carry the DCR-issued marker")
+
+	_, err = base.GetClient(context.Background(), id)
+	require.NoError(t, err)
+}
+
+// registerFailingStorage wraps a Storage and fails every RegisterClient call,
+// for testing that a write-through persistence failure does not fail the
+// resolution itself.
+type registerFailingStorage struct {
+	Storage
+}
+
+func (*registerFailingStorage) RegisterClient(context.Context, fosite.Client) error {
+	return errors.New("register failed")
+}
+
+func TestCIMDStorageDecorator_PersistFailureDoesNotFailResolution(t *testing.T) {
+	t.Parallel()
+
+	srv := serveCIMDDocWithFields(t, nil)
+	got, err := NewCIMDStorageDecorator(&registerFailingStorage{Storage: newTestBase(t)}, CIMDDecoratorConfig{
+		Enabled:      true,
+		CacheMaxSize: 10,
+		FallbackTTL:  time.Minute,
+	})
+	require.NoError(t, err)
+	dec := got.(*CIMDStorageDecorator)
+
+	client, err := dec.fetchOrCached(context.Background(), srv.URL+"/meta.json")
+	require.NoError(t, err, "a write-through persistence failure must not fail the resolution")
+	assert.NotNil(t, client)
 }

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -2104,13 +2104,15 @@ func unmarshalRequester(ctx context.Context, data []byte, s *RedisStorage) (fosi
 		// that was resolved dynamically at authorize time but never persisted
 		// would fail exactly here, surfacing to the client as a bare
 		// invalid_grant at the token endpoint — so log the client id and the
-		// underlying error, which otherwise leave no server-side trace (see
-		// issue #6187).
+		// underlying error once, which otherwise leave no server-side trace
+		// (see issue #6187). The returned error deliberately does not repeat
+		// the client id: all four call sites propagate it up to fosite, which
+		// would otherwise report the same failure to the operator twice.
 		fetchedClient, err := s.GetClient(ctx, stored.ClientID)
 		if err != nil {
 			slog.WarnContext(ctx, "failed to resolve client for stored session",
 				"client_id", stored.ClientID, "error", err)
-			return nil, fmt.Errorf("failed to get client %q for session: %w", stored.ClientID, err)
+			return nil, fmt.Errorf("failed to get client for session: %w", err)
 		}
 		client = fetchedClient
 	}

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -2100,9 +2100,17 @@ func unmarshalRequester(ctx context.Context, data []byte, s *RedisStorage) (fosi
 	if IsSyntheticClientID(stored.ClientID) {
 		client = NewSyntheticClient(stored.ClientID)
 	} else {
+		// This lookup consults only this storage's own client rows: a client
+		// that was resolved dynamically at authorize time but never persisted
+		// would fail exactly here, surfacing to the client as a bare
+		// invalid_grant at the token endpoint — so log the client id and the
+		// underlying error, which otherwise leave no server-side trace (see
+		// issue #6187).
 		fetchedClient, err := s.GetClient(ctx, stored.ClientID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get client for session: %w", err)
+			slog.WarnContext(ctx, "failed to resolve client for stored session",
+				"client_id", stored.ClientID, "error", err)
+			return nil, fmt.Errorf("failed to get client %q for session: %w", stored.ClientID, err)
 		}
 		client = fetchedClient
 	}

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -725,6 +725,46 @@ func TestRedisStorage_GetClient_ConfidentialClientDoesNotMatchAsLoopback(t *test
 	})
 }
 
+// TestRedisStorage_CIMDClientSessionRehydration is the issue #6187 scenario:
+// a session created for a CIMD-resolved client must survive rehydration, which
+// resolves the client through the bare RedisStorage row lookup rather than the
+// CIMD decorator. The decorator's write-through persistence is what makes that
+// row exist. The document server is shut down before rehydration to prove no
+// re-fetch is involved — the session survives even if the document has rotated
+// or disappeared since authorize time.
+func TestRedisStorage_CIMDClientSessionRehydration(t *testing.T) {
+	withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+		srv := serveCIMDDocWithFields(t, nil)
+		decorated, err := NewCIMDStorageDecorator(s, CIMDDecoratorConfig{
+			Enabled:      true,
+			CacheMaxSize: 10,
+			FallbackTTL:  time.Minute,
+		})
+		require.NoError(t, err)
+		dec := decorated.(*CIMDStorageDecorator)
+
+		id := srv.URL + "/meta.json"
+		client, err := dec.fetchOrCached(ctx, id)
+		require.NoError(t, err)
+
+		// The persisted row must carry the anti-bloat TTL: unauthenticated
+		// authorize traffic can mint these rows, so they must never be
+		// permanent.
+		require.Positive(t, mr.TTL(redisKey(s.keyPrefix, KeyTypeClient, id)),
+			"persisted CIMD client row must expire")
+
+		request := newRedisTestRequester("req-cimd", client)
+		require.NoError(t, s.CreateAuthorizeCodeSession(ctx, "cimd-code", request))
+
+		srv.Close()
+
+		retrieved, err := s.GetAuthorizeCodeSession(ctx, "cimd-code", nil)
+		require.NoError(t, err,
+			"rehydration must find the persisted CIMD client without the decorator or a document re-fetch")
+		assert.Equal(t, id, retrieved.GetClient().GetID())
+	})
+}
+
 // TestRedisStorage_RenewClientTTL pins the RenewClientTTL contract: it refreshes
 // a DCR-issued client's TTL to DefaultDCRClientTTL on proven use, leaves
 // pre-provisioned clients (no DCRIssued marker) untouched so a permanent client

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -598,9 +598,18 @@ type ClientRegistry interface {
 	// ClientManager provides client lookup (GetClient)
 	fosite.ClientManager
 
-	// RegisterClient registers a new OAuth client.
-	// This supports both static configuration and dynamic client registration (RFC 7591).
-	// Returns ErrAlreadyExists if a client with the same ID already exists.
+	// RegisterClient registers a new OAuth client. This supports both static
+	// configuration and dynamic client registration (RFC 7591).
+	//
+	// This is an upsert, not an insert: both backends store()/SET the client
+	// unconditionally, overwriting any existing row with the same ID rather
+	// than rejecting it. Re-registering an existing ID is the only mechanism
+	// that renews a DCR-issued client's TTL on the CIMD write-through path
+	// (see CIMDStorageDecorator.fetch), so callers rely on this upsert
+	// behavior, not merely tolerate it. The one exception is the in-memory
+	// backend at capacity: when the client map is full and no DCR-issued
+	// client is old enough to evict, RegisterClient returns ErrClientCapacity
+	// instead of completing the upsert.
 	RegisterClient(ctx context.Context, client fosite.Client) error
 
 	// RenewClientTTL extends the registration TTL of a DCR-issued client (public or


### PR DESCRIPTION
Closes #6187

## Problem

`RedisStorage`'s session rehydration (`unmarshalRequester`) resolves the session's client through the bare storage's own `GetClient` row lookup — never through the `CIMDStorageDecorator`. A CIMD client is resolved dynamically at authorize time and never persisted, so at the token endpoint the lookup fails and every exchange for a CIMD client ends in a bare `invalid_grant`, with no server-side log line. Memory storage keeps the live client object, so only the CIMD × Redis combination breaks (see #6187 for the analysis and repro).

## Change

Of the two directions proposed in the issue, this implements the persistence one, as laid out in https://github.com/stacklok/toolhive/issues/6187#issuecomment-5257321111:

- On every successful CIMD document fetch, the decorator best-effort persists the resolved client into the underlying storage via `RegisterClient` (write-through; a persistence failure WARN-logs and does not fail the resolution).
- The persisted client is marked DCR-issued via the existing `registration.MarkDCRIssued` (since #6215, a CIMD-resolved client is always a shape it already handles), so the row carries the same anti-bloat TTL as DCR registrations and `RenewClientTTL` keeps actively-used rows alive — unauthenticated `/oauth/authorize` traffic can mint these rows, so they must never be permanent.
- Rehydration reads the persisted snapshot without a document re-fetch, so established sessions also survive pod restarts (the decorator's LRU is per-instance memory) and document rotation mid-session.
- Diagnosability: `unmarshalRequester` now WARN-logs the client id and the wrapped error when the client lookup fails, so this failure mode is no longer silent server-side.
- Hardening from the review round: a CIMD-scoped rate limiter guards `/oauth/authorize` before `NewAuthorizeRequest`, URL-shaped client ids from storage are refused while CIMD is disabled, URL-shaped ids are rejected for pre-provisioned delegate clients in config validation, the `RegisterClient` doc comment now states the upsert contract, and the expired-client log path is deduplicated.

## Tests

- Decorator: resolved clients are persisted in the underlying storage and carry the DCR-issued marker; a failing `RegisterClient` does not fail resolution.
- Redis (miniredis): the full #6187 scenario — a CIMD-resolved client's authorize-code session rehydrates successfully with the document server shut down, and the persisted row carries a TTL. This test fails without the write-through and passes with it.

Note: rebased on top of the merged #6283; the two changes share the decorator file, and this PR's delta is re-derived over the landed structure.