### PR TITLE
Push skills unsigned until keyless signing lands

### DIFF
--- a/.github/workflows/skills-build-and-publish.yml
+++ b/.github/workflows/skills-build-and-publish.yml
@@ -109,14 +109,16 @@ jobs:
 
             if [ "$PUSH" = "true" ]; then
               echo "Pushing skill: ${built_ref}"
-              ./thv skill push "$built_ref"
+              # TODO(#6307): pushes are unsigned until keyless push signing lands;
+              # switch to Fulcio/Rekor signing and drop --no-sign once that ships.
+              ./thv skill push "$built_ref" --no-sign
 
               # Also tag as latest when building from a release tag
               if [[ "$GH_REF" == refs/tags/* ]]; then
                 latest_ref="${BASE_REPO}/${skill_name}:latest"
                 echo "Tagging as latest: ${latest_ref}"
                 built_latest=$(./thv skill build "$skill_dir" --tag "$latest_ref")
-                ./thv skill push "$built_latest"
+                ./thv skill push "$built_latest" --no-sign
               fi
 
               echo "Published: ${ref}"


### PR DESCRIPTION
## Summary

- The skills build/publish workflow has been failing on every push-enabled run since the skill-push signing requirement landed: pushing now requires either `--key` or `--no-sign`, and this workflow passed neither, so every push errors with `signing key required`.
- Keyless push signing (#6307) is in progress but not yet shipped (gated on a toolhive-core release), so as an interim fix, pass `--no-sign` to both `thv skill push` invocations to unblock CI. A `TODO(#6307)` marks where to switch to real signing once it lands.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Reviewed the workflow diff manually; change is scoped to adding `--no-sign` to the two existing `thv skill push` calls, no other behavior changes.

Generated with [Claude Code](https://claude.com/claude-code)