### PR TITLE
Pin CodeQL SARIF action comment to v4.37.6

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ jobs:
           fail-build: false
 
       - name: Upload Grype scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         if: always()
         with:
           sarif_file: ${{ steps.grype-scan.outputs.sarif }}


### PR DESCRIPTION
## Summary

The `upload-sarif` action is pinned to commit `5595ccaf91...` but the trailing
version comment still said `# v4`, while that commit actually corresponds to
tag `v4.37.6`. zizmor's `ref-version-mismatch` audit flags this drift on every
PR/main run of the security-scan workflow.

- Update the version comment on the `github/codeql-action/upload-sarif` pin
  in `.github/workflows/security-scan.yml` from `# v4` to `# v4.37.6` so it
  matches the tag the pinned commit actually points to.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

Verified the pinned commit `5595ccaf912efad79be6eef63a5619ff05969be3` is the
commit tagged `v4.37.6` in `github/codeql-action`, matching zizmor's finding
and fix suggestion.

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)