### PR TITLE
Add plugins key to lock file schema

### DIFF
--- a/pkg/skills/lockfile/lockfile.go
+++ b/pkg/skills/lockfile/lockfile.go
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package lockfile manages the project-level skills lock file
-// (toolhive.lock.yaml). The lock file pins the exact name, version, source,
-// and digests of every project-scoped skill install so a team can restore
-// ("thv skill sync") or refresh ("thv skill upgrade") the pinned state on any
-// machine. See RFC THV-0080.
+// Package lockfile manages the project-level lock file (toolhive.lock.yaml).
+// The lock file pins the exact name, version, source, and digests of every
+// project-scoped skill and plugin install so a team can restore
+// ("thv skill sync" / "thv ai-plugin sync") or refresh
+// ("thv skill upgrade" / "thv ai-plugin upgrade") the pinned state on any
+// machine. RFC THV-0080 owns the version and skills: keys; plugins: is the
+// sibling key ratified by the AI-plugin lock track.
 //
 // All filesystem access goes through [Root], a capability type that can only
 // be constructed from a validated project root. Root confines every read and
@@ -31,7 +33,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/skills"
 )
 
-// FileName is the name of the project-level skills lock file, written to the
+// FileName is the name of the project-level lock file, written to the
 // project root alongside .git.
 const FileName = "toolhive.lock.yaml"
 
@@ -40,11 +42,13 @@ const FileName = "toolhive.lock.yaml"
 // parse.
 const CurrentVersion = 1
 
-// Entry represents a single pinned skill installation in the lock file.
+// Entry represents a single pinned skill or plugin installation in the lock file.
 type Entry struct {
-	// Name is the skill's unique name.
+	// Name is the artifact's unique name within its key (skills: or plugins:).
+	// The same name may appear once under each key.
 	Name string `yaml:"name"`
-	// Version is the skill's declared version, if any (from SKILL.md frontmatter).
+	// Version is the artifact's declared version, if any (SKILL.md frontmatter
+	// or .claude-plugin/plugin.json).
 	Version string `yaml:"version,omitempty"`
 	// Source is exactly what the user (or the registry resolver) originally
 	// requested — a plain registry name, an OCI reference, or a git://
@@ -58,7 +62,8 @@ type Entry struct {
 	// digest or a full git commit hash.
 	Digest string `yaml:"digest"`
 	// ContentDigest is a deterministic SHA-256 dirhash of the materialized
-	// skill file set, used for on-disk integrity verification.
+	// file set (skill directory, or the canonical plugin tree ExtractPlugin
+	// writes), used for on-disk integrity verification.
 	ContentDigest string `yaml:"contentDigest,omitempty"`
 	// Provenance records the verified signer identity of the installed
 	// artifact — the trust-on-first-use anchor later installs, syncs, and
@@ -72,11 +77,14 @@ type Entry struct {
 	// signed one clears it, and a signed entry never becomes unsigned
 	// without the same explicit flag.
 	Unsigned bool `yaml:"unsigned,omitempty"`
-	// RequiredBy lists parent skill names for transitively materialized
-	// dependencies (skills declared via toolhive.requires).
+	// RequiredBy lists parent names in the same key (skills: or plugins:)
+	// for transitively materialized dependencies. Plugin v1 does not
+	// populate this; the field is reserved for when plugin requires are
+	// materialized.
 	RequiredBy []string `yaml:"requiredBy,omitempty"`
-	// Explicit is true when the user directly installed this skill; explicit
-	// entries are exempt from cascade removal when RequiredBy becomes empty.
+	// Explicit is true when the user directly installed this artifact;
+	// explicit entries are exempt from cascade removal when RequiredBy
+	// becomes empty.
 	Explicit bool `yaml:"explicit,omitempty"`
 	// Extra round-trips fields this binary does not know about, so a
 	// Load→modify→Save cycle by an older binary preserves rather than strips
@@ -114,6 +122,10 @@ type Lockfile struct {
 	// Skills is the set of pinned skill installations, sorted by name for
 	// stable diffs.
 	Skills []Entry `yaml:"skills,omitempty"`
+	// Plugins is the set of pinned plugin installations, sorted by name
+	// for stable diffs. Validated as its own name/requiredBy graph, so a
+	// skill and a plugin may share a name.
+	Plugins []Entry `yaml:"plugins,omitempty"`
 	// Extra round-trips unknown top-level fields, mirroring Entry.Extra.
 	Extra map[string]any `yaml:",inline"`
 }
@@ -190,50 +202,51 @@ func Load(root Root) (*Lockfile, error) {
 		lf.Version = CurrentVersion
 	}
 	sortEntries(lf.Skills)
+	sortEntries(lf.Plugins)
 	if err := validateLockfile(&lf); err != nil {
 		return nil, err
 	}
 	return &lf, nil
 }
 
-// Get returns the entry for name, if present.
+// Get returns the skills: entry for name, if present.
 func (l *Lockfile) Get(name string) (Entry, bool) {
-	for _, e := range l.Skills {
-		if e.Name == name {
-			return e, true
-		}
-	}
-	return Entry{}, false
+	return getNamed(l.Skills, name)
 }
 
-// Upsert inserts or replaces the entry with a matching name, keeping the
-// slice sorted by name for stable diffs.
+// GetPlugin returns the plugins: entry for name, if present.
+func (l *Lockfile) GetPlugin(name string) (Entry, bool) {
+	return getNamed(l.Plugins, name)
+}
+
+// Upsert inserts or replaces the skills: entry with a matching name, keeping
+// the slice sorted by name for stable diffs. It does not touch plugins:.
 func (l *Lockfile) Upsert(entry Entry) {
-	for i := range l.Skills {
-		if l.Skills[i].Name == entry.Name {
-			l.Skills[i] = entry
-			return
-		}
-	}
-	l.Skills = append(l.Skills, entry)
-	sortEntries(l.Skills)
+	upsertNamed(&l.Skills, entry)
 }
 
-// Remove deletes the entry with the given name, if present. Reports whether
-// an entry was removed.
+// UpsertPlugin inserts or replaces the plugins: entry with a matching name,
+// keeping the slice sorted by name for stable diffs. It does not touch skills:.
+func (l *Lockfile) UpsertPlugin(entry Entry) {
+	upsertNamed(&l.Plugins, entry)
+}
+
+// Remove deletes the skills: entry with the given name, if present. Reports
+// whether an entry was removed.
 func (l *Lockfile) Remove(name string) bool {
-	for i, e := range l.Skills {
-		if e.Name == name {
-			l.Skills = slices.Delete(l.Skills, i, i+1)
-			return true
-		}
-	}
-	return false
+	return removeNamed(&l.Skills, name)
 }
 
-// RemoveParentFromRequiredBy removes parent from every entry's RequiredBy
-// list and returns the names of entries that lost their last parent and are
-// not explicit — the candidates for cascade removal.
+// RemovePlugin deletes the plugins: entry with the given name, if present.
+// Reports whether an entry was removed.
+func (l *Lockfile) RemovePlugin(name string) bool {
+	return removeNamed(&l.Plugins, name)
+}
+
+// RemoveParentFromRequiredBy removes parent from every skills: entry's
+// RequiredBy list and returns the names of entries that lost their last
+// parent and are not explicit — the candidates for cascade removal. It
+// does not touch plugins:.
 func (l *Lockfile) RemoveParentFromRequiredBy(parent string) []string {
 	var cascadeCandidates []string
 	for i := range l.Skills {
@@ -285,6 +298,7 @@ func (l *Lockfile) Save(root Root) error {
 		l.Version = CurrentVersion
 	}
 	sortEntries(l.Skills)
+	sortEntries(l.Plugins)
 
 	if err := validateLockfile(l); err != nil {
 		return fmt.Errorf("refusing to save invalid lock file: %w", err)
@@ -311,8 +325,8 @@ func (l *Lockfile) Save(root Root) error {
 	return nil
 }
 
-// UpsertEntry loads the lock file, upserts entry, and saves it back, all
-// under a single file lock so concurrent installs cannot race on
+// UpsertEntry loads the lock file, upserts a skills: entry, and saves it
+// back, all under a single file lock so concurrent installs cannot race on
 // read-modify-write.
 func UpsertEntry(root Root, entry Entry) error {
 	return Update(root, func(lf *Lockfile) error {
@@ -321,12 +335,34 @@ func UpsertEntry(root Root, entry Entry) error {
 	})
 }
 
-// RemoveEntry loads the lock file, removes the named entry if present, and
-// saves it back, all under a single file lock. Removing an entry that does
-// not exist is a no-op, not an error.
+// UpsertPluginEntry loads the lock file, upserts a plugins: entry, and
+// saves it back, all under a single file lock so concurrent installs cannot
+// race on read-modify-write.
+func UpsertPluginEntry(root Root, entry Entry) error {
+	return Update(root, func(lf *Lockfile) error {
+		lf.UpsertPlugin(entry)
+		return nil
+	})
+}
+
+// RemoveEntry loads the lock file, removes the named skills: entry if
+// present, and saves it back, all under a single file lock. Removing an
+// entry that does not exist is a no-op, not an error.
 func RemoveEntry(root Root, name string) error {
 	return Update(root, func(lf *Lockfile) error {
 		if !lf.Remove(name) {
+			return errSkipSave
+		}
+		return nil
+	})
+}
+
+// RemovePluginEntry loads the lock file, removes the named plugins: entry
+// if present, and saves it back, all under a single file lock. Removing an
+// entry that does not exist is a no-op, not an error.
+func RemovePluginEntry(root Root, name string) error {
+	return Update(root, func(lf *Lockfile) error {
+		if !lf.RemovePlugin(name) {
 			return errSkipSave
 		}
 		return nil
@@ -361,4 +397,34 @@ var errSkipSave = errors.New("lockfile: no changes to save")
 
 func sortEntries(entries []Entry) {
 	slices.SortFunc(entries, func(a, b Entry) int { return strings.Compare(a.Name, b.Name) })
+}
+
+func getNamed(entries []Entry, name string) (Entry, bool) {
+	for _, e := range entries {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
+func upsertNamed(entries *[]Entry, entry Entry) {
+	for i := range *entries {
+		if (*entries)[i].Name == entry.Name {
+			(*entries)[i] = entry
+			return
+		}
+	}
+	*entries = append(*entries, entry)
+	sortEntries(*entries)
+}
+
+func removeNamed(entries *[]Entry, name string) bool {
+	for i, e := range *entries {
+		if e.Name == name {
+			*entries = slices.Delete(*entries, i, i+1)
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/skills/lockfile/lockfile_test.go
+++ b/pkg/skills/lockfile/lockfile_test.go
@@ -69,6 +69,7 @@ func TestLoadMissingFileReturnsEmptyLockfile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, CurrentVersion, lf.Version)
 	assert.Empty(t, lf.Skills)
+	assert.Empty(t, lf.Plugins)
 }
 
 func TestLoadRejectsMalformedYAML(t *testing.T) {
@@ -116,6 +117,7 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, loaded.Skills, 1)
 	assert.Equal(t, entry, loaded.Skills[0])
+	assert.Empty(t, loaded.Plugins)
 }
 
 // TestUnknownFieldsSurviveLoadModifySave freezes the version-skew contract:
@@ -230,6 +232,110 @@ func TestLockfileGetUpsertRemove(t *testing.T) {
 
 	removedAgain := lf.Remove("b-skill")
 	assert.False(t, removedAgain)
+}
+
+func TestPluginSaveAndLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+	root := testRoot(t)
+
+	lf := &Lockfile{Version: CurrentVersion}
+	skill := Entry{
+		Name:              "code-review",
+		Source:            "code-review",
+		ResolvedReference: "ghcr.io/org/code-review:1.0.0",
+		Digest:            ociDigest(1),
+		Explicit:          true,
+	}
+	plugin := Entry{
+		Name:              "code-review", // same name, different key — allowed
+		Version:           "2.0.0",
+		Source:            "code-review",
+		ResolvedReference: "ghcr.io/org/code-review-plugin:2.0.0",
+		Digest:            ociDigest(3),
+		ContentDigest:     ociDigest(4),
+		Explicit:          true,
+	}
+	lf.Upsert(skill)
+	lf.UpsertPlugin(plugin)
+	require.NoError(t, lf.Save(root))
+
+	loaded, err := Load(root)
+	require.NoError(t, err)
+	require.Len(t, loaded.Skills, 1)
+	assert.Equal(t, skill, loaded.Skills[0])
+	require.Len(t, loaded.Plugins, 1)
+	assert.Equal(t, plugin, loaded.Plugins[0])
+}
+
+func TestLockfileGetUpsertRemovePlugin(t *testing.T) {
+	t.Parallel()
+
+	lf := &Lockfile{Version: CurrentVersion}
+
+	_, ok := lf.GetPlugin("missing")
+	assert.False(t, ok)
+
+	a := Entry{Name: "b-plugin", Source: "b-plugin", Digest: ociDigest(3)}
+	c := Entry{Name: "a-plugin", Source: "a-plugin", Digest: ociDigest(4)}
+	lf.UpsertPlugin(a)
+	lf.UpsertPlugin(c)
+
+	require.Len(t, lf.Plugins, 2)
+	assert.Equal(t, "a-plugin", lf.Plugins[0].Name)
+	assert.Equal(t, "b-plugin", lf.Plugins[1].Name)
+	assert.Empty(t, lf.Skills, "UpsertPlugin must not write skills:")
+
+	got, ok := lf.GetPlugin("b-plugin")
+	require.True(t, ok)
+	assert.Equal(t, a.Digest, got.Digest)
+
+	updated := Entry{Name: "b-plugin", Source: "b-plugin", Digest: ociDigest(5)}
+	lf.UpsertPlugin(updated)
+	require.Len(t, lf.Plugins, 2)
+	got, ok = lf.GetPlugin("b-plugin")
+	require.True(t, ok)
+	assert.Equal(t, updated.Digest, got.Digest)
+
+	removed := lf.RemovePlugin("b-plugin")
+	assert.True(t, removed)
+	require.Len(t, lf.Plugins, 1)
+
+	removedAgain := lf.RemovePlugin("b-plugin")
+	assert.False(t, removedAgain)
+}
+
+func TestUpsertPluginEntryAndRemovePluginEntry(t *testing.T) {
+	t.Parallel()
+	root := testRoot(t)
+
+	skill := Entry{Name: "shared-name", Source: "shared-name", Digest: ociDigest(1)}
+	require.NoError(t, UpsertEntry(root, skill))
+
+	plugin := Entry{Name: "shared-name", Source: "shared-name", Digest: ociDigest(3)}
+	require.NoError(t, UpsertPluginEntry(root, plugin))
+
+	lf, err := Load(root)
+	require.NoError(t, err)
+	require.Len(t, lf.Skills, 1)
+	require.Len(t, lf.Plugins, 1)
+	assert.Equal(t, skill.Digest, lf.Skills[0].Digest)
+	assert.Equal(t, plugin.Digest, lf.Plugins[0].Digest)
+
+	other := Entry{Name: "other-plugin", Source: "other-plugin", Digest: ociDigest(6)}
+	require.NoError(t, UpsertPluginEntry(root, other))
+	lf, err = Load(root)
+	require.NoError(t, err)
+	assert.Len(t, lf.Plugins, 2)
+	assert.Len(t, lf.Skills, 1, "plugin upsert must not drop skills:")
+
+	require.NoError(t, RemovePluginEntry(root, "shared-name"))
+	lf, err = Load(root)
+	require.NoError(t, err)
+	require.Len(t, lf.Plugins, 1)
+	assert.Equal(t, "other-plugin", lf.Plugins[0].Name)
+	require.Len(t, lf.Skills, 1, "removing a plugin must not remove the skill of the same name")
+
+	require.NoError(t, RemovePluginEntry(root, "does-not-exist"))
 }
 
 func TestRemoveParentFromRequiredBy(t *testing.T) {
@@ -473,4 +579,55 @@ func TestProvenanceGraduatesFromExtraMap(t *testing.T) {
 	entry, ok = reloaded.Get("signed-skill")
 	require.True(t, ok)
 	assert.Equal(t, "dev@example.com", entry.Provenance.SignerIdentity)
+}
+
+// TestPluginsGraduateFromExtraMap: before this schema change, a plugins:
+// key written by a newer binary round-tripped through Lockfile.Extra. Now
+// that the field is typed, loading such a file must parse it into
+// Lockfile.Plugins — not duplicate it in Extra, which would make Save
+// produce a colliding key. A skills-only lock (no plugins: key) must still
+// load, and unknown top-level fields must still round-trip.
+func TestPluginsGraduateFromExtraMap(t *testing.T) {
+	t.Parallel()
+	root := testRoot(t)
+	path, err := root.Path()
+	require.NoError(t, err)
+
+	handWritten := "" +
+		"version: 1\n" +
+		"futureTopLevelField: keep-me\n" +
+		"skills:\n" +
+		"  - name: my-skill\n" +
+		"    source: my-skill\n" +
+		"    digest: " + ociDigest(1) + "\n" +
+		"plugins:\n" +
+		"  - name: my-plugin\n" +
+		"    source: my-plugin\n" +
+		"    digest: " + ociDigest(2) + "\n" +
+		"    explicit: true\n"
+	require.NoError(t, os.WriteFile(path, []byte(handWritten), 0o644))
+
+	loaded, err := Load(root)
+	require.NoError(t, err)
+	assert.NotContains(t, loaded.Extra, "plugins", "the typed field must not also appear in Extra")
+	plugin, ok := loaded.GetPlugin("my-plugin")
+	require.True(t, ok)
+	assert.Equal(t, ociDigest(2), plugin.Digest)
+	assert.True(t, plugin.Explicit)
+	_, skillOK := loaded.Get("my-skill")
+	require.True(t, skillOK)
+
+	require.NoError(t, UpsertEntry(root, Entry{
+		Name: "other-skill", Source: "other-skill", Digest: ociDigest(3),
+	}))
+	data, err := os.ReadFile(path) //nolint:gosec // fixed test path
+	require.NoError(t, err)
+	saved := string(data)
+	assert.Contains(t, saved, "futureTopLevelField: keep-me")
+	assert.Contains(t, saved, "name: my-plugin")
+
+	reloaded, err := Load(root)
+	require.NoError(t, err)
+	_, ok = reloaded.GetPlugin("my-plugin")
+	require.True(t, ok, "a skills: upsert must not strip plugins:")
 }

--- a/pkg/skills/lockfile/validation.go
+++ b/pkg/skills/lockfile/validation.go
@@ -27,15 +27,28 @@ const (
 	sha1HexLength   = 40
 )
 
-// validateLockfile checks the schema version, every entry, and
-// cross-references requiredBy links against the set of known entries.
+// validateLockfile checks the schema version and every entry. skills: and
+// plugins: are validated as independent name/requiredBy graphs, so a skill
+// and a plugin may share a name, and a requiredBy parent must live in the
+// same key as the entry that names it.
 func validateLockfile(lf *Lockfile) error {
 	if lf.Version != CurrentVersion {
 		return fmt.Errorf("%w: version %d (upgrade thv to read this lock file)", ErrUnsupportedVersion, lf.Version)
 	}
+	if err := validateEntryGraph(lf.Skills); err != nil {
+		return err
+	}
+	if err := validateEntryGraph(lf.Plugins); err != nil {
+		return fmt.Errorf("plugins: %w", err)
+	}
+	return nil
+}
 
-	names := make(map[string]struct{}, len(lf.Skills))
-	for _, entry := range lf.Skills {
+// validateEntryGraph checks uniqueness, per-entry fields, requiredBy
+// cross-references, and cycles within one lock-file key.
+func validateEntryGraph(entries []Entry) error {
+	names := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
 		if err := validateEntry(entry); err != nil {
 			return err
 		}
@@ -45,7 +58,7 @@ func validateLockfile(lf *Lockfile) error {
 		names[entry.Name] = struct{}{}
 	}
 
-	for _, entry := range lf.Skills {
+	for _, entry := range entries {
 		for _, parent := range entry.RequiredBy {
 			if parent == entry.Name {
 				return fmt.Errorf("entry %q: requiredBy references itself", entry.Name)
@@ -56,7 +69,7 @@ func validateLockfile(lf *Lockfile) error {
 		}
 	}
 
-	if cycle := findRequiredByCycle(lf.Skills); len(cycle) > 0 {
+	if cycle := findRequiredByCycle(entries); len(cycle) > 0 {
 		return fmt.Errorf("requiredBy cycle: %s", strings.Join(cycle, " -> "))
 	}
 	return nil

--- a/pkg/skills/lockfile/validation_test.go
+++ b/pkg/skills/lockfile/validation_test.go
@@ -255,6 +255,65 @@ func TestValidateLockfile(t *testing.T) {
 				{Name: "root", Source: "r", Digest: validSHA256Digest, Explicit: true},
 			}},
 		},
+		{
+			name: "valid plugin entry",
+			lf: Lockfile{Version: CurrentVersion, Plugins: []Entry{
+				{Name: "my-plugin", Source: "my-plugin", Digest: validSHA256Digest},
+			}},
+		},
+		{
+			name: "skill and plugin may share a name",
+			lf: Lockfile{Version: CurrentVersion,
+				Skills:  []Entry{{Name: "shared", Source: "s", Digest: validSHA256Digest}},
+				Plugins: []Entry{{Name: "shared", Source: "p", Digest: validSHA256Digest}},
+			},
+		},
+		{
+			name: "duplicate plugin entry names",
+			lf: Lockfile{Version: CurrentVersion, Plugins: []Entry{
+				{Name: "dup", Source: "a", Digest: validSHA256Digest},
+				{Name: "dup", Source: "b", Digest: validSHA256Digest},
+			}},
+			wantErr: "duplicate entry",
+		},
+		{
+			name: "plugin requiredBy references unknown parent",
+			lf: Lockfile{Version: CurrentVersion, Plugins: []Entry{
+				{Name: "dep", Source: "dep", Digest: validSHA256Digest, RequiredBy: []string{"ghost"}},
+			}},
+			wantErr: "unknown parent",
+		},
+		{
+			name: "plugin requiredBy cycle",
+			lf: Lockfile{Version: CurrentVersion, Plugins: []Entry{
+				{Name: "ring-a", Source: "a", Digest: validSHA256Digest, RequiredBy: []string{"ring-b"}},
+				{Name: "ring-b", Source: "b", Digest: validSHA256Digest, RequiredBy: []string{"ring-a"}},
+			}},
+			wantErr: "requiredBy cycle",
+		},
+		{
+			name: "skill requiredBy cannot name a plugin",
+			lf: Lockfile{Version: CurrentVersion,
+				Skills:  []Entry{{Name: "dep", Source: "d", Digest: validSHA256Digest, RequiredBy: []string{"plug"}}},
+				Plugins: []Entry{{Name: "plug", Source: "p", Digest: validSHA256Digest}},
+			},
+			wantErr: "unknown parent",
+		},
+		{
+			name: "plugin requiredBy cannot name a skill",
+			lf: Lockfile{Version: CurrentVersion,
+				Skills:  []Entry{{Name: "sk", Source: "s", Digest: validSHA256Digest}},
+				Plugins: []Entry{{Name: "dep", Source: "d", Digest: validSHA256Digest, RequiredBy: []string{"sk"}}},
+			},
+			wantErr: "unknown parent",
+		},
+		{
+			name: "plugin missing source",
+			lf: Lockfile{Version: CurrentVersion, Plugins: []Entry{
+				{Name: "my-plugin", Digest: validSHA256Digest},
+			}},
+			wantErr: "source is required",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- **Why:** RFC THV-0080 reserved a sibling `plugins:` key on `toolhive.lock.yaml` but only owns `version` and `skills:`. #6300 ratifies that contract so project-scoped AI-plugin installs can be pinned in the same version-1 lock file as skills, without bumping the schema (a v2 bump would hard-fail mixed-version teams) and without mixing the two graphs.
- **What:** Types `Lockfile.Plugins []Entry`, adds `GetPlugin` / `UpsertPlugin` / `RemovePlugin` (and file-locked `UpsertPluginEntry` / `RemovePluginEntry`), and validates `plugins:` as its own name/requiredBy graph. A skill and a plugin may share a name. Unknown top-level fields still round-trip via `Extra`; a handwritten `plugins:` key graduates out of `Extra` into the typed field.

Part of #6300 (AI-plugin lock + Sigstore). Stack 1/5 — schema → lock-service → install-hooks → sync → upgrade. This PR has no consuming callers; wiring into `pluginsvc.Install` lands in PR3.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test` — `./pkg/skills/lockfile` with race detector; full `task test` also ran, with pre-existing failures on `main` in `pluginsvc` SSRF/git-ref tests and a streamable-proxy port clash, none in this package)
- [x] Linting (`task lint-fix`)

Table-driven tests cover plugin round-trip load/save, shared names across keys, independent requiredBy graphs, Extra round-trip of unknown top-level fields, and `plugins:` graduating from the inline Extra map.

## Does this introduce a user-facing change?

No — this schema has no callers yet. Plugin lock recording stays behind `TOOLHIVE_PLUGINS_LOCK_ENABLED` in later PRs of the stack.

## Implementation plan

<details>
<summary>Approved implementation plan (PR1 slice)</summary>

Same `toolhive.lock.yaml`, additive `plugins:` key, schema version stays 1. Reuse `lockfile.Entry` (including provenance/unsigned). Validate skills and plugins as separate graphs. Keep the package at `pkg/skills/lockfile`; do not extract. No feature-gate or install hooks in this PR.

</details>

## Special notes for reviewers

- `Get` / `Upsert` / `Remove` remain skills-only; the plugin variants are explicitly named so a later caller cannot accidentally pin a plugin into `skills:`.
- `requiredBy` on plugin entries is validated but unused in v1 — plugin `requires` are not materialized yet (#6300 follow-up).
- The whole plugin lock feature stays inert until Stack 2 PR10 removes `TOOLHIVE_PLUGINS_LOCK_ENABLED`.
