### PR TITLE
[codex] Strip BOM before filtering JSON responses

### DIFF
--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -166,6 +166,12 @@ func (rfw *ResponseFilteringWriter) Flush() {
 }
 
 func (rfw *ResponseFilteringWriter) processJSONResponse(rawResponse []byte) error {
+	// A client strips a leading BOM per the WHATWG UTF-8 decode algorithm before
+	// parsing JSON, so strip it here too. Otherwise the JSON decoder and the
+	// result probe both reject a response that the client will accept, causing
+	// the unfiltered body to pass through.
+	rawResponse = bytes.TrimPrefix(rawResponse, []byte("\xEF\xBB\xBF"))
+
 	message, err := jsonrpc2.DecodeMessage(rawResponse)
 	response, ok := message.(*jsonrpc2.Response)
 	if err != nil || !ok {

--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -531,6 +531,14 @@ func requiresResponseFiltering(method string) bool {
 // decoder can't parse value-by-value isn't a single parseable JSON document
 // either, so no strict client can read past that point.
 func carriesResult(data []byte) bool {
+	// A client strips a leading BOM per the WHATWG UTF-8 decode algorithm
+	// before parsing JSON, so strip it here too: otherwise a BOM-prefixed
+	// payload (which the client will parse as a successful response) looks
+	// undecodable to the sniff and the filter passes it through unfiltered.
+	// This mirrors the strip in processSSEResponse (see #6088) and covers the
+	// unrecognized-media-type sniff at FlushAndFilter.
+	data = bytes.TrimPrefix(data, []byte("\xEF\xBB\xBF"))
+
 	dec := json.NewDecoder(bytes.NewReader(data))
 	for {
 		var value json.RawMessage

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -1525,7 +1525,40 @@ func TestResponseFilteringWriter_JSON_LeadingBOMBypass(t *testing.T) {
 		"the leading BOM must be dropped from the output, not stripped-for-matching then re-emitted")
 }
 
-// TestResponseFilteringWriter_SSE_ErrorAndResultBypass is a regression test
+// TestResponseFilteringWriter_JSON_LeadingBOMUnrecognizedMediaType is a
+// regression test for the same #5257-class leak on the unrecognized-media-type
+// sniff: a BOM-prefixed list body labeled with an MCP-unsupported media type
+// must still be detected as carrying a result and filtered, not passed through
+// as if it were a benign, result-free body.
+func TestResponseFilteringWriter_JSON_LeadingBOMUnrecognizedMediaType(t *testing.T) {
+	t.Parallel()
+
+	authorizer := newWeatherOnlyAuthorizer(t)
+	req := newUser1Request(t)
+	resultJSON, err := json.Marshal(mcp.ListToolsResult{
+		Tools: []mcp.Tool{
+			{Name: "weather", Description: "Get weather information"},
+			{Name: "admin_tool", Description: "Sensitive admin operations"},
+		},
+	})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	rfw := NewResponseFilteringWriter(rr, authorizer, req, string(mcp.MethodToolsList), nil, nil)
+	rfw.ResponseWriter.Header().Set("Content-Type", "application/x-unknown")
+	body := "\xEF\xBB\xBF" + `{"jsonrpc":"2.0","id":1,"result":` + string(resultJSON) + "}"
+
+	_, err = rfw.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, rfw.FlushAndFilter())
+
+	out := rr.Body.String()
+	assert.NotContains(t, out, "admin_tool",
+		"a leading UTF-8 BOM must not bypass the unrecognized-media-type sniff")
+	assert.Contains(t, out, "weather", "the authorized tool must survive filtering")
+	assert.False(t, strings.HasPrefix(out, "\xEF\xBB\xBF"),
+		"the leading BOM must be dropped from the output, not stripped-for-matching then re-emitted")
+}
 // for a #5257-class leak: jsonrpc2.DecodeMessage and EncodeMessage both
 // populate/re-emit "error" and "result" together on one Response, and
 // filterListResponse's `response.Error != nil` check returned the whole

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -1490,6 +1490,41 @@ func TestResponseFilteringWriter_SSE_LeadingBOMBypass(t *testing.T) {
 		"the leading BOM must be dropped from the output, not stripped-for-matching then re-emitted")
 }
 
+// TestResponseFilteringWriter_JSON_LeadingBOMBypass is a regression test for a
+// #5257-class leak: a client strips a leading UTF-8 BOM per the WHATWG decode
+// algorithm before parsing JSON, but the filter previously decoded the raw
+// body. The BOM made both the decoder and result probe reject the response, so
+// the unauthorized tool passed through unfiltered.
+func TestResponseFilteringWriter_JSON_LeadingBOMBypass(t *testing.T) {
+	t.Parallel()
+
+	authorizer := newWeatherOnlyAuthorizer(t)
+	req := newUser1Request(t)
+	resultJSON, err := json.Marshal(mcp.ListToolsResult{
+		Tools: []mcp.Tool{
+			{Name: "weather", Description: "Get weather information"},
+			{Name: "admin_tool", Description: "Sensitive admin operations"},
+		},
+	})
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	rfw := NewResponseFilteringWriter(rr, authorizer, req, string(mcp.MethodToolsList), nil, nil)
+	rfw.ResponseWriter.Header().Set("Content-Type", "application/json")
+	body := "\xEF\xBB\xBF" + `{"jsonrpc":"2.0","id":1,"result":` + string(resultJSON) + "}"
+
+	_, err = rfw.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, rfw.FlushAndFilter())
+
+	out := rr.Body.String()
+	assert.NotContains(t, out, "admin_tool",
+		"a leading UTF-8 BOM must not bypass the filter")
+	assert.Contains(t, out, "weather", "the authorized tool must survive filtering")
+	assert.False(t, strings.HasPrefix(out, "\xEF\xBB\xBF"),
+		"the leading BOM must be dropped from the output, not stripped-for-matching then re-emitted")
+}
+
 // TestResponseFilteringWriter_SSE_ErrorAndResultBypass is a regression test
 // for a #5257-class leak: jsonrpc2.DecodeMessage and EncodeMessage both
 // populate/re-emit "error" and "result" together on one Response, and


### PR DESCRIPTION
## Summary

- Strip one leading UTF-8 BOM before decoding and filtering `application/json` list responses.
- Add a regression test confirming a BOM-prefixed `tools/list` response is filtered and does not retain the BOM.

## Root cause

A WHATWG/fetch client removes a leading BOM before parsing, but the JSON response filter previously passed the raw body to both `jsonrpc2.DecodeMessage` and `carriesResult`. Both reject a BOM-prefixed body, after which the filter wrote the unfiltered input back to the client.

## Impact

This prevents a BOM-prefixed JSON list response from bypassing Cedar response filtering for clients that strip a leading BOM during UTF-8 decoding.

Fixes #6301.

## Validation

- `go test -v ./pkg/authz -run 'TestResponseFilteringWriter_(JSON|SSE)_LeadingBOMBypass$' -count=1`
- `go test ./pkg/authz -count=1`
