### PR TITLE
Fix field names in external-auth examples

### DIFF
--- a/examples/operator/external-auth/complete_example.yaml
+++ b/examples/operator/external-auth/complete_example.yaml
@@ -28,11 +28,11 @@ spec:
   type: tokenExchange
   tokenExchange:
     # Keycloak token endpoint
-    token_url: https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token
+    tokenUrl: https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token
 
     # OAuth2 client credentials
-    client_id: toolhive-client
-    client_secret_ref:
+    clientId: toolhive-client
+    clientSecretRef:
       name: oauth-client-secret
       key: client-secret
 
@@ -40,10 +40,12 @@ spec:
     audience: mcp-backend
 
     # OAuth2 scopes
-    scope: "openid profile"
+    scopes:
+      - openid
+      - profile
 
     # Extract external token from custom header
-    external_token_header_name: "X-Upstream-Authorization"
+    externalTokenHeaderName: "X-Upstream-Authorization"
 
 ---
 # MCP Server with external authentication

--- a/examples/operator/external-auth/mcpexternalauthconfig_basic.yaml
+++ b/examples/operator/external-auth/mcpexternalauthconfig_basic.yaml
@@ -6,19 +6,20 @@ metadata:
   name: oauth-token-exchange
   namespace: default
 spec:
-  # Type of external authentication (currently only "tokenExchange" is supported)
+  # This example uses tokenExchange. Supported types depend on the consuming
+  # resource; see the MCPExternalAuthConfig CRD reference for the full matrix.
   type: tokenExchange
 
   # Token exchange configuration for OAuth2 token exchange flow
   tokenExchange:
     # OAuth2 token endpoint URL
-    token_url: https://oauth.example.com/token
+    tokenUrl: https://oauth.example.com/token
 
     # OAuth2 client ID
-    client_id: my-client-id
+    clientId: my-client-id
 
     # Reference to Kubernetes Secret containing the client secret
-    client_secret_ref:
+    clientSecretRef:
       name: oauth-client-secret
       key: client-secret
 
@@ -26,8 +27,10 @@ spec:
     audience: backend-service
 
     # Optional: OAuth2 scopes to request
-    scope: "read write"
+    scopes:
+      - read
+      - write
 
     # Optional: Custom header name for extracting external token from incoming requests
     # If not specified, defaults to "Authorization" header
-    # external_token_header_name: "X-Upstream-Token"
+    # externalTokenHeaderName: "X-Upstream-Token"

--- a/examples/operator/external-auth/mcpexternalauthconfig_minimal.yaml
+++ b/examples/operator/external-auth/mcpexternalauthconfig_minimal.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   type: tokenExchange
   tokenExchange:
-    token_url: https://oauth.example.com/token
-    client_id: my-client
-    client_secret_ref:
+    tokenUrl: https://oauth.example.com/token
+    clientId: my-client
+    clientSecretRef:
       name: oauth-secret
       key: client-secret
     audience: my-audience


### PR DESCRIPTION
## Summary

The example manifests under `examples/operator/external-auth/` use snake_case keys (`token_url`, `client_id`, `client_secret_ref`, `external_token_header_name`) where the CRD schema expects camelCase (`tokenUrl`, `clientId`, `clientSecretRef`, `externalTokenHeaderName`), and a `scope` string where the schema defines a `scopes` list — so applying them verbatim fails validation. This updates the manifests to match the schema.

Split out of #6242 per review, so it can land on its own merits.

## Validation

- `kubectl apply --dry-run=server` requires a cluster with the CRDs installed; verified instead that every changed key matches the generated schema in `deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml`.