### PR TITLE
Sweep leaked workloads after local e2e runs

### DIFF
--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -80,12 +80,48 @@ fi
 
 GINKGO_CMD="$GINKGO_CMD ."
 
+# List workload names currently known to thv, one per line. Returns nothing
+# (not an error) if thv isn't available or the call fails, so the sweep below
+# degrades to a no-op instead of crashing the script.
+list_workload_names() {
+    "$THV_BINARY" list --all --format json 2>/dev/null | grep -o '"name": *"[^"]*"' | sed -E 's/.*"([^"]*)"$/\1/'
+}
+
+# Snapshot workloads that already existed before this run, so the post-run
+# sweep only ever touches workloads this run created. A developer's own
+# pre-existing workloads are never in this diff and are never touched.
+PRE_RUN_WORKLOADS="$(list_workload_names || true)"
+
 if eval "$GINKGO_CMD"; then
+    GINKGO_EXIT=0
     echo ""
     echo -e "${GREEN}✓ All E2E tests passed!${NC}"
-    exit 0
 else
+    GINKGO_EXIT=$?
     echo ""
     echo -e "${RED}✗ Some E2E tests failed${NC}"
-    exit 1
 fi
+
+# Safety net: sweep workloads leaked by this run (e.g. Ginkgo's --timeout
+# force-killing the suite mid-test, skipping AfterEach/AfterSuite cleanup).
+# This runs unconditionally, regardless of the ginkgo exit code above, and
+# only removes workloads that appeared during this run (diffed against the
+# pre-run snapshot) -- never a blanket "remove everything thv knows about".
+echo ""
+echo -e "${YELLOW}Checking for leaked e2e workloads...${NC}"
+LEAKED_WORKLOADS="$(comm -13 <(echo "$PRE_RUN_WORKLOADS" | sort) <(list_workload_names | sort) || true)"
+if [ -n "$LEAKED_WORKLOADS" ]; then
+    echo -e "${YELLOW}Sweeping leaked workloads not cleaned up by the test run:${NC}"
+    while IFS= read -r workload; do
+        [ -z "$workload" ] && continue
+        echo "  - $workload"
+        if ! RM_OUTPUT=$("$THV_BINARY" rm "$workload" 2>&1); then
+            echo -e "    ${RED}(failed to remove $workload, leaving for manual cleanup)${NC}"
+            echo "$RM_OUTPUT" | sed 's/^/    /'
+        fi
+    done <<< "$LEAKED_WORKLOADS"
+else
+    echo -e "${GREEN}✓${NC} No leaked workloads found"
+fi
+
+exit "$GINKGO_EXIT"


### PR DESCRIPTION
## Summary

- Local `task test-e2e` runs the whole `test/e2e` Ginkgo suite unfiltered with a single 20m `--timeout`, while CI splits the same suite into ~15 label-filtered jobs (some needing up to 25m for one slice alone). A full local run regularly exceeds the 20m budget.
- When Ginkgo's timeout fires, it force-kills the process after a 30s grace period, skipping any `AfterEach`/`AfterSuite` cleanup that hadn't finished yet. Every `thv` workload (and its Docker network) created up to that point stays behind. Enough of these accumulating over time exhausted the local Docker network address pool and broke unrelated, real MCP workloads on a dev machine.
- Per-test cleanup code itself is not missing or broken — it's just skipped when the whole process dies. This adds a shell-level safety net in `test/e2e/run_tests.sh` that survives that failure mode: it snapshots `thv list --all` before `ginkgo run` and diffs it against the same listing afterward, removing only workloads that appeared during the run. That's deliberately not a hardcoded name-prefix list — test files use dozens of ad hoc naming schemes and there's no existing "e2e"/"test" label to key on — so a before/after diff is the only approach that can't misfire on a workload a developer already had running.
- The sweep runs unconditionally (pass, fail, or timeout-kill) and doesn't change the script's exit code.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

Manual verification only, no full e2e run:
- `bash -n test/e2e/run_tests.sh` — syntax clean
- `shellcheck` — no new blocking findings
- Read through `cmd/thv/app/list.go` and `rm.go` to confirm `thv list --all --format json` and `thv rm <name>` behave as the script assumes

## Does this introduce a user-facing change?

No — this only affects local developer tooling for running the e2e suite.

## Special notes for reviewers

- `test/e2e/run_tests.bat` (Windows) is not touched. The diff-based sweep needs `comm`/process substitution with no clean batch equivalent; mirroring this for Windows would need a different implementation.
- This does not fix the underlying cause of local runs legitimately exceeding the 20m timeout (no label-splitting locally, unlike CI). That's a separate follow-up — this PR only adds the safety net so a timeout-kill stops leaking Docker resources in the meantime.
