### PR TITLE
Add JSON output to vMCP validation

### DIFF
--- a/cmd/thv/app/vmcp.go
+++ b/cmd/thv/app/vmcp.go
@@ -129,6 +129,7 @@ If neither --output nor --config is provided, the generated YAML is written to s
 // newVMCPValidateCommand returns the "vmcp validate" subcommand.
 func newVMCPValidateCommand() *cobra.Command {
 	var configPath string
+	var format string
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate a vMCP configuration file",
@@ -141,10 +142,14 @@ for valid configurations, non-zero with a descriptive error otherwise.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return vmcpcli.Validate(cmd.Context(), vmcpcli.ValidateConfig{
 				ConfigPath: configPath,
+				Format:     format,
+				Writer:     cmd.OutOrStdout(),
 			})
 		},
 	}
 	cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to vMCP configuration file (required)")
+	AddFormatFlag(cmd, &format)
+	cmd.PreRunE = ValidateFormat(&format)
 	_ = cmd.MarkFlagRequired("config")
 	return cmd
 }

--- a/cmd/thv/app/vmcp_test.go
+++ b/cmd/thv/app/vmcp_test.go
@@ -4,6 +4,10 @@
 package app
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,4 +59,49 @@ func TestNewVMCPCommand_InitRegistered(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected 'init' to be registered as a subcommand of 'vmcp'")
+}
+
+func TestNewVMCPValidateCommand_FormatFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := newVMCPValidateCommand()
+	formatFlag := cmd.Flags().Lookup("format")
+	require.NotNil(t, formatFlag, "expected --format flag to be registered")
+	assert.Equal(t, FormatText, formatFlag.DefValue)
+
+	require.NoError(t, formatFlag.Value.Set("yaml"))
+	err := cmd.PreRunE(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid format "yaml"`)
+}
+
+func TestNewVMCPValidateCommand_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "vmcp.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+name: cli-json-vmcp
+groupRef: cli-json-group
+incomingAuth:
+  type: anonymous
+outgoingAuth:
+  source: inline
+  default:
+    type: unauthenticated
+aggregation:
+  conflictResolution: prefix
+  conflictResolutionConfig:
+    prefixFormat: "{workload}_"
+`), 0o600))
+
+	cmd := newVMCPValidateCommand()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--config", configPath, "--format", FormatJSON})
+	require.NoError(t, cmd.Execute())
+
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &summary))
+	assert.Equal(t, true, summary["valid"])
+	assert.Equal(t, "cli-json-vmcp", summary["name"])
 }

--- a/docs/cli/thv_vmcp_validate.md
+++ b/docs/cli/thv_vmcp_validate.md
@@ -29,6 +29,7 @@ thv vmcp validate [flags]
 
 ```
   -c, --config string   Path to vMCP configuration file (required)
+      --format string   Output format (json, text) (default "text")
   -h, --help            help for validate
 ```
 

--- a/pkg/vmcp/cli/validate.go
+++ b/pkg/vmcp/cli/validate.go
@@ -5,8 +5,11 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 
 	"github.com/stacklok/toolhive-core/env"
 	"github.com/stacklok/toolhive/pkg/vmcp/config"
@@ -16,6 +19,23 @@ import (
 type ValidateConfig struct {
 	// ConfigPath is the path to the vMCP YAML configuration file to validate.
 	ConfigPath string
+	// Format controls successful output. Empty or "text" preserves the log summary.
+	Format string
+	// Writer receives JSON output. Nil uses os.Stdout.
+	Writer io.Writer
+}
+
+// ValidationSummary is the stable, secret-free machine-readable validation result.
+type ValidationSummary struct {
+	Valid                bool   `json:"valid"`
+	Name                 string `json:"name"`
+	Group                string `json:"group"`
+	IncomingAuth         string `json:"incoming_auth"`
+	OutgoingAuthSource   string `json:"outgoing_auth_source"`
+	BackendAuthOverrides int    `json:"backend_auth_override_count"`
+	BackendCount         int    `json:"backend_count"`
+	ConflictResolution   string `json:"conflict_resolution"`
+	CompositeToolCount   int    `json:"composite_tool_count"`
 }
 
 // Validate loads and validates a vMCP configuration file, printing a summary
@@ -24,6 +44,9 @@ type ValidateConfig struct {
 func Validate(_ context.Context, cfg ValidateConfig) error {
 	if cfg.ConfigPath == "" {
 		return fmt.Errorf("no configuration file specified, use --config flag")
+	}
+	if cfg.Format != "" && cfg.Format != "text" && cfg.Format != "json" {
+		return fmt.Errorf("unsupported output format %q", cfg.Format)
 	}
 
 	slog.Info(fmt.Sprintf("Validating configuration: %s", cfg.ConfigPath))
@@ -42,6 +65,30 @@ func Validate(_ context.Context, cfg ValidateConfig) error {
 	if err := validator.Validate(vmcpCfg); err != nil {
 		slog.Error(fmt.Sprintf("Configuration validation failed: %v", err))
 		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	summary := ValidationSummary{
+		Valid:                true,
+		Name:                 vmcpCfg.Name,
+		Group:                vmcpCfg.Group,
+		IncomingAuth:         vmcpCfg.IncomingAuth.Type,
+		OutgoingAuthSource:   vmcpCfg.OutgoingAuth.Source,
+		BackendAuthOverrides: len(vmcpCfg.OutgoingAuth.Backends),
+		BackendCount:         len(vmcpCfg.Backends),
+		ConflictResolution:   string(vmcpCfg.Aggregation.ConflictResolution),
+		CompositeToolCount:   len(vmcpCfg.CompositeTools),
+	}
+	if cfg.Format == "json" {
+		writer := cfg.Writer
+		if writer == nil {
+			writer = os.Stdout
+		}
+		encoder := json.NewEncoder(writer)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(summary); err != nil {
+			return fmt.Errorf("failed to encode validation summary: %w", err)
+		}
+		return nil
 	}
 
 	slog.Info("✓ Configuration is valid")

--- a/pkg/vmcp/cli/validate_test.go
+++ b/pkg/vmcp/cli/validate_test.go
@@ -4,11 +4,15 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,5 +117,116 @@ aggregation:
 				require.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestValidateJSONSummaryIsStableAndSecretFree(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "vmcp.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+name: sensitive-vmcp
+groupRef: sensitive-group
+
+backends:
+  - name: first-backend
+    url: http://first.example.test/mcp
+    transport: streamable-http
+  - name: second-backend
+    url: http://second.example.test/sse
+    transport: sse
+
+incomingAuth:
+  type: anonymous
+
+outgoingAuth:
+  source: inline
+  default:
+    type: unauthenticated
+  backends:
+    protected-backend:
+      type: header_injection
+      headerInjection:
+        headerName: X-Private-API-Key
+        headerValue: vmcp-json-secret-value
+
+aggregation:
+  conflictResolution: prefix
+  conflictResolutionConfig:
+    prefixFormat: "{workload}_"
+
+telemetry:
+  headers:
+    X-Telemetry-Token: vmcp-telemetry-secret-value
+
+passthroughHeaders:
+  - X-Tenant-Token
+`), 0o600))
+
+	var output bytes.Buffer
+	err := Validate(context.Background(), ValidateConfig{
+		ConfigPath: path,
+		Format:     "json",
+		Writer:     &output,
+	})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &got))
+	assert.Equal(t, map[string]any{
+		"valid":                       true,
+		"name":                        "sensitive-vmcp",
+		"group":                       "sensitive-group",
+		"incoming_auth":               "anonymous",
+		"outgoing_auth_source":        "inline",
+		"backend_auth_override_count": float64(1),
+		"backend_count":               float64(2),
+		"conflict_resolution":         "prefix",
+		"composite_tool_count":        float64(0),
+	}, got)
+
+	for _, sensitiveValue := range []string{
+		"vmcp-json-secret-value",
+		"vmcp-telemetry-secret-value",
+		"X-Private-API-Key",
+		"X-Telemetry-Token",
+		"X-Tenant-Token",
+		"first.example.test",
+		"second.example.test",
+	} {
+		assert.NotContains(t, output.String(), sensitiveValue)
+	}
+}
+
+//nolint:paralleltest // slog.SetDefault is process-wide and must be restored before parallel tests run.
+func TestValidateTextOutputRemainsCompatible(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vmcp.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(validConfigYAML), 0o600))
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	for _, format := range []string{"", "text"} {
+		logs.Reset()
+		var output bytes.Buffer
+		require.NoError(t, Validate(context.Background(), ValidateConfig{
+			ConfigPath: path,
+			Format:     format,
+			Writer:     &output,
+		}))
+
+		assert.Empty(t, output.String(), "text output must not be written to the JSON writer")
+		for _, summaryLine := range []string{
+			"Configuration is valid",
+			"Name: test-vmcp",
+			"Group: test-group",
+			"Incoming Auth: anonymous",
+			"Outgoing Auth: default only (source: inline)",
+			"Conflict Resolution: prefix",
+		} {
+			assert.Contains(t, logs.String(), summaryLine)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Automation and Agent harnesses need a stable validation result, but `thv vmcp validate` currently emits only human-oriented logs. Parsing those logs is brittle and can accidentally expose configuration details that machine consumers do not need.

- Add `--format json` to `thv vmcp validate` while preserving the existing text behavior by default.
- Return a stable, secret-free summary containing validation status and configuration metadata/counts.
- Validate output formats, route JSON through Cobra's output writer, and document the new flag.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task -t Taskfile.focused.yml test`, using the repository's `-race`, linker, and `gotestfmt` settings for `./pkg/vmcp/cli` and `./cmd/thv/app`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

The full `task test` suite was also attempted. It reached the test phase but unrelated Docker-dependent API/runtime and Envoy container tests could not run because Docker is unavailable in the local environment.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/cli/validate.go` | Add stable JSON summary generation with a restricted, secret-free schema. |
| `pkg/vmcp/cli/validate_test.go` | Verify the JSON field contract, sensitive-value exclusion, and text compatibility. |
| `cmd/thv/app/vmcp.go` | Add the standard format flag and use Cobra's output writer. |
| `cmd/thv/app/vmcp_test.go` | Cover format validation and command-level JSON output. |
| `docs/cli/thv_vmcp_validate.md` | Document the generated `--format` flag. |

## Does this introduce a user-facing change?

Yes. Users can now run `thv vmcp validate --config <path> --format json` and consume a stable validation summary from stdout.

## Special notes for reviewers

The JSON schema deliberately omits backend URLs, headers, policy contents, expanded environment values, and other configuration payloads. `backend_auth_override_count` counts backend-specific outgoing-auth overrides; `backend_count` counts configured static backends.
