### PR TITLE
Point five stale doc paths at the moved files

### DIFF
--- a/docs/operator/virtualmcpserver-observability.md
+++ b/docs/operator/virtualmcpserver-observability.md
@@ -24,7 +24,7 @@ The vMCP uses a decorator pattern to wrap backend clients and workflow executors
 with telemetry instrumentation. This approach provides consistent metrics and
 tracing without modifying the core business logic.
 
-The implementation of both metrics and traces can be found in `pkg/vmcp/server/telemetry.go`.
+The implementation of both metrics and traces can be found in `pkg/vmcp/internal/backendtelemetry/backendtelemetry.go`.
 
 ## Metrics
 

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -24,9 +24,9 @@ go install github.com/swaggo/swag/v2/cmd/swag@v2.0.0-rc4
 
    This will generate:
 
-   - `docs/swagger.json`: OpenAPI 3.1.0 specification
-   - `docs/swagger.yaml`: YAML version of the specification
-   - `docs/docs.go`: Go code containing the specification
+   - `docs/server/swagger.json`: OpenAPI 3.1.0 specification
+   - `docs/server/swagger.yaml`: YAML version of the specification
+   - `docs/server/docs.go`: Go code containing the specification
 
 ## Viewing Documentation
 

--- a/docs/telemetry-migration-guide.md
+++ b/docs/telemetry-migration-guide.md
@@ -247,7 +247,7 @@ metrics use OTEL MCP semantic convention attribute names exclusively (e.g.,
 
 ## vMCP Backend Client Attributes
 
-The vMCP backend client (`pkg/vmcp/server/telemetry.go`) emits both
+The vMCP backend client (`pkg/vmcp/internal/backendtelemetry/backendtelemetry.go`) emits both
 ToolHive-specific and OTEL spec attributes on spans. These are always emitted
 regardless of `useLegacyAttributes` since they serve different purposes:
 


### PR DESCRIPTION
Five documented paths point at files that moved. Git recorded all five as renames, so there
is no judgement in this one: each destination verified present and each source verified
absent at `0b8acf26`.

| document | says | actually |
|---|---|---|
| `docs/server/README.md:27` | `docs/swagger.json` | `docs/server/swagger.json` |
| `docs/server/README.md:28` | `docs/swagger.yaml` | `docs/server/swagger.yaml` |
| `docs/server/README.md:29` | `docs/docs.go` | `docs/server/docs.go` |
| `docs/operator/virtualmcpserver-observability.md:27` | `pkg/vmcp/server/telemetry.go` | `pkg/vmcp/internal/backendtelemetry/backendtelemetry.go` |
| `docs/telemetry-migration-guide.md:250` | `pkg/vmcp/server/telemetry.go` | same |

The first three moved together in `0da4f9a8` ("refactor: openapi, add readme", #448), and the
README that names them **is itself in `docs/server/`** - it points one directory up at its own
neighbours. The other two moved in `87fa2ac8` ("Implement stateless core VMCP constructor",
#5457).

Five lines, three files, no prose changes.

Part of #6387. The other ten findings there are not in this pull request on purpose: they are
subsystems that left for `toolhive-core`, code removed as dead, and a feature that no longer
exists, and the right fix for each is a judgement from inside the project rather than a patch
from outside.

Found by [docproof](https://github.com/melbinjp/docproof), a documentation checker that
resolves documented paths against the repository and its git history.
