### PR TITLE
Fix stale version comment on codespell action pin

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Codespell
-        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2.1
         with:
           skip: .git
           check_filenames: true


### PR DESCRIPTION
## Summary

- The pinned SHA for `codespell-project/actions-codespell` was annotated `# v2`, but that commit is actually tagged `v2.1`, not `v2`. zizmor's `ref-version-mismatch` audit flags this as a stale/misleading version comment (High confidence).
- Updated the comment to `# v2.1` so it accurately reflects the tag the pinned hash points to.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

Confirmed via GitHub that commit `406322e` on `codespell-project/actions-codespell` is tagged `v2.1` (not `v2`), matching zizmor's finding.

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)