### PR TITLE
Ignore unsupported grant types in CIMD documents

### DIFF
--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -467,3 +467,66 @@ func ValidatePublicGrantTypes(grantTypes []string) ([]string, *DCRError) {
 func ValidatePublicResponseTypes(responseTypes []string) ([]string, *DCRError) {
 	return validateResponseTypes(responseTypes)
 }
+
+// FilterPublicGrantTypes returns the subset of grantTypes this server supports
+// for public clients, dropping unsupported entries instead of rejecting the
+// whole set the way ValidatePublicGrantTypes does.
+//
+// This is the right semantics for CIMD: a Client ID Metadata Document
+// describes the client's capabilities across every authorization server it
+// talks to, and the client cannot tailor it per server — VS Code, for
+// example, declares the device_code grant alongside authorization_code, and
+// rejecting the document over a grant type this flow never uses breaks the
+// client entirely. A DCR request, by contrast, is addressed to this server
+// specifically, so ValidatePublicGrantTypes' rejection remains the correct
+// feedback on that path.
+//
+// The surviving set must still include "authorization_code": a client whose
+// supported grant types do not intersect with the only redemption flow this
+// server offers cannot function against it, and a clear error beats a client
+// that registers and then fails every token request. nil/empty input gets the
+// same defaults as DCR.
+func FilterPublicGrantTypes(grantTypes []string) ([]string, *DCRError) {
+	if len(grantTypes) == 0 {
+		return defaultGrantTypes, nil
+	}
+	filtered := make([]string, 0, len(grantTypes))
+	for _, gt := range grantTypes {
+		if allowedGrantTypes[gt] {
+			filtered = append(filtered, gt)
+		}
+	}
+	if !slices.Contains(filtered, "authorization_code") {
+		return nil, &DCRError{
+			Error:            DCRErrorInvalidClientMetadata,
+			ErrorDescription: "grant_types must include 'authorization_code'",
+		}
+	}
+	return filtered, nil
+}
+
+// FilterPublicResponseTypes returns the subset of responseTypes this server
+// supports for public clients, dropping unsupported entries instead of
+// rejecting the whole set. Same reasoning as FilterPublicGrantTypes: a CIMD
+// document declares capabilities across all servers, so an entry this server
+// does not support must not be fatal — but "code" must survive the filter,
+// since it is the only response type this server can serve. nil/empty input
+// gets the same defaults as DCR.
+func FilterPublicResponseTypes(responseTypes []string) ([]string, *DCRError) {
+	if len(responseTypes) == 0 {
+		return defaultResponseTypes, nil
+	}
+	filtered := make([]string, 0, len(responseTypes))
+	for _, rt := range responseTypes {
+		if allowedResponseTypes[rt] {
+			filtered = append(filtered, rt)
+		}
+	}
+	if !slices.Contains(filtered, "code") {
+		return nil, &DCRError{
+			Error:            DCRErrorInvalidClientMetadata,
+			ErrorDescription: "response_types must include 'code'",
+		}
+	}
+	return filtered, nil
+}

--- a/pkg/authserver/server/registration/dcr.go
+++ b/pkg/authserver/server/registration/dcr.go
@@ -487,8 +487,10 @@ func ValidatePublicResponseTypes(responseTypes []string) ([]string, *DCRError) {
 // that registers and then fails every token request. nil/empty input gets the
 // same defaults as DCR.
 func FilterPublicGrantTypes(grantTypes []string) ([]string, *DCRError) {
+	// Clone so callers that store the result (e.g. in a cached fosite client)
+	// never alias the package-level default.
 	if len(grantTypes) == 0 {
-		return defaultGrantTypes, nil
+		return slices.Clone(defaultGrantTypes), nil
 	}
 	filtered := make([]string, 0, len(grantTypes))
 	for _, gt := range grantTypes {
@@ -513,8 +515,9 @@ func FilterPublicGrantTypes(grantTypes []string) ([]string, *DCRError) {
 // since it is the only response type this server can serve. nil/empty input
 // gets the same defaults as DCR.
 func FilterPublicResponseTypes(responseTypes []string) ([]string, *DCRError) {
+	// Clone for the same non-aliasing reason as FilterPublicGrantTypes.
 	if len(responseTypes) == 0 {
-		return defaultResponseTypes, nil
+		return slices.Clone(defaultResponseTypes), nil
 	}
 	filtered := make([]string, 0, len(responseTypes))
 	for _, rt := range responseTypes {

--- a/pkg/authserver/server/registration/dcr_test.go
+++ b/pkg/authserver/server/registration/dcr_test.go
@@ -616,6 +616,72 @@ func TestDefaultGrantTypesAndResponseTypes(t *testing.T) {
 	assert.Contains(t, defaultResponseTypes, "code")
 }
 
+func TestFilterPublicGrantTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		grantTypes []string
+		want       []string
+		wantErr    bool
+	}{
+		{"nil gets defaults", nil, []string{"authorization_code", "refresh_token"}, false},
+		{"empty gets defaults", []string{}, []string{"authorization_code", "refresh_token"}, false},
+		{"supported set passes through", []string{"authorization_code", "refresh_token"},
+			[]string{"authorization_code", "refresh_token"}, false},
+		{"unsupported entries are dropped, not fatal",
+			[]string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"},
+			[]string{"authorization_code", "refresh_token"}, false},
+		{"unsupported-only list rejected (authorization_code missing)",
+			[]string{"urn:ietf:params:oauth:grant-type:device_code", "client_credentials"}, nil, true},
+		{"refresh_token only rejected (authorization_code missing)", []string{"refresh_token"}, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, dcrErr := FilterPublicGrantTypes(tt.grantTypes)
+			if tt.wantErr {
+				require.NotNil(t, dcrErr)
+				assert.Equal(t, DCRErrorInvalidClientMetadata, dcrErr.Error)
+				return
+			}
+			require.Nil(t, dcrErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterPublicResponseTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		responseTypes []string
+		want          []string
+		wantErr       bool
+	}{
+		{"nil gets defaults", nil, []string{"code"}, false},
+		{"code passes through", []string{"code"}, []string{"code"}, false},
+		{"unsupported entries are dropped, not fatal", []string{"code", "token"}, []string{"code"}, false},
+		{"unsupported-only list rejected (code missing)", []string{"token"}, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, dcrErr := FilterPublicResponseTypes(tt.responseTypes)
+			if tt.wantErr {
+				require.NotNil(t, dcrErr)
+				assert.Equal(t, DCRErrorInvalidClientMetadata, dcrErr.Error)
+				return
+			}
+			require.Nil(t, dcrErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestValidateScopeSubset(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/storage/cimd_decorator.go
+++ b/pkg/authserver/storage/cimd_decorator.go
@@ -6,6 +6,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"slices"
 	"strings"
@@ -143,16 +144,32 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 			id, m, defaultCIMDTokenEndpointAuthMethod)
 	}
 
-	// Reject documents that declare grant_types or response_types the embedded AS
-	// does not support for public clients. Uses the same validators as DCR so the
-	// error messages and allowed sets are identical on both registration paths.
-	if _, dcrErr := registration.ValidatePublicGrantTypes(doc.GrantTypes); dcrErr != nil {
+	// Filter — not reject — grant_types and response_types this AS does not
+	// support. A CIMD document describes the client's capabilities across
+	// every AS it talks to and cannot be tailored per server (VS Code
+	// declares device_code alongside authorization_code, see #6290), so an
+	// unsupported entry is ignored rather than failing the whole document.
+	// The filters still reject when the intersection lacks the one flow this
+	// server offers (authorization_code / code): such a client could never
+	// complete a token exchange here, and a clear error at resolution beats
+	// a client that resolves and then fails every token request.
+	grantTypes, dcrErr := registration.FilterPublicGrantTypes(doc.GrantTypes)
+	if dcrErr != nil {
 		return nil, fmt.Errorf("%w: CIMD document at %s: %s",
 			fosite.ErrInvalidClient.WithHint(dcrErr.ErrorDescription), id, dcrErr.ErrorDescription)
 	}
-	if _, dcrErr := registration.ValidatePublicResponseTypes(doc.ResponseTypes); dcrErr != nil {
+	if dropped := len(doc.GrantTypes) - len(grantTypes); dropped > 0 {
+		slog.Debug("CIMD: ignoring grant_types this server does not support",
+			"client_id", id, "declared", doc.GrantTypes, "effective", grantTypes)
+	}
+	responseTypes, dcrErr := registration.FilterPublicResponseTypes(doc.ResponseTypes)
+	if dcrErr != nil {
 		return nil, fmt.Errorf("%w: CIMD document at %s: %s",
 			fosite.ErrInvalidClient.WithHint(dcrErr.ErrorDescription), id, dcrErr.ErrorDescription)
+	}
+	if dropped := len(doc.ResponseTypes) - len(responseTypes); dropped > 0 {
+		slog.Debug("CIMD: ignoring response_types this server does not support",
+			"client_id", id, "declared", doc.ResponseTypes, "effective", responseTypes)
 	}
 
 	// Compute and validate the client scope list consistent with DCR.
@@ -195,7 +212,7 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 		resolvedScopes = registration.UnionScopes(resolvedScopes, d.baselineClientScopes)
 	}
 
-	client := buildFositeClient(doc, resolvedScopes)
+	client := buildFositeClient(doc, resolvedScopes, grantTypes, responseTypes)
 
 	d.cache.Add(id, &cimdCacheEntry{
 		client:  client,
@@ -204,15 +221,6 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 
 	return client, nil
 }
-
-// defaultCIMDGrantTypes are the OAuth 2.0 grant types applied when the CIMD
-// document omits grant_types. CIMD clients are typically public native apps
-// that use the authorization code flow with refresh token rotation.
-var defaultCIMDGrantTypes = []string{"authorization_code", "refresh_token"}
-
-// defaultCIMDResponseTypes are the OAuth 2.0 response types applied when the
-// CIMD document omits response_types.
-var defaultCIMDResponseTypes = []string{"code"}
 
 // defaultCIMDTokenEndpointAuthMethod is the token endpoint authentication
 // method applied when the CIMD document omits token_endpoint_auth_method.
@@ -226,17 +234,15 @@ const defaultCIMDTokenEndpointAuthMethod = "none"
 // resolvedScopes is the already-validated scope list computed by fetch() via
 // registration.ValidateScopes; when empty, DefaultScopes is used — this occurs when
 // the decorator has no ScopesSupported restriction (unconstrained AS).
-func buildFositeClient(doc *cimd.ClientMetadataDocument, resolvedScopes []string) fosite.Client {
-	grantTypes := doc.GrantTypes
-	if len(grantTypes) == 0 {
-		grantTypes = defaultCIMDGrantTypes
-	}
-
-	responseTypes := doc.ResponseTypes
-	if len(responseTypes) == 0 {
-		responseTypes = defaultCIMDResponseTypes
-	}
-
+// grantTypes and responseTypes are the already-filtered lists computed by
+// fetch() via registration.FilterPublicGrantTypes/FilterPublicResponseTypes —
+// the document's declared values with unsupported entries dropped, never
+// empty (the filters apply defaults and reject empty intersections). The
+// stored client therefore carries only grant/response types this server can
+// actually serve, not the document's full declaration.
+func buildFositeClient(
+	doc *cimd.ClientMetadataDocument, resolvedScopes, grantTypes, responseTypes []string,
+) fosite.Client {
 	tokenEndpointAuthMethod := doc.TokenEndpointAuthMethod
 	if tokenEndpointAuthMethod == "" {
 		tokenEndpointAuthMethod = defaultCIMDTokenEndpointAuthMethod

--- a/pkg/authserver/storage/cimd_decorator.go
+++ b/pkg/authserver/storage/cimd_decorator.go
@@ -158,7 +158,7 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 		return nil, fmt.Errorf("%w: CIMD document at %s: %s",
 			fosite.ErrInvalidClient.WithHint(dcrErr.ErrorDescription), id, dcrErr.ErrorDescription)
 	}
-	if dropped := len(doc.GrantTypes) - len(grantTypes); dropped > 0 {
+	if len(grantTypes) < len(doc.GrantTypes) {
 		slog.Debug("CIMD: ignoring grant_types this server does not support",
 			"client_id", id, "declared", doc.GrantTypes, "effective", grantTypes)
 	}
@@ -167,7 +167,7 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 		return nil, fmt.Errorf("%w: CIMD document at %s: %s",
 			fosite.ErrInvalidClient.WithHint(dcrErr.ErrorDescription), id, dcrErr.ErrorDescription)
 	}
-	if dropped := len(doc.ResponseTypes) - len(responseTypes); dropped > 0 {
+	if len(responseTypes) < len(doc.ResponseTypes) {
 		slog.Debug("CIMD: ignoring response_types this server does not support",
 			"client_id", id, "declared", doc.ResponseTypes, "effective", responseTypes)
 	}

--- a/pkg/authserver/storage/cimd_decorator_test.go
+++ b/pkg/authserver/storage/cimd_decorator_test.go
@@ -329,32 +329,32 @@ func TestCIMDStorageDecorator_GetClient_CIMDURLHitsCacheDirectly(t *testing.T) {
 
 // --- buildFositeClient ---
 
-func TestBuildFositeClient_Defaults(t *testing.T) {
-	t.Parallel()
-
-	doc := &cimd.ClientMetadataDocument{
-		ClientID:     "https://example.com/meta.json",
-		RedirectURIs: []string{"https://example.com/callback"},
-	}
-
-	got := buildFositeClient(doc, nil)
-	assert.Equal(t, "https://example.com/meta.json", got.GetID())
-	assert.True(t, got.IsPublic())
-	assert.ElementsMatch(t, []string{"authorization_code", "refresh_token"}, []string(got.GetGrantTypes()))
-	assert.ElementsMatch(t, []string{"code"}, []string(got.GetResponseTypes()))
+// buildFositeClientWithDefaults calls buildFositeClient with the standard
+// filtered grant/response types (what FilterPublicGrantTypes /
+// FilterPublicResponseTypes return for an omitted declaration), for tests
+// that don't exercise those fields.
+func buildFositeClientWithDefaults(doc *cimd.ClientMetadataDocument, scopes []string) fosite.Client {
+	return buildFositeClient(doc, scopes,
+		[]string{"authorization_code", "refresh_token"}, []string{"code"})
 }
 
-func TestBuildFositeClient_ExplicitGrantTypes(t *testing.T) {
+func TestBuildFositeClient_PassesThroughGrantAndResponseTypes(t *testing.T) {
 	t.Parallel()
 
 	doc := &cimd.ClientMetadataDocument{
 		ClientID:     "https://example.com/meta.json",
 		RedirectURIs: []string{"https://example.com/callback"},
-		GrantTypes:   []string{"authorization_code"},
+		// The document's own declaration is ignored: fetch() passes the
+		// filtered lists explicitly, and only those must reach the client.
+		GrantTypes: []string{"authorization_code", "urn:ietf:params:oauth:grant-type:device_code"},
 	}
 
-	got := buildFositeClient(doc, nil)
-	assert.ElementsMatch(t, []string{"authorization_code"}, []string(got.GetGrantTypes()))
+	got := buildFositeClient(doc, nil, []string{"authorization_code"}, []string{"code"})
+	assert.Equal(t, "https://example.com/meta.json", got.GetID())
+	assert.True(t, got.IsPublic())
+	assert.ElementsMatch(t, []string{"authorization_code"}, []string(got.GetGrantTypes()),
+		"the filtered grant types must be stored, not the document's declaration")
+	assert.ElementsMatch(t, []string{"code"}, []string(got.GetResponseTypes()))
 }
 
 func TestBuildFositeClient_ScopeParsing(t *testing.T) {
@@ -367,7 +367,7 @@ func TestBuildFositeClient_ScopeParsing(t *testing.T) {
 	}
 
 	// Scope parsing is done by fetch() before buildFositeClient.
-	got := buildFositeClient(doc, strings.Fields(doc.Scope))
+	got := buildFositeClientWithDefaults(doc, strings.Fields(doc.Scope))
 	assert.ElementsMatch(t, []string{"openid", "profile", "email"}, []string(got.GetScopes()))
 }
 
@@ -379,7 +379,7 @@ func TestBuildFositeClient_LoopbackRedirectWrapsInLoopbackClient(t *testing.T) {
 		RedirectURIs: []string{"http://localhost/callback"},
 	}
 
-	got := buildFositeClient(doc, nil)
+	got := buildFositeClientWithDefaults(doc, nil)
 	// LoopbackClient adds MatchRedirectURI — check the distinctive method is present.
 	type loopbackMatcher interface {
 		MatchRedirectURI(string) bool
@@ -402,7 +402,7 @@ func TestBuildFositeClient_NonLoopbackRedirectReturnsOpenIDConnectClient(t *test
 		RedirectURIs: []string{"https://example.com/callback"},
 	}
 
-	got := buildFositeClient(doc, nil)
+	got := buildFositeClientWithDefaults(doc, nil)
 	_, ok := got.(*fosite.DefaultOpenIDConnectClient)
 	assert.True(t, ok, "non-loopback redirect URI must produce a DefaultOpenIDConnectClient")
 }
@@ -415,7 +415,7 @@ func TestBuildFositeClient_TokenEndpointAuthMethodDefault(t *testing.T) {
 		RedirectURIs: []string{"https://example.com/callback"},
 	}
 
-	got := buildFositeClient(doc, nil)
+	got := buildFositeClientWithDefaults(doc, nil)
 	if oidc, ok := got.(fosite.OpenIDConnectClient); ok {
 		assert.Equal(t, "none", oidc.GetTokenEndpointAuthMethod())
 	}
@@ -473,18 +473,31 @@ func serveCIMDDocWithFields(t *testing.T, mutate func(*cimd.ClientMetadataDocume
 func TestFetch_GrantTypeValidation(t *testing.T) {
 	t.Parallel()
 
+	// A CIMD document declares the client's capabilities across every AS it
+	// talks to, so grant types this server does not support are filtered out
+	// rather than failing the document (#6290). Rejection only happens when
+	// nothing this server supports survives — specifically, when
+	// authorization_code is absent from the intersection.
 	tests := []struct {
-		name       string
-		grantTypes []string
-		wantErr    bool
+		name           string
+		grantTypes     []string
+		wantErr        bool
+		wantGrantTypes []string // asserted on the resolved client when no error
 	}{
-		{"omitted grant_types accepted", nil, false},
-		{"explicit [authorization_code, refresh_token] accepted", []string{"authorization_code", "refresh_token"}, false},
-		{"explicit [authorization_code] accepted", []string{"authorization_code"}, false},
-		{"refresh_token only missing authorization_code rejected", []string{"refresh_token"}, true},
-		{"client_credentials rejected", []string{"client_credentials"}, true},
-		{"implicit rejected", []string{"implicit"}, true},
-		{"device_code rejected", []string{"urn:ietf:params:oauth:grant-type:device_code"}, true},
+		{"omitted grant_types accepted", nil, false,
+			[]string{"authorization_code", "refresh_token"}},
+		{"explicit [authorization_code, refresh_token] accepted", []string{"authorization_code", "refresh_token"}, false,
+			[]string{"authorization_code", "refresh_token"}},
+		{"explicit [authorization_code] accepted", []string{"authorization_code"}, false,
+			[]string{"authorization_code"}},
+		{"device_code alongside authorization_code is ignored, not fatal",
+			[]string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"}, false,
+			[]string{"authorization_code", "refresh_token"}},
+		{"refresh_token only missing authorization_code rejected", []string{"refresh_token"}, true, nil},
+		{"client_credentials only rejected (no supported grant type)", []string{"client_credentials"}, true, nil},
+		{"implicit only rejected (no supported grant type)", []string{"implicit"}, true, nil},
+		{"device_code only rejected (no supported grant type)",
+			[]string{"urn:ietf:params:oauth:grant-type:device_code"}, true, nil},
 	}
 
 	for _, tt := range tests {
@@ -494,7 +507,7 @@ func TestFetch_GrantTypeValidation(t *testing.T) {
 				doc.GrantTypes = tt.grantTypes
 			})
 			dec := newEnabledDecorator(t, newTestBase(t), 10, time.Minute)
-			_, err := dec.fetchOrCached(context.Background(), srv.URL+"/meta.json")
+			client, err := dec.fetchOrCached(context.Background(), srv.URL+"/meta.json")
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.ErrorIs(t, err, fosite.ErrInvalidClient,
@@ -502,9 +515,38 @@ func TestFetch_GrantTypeValidation(t *testing.T) {
 				assert.NotErrorIs(t, err, fosite.ErrNotFound)
 			} else {
 				require.NoError(t, err)
+				assert.ElementsMatch(t, tt.wantGrantTypes, []string(client.GetGrantTypes()),
+					"the resolved client must carry only grant types this server supports")
 			}
 		})
 	}
+}
+
+// TestFetch_VSCodeDocumentResolves is the regression test for #6290: VS
+// Code's real-world client-metadata document declares the device_code grant
+// alongside authorization_code and refresh_token, and its resolution must
+// succeed with device_code filtered out rather than failing the whole
+// document with invalid_client.
+func TestFetch_VSCodeDocumentResolves(t *testing.T) {
+	t.Parallel()
+
+	srv := serveCIMDDocWithFields(t, func(doc *cimd.ClientMetadataDocument) {
+		// Mirror https://vscode.dev/oauth/client-metadata.json (VS Code 1.133.0),
+		// with client_id/redirect kept test-local.
+		doc.ClientName = "Visual Studio Code"
+		doc.GrantTypes = []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"}
+		doc.ResponseTypes = []string{"code"}
+		doc.TokenEndpointAuthMethod = "none"
+		doc.RedirectURIs = []string{"http://127.0.0.1:33418/", "https://vscode.dev/redirect"}
+	})
+	dec := newEnabledDecorator(t, newTestBase(t), 10, time.Minute)
+
+	client, err := dec.fetchOrCached(context.Background(), srv.URL+"/meta.json")
+	require.NoError(t, err, "VS Code's document must resolve (#6290)")
+	assert.True(t, client.IsPublic())
+	assert.ElementsMatch(t, []string{"authorization_code", "refresh_token"}, []string(client.GetGrantTypes()),
+		"device_code must be filtered out, not stored")
+	assert.ElementsMatch(t, []string{"code"}, []string(client.GetResponseTypes()))
 }
 
 // --- response_types validation ---
@@ -512,15 +554,20 @@ func TestFetch_GrantTypeValidation(t *testing.T) {
 func TestFetch_ResponseTypeValidation(t *testing.T) {
 	t.Parallel()
 
+	// Same filtering semantics as grant types: unsupported response types are
+	// ignored, and rejection only happens when "code" — the one response type
+	// this server serves — does not survive the intersection.
 	tests := []struct {
-		name          string
-		responseTypes []string
-		wantErr       bool
+		name              string
+		responseTypes     []string
+		wantErr           bool
+		wantResponseTypes []string // asserted on the resolved client when no error
 	}{
-		{"omitted response_types accepted", nil, false},
-		{"code accepted", []string{"code"}, false},
-		{"token rejected", []string{"token"}, true},
-		{"code id_token rejected (hybrid)", []string{"code id_token"}, true},
+		{"omitted response_types accepted", nil, false, []string{"code"}},
+		{"code accepted", []string{"code"}, false, []string{"code"}},
+		{"token alongside code is ignored, not fatal", []string{"code", "token"}, false, []string{"code"}},
+		{"token only rejected (no supported response type)", []string{"token"}, true, nil},
+		{"code id_token rejected (hybrid)", []string{"code id_token"}, true, nil},
 	}
 
 	for _, tt := range tests {
@@ -530,7 +577,7 @@ func TestFetch_ResponseTypeValidation(t *testing.T) {
 				doc.ResponseTypes = tt.responseTypes
 			})
 			dec := newEnabledDecorator(t, newTestBase(t), 10, time.Minute)
-			_, err := dec.fetchOrCached(context.Background(), srv.URL+"/meta.json")
+			client, err := dec.fetchOrCached(context.Background(), srv.URL+"/meta.json")
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.ErrorIs(t, err, fosite.ErrInvalidClient,
@@ -538,6 +585,8 @@ func TestFetch_ResponseTypeValidation(t *testing.T) {
 				assert.NotErrorIs(t, err, fosite.ErrNotFound)
 			} else {
 				require.NoError(t, err)
+				assert.ElementsMatch(t, tt.wantResponseTypes, []string(client.GetResponseTypes()),
+					"the resolved client must carry only response types this server supports")
 			}
 		})
 	}
@@ -632,6 +681,6 @@ func TestBuildFositeClient_ScopeDefaultsToDefaultScopesWhenNoScopesSupported(t *
 		ClientID:     "https://example.com/meta.json",
 		RedirectURIs: []string{"https://example.com/callback"},
 	}
-	got := buildFositeClient(doc, nil)
+	got := buildFositeClientWithDefaults(doc, nil)
 	assert.ElementsMatch(t, registration.DefaultScopes, []string(got.GetScopes()))
 }


### PR DESCRIPTION
## Summary

VS Code's real-world client-metadata document declares `urn:ietf:params:oauth:grant-type:device_code` in `grant_types` alongside `authorization_code` and `refresh_token`, and the CIMD resolver rejected the entire document over it — surfacing to the user as an opaque `invalid_client` ("The requested OAuth 2.0 Client does not exist") at `/oauth/authorize`. Since VS Code is the client CIMD was explicitly built for (#4825), this broke the feature for its primary consumer.

The root problem is a semantic mismatch: a CIMD document describes the client's capabilities across *every* authorization server it talks to, and the client cannot tailor it per server — so an entry this server doesn't support must not be fatal. A DCR request, by contrast, is addressed to this server specifically, so strict rejection remains correct feedback there.

- New `registration.FilterPublicGrantTypes` / `FilterPublicResponseTypes` drop unsupported entries instead of rejecting the set, but still reject when the intersection lacks the one flow this server offers (`authorization_code` / `code`) — such a client could never complete a token exchange, and a clear error at resolution beats failing every token request
- The CIMD decorator uses the filters; the stored fosite client carries only the filtered types, threaded explicitly into `buildFositeClient` rather than re-read from the raw document
- Dropped entries are logged at Debug with declared vs effective sets, addressing the diagnosability complaint in the issue (nothing was logged server-side)
- DCR's strict `ValidatePublicGrantTypes` / `ValidatePublicResponseTypes` are unchanged

Fixes #6290

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New tests: a regression test resolving VS Code's real document shape (device_code alongside authorization_code, mixed loopback/https redirect URIs), filtered-vs-rejected cases in the decorator's grant/response-type tables, and table-driven tests for the two new filter functions. Pre-existing failures in `pkg/plugins/pluginsvc` and a gosec finding in `cmd/thv/app/upgrade.go` reproduce identically on clean `main` and are unrelated.

## Does this introduce a user-facing change?

MCP clients whose CIMD document declares grant types or response types the embedded auth server does not support (e.g. VS Code's `device_code`) now resolve successfully, with the unsupported entries ignored, instead of failing with `invalid_client`.

## Special notes for reviewers

- The previously tested behavior ("device_code rejected") was deliberate at CIMD implementation time; this PR flips that policy for CIMD only, with the reasoning captured in the `FilterPublicGrantTypes` godoc.
- The issue also notes the `/oauth/authorize` error path logs nothing server-side, which made this hard to diagnose. The Debug log here covers the CIMD-rejection slice of that; the general authorize-path logging gap is left for a follow-up as the issue suggests.

Generated with [Claude Code](https://claude.com/claude-code)
