### PR TITLE
Annotate vMCP optimizer discovery tool

### DIFF
--- a/pkg/vmcp/session/optimizerdec/decorator.go
+++ b/pkg/vmcp/session/optimizerdec/decorator.go
@@ -60,6 +60,11 @@ func NewDecorator(sess sessiontypes.MultiSession, opt optimizer.Optimizer) sessi
 // identical pair; each consumer wires its own handlers around these definitions.
 // A fresh slice is returned on every call so callers cannot mutate shared state.
 func OptimizerTools() []vmcp.Tool {
+	readOnly := true
+	destructive := false
+	idempotent := true
+	openWorld := false
+
 	return []vmcp.Tool{
 		{
 			Name: FindToolName,
@@ -74,6 +79,12 @@ func OptimizerTools() []vmcp.Tool {
 				"baseline_tokens, returned_tokens, and savings_percent. " +
 				"Always call this before call_tool to discover the correct tool name and parameter schema.",
 			InputSchema: findToolInputSchema,
+			Annotations: &vmcp.ToolAnnotations{
+				ReadOnlyHint:    &readOnly,
+				DestructiveHint: &destructive,
+				IdempotentHint:  &idempotent,
+				OpenWorldHint:   &openWorld,
+			},
 		},
 		{
 			Name: CallToolName,

--- a/pkg/vmcp/session/optimizerdec/decorator_test.go
+++ b/pkg/vmcp/session/optimizerdec/decorator_test.go
@@ -52,6 +52,12 @@ func TestOptimizerDecorator_Tools(t *testing.T) {
 		require.Len(t, got, 2)
 		assert.Equal(t, "find_tool", got[0].Name)
 		assert.Equal(t, "call_tool", got[1].Name)
+		require.NotNil(t, got[0].Annotations)
+		assert.True(t, *got[0].Annotations.ReadOnlyHint)
+		assert.False(t, *got[0].Annotations.DestructiveHint)
+		assert.True(t, *got[0].Annotations.IdempotentHint)
+		assert.False(t, *got[0].Annotations.OpenWorldHint)
+		assert.Nil(t, got[1].Annotations)
 		// Both tools must have non-empty input schemas.
 		assert.NotEmpty(t, got[0].InputSchema)
 		assert.NotEmpty(t, got[1].InputSchema)


### PR DESCRIPTION
## Summary

The vMCP optimizer exposes `find_tool` as a local tool-discovery operation, but its MCP definition currently carries no behavioral hints. Clients cannot distinguish this safe discovery step from a tool that may mutate external state, which limits safe retry and tool-selection behavior in Agent workflows.

- Add MCP annotations to `find_tool`: read-only, non-destructive, idempotent, and closed-world.
- Leave `call_tool` unannotated because it can proxy arbitrary backend side effects.

Part of #4357

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task -t Taskfile.focused.yml test`, using the repository's `-race` and linker settings for `./pkg/vmcp/session/optimizerdec` and `./pkg/vmcp/conversion`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/session/optimizerdec/decorator.go` | Add behavioral annotations to `find_tool`. |
| `pkg/vmcp/session/optimizerdec/decorator_test.go` | Assert the discovery tool annotations and preserve the unannotated `call_tool` contract. |

## Does this introduce a user-facing change?

Yes. MCP clients that consume tool annotations can now identify `find_tool` as a safe, retryable local discovery operation.

## Special notes for reviewers

The annotation is deliberately limited to `find_tool`. `call_tool` dispatches arbitrary backend tools, so asserting read-only or non-destructive behavior there would be incorrect.
