### PR TITLE
fix(operator): recreate deleted MCPServer StatefulSet

### DIFF
--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -29,10 +29,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcpv1alpha1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1alpha1"
@@ -581,6 +583,13 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		// Spec updated - return and requeue
 		return ctrl.Result{Requeue: true}, nil
+	}
+
+	if result, err := r.ensureWorkloadStatefulSet(ctx, mcpServer, deployment); err != nil {
+		ctxLogger.Error(err, "Failed to ensure workload StatefulSet")
+		return ctrl.Result{}, err
+	} else if result.Requeue || result.RequeueAfter > 0 {
+		return result, nil
 	}
 
 	return ctrl.Result{}, nil
@@ -1690,8 +1699,21 @@ func (r *MCPServerReconciler) updateMCPServerStatus(ctx context.Context, m *mcpv
 	// Set ReadyReplicas to the count of running pods
 	m.Status.ReadyReplicas = int32(running)
 
-	// Update the status based on pod health
+	// Proxy pods alone are not enough: stdio (and other) transports run the
+	// real MCP process in a sibling StatefulSet created by the proxy-runner.
+	// If that STS is gone, clients hit a dead backend while Ready stays true
+	// (#6343). Surface the gap instead of claiming the server is running.
 	if running > 0 {
+		missing, stsErr := r.statefulSetMissing(ctx, m)
+		if stsErr != nil {
+			return stsErr
+		}
+		if missing {
+			m.Status.Phase = mcpv1beta1.MCPServerPhasePending
+			m.Status.Message = "MCP server proxy is running; recreating missing workload StatefulSet"
+			setReadyCondition(m, metav1.ConditionFalse, mcpv1beta1.ConditionReasonNotReady, m.Status.Message)
+			return r.Status().Update(ctx, m)
+		}
 		m.Status.Phase = mcpv1beta1.MCPServerPhaseReady
 		m.Status.Message = "MCP server is running"
 	} else if failed > 0 {
@@ -3003,6 +3025,12 @@ func (r *MCPServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&mcpv1beta1.MCPServer{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&appsv1.StatefulSet{}).
+		Watches(
+			&appsv1.StatefulSet{},
+			handler.EnqueueRequestsFromMapFunc(r.mapStatefulSetToMCPServer),
+			builder.WithPredicates(predicate.NewPredicateFuncs(isToolhiveStatefulSet)),
+		).
 		Watches(&mcpv1beta1.MCPExternalAuthConfig{}, externalAuthConfigHandler).
 		Watches(&mcpv1beta1.MCPOIDCConfig{}, oidcConfigHandler).
 		Watches(&mcpv1beta1.MCPAuthzConfig{}, authzConfigHandler).

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -1108,7 +1108,7 @@ func (r *MCPServerReconciler) deploymentForMCPServer(
 
 	// Using ConfigMap mode for all configuration
 	// Pod template patch for secrets and service account
-	builder, err := ctrlutil.NewPodTemplateSpecBuilder(m.Spec.PodTemplateSpec, mcpContainerName)
+	ptsBuilder, err := ctrlutil.NewPodTemplateSpecBuilder(m.Spec.PodTemplateSpec, mcpContainerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build PodTemplateSpec: %w", err)
 	}
@@ -1118,7 +1118,7 @@ func (r *MCPServerReconciler) deploymentForMCPServer(
 		defaultSA := mcpServerServiceAccountName(m.Name)
 		serviceAccount = &defaultSA
 	}
-	finalPodTemplateSpec := builder.
+	finalPodTemplateSpec := ptsBuilder.
 		WithServiceAccount(serviceAccount).
 		WithSecrets(m.Spec.Secrets).
 		Build()
@@ -1704,15 +1704,12 @@ func (r *MCPServerReconciler) updateMCPServerStatus(ctx context.Context, m *mcpv
 	// If that STS is gone, clients hit a dead backend while Ready stays true
 	// (#6343). Surface the gap instead of claiming the server is running.
 	if running > 0 {
-		missing, stsErr := r.statefulSetMissing(ctx, m)
+		updated, stsErr := r.statusIfWorkloadStatefulSetMissing(ctx, m)
 		if stsErr != nil {
 			return stsErr
 		}
-		if missing {
-			m.Status.Phase = mcpv1beta1.MCPServerPhasePending
-			m.Status.Message = "MCP server proxy is running; recreating missing workload StatefulSet"
-			setReadyCondition(m, metav1.ConditionFalse, mcpv1beta1.ConditionReasonNotReady, m.Status.Message)
-			return r.Status().Update(ctx, m)
+		if updated {
+			return nil
 		}
 		m.Status.Phase = mcpv1beta1.MCPServerPhaseReady
 		m.Status.Message = "MCP server is running"
@@ -1740,6 +1737,23 @@ func (r *MCPServerReconciler) updateMCPServerStatus(ctx context.Context, m *mcpv
 
 	// Update the status
 	return r.Status().Update(ctx, m)
+}
+
+
+// statusIfWorkloadStatefulSetMissing sets Pending when the proxy is up but the
+// sibling workload STS is gone (#6343). Returns true if status was written.
+func (r *MCPServerReconciler) statusIfWorkloadStatefulSetMissing(ctx context.Context, m *mcpv1beta1.MCPServer) (bool, error) {
+	missing, err := r.statefulSetMissing(ctx, m)
+	if err != nil {
+		return false, err
+	}
+	if !missing {
+		return false, nil
+	}
+	m.Status.Phase = mcpv1beta1.MCPServerPhasePending
+	m.Status.Message = "MCP server proxy is running; recreating missing workload StatefulSet"
+	setReadyCondition(m, metav1.ConditionFalse, mcpv1beta1.ConditionReasonNotReady, m.Status.Message)
+	return true, r.Status().Update(ctx, m)
 }
 
 // deleteIfExists fetches a Kubernetes object by name and namespace, and deletes it if it exists.
@@ -1971,13 +1985,13 @@ func (r *MCPServerReconciler) deploymentNeedsUpdate(
 			serviceAccount = &defaultSA
 		}
 
-		builder, err := ctrlutil.NewPodTemplateSpecBuilder(mcpServer.Spec.PodTemplateSpec, mcpContainerName)
+		ptsBuilder, err := ctrlutil.NewPodTemplateSpecBuilder(mcpServer.Spec.PodTemplateSpec, mcpContainerName)
 		if err != nil {
 			// If we can't parse the PodTemplateSpec, consider it as needing update
 			return true
 		}
 
-		expectedPodTemplateSpec := builder.
+		expectedPodTemplateSpec := ptsBuilder.
 			WithServiceAccount(serviceAccount).
 			WithSecrets(mcpServer.Spec.Secrets).
 			Build()

--- a/cmd/thv-operator/controllers/mcpserver_controller.go
+++ b/cmd/thv-operator/controllers/mcpserver_controller.go
@@ -588,7 +588,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if result, err := r.ensureWorkloadStatefulSet(ctx, mcpServer, deployment); err != nil {
 		ctxLogger.Error(err, "Failed to ensure workload StatefulSet")
 		return ctrl.Result{}, err
-	} else if result.Requeue || result.RequeueAfter > 0 {
+	} else if result.RequeueAfter > 0 {
 		return result, nil
 	}
 
@@ -1711,34 +1711,38 @@ func (r *MCPServerReconciler) updateMCPServerStatus(ctx context.Context, m *mcpv
 		if updated {
 			return nil
 		}
+	}
+	applyMCPServerPhaseFromCounts(m, running, pending, failed, failureReason)
+
+	// Update the status
+	return r.Status().Update(ctx, m)
+}
+
+func applyMCPServerPhaseFromCounts(m *mcpv1beta1.MCPServer, running, pending, failed int, failureReason string) {
+	switch {
+	case running > 0:
 		m.Status.Phase = mcpv1beta1.MCPServerPhaseReady
 		m.Status.Message = "MCP server is running"
-	} else if failed > 0 {
+	case failed > 0:
 		m.Status.Phase = mcpv1beta1.MCPServerPhaseFailed
 		if failureReason != "" {
 			m.Status.Message = fmt.Sprintf("MCP server pod failed: %s", failureReason)
 		} else {
 			m.Status.Message = "MCP server pod failed"
 		}
-	} else if pending > 0 {
+	case pending > 0:
 		m.Status.Phase = mcpv1beta1.MCPServerPhasePending
 		m.Status.Message = "MCP server is starting"
-	} else {
+	default:
 		m.Status.Phase = mcpv1beta1.MCPServerPhasePending
 		m.Status.Message = "No healthy pods found"
 	}
-
-	// Set the top-level Ready condition based on the determined phase
 	if m.Status.Phase == mcpv1beta1.MCPServerPhaseReady {
 		setReadyCondition(m, metav1.ConditionTrue, mcpv1beta1.ConditionReasonReady, "MCP server is running")
 	} else {
 		setReadyCondition(m, metav1.ConditionFalse, mcpv1beta1.ConditionReasonNotReady, m.Status.Message)
 	}
-
-	// Update the status
-	return r.Status().Update(ctx, m)
 }
-
 
 // statusIfWorkloadStatefulSetMissing sets Pending when the proxy is up but the
 // sibling workload STS is gone (#6343). Returns true if status was written.

--- a/cmd/thv-operator/controllers/mcpserver_replicas_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_replicas_test.go
@@ -24,6 +24,15 @@ import (
 	"github.com/stacklok/toolhive/pkg/transport/session"
 )
 
+func testWorkloadStatefulSet(name, namespace string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
 func TestReplicaBehavior(t *testing.T) {
 	t.Parallel()
 
@@ -401,7 +410,7 @@ func TestUpdateMCPServerStatusReadyReplicas(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
-		WithObjects(mcpServer, deployment, runningPod1, runningPod2, pendingPod).
+		WithObjects(mcpServer, deployment, testWorkloadStatefulSet(name, namespace), runningPod1, runningPod2, pendingPod).
 		WithStatusSubresource(&mcpv1beta1.MCPServer{}).
 		Build()
 
@@ -846,7 +855,7 @@ func TestUpdateMCPServerStatusExcludesTerminatingPods(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
-		WithObjects(mcpServer, deployment, runningPod1, runningPod2, terminatingPod).
+		WithObjects(mcpServer, deployment, testWorkloadStatefulSet(name, namespace), runningPod1, runningPod2, terminatingPod).
 		WithStatusSubresource(&mcpv1beta1.MCPServer{}).
 		Build()
 

--- a/cmd/thv-operator/controllers/mcpserver_statefulset.go
+++ b/cmd/thv-operator/controllers/mcpserver_statefulset.go
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+)
+
+// statefulSetHealCooldown is how long we wait after bouncing the proxy
+// Deployment before bouncing again while the workload StatefulSet is still
+// missing. The proxy-runner creates the StatefulSet on start; a tight loop
+// would just restart it forever.
+const statefulSetHealCooldown = 2 * time.Minute
+
+// ensureWorkloadStatefulSet makes sure the proxy-runner's backend StatefulSet
+// still exists. The operator does not build that spec (the runner does via
+// server-side apply), but it owns the lifecycle: if the StatefulSet is
+// deleted, the next reconcile must recreate it by bouncing the proxy so the
+// runner re-applies (#6343).
+//
+// When the StatefulSet exists, we adopt it with a controller owner-reference
+// so Kubernetes GC and owner-based watches work, and so "orphan" cleanup
+// scripts stop treating it as leftover.
+func (r *MCPServerReconciler) ensureWorkloadStatefulSet(
+	ctx context.Context,
+	mcpServer *mcpv1beta1.MCPServer,
+	deployment *appsv1.Deployment,
+) (ctrl.Result, error) {
+	ctxLogger := log.FromContext(ctx)
+
+	sts := &appsv1.StatefulSet{}
+	err := r.Get(ctx, types.NamespacedName{Name: mcpServer.Name, Namespace: mcpServer.Namespace}, sts)
+	if err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("failed to get workload StatefulSet: %w", err)
+	}
+
+	if errors.IsNotFound(err) {
+		ctxLogger.Info("Workload StatefulSet missing; waiting for proxy-runner to recreate it",
+			"MCPServer", mcpServer.Name, "namespace", mcpServer.Namespace)
+
+		// The runner creates the StatefulSet on start. Bounce the proxy only
+		// once it is already Available — otherwise we interrupt the first boot.
+		if deployment != nil && deployment.Status.AvailableReplicas > 0 {
+			if err := r.bounceProxyForMissingStatefulSet(ctx, deployment); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	if err := r.adoptWorkloadStatefulSet(ctx, mcpServer, sts); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// bounceProxyForMissingStatefulSet triggers a rolling restart of the proxy
+// Deployment so the runner re-runs DeployWorkload and recreates the STS.
+func (r *MCPServerReconciler) bounceProxyForMissingStatefulSet(
+	ctx context.Context,
+	deployment *appsv1.Deployment,
+) error {
+	ctxLogger := log.FromContext(ctx)
+
+	if recentlyBounced(deployment) {
+		ctxLogger.V(1).Info("Proxy already bounced recently; waiting for StatefulSet to reappear",
+			"Deployment", deployment.Name)
+		return nil
+	}
+
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = map[string]string{}
+	}
+	deployment.Spec.Template.Annotations[RestartedAtAnnotationKey] = time.Now().UTC().Format(time.RFC3339)
+	if err := r.Update(ctx, deployment); err != nil {
+		return fmt.Errorf("failed to bounce proxy Deployment to recreate StatefulSet: %w", err)
+	}
+	ctxLogger.Info("Bounced proxy Deployment so the runner can recreate the missing StatefulSet",
+		"Deployment", deployment.Name)
+	return nil
+}
+
+func recentlyBounced(deployment *appsv1.Deployment) bool {
+	if deployment.Spec.Template.Annotations == nil {
+		return false
+	}
+	raw := deployment.Spec.Template.Annotations[RestartedAtAnnotationKey]
+	if raw == "" {
+		return false
+	}
+	ts, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return false
+	}
+	return time.Since(ts) < statefulSetHealCooldown
+}
+
+// adoptWorkloadStatefulSet sets a controller owner-reference from the
+// MCPServer onto the runner-created StatefulSet when missing.
+func (r *MCPServerReconciler) adoptWorkloadStatefulSet(
+	ctx context.Context,
+	mcpServer *mcpv1beta1.MCPServer,
+	sts *appsv1.StatefulSet,
+) error {
+	for _, ref := range sts.OwnerReferences {
+		if ref.UID == mcpServer.UID && ref.Controller != nil && *ref.Controller {
+			return nil
+		}
+	}
+	if err := controllerutil.SetControllerReference(mcpServer, sts, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set MCPServer owner on StatefulSet: %w", err)
+	}
+	if err := r.Update(ctx, sts); err != nil {
+		return fmt.Errorf("failed to adopt workload StatefulSet: %w", err)
+	}
+	log.FromContext(ctx).Info("Adopted workload StatefulSet under MCPServer",
+		"StatefulSet", sts.Name, "MCPServer", mcpServer.Name)
+	return nil
+}
+
+// mapStatefulSetToMCPServer enqueues the MCPServer that owns a toolhive
+// StatefulSet, including ones the runner created without an owner-reference.
+func (*MCPServerReconciler) mapStatefulSetToMCPServer(_ context.Context, obj client.Object) []reconcile.Request {
+	sts, ok := obj.(*appsv1.StatefulSet)
+	if !ok {
+		return nil
+	}
+	name := sts.Labels["toolhive-name"]
+	if name == "" {
+		name = sts.Name
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: sts.Namespace},
+	}}
+}
+
+// statefulSetMissing reports whether the runner-managed backend StatefulSet
+// is absent. Used by status so Ready is not claimed on a proxy-only stack.
+func (r *MCPServerReconciler) statefulSetMissing(ctx context.Context, m *mcpv1beta1.MCPServer) (bool, error) {
+	sts := &appsv1.StatefulSet{}
+	err := r.Get(ctx, types.NamespacedName{Name: m.Name, Namespace: m.Namespace}, sts)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
+}
+
+// workloadStatefulSetOwnerPredicate keeps the STS watch on ToolHive-labeled
+// objects so we do not enqueue on unrelated StatefulSets in the namespace.
+func isToolhiveStatefulSet(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	return labels["toolhive"] == "true"
+}

--- a/cmd/thv-operator/controllers/mcpserver_statefulset_test.go
+++ b/cmd/thv-operator/controllers/mcpserver_statefulset_test.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
+	"github.com/stacklok/toolhive/cmd/thv-operator/internal/testutil"
+)
+
+func TestEnsureWorkloadStatefulSet_BouncesWhenMissingAndProxyReady(t *testing.T) {
+	t.Parallel()
+	scheme := testutil.NewScheme(t)
+
+	mcpServer := &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "fetch", Namespace: "default", UID: "uid-fetch"},
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "fetch", Namespace: "default"},
+		Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mcpServer, deployment).Build()
+	r := &MCPServerReconciler{Client: k8sClient, Scheme: scheme}
+
+	result, err := r.ensureWorkloadStatefulSet(context.Background(), mcpServer, deployment)
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "fetch", Namespace: "default"}, updated))
+	require.NotEmpty(t, updated.Spec.Template.Annotations[RestartedAtAnnotationKey],
+		"missing StatefulSet with a ready proxy must bounce the Deployment")
+}
+
+func TestEnsureWorkloadStatefulSet_DoesNotBounceBeforeProxyIsAvailable(t *testing.T) {
+	t.Parallel()
+	scheme := testutil.NewScheme(t)
+
+	mcpServer := &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "fetch", Namespace: "default"},
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "fetch", Namespace: "default"},
+		Status:     appsv1.DeploymentStatus{AvailableReplicas: 0},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mcpServer, deployment).Build()
+	r := &MCPServerReconciler{Client: k8sClient, Scheme: scheme}
+
+	_, err := r.ensureWorkloadStatefulSet(context.Background(), mcpServer, deployment)
+	require.NoError(t, err)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "fetch", Namespace: "default"}, updated))
+	assert.Empty(t, updated.Spec.Template.Annotations[RestartedAtAnnotationKey],
+		"first boot must not bounce the proxy before it has created the StatefulSet")
+}
+
+func TestEnsureWorkloadStatefulSet_AdoptsExisting(t *testing.T) {
+	t.Parallel()
+	scheme := testutil.NewScheme(t)
+
+	mcpServer := &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "fetch", Namespace: "default", UID: "uid-fetch"},
+	}
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fetch",
+			Namespace: "default",
+			Labels:    map[string]string{"toolhive": "true", "toolhive-name": "fetch"},
+		},
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "fetch", Namespace: "default"},
+		Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
+	}
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mcpServer, deployment, sts).Build()
+	r := &MCPServerReconciler{Client: k8sClient, Scheme: scheme}
+
+	result, err := r.ensureWorkloadStatefulSet(context.Background(), mcpServer, deployment)
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+
+	updated := &appsv1.StatefulSet{}
+	require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "fetch", Namespace: "default"}, updated))
+	require.Len(t, updated.OwnerReferences, 1)
+	assert.Equal(t, mcpServer.UID, updated.OwnerReferences[0].UID)
+	assert.Equal(t, ptr.To(true), updated.OwnerReferences[0].Controller)
+}
+
+func TestMapStatefulSetToMCPServer(t *testing.T) {
+	t.Parallel()
+	r := &MCPServerReconciler{}
+	reqs := r.mapStatefulSetToMCPServer(context.Background(), &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fetch",
+			Namespace: "tools",
+			Labels:    map[string]string{"toolhive-name": "fetch"},
+		},
+	})
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "fetch", reqs[0].Name)
+	assert.Equal(t, "tools", reqs[0].Namespace)
+}
+
+func TestRecentlyBounced(t *testing.T) {
+	t.Parallel()
+	assert.False(t, recentlyBounced(&appsv1.Deployment{}))
+
+	fresh := &appsv1.Deployment{}
+	fresh.Spec.Template.Annotations = map[string]string{
+		RestartedAtAnnotationKey: time.Now().UTC().Format(time.RFC3339),
+	}
+	assert.True(t, recentlyBounced(fresh))
+
+	stale := &appsv1.Deployment{}
+	stale.Spec.Template.Annotations = map[string]string{
+		RestartedAtAnnotationKey: time.Now().UTC().Add(-3 * time.Minute).Format(time.RFC3339),
+	}
+	assert.False(t, recentlyBounced(stale))
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ For information on the ToolHive Operator, see the
 - **[Composite Tools Quick Reference](operator/composite-tools-quick-reference.md)** - Quick reference for composite tool configuration
 - **[CRD API Reference](operator/crd-api.md)** - Generated API reference for all CRDs
 - **[Restart Annotation](operator/restart-annotation.md)** - Restarting MCPServer instances via annotations
+- **[MCPServer Workloads](operator/mcpserver-workloads.md)** - Proxy Deployment plus backend StatefulSet, and how a deleted StatefulSet is recreated
 - **[MCPToolConfig Reconciliation](operator/toolconfig-reconciliation.md)** - How MCPToolConfig resources are reconciled
 
 ## Getting started

--- a/docs/operator/mcpserver-workloads.md
+++ b/docs/operator/mcpserver-workloads.md
@@ -1,0 +1,32 @@
+# MCPServer workloads
+
+An operator-managed `MCPServer` is two Kubernetes workloads, not one.
+
+| Object | Kind | What it runs |
+| --- | --- | --- |
+| `<name>` | Deployment | Proxy-runner (`thv` / HTTP listener). This is what the Service targets. |
+| `<name>` | StatefulSet | The MCP process itself (image, `npx`, `uvx`, …). |
+
+`kubectl get pods` therefore shows two pods per stdio server. The StatefulSet
+pod is not leftover. Do not delete it.
+
+## Recreate if the StatefulSet is deleted
+
+The operator owns that StatefulSet. If it is missing, the next reconcile
+bounces the proxy Deployment so the runner re-applies it, and the
+`MCPServer` stays `Pending` until the StatefulSet is back.
+
+Do **not** delete the `MCPServer` custom resource just to recover a missing
+StatefulSet.
+
+## Supported bounce
+
+See [restart-annotation.md](./restart-annotation.md). Prefer:
+
+```bash
+kubectl annotate mcpserver <name> \
+  mcpserver.toolhive.stacklok.dev/restarted-at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+Do not delete the StatefulSet to bounce the server; the operator will
+treat that as a missing workload and recreate it.


### PR DESCRIPTION
## Cross-links

- Issue: https://github.com/stacklok/toolhive/issues/6343
- Maintainer direction (watch/recreate STS + document dual-pod model): https://github.com/stacklok/toolhive/issues/6343#issuecomment-5332550398
- PR announcement: https://github.com/stacklok/toolhive/issues/6343#issuecomment-5338661506

## Summary

Deleting the runner-created MCPServer StatefulSet left the proxy Deployment
up and `Ready=true`. Clients hit a dead backend. The operator created the
Deployment but did not watch/adopt the STS, so orphan-cleanup scripts treated
it as leftover.

- Watch ToolHive StatefulSets and adopt a controller owner-ref on the
  MCPServer
- If the STS is missing and the proxy is already Available, bounce the proxy
  (existing `restarted-at` annotation, 2m cooldown) so the runner re-applies
- If the proxy is not yet Available, only requeue (do not interrupt first
  boot)
- Status: proxy running + STS missing → Pending, Ready=False
- Document the dual Deployment + StatefulSet model

Fixes #6343

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] `go test -ldflags=-extldflags=-Wl,-w ./cmd/thv-operator/controllers/ -run 'TestEnsureWorkloadStatefulSet|TestMapStatefulSetToMCPServer|TestRecentlyBounced'`
- [ ] CI unit / operator tests
- [ ] After merge: deleting the workload STS should bounce the proxy, recreate
      the STS, and keep MCPServer Pending until it is back

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

No CRD schema change. RBAC already includes StatefulSets.

## Does this introduce a user-facing change?

Yes. A deleted MCPServer workload StatefulSet is recreated on the next
reconcile, and Ready is no longer claimed on a proxy-only stack. See
`docs/operator/mcpserver-workloads.md`.

## Special notes for reviewers

The operator still does not author the STS spec — the proxy-runner does via
SSA. Recreate is "bounce the runner so it applies again," which matches how
the STS is born. Cooldown avoids a restart loop while the runner is still
starting.
