### PR TITLE
Record certificate ref and runner in lock provenance

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1785,8 +1785,16 @@ const docTemplate = `{
                         "description": "Provisional marks provenance with a documented verification gap\n(git signatures until transparency-log validation lands).",
                         "type": "boolean"
                     },
+                    "repository_ref": {
+                        "description": "RepositoryRef is the git ref the signing workflow ran on, from Fulcio\ncertificate extension 1.3.6.1.4.1.57264.1.14. Empty means\nunconstrained, matching lock files written before the field existed.",
+                        "type": "string"
+                    },
                     "repository_uri": {
                         "description": "RepositoryURI is the source repository from the certificate\nextensions, when present.",
+                        "type": "string"
+                    },
+                    "runner_environment": {
+                        "description": "RunnerEnvironment is the runner class the signing workflow executed in\n(e.g. \"github-hosted\"), from Fulcio certificate extension\n1.3.6.1.4.1.57264.1.11. Empty means unconstrained.",
                         "type": "string"
                     },
                     "signer_identity": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1778,8 +1778,16 @@
                         "description": "Provisional marks provenance with a documented verification gap\n(git signatures until transparency-log validation lands).",
                         "type": "boolean"
                     },
+                    "repository_ref": {
+                        "description": "RepositoryRef is the git ref the signing workflow ran on, from Fulcio\ncertificate extension 1.3.6.1.4.1.57264.1.14. Empty means\nunconstrained, matching lock files written before the field existed.",
+                        "type": "string"
+                    },
                     "repository_uri": {
                         "description": "RepositoryURI is the source repository from the certificate\nextensions, when present.",
+                        "type": "string"
+                    },
+                    "runner_environment": {
+                        "description": "RunnerEnvironment is the runner class the signing workflow executed in\n(e.g. \"github-hosted\"), from Fulcio certificate extension\n1.3.6.1.4.1.57264.1.11. Empty means unconstrained.",
                         "type": "string"
                     },
                     "signer_identity": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1876,10 +1876,22 @@ components:
             Provisional marks provenance with a documented verification gap
             (git signatures until transparency-log validation lands).
           type: boolean
+        repository_ref:
+          description: |-
+            RepositoryRef is the git ref the signing workflow ran on, from Fulcio
+            certificate extension 1.3.6.1.4.1.57264.1.14. Empty means
+            unconstrained, matching lock files written before the field existed.
+          type: string
         repository_uri:
           description: |-
             RepositoryURI is the source repository from the certificate
             extensions, when present.
+          type: string
+        runner_environment:
+          description: |-
+            RunnerEnvironment is the runner class the signing workflow executed in
+            (e.g. "github-hosted"), from Fulcio certificate extension
+            1.3.6.1.4.1.57264.1.11. Empty means unconstrained.
           type: string
         signer_identity:
           description: |-

--- a/pkg/skills/client/client_test.go
+++ b/pkg/skills/client/client_test.go
@@ -309,6 +309,25 @@ func TestInfo(t *testing.T) {
 			statusCode: http.StatusOK,
 		},
 		{
+			// `thv skill info` reports trust state from this response alone, so
+			// a provenance field the server records but the wire shape drops is
+			// invisible to the user.
+			name:     "provenance reaches the info renderer",
+			opts:     skills.InfoOptions{Name: "signed-skill"},
+			wantPath: skillsBasePath + "/signed-skill",
+			response: skills.SkillInfo{
+				Metadata: skills.SkillMetadata{Name: "signed-skill", Version: "1.0.0"},
+				Provenance: &skills.ProvenanceInfo{
+					SignerIdentity:    "/.github/workflows/release.yml",
+					CertIssuer:        "https://token.actions.githubusercontent.com",
+					RepositoryURI:     "https://github.com/org/signed-skill",
+					RepositoryRef:     "refs/tags/v1.0.0",
+					RunnerEnvironment: "github-hosted",
+				},
+			},
+			statusCode: http.StatusOK,
+		},
+		{
 			name:       "not found",
 			opts:       skills.InfoOptions{Name: "missing"},
 			wantPath:   skillsBasePath + "/missing",
@@ -968,6 +987,19 @@ func TestInstallCarriesTrustStateBackToCaller(t *testing.T) {
 					SignerIdentity: "/.github/workflows/build-skills.yml",
 					CertIssuer:     "https://token.actions.githubusercontent.com",
 					RepositoryURI:  "https://github.com/stacklok/dockyard",
+				},
+			},
+		},
+		{
+			name: "certificate ref and runner environment survive the round trip",
+			response: installResponse{
+				Skill: skills.InstalledSkill{Metadata: skills.SkillMetadata{Name: "pinned-skill"}},
+				Provenance: &skills.ProvenanceInfo{
+					SignerIdentity:    "/.github/workflows/build-skills.yml",
+					CertIssuer:        "https://token.actions.githubusercontent.com",
+					RepositoryURI:     "https://github.com/stacklok/dockyard",
+					RepositoryRef:     "refs/heads/main",
+					RunnerEnvironment: "github-hosted",
 				},
 			},
 		},

--- a/pkg/skills/lockfile/lockfile.go
+++ b/pkg/skills/lockfile/lockfile.go
@@ -105,6 +105,16 @@ type Provenance struct {
 	// RepositoryURI is the source repository from the Fulcio certificate
 	// extensions, when present.
 	RepositoryURI string `yaml:"repositoryUri,omitempty"`
+	// RepositoryRef is the git ref the signing workflow ran on, from Fulcio
+	// certificate extension 1.3.6.1.4.1.57264.1.14, when present. Empty
+	// means unconstrained: every lock file written before this field existed
+	// omits it, and such entries must keep verifying against any ref.
+	RepositoryRef string `yaml:"repositoryRef,omitempty"`
+	// RunnerEnvironment is the runner class the signing workflow executed in
+	// (e.g. "github-hosted"), from Fulcio certificate extension
+	// 1.3.6.1.4.1.57264.1.11, when present. Empty means unconstrained, for
+	// the same backward-compatibility reason as RepositoryRef.
+	RunnerEnvironment string `yaml:"runnerEnvironment,omitempty"`
 	// SigstoreURL is the Sigstore instance the signature chains to.
 	SigstoreURL string `yaml:"sigstoreUrl,omitempty"`
 	// Provisional marks provenance whose verification has a documented

--- a/pkg/skills/lockfile/lockfile_test.go
+++ b/pkg/skills/lockfile/lockfile_test.go
@@ -506,10 +506,12 @@ func TestProvenanceRoundTrip(t *testing.T) {
 		ResolvedReference: "ghcr.io/org/signed-skill:latest",
 		Digest:            ociDigest(1),
 		Provenance: &Provenance{
-			SignerIdentity: "/.github/workflows/release.yml",
-			CertIssuer:     "https://token.actions.githubusercontent.com",
-			RepositoryURI:  "https://github.com/org/signed-skill",
-			SigstoreURL:    "https://rekor.sigstore.dev",
+			SignerIdentity:    "/.github/workflows/release.yml",
+			CertIssuer:        "https://token.actions.githubusercontent.com",
+			RepositoryURI:     "https://github.com/org/signed-skill",
+			RepositoryRef:     "refs/heads/main",
+			RunnerEnvironment: "github-hosted",
+			SigstoreURL:       "https://rekor.sigstore.dev",
 		},
 		Explicit: true,
 	}
@@ -537,6 +539,56 @@ func TestProvenanceRoundTrip(t *testing.T) {
 	require.True(t, ok)
 	assert.True(t, gotUnsigned.Unsigned)
 	assert.Nil(t, gotUnsigned.Provenance)
+}
+
+// TestProvenanceWithoutRefFieldsIsUnconstrained pins the compatibility
+// contract for repositoryRef and runnerEnvironment: every lock file written
+// before they existed omits them, so absent must mean unconstrained. Such a
+// file must load with both empty, must not gain the new keys when re-saved,
+// and must reach a byte-stable form so an install by a newer binary produces
+// no spurious diff for entries it did not touch.
+func TestProvenanceWithoutRefFieldsIsUnconstrained(t *testing.T) {
+	t.Parallel()
+	root := testRoot(t)
+	path, err := root.Path()
+	require.NoError(t, err)
+
+	preExisting := "" +
+		"version: 1\n" +
+		"skills:\n" +
+		"  - name: legacy-skill\n" +
+		"    source: ghcr.io/org/legacy-skill\n" +
+		"    digest: " + ociDigest(1) + "\n" +
+		"    provenance:\n" +
+		"      signerIdentity: /.github/workflows/release.yml\n" +
+		"      certIssuer: https://token.actions.githubusercontent.com\n" +
+		"      repositoryUri: https://github.com/org/legacy-skill\n" +
+		"    explicit: true\n"
+	require.NoError(t, os.WriteFile(path, []byte(preExisting), 0o644))
+
+	loaded, err := Load(root)
+	require.NoError(t, err)
+	entry, ok := loaded.Get("legacy-skill")
+	require.True(t, ok)
+	require.NotNil(t, entry.Provenance)
+	assert.Empty(t, entry.Provenance.RepositoryRef)
+	assert.Empty(t, entry.Provenance.RunnerEnvironment)
+	assert.Equal(t, "https://github.com/org/legacy-skill", entry.Provenance.RepositoryURI)
+	assert.Empty(t, entry.Extra, "the new keys must not surface through the inline Extra map")
+
+	require.NoError(t, loaded.Save(root))
+	saved, err := os.ReadFile(path) //nolint:gosec // fixed test path
+	require.NoError(t, err)
+	assert.NotContains(t, string(saved), "repositoryRef")
+	assert.NotContains(t, string(saved), "runnerEnvironment")
+
+	reloaded, err := Load(root)
+	require.NoError(t, err)
+	require.NoError(t, reloaded.Save(root))
+	resaved, err := os.ReadFile(path) //nolint:gosec // fixed test path
+	require.NoError(t, err)
+	assert.Equal(t, string(saved), string(resaved),
+		"a lock file predating the ref fields must reach a byte-stable form")
 }
 
 // TestProvenanceGraduatesFromExtraMap: before this schema change, a

--- a/pkg/skills/lockfile/validation.go
+++ b/pkg/skills/lockfile/validation.go
@@ -180,10 +180,12 @@ func validateProvenance(p *Provenance) error {
 		return errors.New("certIssuer is required")
 	}
 	fields := map[string]string{
-		"signerIdentity": p.SignerIdentity,
-		"certIssuer":     p.CertIssuer,
-		"repositoryUri":  p.RepositoryURI,
-		"sigstoreUrl":    p.SigstoreURL,
+		"signerIdentity":    p.SignerIdentity,
+		"certIssuer":        p.CertIssuer,
+		"repositoryUri":     p.RepositoryURI,
+		"repositoryRef":     p.RepositoryRef,
+		"runnerEnvironment": p.RunnerEnvironment,
+		"sigstoreUrl":       p.SigstoreURL,
 	}
 	for name, value := range fields {
 		if value == "" {

--- a/pkg/skills/lockfile/validation_test.go
+++ b/pkg/skills/lockfile/validation_test.go
@@ -241,6 +241,39 @@ func TestValidateLockfile(t *testing.T) {
 			wantErr: "exceeds",
 		},
 		{
+			name: "provenance with ref and runner environment is valid",
+			lf: Lockfile{Version: CurrentVersion, Skills: []Entry{
+				{Name: "signed", Source: "s", Digest: validSHA256Digest, Provenance: &Provenance{
+					SignerIdentity:    "/.github/workflows/release.yml",
+					CertIssuer:        "https://token.actions.githubusercontent.com",
+					RepositoryRef:     "refs/heads/main",
+					RunnerEnvironment: "github-hosted",
+				}},
+			}},
+		},
+		{
+			name: "provenance repositoryRef with control characters rejected",
+			lf: Lockfile{Version: CurrentVersion, Skills: []Entry{
+				{Name: "signed", Source: "s", Digest: validSHA256Digest, Provenance: &Provenance{
+					SignerIdentity: "dev@example.com",
+					CertIssuer:     "https://accounts.example.com",
+					RepositoryRef:  "refs/heads/ma\x1b[31min",
+				}},
+			}},
+			wantErr: "non-graphic",
+		},
+		{
+			name: "provenance runnerEnvironment too long rejected",
+			lf: Lockfile{Version: CurrentVersion, Skills: []Entry{
+				{Name: "signed", Source: "s", Digest: validSHA256Digest, Provenance: &Provenance{
+					SignerIdentity:    "dev@example.com",
+					CertIssuer:        "https://accounts.example.com",
+					RunnerEnvironment: strings.Repeat("a", maxReferenceLength+1),
+				}},
+			}},
+			wantErr: "exceeds",
+		},
+		{
 			name: "unsigned exception alone is valid",
 			lf: Lockfile{Version: CurrentVersion, Skills: []Entry{
 				{Name: "unsigned", Source: "s", Digest: validSHA256Digest, Unsigned: true},

--- a/pkg/skills/options.go
+++ b/pkg/skills/options.go
@@ -108,6 +108,14 @@ type ProvenanceInfo struct {
 	// RepositoryURI is the source repository from the certificate
 	// extensions, when present.
 	RepositoryURI string `json:"repository_uri,omitempty"`
+	// RepositoryRef is the git ref the signing workflow ran on, from Fulcio
+	// certificate extension 1.3.6.1.4.1.57264.1.14. Empty means
+	// unconstrained, matching lock files written before the field existed.
+	RepositoryRef string `json:"repository_ref,omitempty"`
+	// RunnerEnvironment is the runner class the signing workflow executed in
+	// (e.g. "github-hosted"), from Fulcio certificate extension
+	// 1.3.6.1.4.1.57264.1.11. Empty means unconstrained.
+	RunnerEnvironment string `json:"runner_environment,omitempty"`
 	// SigstoreURL is the Sigstore instance the signature chains to.
 	SigstoreURL string `json:"sigstore_url,omitempty"`
 	// Provisional marks provenance with a documented verification gap

--- a/pkg/skills/skillsvc/verify.go
+++ b/pkg/skills/skillsvc/verify.go
@@ -277,11 +277,13 @@ func provenanceInfoFromLock(p *lockfile.Provenance) *skills.ProvenanceInfo {
 		return nil
 	}
 	return &skills.ProvenanceInfo{
-		SignerIdentity: p.SignerIdentity,
-		CertIssuer:     p.CertIssuer,
-		RepositoryURI:  p.RepositoryURI,
-		SigstoreURL:    p.SigstoreURL,
-		Provisional:    p.Provisional,
+		SignerIdentity:    p.SignerIdentity,
+		CertIssuer:        p.CertIssuer,
+		RepositoryURI:     p.RepositoryURI,
+		RepositoryRef:     p.RepositoryRef,
+		RunnerEnvironment: p.RunnerEnvironment,
+		SigstoreURL:       p.SigstoreURL,
+		Provisional:       p.Provisional,
 	}
 }
 
@@ -292,11 +294,13 @@ func provenanceInfoToLock(p *skills.ProvenanceInfo) *lockfile.Provenance {
 		return nil
 	}
 	return &lockfile.Provenance{
-		SignerIdentity: p.SignerIdentity,
-		CertIssuer:     p.CertIssuer,
-		RepositoryURI:  p.RepositoryURI,
-		SigstoreURL:    p.SigstoreURL,
-		Provisional:    p.Provisional,
+		SignerIdentity:    p.SignerIdentity,
+		CertIssuer:        p.CertIssuer,
+		RepositoryURI:     p.RepositoryURI,
+		RepositoryRef:     p.RepositoryRef,
+		RunnerEnvironment: p.RunnerEnvironment,
+		SigstoreURL:       p.SigstoreURL,
+		Provisional:       p.Provisional,
 	}
 }
 

--- a/pkg/skills/skillsvc/verify_test.go
+++ b/pkg/skills/skillsvc/verify_test.go
@@ -5,6 +5,7 @@ package skillsvc
 
 import (
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -309,6 +310,45 @@ func TestVerifyLocalInstall(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.unsigned, decision.unsigned)
 		})
+	}
+}
+
+// TestProvenanceConversionsPreserveEveryField guards the lock <-> API
+// plumbing. A field added to one provenance shape but forgotten in a
+// conversion silently drops recorded trust data in transit, and no
+// printer-level test would notice.
+func TestProvenanceConversionsPreserveEveryField(t *testing.T) {
+	t.Parallel()
+
+	locked := &lockfile.Provenance{
+		SignerIdentity:    testSignerIdentity,
+		CertIssuer:        testCertIssuer,
+		RepositoryURI:     "https://github.com/org/repo",
+		RepositoryRef:     "refs/heads/main",
+		RunnerEnvironment: "github-hosted",
+		SigstoreURL:       "https://rekor.sigstore.dev",
+		Provisional:       true,
+	}
+	requireAllFieldsSet(t, locked)
+
+	info := provenanceInfoFromLock(locked)
+	requireAllFieldsSet(t, info)
+	assert.Equal(t, locked, provenanceInfoToLock(info))
+
+	assert.Nil(t, provenanceInfoFromLock(nil))
+	assert.Nil(t, provenanceInfoToLock(nil))
+}
+
+// requireAllFieldsSet fails when any field of the struct pointed to by v holds
+// its zero value, so a field added to one provenance shape without a matching
+// line in the conversions is caught here rather than in production.
+func requireAllFieldsSet(t *testing.T, v any) {
+	t.Helper()
+	rv := reflect.ValueOf(v).Elem()
+	for i := range rv.NumField() {
+		assert.False(t, rv.Field(i).IsZero(),
+			"%s.%s is zero: wire it through the provenance conversions and this fixture",
+			rv.Type().Name(), rv.Type().Field(i).Name)
 	}
 }
 


### PR DESCRIPTION
## Summary

- A Fulcio certificate carries more identity than the lock file records. Two extensions are currently discarded: the git ref the signing workflow ran on (OID `1.3.6.1.4.1.57264.1.14`) and the runner environment it executed in (OID `1.3.6.1.4.1.57264.1.11`). Without them, a recorded trust anchor means "this repository and workflow, on *any* ref, from *any* runner" — a workflow triggered on an attacker-pushed branch still satisfies the lock entry.
- Recording them tightens the guarantee to "this repository and workflow, *this* ref, *this* runner class", which is the trust model the follow-up enforcement change needs to compare against.
- This PR is **schema and plumbing only**: it adds `repositoryRef` / `runnerEnvironment` to the lock provenance block and threads them through the existing lock ↔ service ↔ API conversions so nothing is dropped in transit. Extraction from the certificate and enforcement against the locked values land in a follow-up PR, so the fields stay empty for freshly verified installs until then.
- Both fields are optional and absent means **unconstrained**. Every lock file written before this change omits them, so old locks must load, re-save without gaining keys, and behave exactly as before — pinned by a dedicated test.

Part of #6309.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Tests added:

- `TestProvenanceWithoutRefFieldsIsUnconstrained` (`pkg/skills/lockfile`) — a hand-written lock file with a `provenance:` block predating both fields loads with them empty, does not leak them into the inline `Extra` map, re-saves without the new keys appearing, and reaches a byte-stable form so an install by a newer binary produces no spurious diff for entries it did not touch.
- `TestProvenanceRoundTrip` (`pkg/skills/lockfile`) — extended so both new fields round-trip through Save → Load when present.
- `validateLockfile` table cases — both fields accepted when well-formed, and rejected for control characters / over-length, matching the existing `repositoryUri` treatment.
- `TestProvenanceConversionsPreserveEveryField` (`pkg/skills/skillsvc`) — reflection-backed guard over `provenanceInfoFromLock` / `provenanceInfoToLock`: it fails if *any* field of either provenance shape is left zero after conversion, so a future field added to one shape but forgotten in a conversion is caught here. Verified it actually fails by temporarily deleting a field from a conversion.
- `pkg/skills/client` wire round-trips — a case in `TestInstallCarriesTrustStateBackToCaller` and one in `TestInfo` carrying both new fields across the HTTP boundary. The CLI is a pure HTTP client, so a field the service sets but the wire shape drops is invisible in production even though a printer-level unit test still passes; this has bitten this code path before.

`task test` passes apart from `TestMCPGoClientInitializeAndPing` in `pkg/transport/proxy/streamable`, which binds hardcoded port 8096 and fails on this machine because another process holds it. Unrelated to this change (no shared code); the touched packages plus `pkg/api/v1` and `cmd/thv/app` all pass under the Taskfile's flags.

## Does this introduce a user-facing change?

No. The lock file gains two optional keys that nothing populates yet, and no CLI output changed. `docs/server/*` is regenerated (`task docs`) because the new fields are part of the API response schema.

## Special notes for reviewers

- `provenanceInfoFromResult` is deliberately untouched: `verifier.Result` has no ref or runner fields yet, so adding them there is the follow-up PR's job. The consequence is that the new fields stay empty whenever provenance is populated from a fresh verification, and only carry values once extraction lands.
- The API layer reuses `skills.ProvenanceInfo` directly rather than defining a parallel response DTO, so no separate API type or conversion function needed changing — `pkg/skills/client/dto.go` and `pkg/api/v1/skills_types.go` both reference the same struct.
- Validation intentionally does *not* fail on absence. The whole point of the compatibility contract is that an empty value means unconstrained; only a present-but-malformed value is rejected.

Generated with [Claude Code](https://claude.com/claude-code)
