### PR TITLE
Deduplicate refreshes by storage row

### DIFF
--- a/docs/arch/11-auth-server-storage.md
+++ b/docs/arch/11-auth-server-storage.md
@@ -176,6 +176,26 @@ The implementation uses different strategies based on consistency requirements:
 - **Pipelines** (`MULTI`/`EXEC`) for batched operations: authorization code invalidation, token session creation with secondary index updates
 - **Individual commands** with best-effort cleanup: token revocation, refresh token rotation — partial failures are safe since orphaned keys expire via TTL
 
+### Refresh Coordination Scope
+
+When an expired upstream access token is refreshed, `UpstreamTokenStorage` derives
+an opaque SHA-256 identity from its storage-defined row representation. For
+Redis, that representation is its row-key format, so two `(sessionID,
+providerName)` pairs that happen to produce the same Redis key resolve to the
+same identity — that's safe because they're the same physical row. What's
+not allowed is aliasing two pairs that are genuinely different rows: the
+auth server uses this identity only as the key for its in-process
+`singleflight` group, then its leader re-reads the row before redeeming its
+refresh token, and it reads/writes under its own sessionID — aliasing
+distinct rows would cross credentials between sessions. This prevents
+duplicate redemption from stale concurrent callers served by the same
+process; the identity is not persisted, logged, or exposed.
+
+This is deliberately narrower than #4122: it does not provide distributed
+coordination across replicas, row-addressed mutation, compare-and-swap, or any
+other cross-process consistency guarantee. Redis remains the durable storage
+backend, while each replica coordinates only its own in-flight refreshes.
+
 ### Serialization
 
 All values are stored as JSON. The implementation uses defensive copies on read and write to prevent caller mutations from affecting stored data.

--- a/pkg/auth/upstreamtoken/service.go
+++ b/pkg/auth/upstreamtoken/service.go
@@ -16,8 +16,9 @@ import (
 // InProcessService implements the Service interface for in-process use.
 // It composes storage (read) and refresher (refresh + persist) to provide a
 // single GetValidTokens call. Concurrent-refresh deduplication is delegated to
-// the refresher's own singleflight.Group so the same Group covers both the
-// handler's chain-walk path and the runtime token-swap path.
+// the refresher's own singleflight.Group keyed by an opaque storage-row identity,
+// so the same Group covers both the handler's chain-walk path and the runtime
+// token-swap path within this process.
 type InProcessService struct {
 	storage   storage.UpstreamTokenStorage
 	refresher storage.UpstreamTokenRefresher
@@ -147,7 +148,8 @@ func (s *InProcessService) GetAllUpstreamCredentials(
 
 // refreshOrFail attempts a refresh via the shared refresher and maps errors to
 // the service's sentinel errors. Deduplication of concurrent refreshes for the
-// same (session, provider) pair is handled inside the refresher.
+// same logical upstream-token row is handled inside the refresher using an
+// opaque storage-row identity.
 func (s *InProcessService) refreshOrFail(
 	ctx context.Context,
 	sessionID string,

--- a/pkg/authserver/refresher.go
+++ b/pkg/authserver/refresher.go
@@ -37,8 +37,8 @@ const upstreamDeleteTimeout = 5 * time.Second
 // a set of upstream OAuth2Providers (keyed by provider name) and
 // UpstreamTokenStorage (for persisting the refreshed tokens). On each refresh
 // call it dispatches to the correct provider based on the expired token's
-// ProviderID, deduplicating concurrent refreshes for the same
-// (session, provider) pair via sfGroup.
+// ProviderID. It deduplicates concurrent refreshes by the opaque storage-row
+// identity returned by UpstreamTokenStorage, within this process only.
 type upstreamTokenRefresher struct {
 	providers            map[string]upstream.OAuth2Provider
 	storage              storage.UpstreamTokenStorage
@@ -49,10 +49,12 @@ type upstreamTokenRefresher struct {
 // Compile-time check that upstreamTokenRefresher implements storage.UpstreamTokenRefresher.
 var _ storage.UpstreamTokenRefresher = (*upstreamTokenRefresher)(nil)
 
-// RefreshAndStore deduplicates concurrent refreshes for the same (session,
-// provider) pair, then delegates to refreshAndStore. The detached-context
-// timeout ensures waiting callers are not abandoned if the initiating request
-// cancels before the upstream round-trip completes.
+// RefreshAndStore validates deterministic input errors before resolving the
+// opaque storage-row identity used to deduplicate a refresh within this process.
+// The leader re-reads that row under a detached timeout so it never redeems a
+// stale refresh token supplied by a caller. It only short-circuits on that
+// re-read when the row is actually unexpired; a storage backend that returns
+// tokens without checking expiry does not fool it into skipping the refresh.
 func (r *upstreamTokenRefresher) RefreshAndStore(
 	ctx context.Context,
 	sessionID string,
@@ -61,14 +63,47 @@ func (r *upstreamTokenRefresher) RefreshAndStore(
 	if expired == nil {
 		return nil, errors.New("expired tokens are required")
 	}
+	if expired.RefreshToken == "" {
+		return nil, errors.New("no refresh token available for upstream token refresh")
+	}
+	if _, ok := r.providers[expired.ProviderID]; !ok {
+		return nil, fmt.Errorf("no upstream provider configured for %q", expired.ProviderID)
+	}
 
-	// providerName == ProviderID throughout the authserver; both originate from
-	// UpstreamConfig.Name and are stored verbatim in UpstreamTokens.ProviderID.
-	key := sessionID + ":" + expired.ProviderID
-	result, err, _ := r.sfGroup.Do(key, func() (any, error) {
+	rowID, err := r.storage.ResolveUpstreamTokenRowID(ctx, sessionID, expired.ProviderID)
+	if err != nil {
+		return nil, err
+	}
+	if rowID == "" {
+		return nil, errors.New("upstream token row ID cannot be empty")
+	}
+
+	result, err, _ := r.sfGroup.Do(string(rowID), func() (any, error) {
 		refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
 		defer cancel()
-		return r.refreshAndStore(refreshCtx, sessionID, expired)
+
+		authoritative, readErr := r.storage.GetUpstreamTokens(refreshCtx, sessionID, expired.ProviderID)
+		if readErr == nil {
+			// Some storage implementations may return tokens without checking
+			// access-token expiry (the interface does not require it; see
+			// storage.UpstreamTokenStorage.GetUpstreamTokens). Only short-circuit
+			// when the re-read row is actually unexpired; otherwise fall through
+			// and refresh using it as the authoritative row.
+			if authoritative == nil {
+				return nil, fmt.Errorf(
+					"upstream token row missing on re-read for session %q provider %q",
+					sessionID, expired.ProviderID,
+				)
+			}
+			if !authoritative.IsExpired(time.Now()) {
+				return authoritative, nil
+			}
+			return r.refreshAndStore(refreshCtx, sessionID, authoritative)
+		}
+		if !errors.Is(readErr, storage.ErrExpired) || authoritative == nil {
+			return nil, readErr
+		}
+		return r.refreshAndStore(refreshCtx, sessionID, authoritative)
 	})
 	if err != nil {
 		return nil, err
@@ -77,7 +112,8 @@ func (r *upstreamTokenRefresher) RefreshAndStore(
 	if !ok || refreshed == nil {
 		return nil, errors.New("unexpected nil result from upstream token refresh")
 	}
-	return refreshed, nil
+	refreshedCopy := *refreshed
+	return &refreshedCopy, nil
 }
 
 // refreshAndStore performs the actual token refresh and storage write.

--- a/pkg/authserver/refresher_test.go
+++ b/pkg/authserver/refresher_test.go
@@ -381,6 +381,10 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 
 			mockProvider := upstreammocks.NewMockOAuth2Provider(ctrl)
 			mockStorage := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+			mockStorage.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), gomock.Any(), gomock.Any()).
+				AnyTimes().Return(storage.UpstreamTokenRowID("test-row"), nil)
+			mockStorage.EXPECT().GetUpstreamTokens(gomock.Any(), gomock.Any(), gomock.Any()).
+				AnyTimes().Return(tt.expired, storage.ErrExpired)
 
 			tt.setupProvider(t, mockProvider)
 			tt.setupStorage(t, mockStorage)
@@ -410,10 +414,10 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 }
 
 // waitGroupTimeout blocks until wg is done, failing the test if that takes
-// longer than d. Without it, a synchronization regression (or a panicking
+// longer than five seconds. Without it, a synchronization regression (or a panicking
 // goroutine) would hang the test until the global go test timeout instead of
 // failing fast with a clear message.
-func waitGroupTimeout(t *testing.T, wg *sync.WaitGroup, d time.Duration, msg string) {
+func waitGroupTimeout(t *testing.T, wg *sync.WaitGroup, msg string) {
 	t.Helper()
 	done := make(chan struct{})
 	go func() {
@@ -422,14 +426,14 @@ func waitGroupTimeout(t *testing.T, wg *sync.WaitGroup, d time.Duration, msg str
 	}()
 	select {
 	case <-done:
-	case <-time.After(d):
+	case <-time.After(5 * time.Second):
 		t.Fatal(msg)
 	}
 }
 
 // TestUpstreamTokenRefresher_SingleflightDedup proves that concurrent
-// RefreshAndStore calls for the same (session, provider) key result in exactly
-// one upstream redemption, and that distinct keys are independent.
+// RefreshAndStore calls resolving to the same storage-row identity result in
+// exactly one upstream redemption, while distinct identities are independent.
 //
 // The same-key sub-test holds the leader's in-flight call open on a
 // test-controlled release channel while the followers join it, then asserts the
@@ -484,6 +488,10 @@ func TestUpstreamTokenRefresher_SingleflightDedup(t *testing.T) {
 		// invokeCount tracks actual provider invocations.
 		var invokeCount atomic.Int64
 
+		mockStorage.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session-1", "github").
+			AnyTimes().Return(storage.UpstreamTokenRowID("session-1-github"), nil)
+		mockStorage.EXPECT().GetUpstreamTokens(gomock.Any(), "session-1", "github").
+			Times(1).Return(expired, storage.ErrExpired)
 		mockProvider.EXPECT().
 			RefreshTokens(gomock.Any(), "old-refresh", "sub-1").
 			Times(1).
@@ -543,13 +551,13 @@ func TestUpstreamTokenRefresher_SingleflightDedup(t *testing.T) {
 		// Wait for every goroutine to have reached RefreshAndStore, then give the
 		// followers a brief settle to park inside sfGroup.Do before releasing the
 		// leader. The leader holds the key open the whole time, so once released
-		// it returns the single shared result to all joined followers.
+		// each caller receives a distinct copy of the completed result.
 		require.Eventually(t, func() bool { return entered.Load() == n }, 5*time.Second, time.Millisecond,
 			"all goroutines should reach RefreshAndStore")
 		time.Sleep(100 * time.Millisecond)
 		close(release)
 
-		waitGroupTimeout(t, &wg, 5*time.Second,
+		waitGroupTimeout(t, &wg,
 			"timeout waiting for concurrent RefreshAndStore callers to complete")
 
 		for i := range n {
@@ -558,6 +566,13 @@ func TestUpstreamTokenRefresher_SingleflightDedup(t *testing.T) {
 			assert.Equal(t, "new-access", results[i].AccessToken,
 				"goroutine %d got wrong access token", i)
 		}
+		for i := 1; i < n; i++ {
+			assert.NotSame(t, results[0], results[i],
+				"goroutine %d must receive an independent result pointer", i)
+		}
+		results[0].AccessToken = "mutated-access"
+		assert.Equal(t, "new-access", results[1].AccessToken,
+			"mutating one caller's result must not change another caller's result")
 		assert.Equal(t, int64(1), invokeCount.Load(),
 			"upstream provider must be invoked exactly once despite %d concurrent callers", n)
 		// mockStorage Times(1) independently enforces exactly one store write.
@@ -569,6 +584,14 @@ func TestUpstreamTokenRefresher_SingleflightDedup(t *testing.T) {
 		const numProviders = 3
 		ctrl := gomock.NewController(t)
 		mockStorage := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		mockStorage.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session-x", gomock.Any()).
+			AnyTimes().DoAndReturn(func(_ context.Context, _ string, providerID string) (storage.UpstreamTokenRowID, error) {
+			return storage.UpstreamTokenRowID(providerID), nil
+		})
+		mockStorage.EXPECT().GetUpstreamTokens(gomock.Any(), "session-x", gomock.Any()).
+			AnyTimes().DoAndReturn(func(_ context.Context, _ string, providerID string) (*storage.UpstreamTokens, error) {
+			return &storage.UpstreamTokens{ProviderID: providerID, RefreshToken: "rt-" + providerID, UpstreamSubject: "s"}, storage.ErrExpired
+		})
 
 		providers := make(map[string]upstream.OAuth2Provider, numProviders)
 		for i := range numProviders {
@@ -615,9 +638,256 @@ func TestUpstreamTokenRefresher_SingleflightDedup(t *testing.T) {
 				assert.NotNil(t, result)
 			}(tok)
 		}
-		waitGroupTimeout(t, &wg, 5*time.Second,
+		waitGroupTimeout(t, &wg,
 			"timeout waiting for distinct-key RefreshAndStore callers to complete")
 		// gomock Times(1) per mock provider asserts each distinct key ran
 		// exactly once through the actual upstream call.
+	})
+
+	t.Run("distinct row identities for equivalent sessions refresh independently", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		mockStorage := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		mockProvider := upstreammocks.NewMockOAuth2Provider(ctrl)
+		expiredA := &storage.UpstreamTokens{
+			ProviderID: "github", RefreshToken: "old-refresh", UpstreamSubject: "subject", UserID: "user", ClientID: "client",
+		}
+		expiredB := &storage.UpstreamTokens{
+			ProviderID: "github", RefreshToken: "old-refresh", UpstreamSubject: "subject", UserID: "user", ClientID: "client",
+		}
+		providerEntered := make(chan struct{})
+		release := make(chan struct{})
+		var releaseOnce sync.Once
+		t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+		var providerCalls atomic.Int64
+
+		mockStorage.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session-a", "github").
+			Times(1).Return(storage.UpstreamTokenRowID("physical-row-a"), nil)
+		mockStorage.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session-b", "github").
+			Times(1).Return(storage.UpstreamTokenRowID("physical-row-b"), nil)
+		mockStorage.EXPECT().GetUpstreamTokens(gomock.Any(), "session-a", "github").
+			Times(1).Return(expiredA, storage.ErrExpired)
+		mockStorage.EXPECT().GetUpstreamTokens(gomock.Any(), "session-b", "github").
+			Times(1).Return(expiredB, storage.ErrExpired)
+		mockProvider.EXPECT().RefreshTokens(gomock.Any(), "old-refresh", "subject").Times(2).
+			DoAndReturn(func(ctx context.Context, _, _ string) (*upstream.Tokens, error) {
+				if providerCalls.Add(1) == 2 {
+					close(providerEntered)
+				}
+				select {
+				case <-release:
+					return &upstream.Tokens{AccessToken: "new-access", ExpiresAt: newExpiry}, nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			})
+		mockStorage.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-a", "github", gomock.Any()).Times(1).Return(nil)
+		mockStorage.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-b", "github", gomock.Any()).Times(1).Return(nil)
+
+		refresher := &upstreamTokenRefresher{
+			providers:            map[string]upstream.OAuth2Provider{"github": mockProvider},
+			storage:              mockStorage,
+			refreshTokenLifespan: 24 * time.Hour,
+		}
+		var wg sync.WaitGroup
+		errs := make([]error, 2)
+		wg.Add(2)
+		for i, sessionID := range []string{"session-a", "session-b"} {
+			go func(i int, sessionID string) {
+				defer wg.Done()
+				_, errs[i] = refresher.RefreshAndStore(context.Background(), sessionID, expiredA)
+			}(i, sessionID)
+		}
+
+		select {
+		case <-providerEntered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for both distinct rows to enter the provider")
+		}
+		releaseOnce.Do(func() { close(release) })
+		waitGroupTimeout(t, &wg,
+			"timeout waiting for distinct-row RefreshAndStore callers to complete")
+		for i := range errs {
+			require.NoError(t, errs[i], "caller %d got error", i)
+		}
+		assert.Equal(t, int64(2), providerCalls.Load(),
+			"each distinct physical row must invoke the provider once")
+		// mockStorage Times(1) per session independently asserts one store per row.
+	})
+}
+
+func TestUpstreamTokenRefresher_RowIdentity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same row identity across sessions refreshes and writes once", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		store := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		provider := upstreammocks.NewMockOAuth2Provider(ctrl)
+		expired := &storage.UpstreamTokens{ProviderID: "github", RefreshToken: "stale", UpstreamSubject: "subject"}
+		leaderEntered := make(chan struct{})
+		followerResolved := make(chan struct{})
+		release := make(chan struct{})
+		var resolves atomic.Int64
+
+		store.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), gomock.Any(), "github").
+			Times(2).DoAndReturn(func(_ context.Context, _, _ string) (storage.UpstreamTokenRowID, error) {
+			if resolves.Add(1) == 2 {
+				close(followerResolved)
+			}
+			return storage.UpstreamTokenRowID("shared-row"), nil
+		})
+		store.EXPECT().GetUpstreamTokens(gomock.Any(), "leader", "github").
+			Times(1).Return(expired, storage.ErrExpired)
+		provider.EXPECT().RefreshTokens(gomock.Any(), "stale", "subject").Times(1).
+			DoAndReturn(func(ctx context.Context, _, _ string) (*upstream.Tokens, error) {
+				close(leaderEntered)
+				select {
+				case <-release:
+					return &upstream.Tokens{AccessToken: "fresh", ExpiresAt: time.Now().Add(time.Hour)}, nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			})
+		store.EXPECT().StoreUpstreamTokens(gomock.Any(), "leader", "github", gomock.Any()).Times(1).Return(nil)
+
+		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
+		var wg sync.WaitGroup
+		var leaderResult, followerResult *storage.UpstreamTokens
+		var leaderErr, followerErr error
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			leaderResult, leaderErr = refresher.RefreshAndStore(context.Background(), "leader", expired)
+		}()
+		select {
+		case <-leaderEntered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for leader to start refresh")
+		}
+		go func() {
+			defer wg.Done()
+			followerResult, followerErr = refresher.RefreshAndStore(context.Background(), "follower", &storage.UpstreamTokens{ProviderID: "github", RefreshToken: "different-stale"})
+		}()
+		select {
+		case <-followerResolved:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for follower to resolve shared row")
+		}
+		close(release)
+		waitGroupTimeout(t, &wg, "timeout waiting for row-identity refresh callers")
+		require.NoError(t, leaderErr)
+		require.NoError(t, followerErr)
+		require.NotNil(t, leaderResult)
+		require.NotNil(t, followerResult)
+		assert.Equal(t, "fresh", leaderResult.AccessToken)
+		assert.Equal(t, "fresh", followerResult.AccessToken)
+		assert.NotSame(t, leaderResult, followerResult)
+		leaderResult.AccessToken = "mutated-access"
+		assert.Equal(t, "fresh", followerResult.AccessToken,
+			"mutating one session's result must not change the other session's result")
+	})
+
+	t.Run("late stale caller returns authoritative fresh row", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		store := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		provider := upstreammocks.NewMockOAuth2Provider(ctrl)
+		expired := &storage.UpstreamTokens{ProviderID: "github", RefreshToken: "stale", UpstreamSubject: "subject"}
+		fresh := &storage.UpstreamTokens{ProviderID: "github", AccessToken: "fresh", RefreshToken: "rotated"}
+
+		store.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session", "github").Times(2).
+			Return(storage.UpstreamTokenRowID("row"), nil)
+		store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Times(1).Return(expired, storage.ErrExpired)
+		store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Times(1).Return(fresh, nil)
+		provider.EXPECT().RefreshTokens(gomock.Any(), "stale", "subject").Times(1).
+			Return(&upstream.Tokens{AccessToken: "fresh", RefreshToken: "rotated", ExpiresAt: time.Now().Add(time.Hour)}, nil)
+		store.EXPECT().StoreUpstreamTokens(gomock.Any(), "session", "github", gomock.Any()).Times(1).Return(nil)
+
+		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
+		_, err := refresher.RefreshAndStore(context.Background(), "session", expired)
+		require.NoError(t, err)
+		result, err := refresher.RefreshAndStore(context.Background(), "session", expired)
+		require.NoError(t, err)
+		assert.NotSame(t, fresh, result)
+		assert.Equal(t, fresh, result)
+		result.AccessToken = "mutated-access"
+		assert.Equal(t, "fresh", fresh.AccessToken, "mutating the returned result must not change the stored result")
+	})
+
+	t.Run("re-read returns expired row without ErrExpired - still refreshes", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		store := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		provider := upstreammocks.NewMockOAuth2Provider(ctrl)
+		expired := &storage.UpstreamTokens{ProviderID: "github", RefreshToken: "stale", UpstreamSubject: "subject"}
+		// staleButUnflagged simulates a storage backend that does not check
+		// access-token expiry on GetUpstreamTokens (per the interface docs):
+		// it returns (row, nil) even though ExpiresAt is in the past.
+		staleButUnflagged := &storage.UpstreamTokens{
+			ProviderID:      "github",
+			RefreshToken:    "stale",
+			UpstreamSubject: "subject",
+			ExpiresAt:       time.Now().Add(-time.Hour),
+		}
+
+		store.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session", "github").Times(2).
+			Return(storage.UpstreamTokenRowID("row"), nil)
+		store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Times(1).Return(expired, storage.ErrExpired)
+		store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Times(1).Return(staleButUnflagged, nil)
+		provider.EXPECT().RefreshTokens(gomock.Any(), "stale", "subject").Times(2).
+			Return(&upstream.Tokens{AccessToken: "fresh", RefreshToken: "rotated", ExpiresAt: time.Now().Add(time.Hour)}, nil)
+		store.EXPECT().StoreUpstreamTokens(gomock.Any(), "session", "github", gomock.Any()).Times(2).Return(nil)
+
+		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
+		_, err := refresher.RefreshAndStore(context.Background(), "session", expired)
+		require.NoError(t, err)
+		result, err := refresher.RefreshAndStore(context.Background(), "session", expired)
+		require.NoError(t, err)
+		assert.Equal(t, "fresh", result.AccessToken,
+			"a re-read row that is expired but not flagged ErrExpired must still be refreshed")
+	})
+
+	t.Run("re-read returns nil row without error - fails loudly", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		store := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		provider := upstreammocks.NewMockOAuth2Provider(ctrl)
+
+		store.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session", "github").
+			Return(storage.UpstreamTokenRowID("row"), nil)
+		store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").
+			Return((*storage.UpstreamTokens)(nil), nil)
+
+		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
+		_, err := refresher.RefreshAndStore(context.Background(), "session",
+			&storage.UpstreamTokens{ProviderID: "github", RefreshToken: "stale"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing on re-read")
+	})
+
+	t.Run("resolver errors and empty identities stop before refresh", func(t *testing.T) {
+		t.Parallel()
+		for _, tt := range []struct {
+			name string
+			id   storage.UpstreamTokenRowID
+			err  error
+		}{
+			{name: "resolver error", err: errors.New("resolve failed")},
+			{name: "empty identity"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				ctrl := gomock.NewController(t)
+				store := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+				provider := upstreammocks.NewMockOAuth2Provider(ctrl)
+				store.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session", "github").Return(tt.id, tt.err)
+				refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
+
+				_, err := refresher.RefreshAndStore(context.Background(), "session", &storage.UpstreamTokens{ProviderID: "github", RefreshToken: "stale"})
+				require.Error(t, err)
+			})
+		}
 	})
 }

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -205,7 +205,8 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage, opts ...se
 	// refresh an expired upstream leg during login instead of skipping it and
 	// failing later at MCP-request token-swap time. The same instance is stored
 	// on the server so UpstreamTokenRefresher() returns the identical object,
-	// ensuring both paths share one singleflight.Group.
+	// ensuring both paths share one process-local singleflight.Group keyed by
+	// opaque storage-row identity.
 	refresher := newUpstreamTokenRefresher(upstreams, stor, cfg.RefreshTokenLifespan)
 	handlerInstance, err := handlers.NewHandler(fositeProvider, authServerConfig, stor, upstreams,
 		buildHandlerOptions(refresher, cfg.UpstreamFilter)...)
@@ -324,8 +325,8 @@ func (s *server) DCRStore() storage.DCRCredentialStore {
 
 // UpstreamTokenRefresher returns the single shared refresher constructed in
 // newServer. Both the handler's chain-walk path and the runtime token-swap
-// path use this instance, ensuring concurrent refreshes for the same
-// (session, provider) pair are deduplicated by a single singleflight.Group.
+// path use this instance, ensuring concurrent refreshes for the same logical
+// upstream-token row are deduplicated by one process-local singleflight.Group.
 func (s *server) UpstreamTokenRefresher() storage.UpstreamTokenRefresher {
 	return s.upstreamRefresher
 }

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -863,6 +863,18 @@ func (s *MemoryStorage) DeletePKCERequestSession(_ context.Context, signature st
 // Upstream Token Storage
 // -----------------------
 
+// ResolveUpstreamTokenRowID returns an opaque ID for process-local refresh
+// coordination of a logical upstream-token row.
+func (*MemoryStorage) ResolveUpstreamTokenRowID(_ context.Context, sessionID, providerName string) (UpstreamTokenRowID, error) {
+	if sessionID == "" {
+		return "", fosite.ErrInvalidRequest.WithHint("session ID cannot be empty")
+	}
+	if providerName == "" {
+		return "", fosite.ErrInvalidRequest.WithHint("provider name cannot be empty")
+	}
+	return upstreamTokenRowID(sessionID, providerName), nil
+}
+
 // StoreUpstreamTokens stores the upstream IDP tokens for a session and provider.
 // A defensive copy is made to prevent aliasing issues.
 func (s *MemoryStorage) StoreUpstreamTokens(_ context.Context, sessionID, providerName string, tokens *UpstreamTokens) error {

--- a/pkg/authserver/storage/mocks/mock_storage.go
+++ b/pkg/authserver/storage/mocks/mock_storage.go
@@ -331,6 +331,21 @@ func (mr *MockUpstreamTokenStorageMockRecorder) GetUpstreamTokens(ctx, sessionID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpstreamTokens", reflect.TypeOf((*MockUpstreamTokenStorage)(nil).GetUpstreamTokens), ctx, sessionID, providerName)
 }
 
+// ResolveUpstreamTokenRowID mocks base method.
+func (m *MockUpstreamTokenStorage) ResolveUpstreamTokenRowID(ctx context.Context, sessionID, providerName string) (storage.UpstreamTokenRowID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveUpstreamTokenRowID", ctx, sessionID, providerName)
+	ret0, _ := ret[0].(storage.UpstreamTokenRowID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveUpstreamTokenRowID indicates an expected call of ResolveUpstreamTokenRowID.
+func (mr *MockUpstreamTokenStorageMockRecorder) ResolveUpstreamTokenRowID(ctx, sessionID, providerName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveUpstreamTokenRowID", reflect.TypeOf((*MockUpstreamTokenStorage)(nil).ResolveUpstreamTokenRowID), ctx, sessionID, providerName)
+}
+
 // StoreUpstreamTokens mocks base method.
 func (m *MockUpstreamTokenStorage) StoreUpstreamTokens(ctx context.Context, sessionID, providerName string, tokens *storage.UpstreamTokens) error {
 	m.ctrl.T.Helper()
@@ -977,6 +992,21 @@ func (m *MockStorage) RenewClientTTL(ctx context.Context, client fosite.Client) 
 func (mr *MockStorageMockRecorder) RenewClientTTL(ctx, client any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenewClientTTL", reflect.TypeOf((*MockStorage)(nil).RenewClientTTL), ctx, client)
+}
+
+// ResolveUpstreamTokenRowID mocks base method.
+func (m *MockStorage) ResolveUpstreamTokenRowID(ctx context.Context, sessionID, providerName string) (storage.UpstreamTokenRowID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveUpstreamTokenRowID", ctx, sessionID, providerName)
+	ret0, _ := ret[0].(storage.UpstreamTokenRowID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveUpstreamTokenRowID indicates an expected call of ResolveUpstreamTokenRowID.
+func (mr *MockStorageMockRecorder) ResolveUpstreamTokenRowID(ctx, sessionID, providerName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveUpstreamTokenRowID", reflect.TypeOf((*MockStorage)(nil).ResolveUpstreamTokenRowID), ctx, sessionID, providerName)
 }
 
 // RevokeAccessToken mocks base method.

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1044,6 +1044,18 @@ func (s *RedisStorage) StoreUpstreamTokens(ctx context.Context, sessionID, provi
 	return nil
 }
 
+// ResolveUpstreamTokenRowID returns an opaque ID for process-local refresh
+// coordination of a logical upstream-token row.
+func (s *RedisStorage) ResolveUpstreamTokenRowID(_ context.Context, sessionID, providerName string) (UpstreamTokenRowID, error) {
+	if sessionID == "" {
+		return "", fosite.ErrInvalidRequest.WithHint("session ID cannot be empty")
+	}
+	if providerName == "" {
+		return "", fosite.ErrInvalidRequest.WithHint("provider name cannot be empty")
+	}
+	return upstreamTokenRowID(redisUpstreamKey(s.keyPrefix, sessionID, providerName)), nil
+}
+
 // GetUpstreamTokens retrieves the upstream IDP tokens for a session and provider.
 // Returns a new UpstreamTokens struct deserialized from Redis, which acts as
 // a defensive copy - callers cannot modify the stored data by mutating the return value.

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"slices"
 	"sort"
 	"time"
@@ -550,6 +551,23 @@ type ClientRegistry interface {
 	RenewClientTTL(ctx context.Context, client fosite.Client) error
 }
 
+// UpstreamTokenRowID is an opaque, process-local coordination key for one
+// logical upstream token row. Callers must not persist, log, or expose it.
+type UpstreamTokenRowID string
+
+// upstreamTokenRowID returns a SHA-256 digest of the supplied row-key components.
+// Each component is length-prefixed so the encoding is self-delimiting: distinct
+// inputs cannot share a canonical representation when a component contains the
+// delimiter. Hashing keeps the session ID out of a value that is easy to log.
+func upstreamTokenRowID(components ...string) UpstreamTokenRowID {
+	h := sha256.New()
+	for _, component := range components {
+		// hash.Hash.Write never returns an error.
+		_, _ = fmt.Fprintf(h, "%d:%s", len(component), component)
+	}
+	return UpstreamTokenRowID(hex.EncodeToString(h.Sum(nil)))
+}
+
 // UpstreamTokenStorage provides storage for tokens obtained from upstream identity providers.
 // The auth server exposes this interface via Server.UpstreamTokenStorage() for use by
 // middleware that needs to retrieve upstream tokens (e.g., token swap middleware that
@@ -560,6 +578,23 @@ type ClientRegistry interface {
 // A secondary lookup by (userID, providerID) is exposed via GetLatestUpstreamTokensForUser;
 // see that method for usage and security contract.
 type UpstreamTokenStorage interface {
+	// ResolveUpstreamTokenRowID returns an opaque non-empty identity for the
+	// (sessionID, providerName) row. Equal physical rows must resolve to equal
+	// IDs; implementations must NOT alias rows that are not physically the
+	// same row (e.g. two distinct sessionIDs), because the singleflight leader
+	// reads and writes under its own sessionID, and aliasing distinct rows
+	// would cross credentials between sessions. A backend whose storage key is
+	// derived from (sessionID, providerName) may legitimately map two
+	// different (sessionID, providerName) pairs to the same ID when they are
+	// the same physical row under that key scheme.
+	//
+	// Resolution must be local and side-effect-free (no I/O): it is called
+	// before the singleflight joins, so any I/O here gives every concurrent
+	// caller its own round-trip and partially defeats the deduplication. This
+	// ID is solely for process-local refresh coordination: callers must not
+	// persist, log, or expose it.
+	ResolveUpstreamTokenRowID(ctx context.Context, sessionID, providerName string) (UpstreamTokenRowID, error)
+
 	// StoreUpstreamTokens stores the upstream IDP tokens for a session and provider.
 	// The providerName identifies which upstream provider these tokens belong to.
 	StoreUpstreamTokens(ctx context.Context, sessionID, providerName string, tokens *UpstreamTokens) error

--- a/pkg/authserver/storage/types_test.go
+++ b/pkg/authserver/storage/types_test.go
@@ -15,8 +15,13 @@
 package storage
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/ory/fosite"
 )
 
 func TestUpstreamTokens_IsExpired(t *testing.T) {
@@ -86,6 +91,72 @@ func TestUpstreamTokens_IsExpired(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("IsExpired(%v) = %v, want %v (expiresAt=%v)",
 					tt.checkTime, got, tt.want, tt.expiresAt)
+			}
+		})
+	}
+}
+
+func TestUpstreamTokenRowIDResolution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		resolver              UpstreamTokenStorage
+		delimiterRowsDistinct bool
+	}{
+		{name: "memory", resolver: NewMemoryStorage(), delimiterRowsDistinct: true},
+		{name: "redis", resolver: &RedisStorage{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if memory, ok := tt.resolver.(*MemoryStorage); ok {
+				t.Cleanup(func() { _ = memory.Close() })
+			}
+
+			first, err := tt.resolver.ResolveUpstreamTokenRowID(context.Background(), "session:one", "provider:one")
+			if err != nil {
+				t.Fatalf("resolve first row: %v", err)
+			}
+			again, err := tt.resolver.ResolveUpstreamTokenRowID(context.Background(), "session:one", "provider:one")
+			if err != nil {
+				t.Fatalf("resolve same row: %v", err)
+			}
+			otherSession, err := tt.resolver.ResolveUpstreamTokenRowID(context.Background(), "session", "one:provider:one")
+			if err != nil {
+				t.Fatalf("resolve delimiter row: %v", err)
+			}
+			otherProvider, err := tt.resolver.ResolveUpstreamTokenRowID(context.Background(), "session:one", "provider:two")
+			if err != nil {
+				t.Fatalf("resolve different provider: %v", err)
+			}
+
+			if first == "" {
+				t.Error("row ID must not be empty")
+			}
+			if first != again {
+				t.Errorf("same row IDs differ: %q and %q", first, again)
+			}
+			if tt.delimiterRowsDistinct {
+				if first == otherSession {
+					t.Errorf("distinct delimiter rows must have distinct IDs: %q and %q", first, otherSession)
+				}
+			} else if first != otherSession {
+				t.Errorf("equivalent Redis row keys must have equal IDs: %q and %q", first, otherSession)
+			}
+			if first == otherProvider || otherSession == otherProvider {
+				t.Errorf("distinct rows must have distinct IDs: %q, %q, %q", first, otherSession, otherProvider)
+			}
+			if strings.Contains(string(first), "session") || strings.Contains(string(first), "provider") {
+				t.Errorf("row ID must be opaque, got %q", first)
+			}
+
+			for _, input := range [][2]string{{"", "provider"}, {"session", ""}} {
+				_, err := tt.resolver.ResolveUpstreamTokenRowID(context.Background(), input[0], input[1])
+				if !errors.Is(err, fosite.ErrInvalidRequest) {
+					t.Errorf("resolve(%q, %q) error = %v, want invalid request", input[0], input[1], err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Rotating refresh tokens can be redeemed twice when callers resolve to the same storage row but use different session IDs; this can trigger IdP replay detection and revoke the credential family.
- Key in-process refresh coordination on an opaque storage-row identity, re-read the authoritative row within the flight, and return isolated token copies to each caller.
- Add regression coverage for aliased rows, late stale callers, independent rows, resolver failures, and opaque identity behavior.

Fixes #6356

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`) — run; blocked by the unrelated Docker predefined-address-pool exhaustion in `pkg/container/docker/TestCreateNetwork_ConcurrentSameName`.
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

| File | Change |
|------|--------|
| `pkg/authserver/storage/types.go` | Add opaque storage-row identity resolution contract. |
| `pkg/authserver/storage/{memory,redis}.go` | Derive hashed identities from each backend’s row representation. |
| `pkg/authserver/refresher.go` | Coordinate by row, re-read authoritatively, and isolate returned results. |
| `pkg/authserver/refresher_test.go` | Cover concurrent, stale, failure, and result-isolation cases. |
| `pkg/authserver/storage/types_test.go` | Cover backend row-ID behavior. |
| `docs/arch/11-auth-server-storage.md` | Document the process-local scope and #4122 boundary. |

## Does this introduce a user-facing change?

No

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

1. Add a non-empty opaque `UpstreamTokenRowID` and resolver to `UpstreamTokenStorage`; storage defines which logical lookups share a row.
2. Implement a collision-resistant hashed row identity in Memory and Redis without exposing row keys.
3. Resolve the row ID before `singleflight`, then re-read the authoritative row inside the bounded flight; return a fresh row directly or refresh the re-read expired snapshot.
4. Preserve the existing leader session/provider write and rotated-token cleanup path under the storage consistency contract.
5. Test aliased rows, late stale callers, distinct rows, resolver failures, and isolated result pointers.
6. Regenerate mocks and run lint, tests, and license checks.

</details>

## Special notes for reviewers

- This prevents duplicate refresh-token redemption for one storage row within one process. Cross-replica coordination and CAS-style protection remain out of scope and are tracked by #4122.
- `task test` reached the changed auth/storage packages successfully but failed in the Docker network test because the local Docker daemon had exhausted its predefined address pools.
