### PR TITLE
fix(authz): commit recorded status before flushing in ResponseFilteri…

### DIFF
--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -158,9 +158,19 @@ func (rfw *ResponseFilteringWriter) FlushAndFilter() error {
 // implicit WriteHeader(200), sending headers to the wire. If the stale
 // Content-Length is still present at that point, it's too late to remove it in
 // FlushAndFilter().
+//
+// Commit the recorded status before the first flush. Without this, the implicit
+// 200 would also rewrite a non-2xx backend status (e.g. 500) to 200 on the
+// wire, defeating the non-2xx passthrough precondition in FlushAndFilter(): a
+// fetch-based MCP client gates list delivery on response.ok, so an unfiltered
+// list body would be delivered under a fabricated 200. Committing here keeps
+// the wire status identical to the recorded backend status; SSE (statusCode
+// 200) is unaffected and later WriteHeader calls in FlushAndFilter become
+// no-ops instead of corrupting the status.
 func (rfw *ResponseFilteringWriter) Flush() {
 	if flusher, ok := rfw.ResponseWriter.(http.Flusher); ok {
 		rfw.ResponseWriter.Header().Del("Content-Length")
+		rfw.ResponseWriter.WriteHeader(rfw.statusCode)
 		flusher.Flush()
 	}
 }

--- a/pkg/authz/response_filter_status_commit_test.go
+++ b/pkg/authz/response_filter_status_commit_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package authz
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/jsonrpc2"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/authz/authorizers/cedar"
+	mcpparser "github.com/stacklok/toolhive/pkg/mcp"
+)
+
+// TestResponseFilteringWriter_Non2xxStatusPreservedOnWire reproduces the
+// production transparent-proxy wiring (real HTTP server + httputil.ReverseProxy
+// with FlushInterval:-1 + ResponseFilteringWriter) and asserts that a non-2xx
+// backend status survives on the wire. Regression for the bypass where Flush()
+// committed an implicit 200 before FlushAndFilter() ran, so the non-2xx
+// passthrough branch (safe only when the client actually observes a non-2xx
+// status) delivered an unfiltered list body under a fabricated 200.
+func TestResponseFilteringWriter_Non2xxStatusPreservedOnWire(t *testing.T) {
+	t.Parallel()
+
+	authorizer, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{
+		Policies:     []string{`permit(principal, action == Action::"call_tool", resource == Tool::"weather");`},
+		EntitiesJSON: `[]`,
+	}, "")
+	require.NoError(t, err)
+
+	backendResult := mcp.ListToolsResult{Tools: []mcp.Tool{
+		{Name: "weather", Description: "Get weather information"},
+		{Name: "calculator", Description: "Perform calculations"},
+		{Name: "admin_tool", Description: "Administrative operations"},
+	}}
+	resultData, err := json.Marshal(backendResult)
+	require.NoError(t, err)
+	backendRPCResponse := &jsonrpc2.Response{ID: jsonrpc2.Int64ID(1), Result: json.RawMessage(resultData)}
+	backendBody, err := jsonrpc2.EncodeMessage(backendRPCResponse)
+	require.NoError(t, err)
+
+	// Backend returns the same list body with a caller-chosen status code.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		code := http.StatusOK
+		if v := r.URL.Query().Get("code"); v != "" {
+			fmt.Sscanf(v, "%d", &code)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		_, _ = w.Write(backendBody)
+	}))
+	defer backend.Close()
+	backendURL, _ := url.Parse(backend.URL)
+
+	// Frontend mirrors the authz-middleware + transparent-proxy wiring.
+	frontend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{
+			Subject: "user123", Name: "Test User",
+			Claims: jwt.MapClaims{"sub": "user123", "name": "Test User"},
+		}}
+		ctx := auth.WithIdentity(r.Context(), identity)
+		parsed := &mcpparser.ParsedMCPRequest{Method: string(mcp.MethodToolsList), ID: float64(1)}
+		ctx = context.WithValue(ctx, mcpparser.MCPRequestContextKey, parsed)
+		r = r.WithContext(ctx)
+
+		filteringWriter := NewResponseFilteringWriter(w, authorizer, r, string(mcp.MethodToolsList), nil, nil)
+		proxy := httputil.NewSingleHostReverseProxy(backendURL)
+		proxy.FlushInterval = -1 // production transparent proxy
+		proxy.ServeHTTP(filteringWriter, r)
+		require.NoError(t, filteringWriter.FlushAndFilter())
+	}))
+	defer frontend.Close()
+
+	do := func(query string) (*http.Response, []byte) {
+		resp, err := http.Get(frontend.URL + "/mcp" + query)
+		require.NoError(t, err)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp, body
+	}
+
+	// 2xx list responses must still be filtered (admin_tool removed).
+	resp200, body200 := do("")
+	assert.Equal(t, http.StatusOK, resp200.StatusCode)
+	assert.Contains(t, string(body200), "weather")
+	assert.NotContains(t, string(body200), "admin_tool")
+
+	// Non-2xx list responses must reach the client with the non-2xx status, so
+	// the passthrough precondition (client gates list delivery on response.ok)
+	// holds.
+	for _, code := range []int{http.StatusInternalServerError, http.StatusNotFound} {
+		resp, body := do(fmt.Sprintf("?code=%d", code))
+		assert.Equalf(t, code, resp.StatusCode,
+			"non-2xx backend status %d was rewritten on the wire; the unfiltered list body would be delivered as 200", code)
+		// The passthrough branch is intentionally body-preserving for error
+		// responses; the security property is that the client sees the non-2xx
+		// status and does not deliver the body.
+		assert.Equal(t, string(backendBody), string(body))
+	}
+}


### PR DESCRIPTION
## Summary

`ResponseFilteringWriter` filters 2xx list responses (`tools/list`, `prompts/list`, `resources/list`, `find_tool`) against Cedar policies. Its non-2xx passthrough branch (`FlushAndFilter`) is safe only because a fetch-based MCP client gates list delivery on `response.ok` (200-299). In the production transparent-proxy path (`httputil.ReverseProxy` with `FlushInterval: -1`, `pkg/transport/proxy/transparent/transparent_proxy.go:1220-1221`), the proxy calls `Flush()` while copying the backend response, and the first `Flush()` on a fresh net/http writer commits the headers with an **implicit `WriteHeader(200)`** before `FlushAndFilter()` runs. `FlushAndFilter` then takes the non-2xx passthrough branch from the recorded status (e.g. 500), its `WriteHeader(500)` is a no-op, and the **unfiltered** buffered list body is delivered under a fabricated 200 — the #5257-class bypass on the non-2xx branch. Legitimate 4xx/5xx statuses are also silently rewritten to 200 (functional breakage).

WHAT changed:

- `ResponseFilteringWriter.Flush()` now commits the recorded status (`rfw.ResponseWriter.WriteHeader(rfw.statusCode)`) before flushing the downstream writer, so the wire status reflects the real backend status instead of the implicit 200. SSE (statusCode 200) is unaffected; later `WriteHeader` calls in `FlushAndFilter` become no-ops instead of corrupting the status.
- Add a regression test over the production wiring (real HTTP server + `ReverseProxy` `FlushInterval:-1` + `ResponseFilteringWriter`) asserting a 500/404 list response reaches the client with the non-2xx status while 2xx responses are still filtered.

Fixes #6332 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Run: `go test ./pkg/authz/...`. New test: `TestResponseFilteringWriter_Non2xxStatusPreservedOnWire` (in `pkg/authz/response_filter_status_commit_test.go`). Verified the new test FAILS without the source fix (backend 500/404 rewritten to 200 on the wire) and PASSES with it; full `pkg/authz/...` suite passes.

Lint: `golangci-lint run ./pkg/authz/` reports only 3 pre-existing `gci` issues in files this PR does not touch (`pkg/authz/annotation_cache.go`, `pkg/authz/authorizers.go`, `pkg/authz/config.go`); neither of this PR's files is flagged. `go vet` clean. (`gofmt` on a Windows checkout with `core.autocrlf=true` flags every Go file in the repo due to CRLF working-tree line endings; commits are LF-normalized and CI runs on Linux.)

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Changes

| File | Change |
|------|--------|
| `pkg/authz/response_filter.go` | `Flush()` commits the recorded status (`WriteHeader(rfw.statusCode)`) before flushing downstream |
| `pkg/authz/response_filter_status_commit_test.go` | Add regression test asserting non-2xx status survives on the wire and 2xx filtering is preserved |

## Does this introduce a user-facing change?

Yes: a backend answering a list method with a non-2xx status (e.g. 500) can no longer have the full, unfiltered tools/prompts/resources list delivered to the client as HTTP 200; the client now observes the real non-2xx status. Legitimate 4xx/5xx backend statuses are no longer silently rewritten to 200.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

One root cause: the deferred-write design assumes `FlushAndFilter` controls header-commit timing, but the streaming-support `Flush()` touches the downstream writer first and commits an implicit 200.

- `Flush()` (`response_filter.go`): after deleting `Content-Length`, commit the recorded status before `flusher.Flush()`. Idempotent for repeated flushes (headers already committed → no-op).
- Non-2xx passthrough branch unchanged: it stays body-preserving for error responses by design; the security property is restored because the client observes the real non-2xx status.
- Regression test drives the real HTTP server + `ReverseProxy` `FlushInterval:-1` chain and asserts 500/404 reach the client unchanged while a 200 list is still filtered.

</details>

## Special notes for reviewers

- The fix is a one-line behavior change in `Flush()` plus a comment explaining why. SSE (statusCode 200) and the 2xx filtering path are unaffected — committing 200 is identical to the previous implicit 200.
- Defense-in-depth (fail-closed sniffing of a result-bearing body in the non-2xx passthrough branch) is deliberately left out of this PR: it would change error-body passthrough semantics and is orthogonal to the root cause here.
- The writer in the regression test is constructed directly rather than via `AuthorizationMiddleware`; the exercised behavior (deferred write + early streaming flush + filter) is identical.
