### PR TITLE
Preserve queued SSE progress notifications

### DIFF
--- a/pkg/transport/proxy/streamable/dispatcher_standalone_sse_integration_test.go
+++ b/pkg/transport/proxy/streamable/dispatcher_standalone_sse_integration_test.go
@@ -691,6 +691,80 @@ func TestPostSSE_ProgressTokenClearedAfterRequestCompletes(t *testing.T) {
 	}, time.Second, 5*time.Millisecond, "progress token must be dropped once its request completes")
 }
 
+// TestPostSSE_ProgressQueuedWithFinalResponseIsPreserved verifies that a
+// progress notification already queued when the final response is delivered
+// is written before the final response rather than lost to select scheduling.
+func TestPostSSE_ProgressQueuedWithFinalResponseIsPreserved(t *testing.T) {
+	t.Parallel()
+
+	port := pickFreePort(t)
+	proxy, ctx := startProxyOnly(t, port)
+	received := make(chan *jsonrpc2.Request, 1)
+
+	go func() {
+		for {
+			select {
+			case msg := <-proxy.GetMessageChannel():
+				req, ok := msg.(*jsonrpc2.Request)
+				if !ok {
+					continue
+				}
+				if _, ok := extractMetaProgressToken(req.Params); ok {
+					received <- req
+					continue
+				}
+				response, err := jsonrpc2.NewResponse(req.ID, map[string]any{"ok": true}, nil)
+				if err == nil {
+					proxy.responseCh <- response
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	sessID := establishSession(t, port)
+	body := `{"jsonrpc":"2.0","id":"call-queued","method":"tools/call","params":{"_meta":{"progressToken":"client-token"}}}`
+	resp, reader := postSSE(ctx, t, port, sessID, body)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	var req *jsonrpc2.Request
+	select {
+	case req = <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for backend request")
+	}
+	_, ok := extractMetaProgressToken(req.Params)
+	require.True(t, ok)
+	var route progressRoute
+	require.Eventually(t, func() bool {
+		proxy.routing.ptMu.Lock()
+		defer proxy.routing.ptMu.Unlock()
+		for _, candidate := range proxy.routing.ptToks {
+			route = candidate
+			return true
+		}
+		return false
+	}, time.Second, time.Millisecond, "progress route should be registered")
+
+	progress, err := jsonrpc2.NewNotification("notifications/progress", map[string]any{
+		"progressToken": "client-token",
+		"progress":      1,
+	})
+	require.NoError(t, err)
+	route.deliver <- progress
+
+	final, err := jsonrpc2.NewResponse(req.ID, map[string]any{"ok": true}, nil)
+	require.NoError(t, err)
+	proxy.responseCh <- final
+
+	first := readSSEData(t, reader)
+	assert.Contains(t, first, "notifications/progress")
+	assert.Contains(t, first, `"progressToken":"client-token"`)
+	second := readSSEData(t, reader)
+	assert.Contains(t, second, `"id":"call-queued"`)
+}
+
 // TestPostSSE_ResourcesUpdated_SubscribersOnlyAndUpstreamRefCounted is the
 // resources/subscribe|unsubscribe SECURITY + ref-counting regression:
 //   - A subscribes uri1, B subscribes uri2: a resources/updated{uri1}

--- a/pkg/transport/proxy/streamable/streamable_proxy.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy.go
@@ -728,6 +728,9 @@ func (p *HTTPProxy) handleSingleRequestSSE(
 			// Progress does not end the request; keep waiting for more
 			// progress or the final response.
 		case msg := <-waitCh:
+			if p.writePendingSSEProgress(w, flusher, deliverCh) {
+				return
+			}
 			p.writeSingleRequestSSEFinalResponse(w, flusher, msg, ck)
 			return
 		case <-ctx.Done():
@@ -741,6 +744,33 @@ func (p *HTTPProxy) handleSingleRequestSSE(
 			return
 		}
 	}
+}
+
+// writePendingSSEProgress drains progress notifications that arrived before a
+// final response was selected. It returns true when writing fails.
+func (p *HTTPProxy) writePendingSSEProgress(
+	w http.ResponseWriter, flusher http.Flusher, deliverCh <-chan jsonrpc2.Message,
+) bool {
+	for deliverCh != nil {
+		select {
+		case progressMsg, ok := <-deliverCh:
+			if !ok {
+				return false
+			}
+			data, err := jsonrpc2.EncodeMessage(progressMsg)
+			if err != nil {
+				slog.Error("failed to encode progress notification", "error", err)
+				continue
+			}
+			if err := writeSSEData(w, flusher, data); err != nil {
+				slog.Debug("failed to write progress notification to SSE stream", "error", err)
+				return true
+			}
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // writeSingleRequestSSEFinalResponse restores msg's original client ID (if it

--- a/pkg/transport/proxy/streamable/streamable_proxy_test.go
+++ b/pkg/transport/proxy/streamable/streamable_proxy_test.go
@@ -36,6 +36,24 @@ func TestNewHTTPProxy(t *testing.T) {
 	assert.NotNil(t, proxy.responseCh)
 }
 
+func TestWritePendingSSEProgressDrainsBeforeFinalResponse(t *testing.T) {
+	proxy := NewHTTPProxy("localhost", 8080, nil, nil)
+	progressCh := make(chan jsonrpc2.Message, 1)
+	progress, err := jsonrpc2.NewNotification("notifications/progress", map[string]any{
+		"progressToken": "client-token",
+		"progress":      1,
+	})
+	require.NoError(t, err)
+	progressCh <- progress
+
+	recorder := httptest.NewRecorder()
+	flusher, ok := any(recorder).(http.Flusher)
+	require.True(t, ok)
+	require.False(t, proxy.writePendingSSEProgress(recorder, flusher, progressCh))
+	assert.Contains(t, recorder.Body.String(), "notifications/progress")
+	assert.Len(t, progressCh, 0)
+}
+
 // TestProxyChannelCommunication tests basic proxy channel communication
 //
 //nolint:paralleltest // Test modifies shared proxy state


### PR DESCRIPTION
Fixes #6349

Issue: https://github.com/stacklok/toolhive/issues/6349

Problem: A POST-SSE request can lose progress notifications when a final response arrives at nearly the same time.

Root cause: The progress and final-response channels are both buffered, so select can choose the final response while a progress notification remains queued.

Change: Drain queued progress notifications before writing the final SSE response.

Tests:
- Added a regression test for a queued progress notification and final response.
- Added unit coverage for draining pending progress notifications.