### PR TITLE
Guard test backend ready channel against double close

### DIFF
--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -140,6 +140,10 @@ type listChangedTestBackend struct {
 	// ready closes once OnRegisterSession has captured session, decoupling
 	// addTool/addResource/addPrompt from the client-side race noted below.
 	ready chan struct{}
+	// readyOnce guards the close: OnRegisterSession fires once per registered
+	// session, and a backend can legitimately serve more than one client, so an
+	// unguarded close panics with "close of closed channel" (#6362).
+	readyOnce sync.Once
 
 	mu        sync.Mutex
 	session   mcpserver.ClientSession
@@ -233,7 +237,7 @@ func newListChangedTestBackend(t *testing.T) *listChangedTestBackend {
 		}
 		sessionWithPrompts.SetSessionPrompts(prompts)
 
-		close(b.ready)
+		b.readyOnce.Do(func() { close(b.ready) })
 	})
 
 	srv := mcpserver.NewMCPServer("list-changed-backend", "1.0.0",


### PR DESCRIPTION
## Summary

`TestCreateMCPClient_ContinuousListeningGatedOnSink` shares one `listChangedTestBackend` across two `t.Parallel()` subtests, each of which connects its own MCP client. The backend's `OnRegisterSession` hook did an unguarded `close(b.ready)` — but that hook fires once per *registered session*, not once per backend. When both clients registered, the channel was closed twice and the test binary died with `panic: close of closed channel`.

Because the panic aborts the whole binary, it surfaced as a failure of whatever unrelated test happened to be mid-run — `TestInitAndQueryCapabilities_FatalErrors`, `TestParsingMiddlewareWithRealMCPClients`, a `pkg/ignore` test — which made it look like several different flakes rather than one bug.

The fix guards the close with a `sync.Once`, so the helper is correct no matter how many sessions register. The alternative (give each subtest its own backend) fixes this call site but leaves the helper fragile for the next test that shares one.

Closes #6362

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Unit tests pass

Reproduced first, then verified the fix. The panic needs varied `GOMAXPROCS`; it does not fire at default parallelism.

Before (fires within ~3 iterations):

```
go test -race -count=40 -cpu=1,2,8 ./pkg/vmcp/session/internal/backend/
...
panic: close of closed channel
	pkg/vmcp/session/internal/backend/mcp_session_test.go:236
	mcpcompat/server.(*Hooks).registerSession
	mcpcompat/server.(*MCPServer).registerAndSync
	go-sdk/mcp.(*ServerSession).initialized
```

After: 4 × `-count=40 -cpu=1,2,8` (480 runs) all green. A separate 720-run check during investigation was also clean.

Plain `-count=60` at default `-cpu` stayed green both before and after, which is why this only showed up on CI runners.

## Does this introduce a user-facing change?

No — test-only change.

Generated with [Claude Code](https://claude.com/claude-code)
