### PR TITLE
Fix atomic local state writes

### DIFF
--- a/pkg/groups/cli_manager.go
+++ b/pkg/groups/cli_manager.go
@@ -55,10 +55,12 @@ func (m *cliManager) Create(ctx context.Context, name string) error {
 		}
 		return fmt.Errorf("failed to create group: %w", err)
 	}
+	closed := false
 	defer func() {
-		if err := writer.Close(); err != nil {
-			// Non-fatal: writer cleanup failure
-			slog.Warn("failed to close writer", "error", err)
+		if !closed {
+			if err := state.AbortWriter(writer); err != nil {
+				slog.Warn("failed to abort group writer", "name", name, "error", err)
+			}
 		}
 	}()
 
@@ -69,12 +71,14 @@ func (m *cliManager) Create(ctx context.Context, name string) error {
 		return fmt.Errorf("failed to write group: %w", err)
 	}
 
-	// Ensure the writer is flushed
-	if syncer, ok := writer.(interface{ Sync() error }); ok {
-		if err := syncer.Sync(); err != nil {
-			return fmt.Errorf("failed to sync group file: %w", err)
+	if err := writer.Close(); err != nil {
+		closed = true
+		if httperr.Code(err) == http.StatusConflict {
+			return fmt.Errorf("%w: %s", ErrGroupAlreadyExists, name)
 		}
+		return fmt.Errorf("failed to close group writer: %w", err)
 	}
+	closed = true
 
 	return nil
 }
@@ -223,10 +227,12 @@ func (m *cliManager) saveGroup(ctx context.Context, group *Group) error {
 	if err != nil {
 		return fmt.Errorf("failed to get writer for group: %w", err)
 	}
+	closed := false
 	defer func() {
-		if err := writer.Close(); err != nil {
-			// Non-fatal: writer cleanup failure
-			slog.Warn("failed to close writer", "error", err)
+		if !closed {
+			if err := state.AbortWriter(writer); err != nil {
+				slog.Warn("failed to abort group writer", "name", group.Name, "error", err)
+			}
 		}
 	}()
 
@@ -236,12 +242,11 @@ func (m *cliManager) saveGroup(ctx context.Context, group *Group) error {
 		return fmt.Errorf("failed to write group: %w", err)
 	}
 
-	// Ensure the writer is flushed
-	if closer, ok := writer.(interface{ Sync() error }); ok {
-		if err := closer.Sync(); err != nil {
-			return fmt.Errorf("failed to sync group file: %w", err)
-		}
+	if err := writer.Close(); err != nil {
+		closed = true
+		return fmt.Errorf("failed to close group writer: %w", err)
 	}
+	closed = true
 
 	return nil
 }

--- a/pkg/groups/cli_manager_test.go
+++ b/pkg/groups/cli_manager_test.go
@@ -28,26 +28,25 @@ func TestManager_Create(t *testing.T) {
 	tests := []struct {
 		name        string
 		groupName   string
-		setupMock   func(*mocks.MockStore)
+		writer      *mockWriteCloser
+		setupMock   func(*mocks.MockStore, *mockWriteCloser)
 		expectError bool
 		errorMsg    string
+		aborted     bool
 	}{
 		{
 			name:      "successful creation",
 			groupName: testGroupName,
-			setupMock: func(mock *mocks.MockStore) {
-				mock.EXPECT().
-					CreateExclusive(gomock.Any(), testGroupName).
-					Return(&mockWriteCloser{}, nil)
+			writer:    &mockWriteCloser{},
+			setupMock: func(mock *mocks.MockStore, writer *mockWriteCloser) {
+				mock.EXPECT().CreateExclusive(gomock.Any(), testGroupName).Return(writer, nil)
 			},
-			expectError: false,
 		},
 		{
 			name:      "group already exists",
 			groupName: "existinggroup",
-			setupMock: func(mock *mocks.MockStore) {
-				mock.EXPECT().
-					CreateExclusive(gomock.Any(), "existinggroup").
+			setupMock: func(mock *mocks.MockStore, _ *mockWriteCloser) {
+				mock.EXPECT().CreateExclusive(gomock.Any(), "existinggroup").
 					Return(nil, httperr.WithCode(errors.New("state 'existinggroup' already exists"), http.StatusConflict))
 			},
 			expectError: true,
@@ -56,10 +55,8 @@ func TestManager_Create(t *testing.T) {
 		{
 			name:      "create exclusive fails with other error",
 			groupName: testGroupName,
-			setupMock: func(mock *mocks.MockStore) {
-				mock.EXPECT().
-					CreateExclusive(gomock.Any(), testGroupName).
-					Return(nil, errors.New("disk full"))
+			setupMock: func(mock *mocks.MockStore, _ *mockWriteCloser) {
+				mock.EXPECT().CreateExclusive(gomock.Any(), testGroupName).Return(nil, errors.New("disk full"))
 			},
 			expectError: true,
 			errorMsg:    "failed to create group",
@@ -67,25 +64,45 @@ func TestManager_Create(t *testing.T) {
 		{
 			name:      "writer encoding fails",
 			groupName: testGroupName,
-			setupMock: func(mock *mocks.MockStore) {
-				mock.EXPECT().
-					CreateExclusive(gomock.Any(), testGroupName).
-					Return(&mockWriteCloser{writeError: errors.New("write failed")}, nil)
+			writer:    &mockWriteCloser{writeError: errors.New("write failed")},
+			setupMock: func(mock *mocks.MockStore, writer *mockWriteCloser) {
+				mock.EXPECT().CreateExclusive(gomock.Any(), testGroupName).Return(writer, nil)
 			},
 			expectError: true,
 			errorMsg:    "failed to write group",
+			aborted:     true,
+		},
+		{
+			name:      "create conflicts when writer closes",
+			groupName: testGroupName,
+			writer:    &mockWriteCloser{closeError: httperr.WithCode(errors.New("state already exists"), http.StatusConflict)},
+			setupMock: func(mock *mocks.MockStore, writer *mockWriteCloser) {
+				mock.EXPECT().CreateExclusive(gomock.Any(), testGroupName).Return(writer, nil)
+			},
+			expectError: true,
+			errorMsg:    "already exists",
+		},
+		{
+			name:      "create returns writer close error",
+			groupName: testGroupName,
+			writer:    &mockWriteCloser{closeError: errors.New("close failed")},
+			setupMock: func(mock *mocks.MockStore, writer *mockWriteCloser) {
+				mock.EXPECT().CreateExclusive(gomock.Any(), testGroupName).Return(writer, nil)
+			},
+			expectError: true,
+			errorMsg:    "failed to close group writer",
 		},
 		{
 			name:        "invalid name - uppercase",
 			groupName:   "MyGroup",
-			setupMock:   func(_ *mocks.MockStore) {}, // validation fails before store access
+			setupMock:   func(_ *mocks.MockStore, _ *mockWriteCloser) {}, // validation fails before store access
 			expectError: true,
 			errorMsg:    "must be lowercase",
 		},
 		{
 			name:        "invalid name - mixed case",
 			groupName:   "DefAult",
-			setupMock:   func(_ *mocks.MockStore) {}, // validation fails before store access
+			setupMock:   func(_ *mocks.MockStore, _ *mockWriteCloser) {}, // validation fails before store access
 			expectError: true,
 			errorMsg:    "must be lowercase",
 		},
@@ -100,19 +117,18 @@ func TestManager_Create(t *testing.T) {
 
 			mockStore := mocks.NewMockStore(ctrl)
 			manager := &cliManager{groupStore: mockStore}
+			tt.setupMock(mockStore, tt.writer)
 
-			// Set up mock expectations
-			tt.setupMock(mockStore)
-
-			// Execute operation
 			err := manager.Create(context.Background(), tt.groupName)
 
-			// Verify results
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
 				assert.NoError(t, err)
+			}
+			if tt.writer != nil {
+				assert.Equal(t, tt.aborted, tt.writer.aborted)
 			}
 		})
 	}
@@ -659,6 +675,17 @@ func TestManager_Update(t *testing.T) {
 			},
 		},
 		{
+			name:  "returns error when writer close fails",
+			group: &Group{Name: testGroupName},
+			setupMock: func(mock *mocks.MockStore) {
+				mock.EXPECT().
+					GetWriter(gomock.Any(), testGroupName).
+					Return(&mockWriteCloser{closeError: errors.New("close failed")}, nil)
+			},
+			expectError: true,
+			errorMsg:    "failed to close group writer",
+		},
+		{
 			name:  "returns error when writer fails",
 			group: &Group{Name: testGroupName},
 			setupMock: func(mock *mocks.MockStore) {
@@ -700,6 +727,7 @@ type mockWriteCloser struct {
 	data       []byte
 	writeError error
 	closeError error
+	aborted    bool
 }
 
 func (m *mockWriteCloser) Write(p []byte) (n int, err error) {
@@ -714,6 +742,7 @@ func (m *mockWriteCloser) Close() error {
 	return m.closeError
 }
 
-func (*mockWriteCloser) Sync() error {
+func (m *mockWriteCloser) Abort() error {
+	m.aborted = true
 	return nil
 }

--- a/pkg/migration/telemetry_config.go
+++ b/pkg/migration/telemetry_config.go
@@ -274,15 +274,23 @@ func migrateTelemetryConfigForWorkload(ctx context.Context, store state.Store, n
 	if err != nil {
 		return false, fmt.Errorf("failed to get writer for %s: %w", name, err)
 	}
+	closed := false
 	defer func() {
-		if closeErr := writer.Close(); closeErr != nil {
-			slog.Warn("failed to close writer", "name", name, "error", closeErr)
+		if !closed {
+			if err := state.AbortWriter(writer); err != nil {
+				slog.Warn("failed to abort writer", "name", name, "error", err)
+			}
 		}
 	}()
 
 	if _, err := writer.Write(migratedData); err != nil {
 		return false, fmt.Errorf("failed to write migrated config for %s: %w", name, err)
 	}
+	if err := writer.Close(); err != nil {
+		closed = true
+		return false, fmt.Errorf("failed to close writer for %s: %w", name, err)
+	}
+	closed = true
 
 	slog.Debug("migrated telemetry config samplingRate from float to string", "workload", name)
 	return true, nil

--- a/pkg/state/interface.go
+++ b/pkg/state/interface.go
@@ -7,24 +7,51 @@ package state
 
 import (
 	"context"
+	"fmt"
 	"io"
 )
 
+// Aborter is implemented by state writers that can discard uncommitted data.
+// Abort must release the writer's resources without publishing its contents.
+type Aborter interface {
+	Abort() error
+}
+
+// AbortWriter discards uncommitted data written to writer.
+//
+// Writers returned by Store.GetWriter and Store.CreateExclusive must implement
+// Aborter. Callers must use AbortWriter, rather than Close, when abandoning a
+// write because Close may publish the data.
+func AbortWriter(writer io.WriteCloser) error {
+	aborter, ok := writer.(Aborter)
+	if !ok {
+		return fmt.Errorf("state writer does not support abort")
+	}
+	return aborter.Abort()
+}
+
 //go:generate mockgen -destination=mocks/mock_store.go -package=mocks -source=interface.go Store
 
-// Store defines the interface for runner state storage operations
+// Store defines the interface for runner state storage operations. Writers returned by
+// GetWriter and CreateExclusive must support Aborter; callers must call AbortWriter
+// rather than Close when abandoning a write, since Close may publish it.
 type Store interface {
 	// GetReader returns a reader for the state data
 	// This is useful for streaming large state data
 	GetReader(ctx context.Context, name string) (io.ReadCloser, error)
 
-	// GetWriter returns a writer for the state data
-	// This is useful for streaming large state data
+	// GetWriter returns a writer for the state data. For stores that publish state on Close,
+	// callers must return Close errors because the write may not be visible until Close succeeds.
+	// Callers must use AbortWriter instead of Close when abandoning a write, because Close may publish it.
+	// This is useful for streaming large state data.
 	GetWriter(ctx context.Context, name string) (io.WriteCloser, error)
 
 	// CreateExclusive creates a new state entry exclusively, returning an error if it already exists.
+	// For stores that publish state on Close, exclusivity is enforced at Close and Close can return
+	// an error with http.StatusConflict if another writer published the entry first.
+	// Callers must return Close errors and use AbortWriter rather than Close when abandoning a write,
+	// because the write may not be visible until Close succeeds.
 	// This provides atomic check-and-create semantics to prevent race conditions.
-	// Returns a writer for the new state data, or an error with http.StatusConflict if the entry exists.
 	CreateExclusive(ctx context.Context, name string) (io.WriteCloser, error)
 
 	// Delete removes the data for the given name

--- a/pkg/state/kubernetes.go
+++ b/pkg/state/kubernetes.go
@@ -61,3 +61,8 @@ func (*noopWriteCloser) Write(p []byte) (n int, err error) {
 func (*noopWriteCloser) Close() error {
 	return nil
 }
+
+// Abort is a no-op.
+func (*noopWriteCloser) Abort() error {
+	return nil
+}

--- a/pkg/state/kubernetes_test.go
+++ b/pkg/state/kubernetes_test.go
@@ -169,6 +169,18 @@ func TestNoopWriteCloser_Close(t *testing.T) {
 	}
 }
 
+func TestNoopWriteCloser_Abort(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, AbortWriter(&noopWriteCloser{}))
+}
+
+func TestAbortWriter_UnsupportedWriter(t *testing.T) {
+	t.Parallel()
+
+	assert.Error(t, AbortWriter(&noAbortWriteCloser{}))
+}
+
 func TestNoopWriteCloser_WriteAndClose(t *testing.T) {
 	t.Parallel()
 	writer := &noopWriteCloser{}
@@ -196,10 +208,20 @@ func TestKubernetesStore_InterfaceCompliance(t *testing.T) {
 	var _ = NewKubernetesStore()
 }
 
-// TestNoopWriteCloser_InterfaceCompliance verifies that noopWriteCloser implements io.WriteCloser
+type noAbortWriteCloser struct{}
+
+func (*noAbortWriteCloser) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (*noAbortWriteCloser) Close() error {
+	return nil
+}
+
 func TestNoopWriteCloser_InterfaceCompliance(t *testing.T) {
 	t.Parallel()
 	var _ io.WriteCloser = &noopWriteCloser{}
 	var _ io.Writer = &noopWriteCloser{}
 	var _ io.Closer = &noopWriteCloser{}
+	var _ Aborter = &noopWriteCloser{}
 }

--- a/pkg/state/local.go
+++ b/pkg/state/local.go
@@ -5,8 +5,10 @@ package state
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -85,42 +87,97 @@ func (s *LocalStore) GetReader(_ context.Context, name string) (io.ReadCloser, e
 	return file, nil
 }
 
-// GetWriter returns a writer for the state data
+// localWriter writes state to a temporary file and publishes it when closed.
+type localWriter struct {
+	file       *os.File
+	tempPath   string
+	targetPath string
+	exclusive  bool
+}
+
+// Write writes state data to the temporary file.
+func (w *localWriter) Write(p []byte) (int, error) {
+	return w.file.Write(p)
+}
+
+// Sync flushes the temporary file to durable storage.
+func (w *localWriter) Sync() error {
+	return w.file.Sync()
+}
+
+// Close syncs and closes the temporary file before atomically publishing it.
+func (w *localWriter) Close() error {
+	if err := w.file.Sync(); err != nil {
+		return w.cleanupAfterError(err)
+	}
+	if err := w.file.Close(); err != nil {
+		return w.removeTemp(err)
+	}
+
+	if w.exclusive {
+		if err := os.Link(w.tempPath, w.targetPath); err != nil {
+			if os.IsExist(err) {
+				return w.removeTemp(httperr.WithCode(
+					fmt.Errorf("state '%s' already exists", strings.TrimSuffix(filepath.Base(w.targetPath), FileExtension)),
+					http.StatusConflict,
+				))
+			}
+			return w.removeTemp(fmt.Errorf("failed to publish state file: %w", err))
+		}
+		if err := os.Remove(w.tempPath); err != nil && !os.IsNotExist(err) {
+			slog.Warn("failed to remove published temporary state file", "path", w.tempPath, "error", err)
+		}
+		return nil
+	}
+
+	if err := os.Rename(w.tempPath, w.targetPath); err != nil {
+		return w.removeTemp(fmt.Errorf("failed to publish state file: %w", err))
+	}
+	return nil
+}
+
+// Abort closes and removes the temporary file without publishing it.
+func (w *localWriter) Abort() error {
+	return w.cleanupAfterError(nil)
+}
+
+func (w *localWriter) cleanupAfterError(err error) error {
+	return w.removeTemp(errors.Join(err, w.file.Close()))
+}
+
+func (w *localWriter) removeTemp(err error) error {
+	if removeErr := os.Remove(w.tempPath); removeErr != nil && !os.IsNotExist(removeErr) {
+		return errors.Join(err, fmt.Errorf("failed to remove temporary state file: %w", removeErr))
+	}
+	return err
+}
+
+// GetWriter returns a writer for the state data. Data is atomically published when the writer is closed.
 func (s *LocalStore) GetWriter(_ context.Context, name string) (io.WriteCloser, error) {
 	filePath, err := s.getFilePath(name)
 	if err != nil {
 		return nil, err
 	}
-	// #nosec G304 - path traversal is prevented by the containment check in getFilePath
-	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create file: %w", err)
-	}
 
-	return file, nil
+	return s.newWriter(filePath, false)
 }
 
-// CreateExclusive creates a new state entry exclusively, failing if it already exists.
-// This provides atomic check-and-create semantics using O_EXCL to prevent race conditions.
+// CreateExclusive creates a new state entry exclusively. Data is atomically published when the writer is closed.
 func (s *LocalStore) CreateExclusive(_ context.Context, name string) (io.WriteCloser, error) {
 	filePath, err := s.getFilePath(name)
 	if err != nil {
 		return nil, err
 	}
-	// O_EXCL with O_CREATE provides atomic check-and-create behavior.
-	// #nosec G304 - path traversal is prevented by the containment check in getFilePath
-	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-	if err != nil {
-		if os.IsExist(err) {
-			return nil, httperr.WithCode(
-				fmt.Errorf("state '%s' already exists", name),
-				http.StatusConflict,
-			)
-		}
-		return nil, fmt.Errorf("failed to create file: %w", err)
+	if _, err := os.Lstat(filePath); err == nil {
+		return nil, httperr.WithCode(
+			fmt.Errorf("state '%s' already exists", name),
+			http.StatusConflict,
+		)
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to check state file: %w", err)
 	}
 
-	return file, nil
+	return s.newWriter(filePath, true)
 }
 
 // Delete removes the data for the given name
@@ -181,4 +238,13 @@ func (s *LocalStore) Exists(_ context.Context, name string) (bool, error) {
 		return false, fmt.Errorf("failed to check if state exists: %w", err)
 	}
 	return true, nil
+}
+
+func (*LocalStore) newWriter(filePath string, exclusive bool) (io.WriteCloser, error) {
+	file, err := os.CreateTemp(filepath.Dir(filePath), "."+filepath.Base(filePath)+".tmp-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary state file: %w", err)
+	}
+
+	return &localWriter{file: file, tempPath: file.Name(), targetPath: filePath, exclusive: exclusive}, nil
 }

--- a/pkg/state/local_test.go
+++ b/pkg/state/local_test.go
@@ -5,12 +5,17 @@ package state
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-core/httperr"
 )
 
 // newTestLocalStore creates a LocalStore rooted at a temp directory for testing.
@@ -79,6 +84,11 @@ func TestLocalStore_ValidNamesWork(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, r.Close())
 
+	// A published entry must reject another exclusive create immediately.
+	_, err = store.CreateExclusive(ctx, "mystate")
+	require.Error(t, err)
+	assert.Equal(t, http.StatusConflict, httperr.Code(err))
+
 	// List should return it
 	names, err := store.List(ctx)
 	require.NoError(t, err)
@@ -89,6 +99,129 @@ func TestLocalStore_ValidNamesWork(t *testing.T) {
 	exists, err = store.Exists(ctx, "mystate")
 	require.NoError(t, err)
 	assert.False(t, exists)
+}
+
+func TestLocalStore_GetWriterPublishesOnClose(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestLocalStore(t)
+	original := []byte("complete original state")
+	replacement := []byte("incomplete replacement")
+
+	writer, err := store.GetWriter(ctx, "state")
+	require.NoError(t, err)
+	_, err = writer.Write(original)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	writer, err = store.GetWriter(ctx, "state")
+	require.NoError(t, err)
+	_, err = writer.Write(replacement)
+	require.NoError(t, err)
+
+	names, err := store.List(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"state"}, names)
+
+	reader, err := store.GetReader(ctx, "state")
+	require.NoError(t, err)
+	contents, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, original, contents)
+
+	abortLocalWriter(t, writer)
+
+	reader, err = store.GetReader(ctx, "state")
+	require.NoError(t, err)
+	contents, err = io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, original, contents)
+	assertNoTemporaryFiles(t, store)
+}
+
+func TestLocalStore_CreateExclusivePublishesOnClose(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestLocalStore(t)
+	writer, err := store.CreateExclusive(ctx, "state")
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("incomplete state"))
+	require.NoError(t, err)
+
+	names, err := store.List(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, names)
+
+	reader, err := store.GetReader(ctx, "state")
+	require.Error(t, err)
+	assert.Nil(t, reader)
+	assert.Equal(t, http.StatusNotFound, httperr.Code(err))
+	abortLocalWriter(t, writer)
+
+	exists, err := store.Exists(ctx, "state")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assertNoTemporaryFiles(t, store)
+}
+
+func TestLocalStore_CompetingExclusiveWriters(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestLocalStore(t)
+	first, err := store.CreateExclusive(ctx, "state")
+	require.NoError(t, err)
+	second, err := store.CreateExclusive(ctx, "state")
+	require.NoError(t, err)
+	_, err = first.Write([]byte("first"))
+	require.NoError(t, err)
+	_, err = second.Write([]byte("second"))
+	require.NoError(t, err)
+
+	results := make(chan error, 2)
+	go func() { results <- first.Close() }()
+	go func() { results <- second.Close() }()
+
+	firstErr := receiveCloseResult(t, results)
+	secondErr := receiveCloseResult(t, results)
+	assert.True(t, (firstErr == nil && httperr.Code(secondErr) == http.StatusConflict) ||
+		(secondErr == nil && httperr.Code(firstErr) == http.StatusConflict))
+
+	contents, err := os.ReadFile(filepath.Join(store.basePath, "state"+FileExtension))
+	require.NoError(t, err)
+	assert.Contains(t, [][]byte{[]byte("first"), []byte("second")}, contents)
+	assertNoTemporaryFiles(t, store)
+}
+
+func receiveCloseResult(t *testing.T, results <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-results:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for exclusive writer to close")
+		return nil
+	}
+}
+
+func abortLocalWriter(t *testing.T, writer io.WriteCloser) {
+	t.Helper()
+	aborter, ok := writer.(interface{ Abort() error })
+	require.True(t, ok)
+	require.NoError(t, aborter.Abort())
+}
+
+func assertNoTemporaryFiles(t *testing.T, store *LocalStore) {
+	t.Helper()
+	entries, err := os.ReadDir(store.basePath)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.NotContains(t, entry.Name(), ".tmp-")
+	}
 }
 
 func TestLocalStore_FileStaysInsideBasePath(t *testing.T) {

--- a/pkg/state/mocks/mock_store.go
+++ b/pkg/state/mocks/mock_store.go
@@ -17,6 +17,44 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+// MockAborter is a mock of Aborter interface.
+type MockAborter struct {
+	ctrl     *gomock.Controller
+	recorder *MockAborterMockRecorder
+	isgomock struct{}
+}
+
+// MockAborterMockRecorder is the mock recorder for MockAborter.
+type MockAborterMockRecorder struct {
+	mock *MockAborter
+}
+
+// NewMockAborter creates a new mock instance.
+func NewMockAborter(ctrl *gomock.Controller) *MockAborter {
+	mock := &MockAborter{ctrl: ctrl}
+	mock.recorder = &MockAborterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAborter) EXPECT() *MockAborterMockRecorder {
+	return m.recorder
+}
+
+// Abort mocks base method.
+func (m *MockAborter) Abort() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Abort")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Abort indicates an expected call of Abort.
+func (mr *MockAborterMockRecorder) Abort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockAborter)(nil).Abort))
+}
+
 // MockStore is a mock of Store interface.
 type MockStore struct {
 	ctrl     *gomock.Controller

--- a/pkg/state/runconfig.go
+++ b/pkg/state/runconfig.go
@@ -89,9 +89,12 @@ func SaveRunConfig[T RunConfigPersister](ctx context.Context, config T) error {
 	if err != nil {
 		return fmt.Errorf("failed to get writer for state: %w", err)
 	}
+	closed := false
 	defer func() {
-		if err := writer.Close(); err != nil {
-			slog.Warn("Failed to close writer", "error", err)
+		if !closed {
+			if err := AbortWriter(writer); err != nil {
+				slog.Warn("failed to abort run configuration writer", "name", config.GetBaseName(), "error", err)
+			}
 		}
 	}()
 
@@ -99,6 +102,11 @@ func SaveRunConfig[T RunConfigPersister](ctx context.Context, config T) error {
 	if err := config.WriteJSON(writer); err != nil {
 		return fmt.Errorf("failed to write run configuration: %w", err)
 	}
+	if err := writer.Close(); err != nil {
+		closed = true
+		return fmt.Errorf("failed to close run configuration writer: %w", err)
+	}
+	closed = true
 
 	slog.Debug("Saved run configuration", "name", config.GetBaseName())
 	return nil


### PR DESCRIPTION
## Summary

Local state writes (`GetWriter`/`CreateExclusive` on `LocalStore`) previously opened the target
file directly and wrote to it in place. A failed or aborted write (e.g. process crash or error
mid-write) could leave a truncated or partially-written state file behind, and `CreateExclusive`'s
"exists" check and file creation were not atomic with each other.

- `LocalStore` writers now write to a temp file in the same directory and publish it atomically
  on `Close` — via `os.Rename` for `GetWriter`, and `os.Link` (which fails if the target already
  exists) for `CreateExclusive`, closing the exclusivity race.
- Added an `Aborter` interface and `state.AbortWriter` helper so callers can explicitly discard
  an in-progress write instead of relying on `Close`, which now publishes data and can itself fail.
- Updated all callers (`pkg/groups`, `pkg/migration`, `pkg/state/runconfig.go`) to call
  `AbortWriter` in their deferred cleanup instead of `Close`, and to check the error from the
  final `Close`, since publishing can now fail (e.g. `CreateExclusive` conflict).

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Special notes for reviewers

`state.Store` writers are now required to implement `Aborter`; both `LocalStore` and the
Kubernetes no-op store were updated. Any future `Store` implementation needs to do the same.

Generated with [Claude Code](https://claude.com/claude-code)