### PR TITLE
Report a rejected stored credential as re-login required

### DIFF
--- a/pkg/auth/monitored_token_source.go
+++ b/pkg/auth/monitored_token_source.go
@@ -9,10 +9,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -21,6 +19,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/stacklok/toolhive/pkg/auth/oautherr"
 	"github.com/stacklok/toolhive/pkg/container/runtime"
 )
 
@@ -648,92 +647,28 @@ func isTransientNetworkError(err error) bool {
 	return false
 }
 
-// isPermanentTokenEndpointError reports whether err is an *oauth2.RetrieveError
-// whose response carries a structured RFC 6749 'error' code, implying the
-// OAuth server itself rendered a verdict on the cached credentials
-// (invalid_grant, invalid_client, etc.). Used at state-transition
-// boundaries to decide whether to emit a DCR/CIMD remediation hint
-// alongside the unauthentication.
-//
-// This is the strict inverse of isTransientRetrieveError on the
-// *oauth2.RetrieveError branch: a response is "permanent" iff the
-// classifier would NOT call it transient. Concretely, the Warn fires
-// only when ErrorCode is populated. 4xx responses without an OAuth
-// error code (HTML pages from a WAF, CDN, or reverse proxy) — like
-// 5xx, 429, 408, and nil-Response shapes — are treated as
-// non-permanent because we have no OAuth-protocol verdict to act on.
-// Recommending the user delete cached credentials based on a non-
-// spec-compliant response would frequently mislead operators whose
-// real problem is upstream of the OAuth server.
+// isPermanentTokenEndpointError reports whether the OAuth server itself
+// rendered a verdict on the cached credentials (invalid_grant, invalid_client,
+// etc.). Used at state-transition boundaries to decide whether to emit a
+// DCR/CIMD remediation hint alongside the unauthentication. The rules live in
+// pkg/auth/oautherr; see IsPermanentCredentialError for why a non-spec-compliant
+// 4xx is deliberately not "permanent".
 func isPermanentTokenEndpointError(err error) bool {
-	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
-	if !ok || retrieveErr.Response == nil {
-		return false
-	}
-	return !isTransientRetrieveError(retrieveErr)
+	return oautherr.IsPermanentCredentialError(err)
 }
 
 // isTransientRetrieveError reports whether an *oauth2.RetrieveError should
-// be treated as transient. The classification rules are:
-//
-//   - nil Response: non-transient. There is no signal to act on, so we fall
-//     through to the unauthenticated path rather than retry blindly.
-//   - 5xx status: transient (server-side issue, likely to resolve).
-//   - 429 Too Many Requests: transient regardless of body (HTTP standard).
-//   - 4xx with an empty ErrorCode: transient. The oauth2 library populates
-//     ErrorCode from the RFC 6749 'error' field in a JSON response body. An
-//     empty ErrorCode means the response was not a parseable OAuth error —
-//     typically an HTML page from a WAF, CDN, or reverse proxy that
-//     intercepted the request before it reached the OAuth server. These
-//     infrastructure errors (Cloudflare blocks, residential-IP allowlist
-//     misses, transient bad-config deploys) commonly resolve on their own.
-//   - 4xx with a populated ErrorCode: permanent. The OAuth server returned
-//     a structured error code (invalid_grant, invalid_client, etc.) telling
-//     us specifically what's wrong; retrying won't help.
+// be treated as transient. The rules live in pkg/auth/oautherr so this
+// package and the LLM-gateway token source cannot drift on them.
 func isTransientRetrieveError(retrieveErr *oauth2.RetrieveError) bool {
-	if retrieveErr.Response == nil {
-		return false
-	}
-	statusCode := retrieveErr.Response.StatusCode
-
-	if statusCode >= 500 {
-		slog.Debug("treating OAuth server error as transient",
-			"status_code", statusCode,
-		)
-		return true
-	}
-
-	if statusCode == http.StatusTooManyRequests {
-		slog.Debug("treating OAuth rate-limit response as transient",
-			"status_code", statusCode,
-			"error_code", retrieveErr.ErrorCode,
-		)
-		return true
-	}
-
-	if retrieveErr.ErrorCode == "" {
-		slog.Debug("treating OAuth 4xx without error code as transient",
-			"status_code", statusCode,
-		)
-		return true
-	}
-
-	return false
+	return oautherr.IsTransientRetrieveError(retrieveErr)
 }
 
 // isOAuthParseError detects errors from the oauth2 library that indicate the
-// token endpoint returned an unparsable response body on a 2xx status. This
-// typically happens when a load balancer, CDN, or reverse proxy intercepts the
-// request and returns its own HTML page instead of the expected JSON token
-// response. The oauth2 library uses fmt.Errorf with %v (not %w) for these
-// errors, so string matching is the only reliable detection method.
+// token endpoint returned an unparsable response body on a 2xx status. The
+// detection lives in pkg/auth/oautherr.
 func isOAuthParseError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "oauth2: cannot parse json") ||
-		strings.Contains(msg, "oauth2: cannot parse response")
+	return oautherr.IsParseError(err)
 }
 
 // stopMonitoringOnce idempotently closes the stopMonitoring channel. It

--- a/pkg/auth/oautherr/oautherr.go
+++ b/pkg/auth/oautherr/oautherr.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package oautherr classifies OAuth token-endpoint failures as transient or
+// permanent.
+//
+// The distinction matters wherever a cached credential is exchanged without a
+// human present: a transient failure (the IdP is down, rate-limiting, or a WAF
+// answered instead of it) is worth retrying, while a permanent one means the
+// OAuth server itself rendered a verdict on the credential and no amount of
+// retrying will help — the only way forward is a fresh interactive login.
+//
+// It is a leaf package so both the token-source construction path and the
+// workload auth monitor can share one implementation instead of each carrying
+// its own copy of the rules.
+package oautherr
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+// IsTransientRetrieveError reports whether an *oauth2.RetrieveError should be
+// treated as transient. The classification rules are:
+//
+//   - nil Response: non-transient. There is no signal to act on, so callers
+//     fall through to the unauthenticated path rather than retry blindly.
+//   - 5xx status: transient (server-side issue, likely to resolve).
+//   - 429 Too Many Requests: transient regardless of body (HTTP standard).
+//   - 4xx with an empty ErrorCode: transient. The oauth2 library populates
+//     ErrorCode from the RFC 6749 'error' field in a JSON response body. An
+//     empty ErrorCode means the response was not a parseable OAuth error —
+//     typically an HTML page from a WAF, CDN, or reverse proxy that
+//     intercepted the request before it reached the OAuth server. These
+//     infrastructure errors (Cloudflare blocks, residential-IP allowlist
+//     misses, transient bad-config deploys) commonly resolve on their own.
+//   - 4xx with a populated ErrorCode: permanent. The OAuth server returned
+//     a structured error code (invalid_grant, invalid_client, etc.) telling
+//     us specifically what's wrong; retrying won't help.
+func IsTransientRetrieveError(retrieveErr *oauth2.RetrieveError) bool {
+	if retrieveErr == nil || retrieveErr.Response == nil {
+		return false
+	}
+	statusCode := retrieveErr.Response.StatusCode
+
+	if statusCode >= 500 {
+		return true
+	}
+	if statusCode == http.StatusTooManyRequests {
+		return true
+	}
+	if retrieveErr.ErrorCode == "" {
+		return true
+	}
+	return false
+}
+
+// IsPermanentCredentialError reports whether err is an *oauth2.RetrieveError
+// whose response carries a structured RFC 6749 'error' code, implying the
+// OAuth server itself rendered a verdict on the cached credentials
+// (invalid_grant, invalid_client, etc.).
+//
+// This is the strict inverse of IsTransientRetrieveError on the
+// *oauth2.RetrieveError branch: a response is "permanent" iff the classifier
+// would NOT call it transient. Concretely, it is true only when ErrorCode is
+// populated. 4xx responses without an OAuth error code (HTML pages from a WAF,
+// CDN, or reverse proxy) — like 5xx, 429, 408, and nil-Response shapes — are
+// treated as non-permanent because there is no OAuth-protocol verdict to act
+// on. Telling a user their stored credential is dead based on a
+// non-spec-compliant response would frequently mislead operators whose real
+// problem is upstream of the OAuth server.
+func IsPermanentCredentialError(err error) bool {
+	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
+	if !ok || retrieveErr.Response == nil {
+		return false
+	}
+	return !IsTransientRetrieveError(retrieveErr)
+}
+
+// RetrieveErrorCode returns the RFC 6749 'error' code from err when err wraps
+// an *oauth2.RetrieveError, and "" otherwise.
+//
+// The code and description are the only two fields of a RetrieveError safe to
+// put in a message: its Error() embeds the raw response body, which for a token
+// endpoint can echo back bearer material. Callers building a user-facing string
+// should reach for this rather than the error's own text.
+func RetrieveErrorCode(err error) string {
+	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
+	if !ok {
+		return ""
+	}
+	return retrieveErr.ErrorCode
+}
+
+// IsParseError detects errors from the oauth2 library that indicate the token
+// endpoint returned an unparsable response body on a 2xx status. This
+// typically happens when a load balancer, CDN, or reverse proxy intercepts the
+// request and returns its own HTML page instead of the expected JSON token
+// response. The oauth2 library uses fmt.Errorf with %v (not %w) for these
+// errors, so string matching is the only reliable detection method.
+func IsParseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "oauth2: cannot parse json") ||
+		strings.Contains(msg, "oauth2: cannot parse response")
+}

--- a/pkg/auth/oautherr/oautherr.go
+++ b/pkg/auth/oautherr/oautherr.go
@@ -72,6 +72,11 @@ func IsTransientRetrieveError(retrieveErr *oauth2.RetrieveError) bool {
 // on. Telling a user their stored credential is dead based on a
 // non-spec-compliant response would frequently mislead operators whose real
 // problem is upstream of the OAuth server.
+//
+// "Permanent" here means only "retrying will not help". It does NOT mean the
+// stored credential is dead — invalid_client and unauthorized_client indict the
+// client registration, not the refresh token. Callers deciding whether to tell
+// a user to log in again want IsRejectedRefreshGrant instead.
 func IsPermanentCredentialError(err error) bool {
 	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
 	if !ok || retrieveErr.Response == nil {
@@ -80,19 +85,32 @@ func IsPermanentCredentialError(err error) bool {
 	return !IsTransientRetrieveError(retrieveErr)
 }
 
-// RetrieveErrorCode returns the RFC 6749 'error' code from err when err wraps
-// an *oauth2.RetrieveError, and "" otherwise.
+// rejectedGrantCode is the RFC 6749 'error' code a token endpoint returns when
+// the grant it was handed is invalid, expired, revoked, or was issued to a
+// different client. On a refresh exchange it is the one code that indicts the
+// stored refresh token itself.
+const rejectedGrantCode = "invalid_grant"
+
+// IsRejectedRefreshGrant reports whether err is an *oauth2.RetrieveError in
+// which the OAuth server rejected the refresh token itself: an RFC 6749
+// 'invalid_grant' on a response IsTransientRetrieveError does not already
+// excuse.
 //
-// The code and description are the only two fields of a RetrieveError safe to
-// put in a message: its Error() embeds the raw response body, which for a token
-// endpoint can echo back bearer material. Callers building a user-facing string
-// should reach for this rather than the error's own text.
-func RetrieveErrorCode(err error) string {
+// This is deliberately narrower than IsPermanentCredentialError, and the two
+// answer different questions. Both describe failures retrying cannot fix, but
+// only invalid_grant means a fresh interactive login is the remedy.
+// invalid_client, unauthorized_client, and invalid_scope are just as permanent
+// and just as pointless to retry, yet they indict the client registration or
+// the requested scopes — running the login flow again against the same broken
+// configuration reproduces them exactly, so telling the user to log in again
+// sends them in a circle. Callers rendering a re-login remediation must key off
+// this predicate; callers that only need "stop retrying" want the broader one.
+func IsRejectedRefreshGrant(err error) bool {
 	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
-	if !ok {
-		return ""
+	if !ok || retrieveErr.ErrorCode != rejectedGrantCode {
+		return false
 	}
-	return retrieveErr.ErrorCode
+	return IsPermanentCredentialError(err)
 }
 
 // IsParseError detects errors from the oauth2 library that indicate the token

--- a/pkg/auth/oautherr/oautherr_test.go
+++ b/pkg/auth/oautherr/oautherr_test.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package oautherr_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+
+	"github.com/stacklok/toolhive/pkg/auth/oautherr"
+)
+
+func retrieveErr(status int, code string) *oauth2.RetrieveError {
+	return &oauth2.RetrieveError{
+		Response:  &http.Response{StatusCode: status},
+		ErrorCode: code,
+	}
+}
+
+func TestIsTransientRetrieveError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *oauth2.RetrieveError
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"nil response carries no signal", &oauth2.RetrieveError{ErrorCode: "invalid_grant"}, false},
+		{"500 is a server-side blip", retrieveErr(http.StatusInternalServerError, ""), true},
+		{"503 is a server-side blip", retrieveErr(http.StatusServiceUnavailable, "temporarily_unavailable"), true},
+		{"429 is transient regardless of body", retrieveErr(http.StatusTooManyRequests, "invalid_grant"), true},
+		{"4xx without a code is infrastructure", retrieveErr(http.StatusForbidden, ""), true},
+		{"invalid_grant is a verdict", retrieveErr(http.StatusBadRequest, "invalid_grant"), false},
+		{"invalid_client is a verdict", retrieveErr(http.StatusUnauthorized, "invalid_client"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, oautherr.IsTransientRetrieveError(tt.err))
+		})
+	}
+}
+
+func TestIsPermanentCredentialError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated error", errors.New("keyring is locked"), false},
+		{"nil response is not a verdict", &oauth2.RetrieveError{ErrorCode: "invalid_grant"}, false},
+		{"5xx is not a verdict", retrieveErr(http.StatusBadGateway, ""), false},
+		{"429 is not a verdict", retrieveErr(http.StatusTooManyRequests, "invalid_grant"), false},
+		{"4xx without a code is not a verdict", retrieveErr(http.StatusForbidden, ""), false},
+		{"invalid_grant is a verdict", retrieveErr(http.StatusBadRequest, "invalid_grant"), true},
+		{"wrapped verdict is still found", fmt.Errorf("refresh failed: %w", retrieveErr(http.StatusBadRequest, "invalid_grant")), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, oautherr.IsPermanentCredentialError(tt.err))
+		})
+	}
+}
+
+func TestRetrieveErrorCode(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, oautherr.RetrieveErrorCode(nil))
+	assert.Empty(t, oautherr.RetrieveErrorCode(errors.New("not an oauth error")))
+	assert.Equal(t, "invalid_grant",
+		oautherr.RetrieveErrorCode(retrieveErr(http.StatusBadRequest, "invalid_grant")))
+	assert.Equal(t, "invalid_grant",
+		oautherr.RetrieveErrorCode(fmt.Errorf("wrapped: %w", retrieveErr(http.StatusBadRequest, "invalid_grant"))))
+}
+
+func TestIsParseError(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, oautherr.IsParseError(nil))
+	assert.False(t, oautherr.IsParseError(errors.New("some other failure")))
+	assert.True(t, oautherr.IsParseError(errors.New("oauth2: cannot parse json")))
+	assert.True(t, oautherr.IsParseError(fmt.Errorf("wrapped: %w", errors.New("oauth2: cannot parse response"))))
+}

--- a/pkg/auth/oautherr/oautherr_test.go
+++ b/pkg/auth/oautherr/oautherr_test.go
@@ -72,15 +72,44 @@ func TestIsPermanentCredentialError(t *testing.T) {
 	}
 }
 
-func TestRetrieveErrorCode(t *testing.T) {
+func TestIsRejectedRefreshGrant(t *testing.T) {
 	t.Parallel()
 
-	assert.Empty(t, oautherr.RetrieveErrorCode(nil))
-	assert.Empty(t, oautherr.RetrieveErrorCode(errors.New("not an oauth error")))
-	assert.Equal(t, "invalid_grant",
-		oautherr.RetrieveErrorCode(retrieveErr(http.StatusBadRequest, "invalid_grant")))
-	assert.Equal(t, "invalid_grant",
-		oautherr.RetrieveErrorCode(fmt.Errorf("wrapped: %w", retrieveErr(http.StatusBadRequest, "invalid_grant"))))
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated error", errors.New("keyring is locked"), false},
+		{"invalid_grant is the credential verdict", retrieveErr(http.StatusBadRequest, "invalid_grant"), true},
+		{"wrapped invalid_grant is still found",
+			fmt.Errorf("refresh failed: %w", retrieveErr(http.StatusBadRequest, "invalid_grant")), true},
+
+		// Permanent, but a verdict on the client rather than the credential:
+		// a fresh login reproduces these unchanged.
+		{"invalid_client indicts the registration", retrieveErr(http.StatusUnauthorized, "invalid_client"), false},
+		{"unauthorized_client indicts the registration", retrieveErr(http.StatusBadRequest, "unauthorized_client"), false},
+		{"invalid_scope indicts the request", retrieveErr(http.StatusBadRequest, "invalid_scope"), false},
+
+		// Shapes the transient classifier already excuses stay excused, even
+		// when the body claims invalid_grant.
+		{"429 is transient regardless of body", retrieveErr(http.StatusTooManyRequests, "invalid_grant"), false},
+		{"5xx is transient regardless of body", retrieveErr(http.StatusBadGateway, "invalid_grant"), false},
+		{"nil response carries no signal", &oauth2.RetrieveError{ErrorCode: "invalid_grant"}, false},
+
+		// The 'error' field is arbitrary server-chosen text; only the exact
+		// literal counts.
+		{"a code merely containing invalid_grant does not count",
+			retrieveErr(http.StatusBadRequest, "invalid_grant\r\nX-Injected: 1"), false},
+		{"empty code is not a verdict", retrieveErr(http.StatusForbidden, ""), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, oautherr.IsRejectedRefreshGrant(tt.err))
+		})
+	}
 }
 
 func TestIsParseError(t *testing.T) {

--- a/pkg/auth/tokensource/tokensource.go
+++ b/pkg/auth/tokensource/tokensource.go
@@ -179,52 +179,53 @@ func (t *OAuthTokenSource) Token(ctx context.Context) (string, error) {
 // classifyTerminalError decides which error a non-interactive caller sees when
 // every cache tier has failed.
 //
-// A permanent token-endpoint verdict (invalid_grant, invalid_client) means the
-// OAuth server itself rejected the stored refresh token: retrying cannot fix
-// it, and only a fresh interactive login can. Returning the raw OAuth error
-// there is actively misleading, because callers that distinguish "you must log
-// in again" from "the provider is having a bad day" all key off FallbackErr,
-// and a dead credential is precisely the case that needs the re-login
-// remediation. So a permanent verdict is reported as FallbackErr with the cause
-// still reachable underneath; every other failure (5xx, 429, a WAF page, a
-// locked keyring) surfaces verbatim so the caller can retry or fix the real
-// problem.
+// An RFC 6749 invalid_grant means the OAuth server rejected the stored refresh
+// token itself: it expired, was revoked, or was rotated out from under us.
+// Retrying cannot fix that, and only a fresh interactive login can. Returning
+// the raw OAuth error there is actively misleading, because callers that
+// distinguish "you must log in again" from "the provider is having a bad day"
+// all key off FallbackErr, and a dead refresh token is precisely the case that
+// needs the re-login remediation.
+//
+// Every other failure surfaces verbatim, including the permanent ones. A 5xx,
+// a 429, a WAF page, or a locked keyring is worth retrying or fixing in place.
+// invalid_client, unauthorized_client, and invalid_scope are not worth
+// retrying, but they are verdicts on the client registration or the requested
+// scopes rather than on the credential, so logging in again reproduces them
+// unchanged — reporting them as FallbackErr would send the user in a circle
+// while hiding the code that names the real problem.
 //
 // The stored credential is deliberately NOT deleted here. With an IdP that
 // rotates refresh tokens, a sibling process may have just written a newer token
 // under the same key, and the next Token() call re-reads the secrets provider;
 // deleting on a rejection would destroy that cross-process recovery.
 func (t *OAuthTokenSource) classifyTerminalError(lastErr error) error {
-	if t.opts.FallbackErr == nil || !oautherr.IsPermanentCredentialError(lastErr) {
+	if t.opts.FallbackErr == nil || !oautherr.IsRejectedRefreshGrant(lastErr) {
 		return lastErr
 	}
-	return &credentialRejectedError{
-		fallback: t.opts.FallbackErr,
-		cause:    lastErr,
-		code:     oautherr.RetrieveErrorCode(lastErr),
-	}
+	return &credentialRejectedError{fallback: t.opts.FallbackErr, cause: lastErr}
 }
 
 // credentialRejectedError marks a non-interactive failure where the identity
-// provider rejected the stored credential. It wraps BOTH the caller's
+// provider rejected the stored refresh token. It wraps BOTH the caller's
 // FallbackErr (so errors.Is finds the re-login sentinel) and the underlying
 // cause (so errors.As can still reach the *oauth2.RetrieveError).
 //
-// Error() renders only the sentinel plus the RFC 6749 error code on purpose. An
-// *oauth2.RetrieveError's own Error() embeds the raw token-endpoint response
-// body, which can echo back bearer material, so it must never reach a log line
-// or a user-facing string.
+// Error() interpolates nothing from the token endpoint, on purpose. The whole
+// response is untrusted input: an *oauth2.RetrieveError's own Error() embeds the
+// raw body, which can echo back bearer material, and even the parsed RFC 6749
+// 'error' field is an arbitrary server-chosen string that may carry secrets or
+// control characters into a log line. Since this type is only constructed for
+// invalid_grant, the code carries no information the fixed sentence does not
+// already convey. Diagnostics that need the exact verdict reach the cause
+// through errors.As.
 type credentialRejectedError struct {
 	fallback error
 	cause    error
-	code     string
 }
 
 func (e *credentialRejectedError) Error() string {
-	if e.code == "" {
-		return fmt.Sprintf("%s (the identity provider rejected the stored credential)", e.fallback)
-	}
-	return fmt.Sprintf("%s (the identity provider rejected the stored credential: %s)", e.fallback, e.code)
+	return fmt.Sprintf("%s (the identity provider rejected the stored credential)", e.fallback)
 }
 
 // Unwrap exposes both the sentinel and the cause to errors.Is / errors.As.

--- a/pkg/auth/tokensource/tokensource.go
+++ b/pkg/auth/tokensource/tokensource.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/stacklok/toolhive/pkg/auth/oauth"
+	"github.com/stacklok/toolhive/pkg/auth/oautherr"
 	"github.com/stacklok/toolhive/pkg/auth/remote"
 	"github.com/stacklok/toolhive/pkg/secrets"
 )
@@ -160,7 +161,7 @@ func (t *OAuthTokenSource) Token(ctx context.Context) (string, error) {
 	// Tier 3: browser OIDC+PKCE flow — only in interactive mode.
 	if !t.opts.Interactive {
 		if lastErr != nil {
-			return "", lastErr
+			return "", t.classifyTerminalError(lastErr)
 		}
 		return "", t.opts.FallbackErr
 	}
@@ -174,6 +175,60 @@ func (t *OAuthTokenSource) Token(ctx context.Context) (string, error) {
 	t.cacheAccessToken(ctx, tok.AccessToken, tok.Expiry)
 	return tok.AccessToken, nil
 }
+
+// classifyTerminalError decides which error a non-interactive caller sees when
+// every cache tier has failed.
+//
+// A permanent token-endpoint verdict (invalid_grant, invalid_client) means the
+// OAuth server itself rejected the stored refresh token: retrying cannot fix
+// it, and only a fresh interactive login can. Returning the raw OAuth error
+// there is actively misleading, because callers that distinguish "you must log
+// in again" from "the provider is having a bad day" all key off FallbackErr,
+// and a dead credential is precisely the case that needs the re-login
+// remediation. So a permanent verdict is reported as FallbackErr with the cause
+// still reachable underneath; every other failure (5xx, 429, a WAF page, a
+// locked keyring) surfaces verbatim so the caller can retry or fix the real
+// problem.
+//
+// The stored credential is deliberately NOT deleted here. With an IdP that
+// rotates refresh tokens, a sibling process may have just written a newer token
+// under the same key, and the next Token() call re-reads the secrets provider;
+// deleting on a rejection would destroy that cross-process recovery.
+func (t *OAuthTokenSource) classifyTerminalError(lastErr error) error {
+	if t.opts.FallbackErr == nil || !oautherr.IsPermanentCredentialError(lastErr) {
+		return lastErr
+	}
+	return &credentialRejectedError{
+		fallback: t.opts.FallbackErr,
+		cause:    lastErr,
+		code:     oautherr.RetrieveErrorCode(lastErr),
+	}
+}
+
+// credentialRejectedError marks a non-interactive failure where the identity
+// provider rejected the stored credential. It wraps BOTH the caller's
+// FallbackErr (so errors.Is finds the re-login sentinel) and the underlying
+// cause (so errors.As can still reach the *oauth2.RetrieveError).
+//
+// Error() renders only the sentinel plus the RFC 6749 error code on purpose. An
+// *oauth2.RetrieveError's own Error() embeds the raw token-endpoint response
+// body, which can echo back bearer material, so it must never reach a log line
+// or a user-facing string.
+type credentialRejectedError struct {
+	fallback error
+	cause    error
+	code     string
+}
+
+func (e *credentialRejectedError) Error() string {
+	if e.code == "" {
+		return fmt.Sprintf("%s (the identity provider rejected the stored credential)", e.fallback)
+	}
+	return fmt.Sprintf("%s (the identity provider rejected the stored credential: %s)", e.fallback, e.code)
+}
+
+// Unwrap exposes both the sentinel and the cause to errors.Is / errors.As.
+func (e *credentialRejectedError) Unwrap() []error { return []error{e.fallback, e.cause} }
 
 // tryInMemoryToken tries the in-memory token source (tier 1).
 // Returns (token, nil) on success, ("", errCacheMiss) when no source is set,

--- a/pkg/auth/tokensource/tokensource_test.go
+++ b/pkg/auth/tokensource/tokensource_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/oauth2"
 
 	"github.com/stacklok/toolhive/pkg/auth/oauth"
 	"github.com/stacklok/toolhive/pkg/auth/tokensource"
@@ -685,4 +686,142 @@ func TestToken_Interactive_SkipBrowser_ForwardedToFlow(t *testing.T) {
 			assert.Equal(t, tc.skipBrowser, gotSkip, "SkipBrowser option must be forwarded to flow.Start verbatim")
 		})
 	}
+}
+
+// ── A rejected stored credential reports as FallbackErr ──────────────────────
+
+// fakeOIDCServerRejecting serves discovery normally but answers every token
+// exchange with an RFC 6749 error response, the shape an IdP returns once a
+// refresh token has expired, been revoked, or been rotated out from under the
+// caller. status and errorCode control the response.
+func fakeOIDCServerRejecting(t *testing.T, status int, errorCode string) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+
+	oidcHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"issuer":%q,"authorization_endpoint":%q,"token_endpoint":%q,"jwks_uri":%q,"response_types_supported":["code"]}`,
+			srv.URL, srv.URL+"/auth", srv.URL+"/token", srv.URL+"/jwks")
+	}
+	mux.HandleFunc("/.well-known/openid-configuration", oidcHandler)
+	mux.HandleFunc("/.well-known/oauth-authorization-server", oidcHandler)
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if errorCode == "" {
+			// A non-spec-compliant body, as a WAF or reverse proxy would return.
+			_, _ = fmt.Fprint(w, `<html>blocked</html>`)
+			return
+		}
+		_, _ = fmt.Fprintf(w,
+			`{"error":%q,"error_description":"the refresh token is invalid or has expired","secret":"rt-should-not-leak"}`,
+			errorCode)
+	})
+
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// storedRefreshTokenOnly wires a secrets mock that misses the access-token cache
+// and returns a stored refresh token for the base key.
+func storedRefreshTokenOnly(t *testing.T) *secretsmocks.MockProvider {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mock := secretsmocks.NewMockProvider(ctrl)
+	mock.EXPECT().
+		GetSecret(gomock.Any(), gomock.AssignableToTypeOf("")).
+		DoAndReturn(func(_ context.Context, key string) (string, error) {
+			if strings.HasSuffix(key, "_AT") {
+				return "", errors.New("not found")
+			}
+			return testRefreshToken, nil
+		}).AnyTimes()
+	mock.EXPECT().SetSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	return mock
+}
+
+// A permanent token-endpoint verdict means the stored credential is dead and
+// only an interactive login can replace it. Callers keyed on FallbackErr to
+// render their re-login remediation must therefore see FallbackErr, not the raw
+// OAuth error, which reads like a transient provider fault.
+func TestToken_NonInteractive_PermanentVerdict_ReportsFallbackErr(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOIDCServerRejecting(t, http.StatusBadRequest, "invalid_grant")
+	opts := optsWithFakeOIDC(srv, storedRefreshTokenOnly(t))
+
+	_, err := tokensource.New(opts).Token(context.Background())
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errTestFallback,
+		"a rejected stored credential must report as FallbackErr so callers render the re-login remediation")
+}
+
+// The cause stays reachable underneath the sentinel so diagnostics can still
+// identify which verdict the IdP rendered.
+func TestToken_NonInteractive_PermanentVerdict_KeepsCauseReachable(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOIDCServerRejecting(t, http.StatusBadRequest, "invalid_client")
+	opts := optsWithFakeOIDC(srv, storedRefreshTokenOnly(t))
+
+	_, err := tokensource.New(opts).Token(context.Background())
+
+	require.Error(t, err)
+	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
+	require.True(t, ok, "the underlying *oauth2.RetrieveError must stay reachable via errors.As")
+	assert.Equal(t, "invalid_client", retrieveErr.ErrorCode)
+	assert.Contains(t, err.Error(), "invalid_client", "the safe RFC 6749 code belongs in the message")
+}
+
+// An *oauth2.RetrieveError's own Error() embeds the raw token-endpoint response
+// body, which can echo back bearer material. The rendered message must carry
+// only the sentinel and the error code.
+func TestToken_NonInteractive_PermanentVerdict_MessageOmitsResponseBody(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOIDCServerRejecting(t, http.StatusBadRequest, "invalid_grant")
+	opts := optsWithFakeOIDC(srv, storedRefreshTokenOnly(t))
+
+	_, err := tokensource.New(opts).Token(context.Background())
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "rt-should-not-leak",
+		"the raw token-endpoint response body must never reach the rendered message")
+}
+
+// A 5xx is the IdP having a bad day, not a verdict on the credential. It must
+// surface verbatim so the caller can retry rather than telling the user to log
+// in again.
+func TestToken_NonInteractive_TransientVerdict_SurfacesVerbatim(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOIDCServerRejecting(t, http.StatusServiceUnavailable, "temporarily_unavailable")
+	opts := optsWithFakeOIDC(srv, storedRefreshTokenOnly(t))
+
+	_, err := tokensource.New(opts).Token(context.Background())
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, errTestFallback),
+		"a 5xx from the token endpoint is transient and must not be reported as a dead credential")
+}
+
+// A 4xx with no parseable OAuth error code is infrastructure (a WAF or CDN
+// page), not an OAuth verdict, so it must not be reported as a dead credential
+// either.
+func TestToken_NonInteractive_UnparseableRejection_SurfacesVerbatim(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOIDCServerRejecting(t, http.StatusForbidden, "")
+	opts := optsWithFakeOIDC(srv, storedRefreshTokenOnly(t))
+
+	_, err := tokensource.New(opts).Token(context.Background())
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, errTestFallback),
+		"a 4xx without an OAuth error code is upstream infrastructure, not a credential verdict")
 }

--- a/pkg/auth/tokensource/tokensource_test.go
+++ b/pkg/auth/tokensource/tokensource_test.go
@@ -32,6 +32,12 @@ const (
 	testClientID     = "test-client"
 	testKeyPrefix    = "TEST_OAUTH_"
 	testRefreshToken = "stored-rt"
+
+	// Markers planted in the fake token endpoint's error response. Everything a
+	// token endpoint sends back is untrusted, so tests assert none of it reaches
+	// a rendered message.
+	testResponseBodySecret = "rt-should-not-leak"
+	testErrorDescription   = "the refresh token is invalid or has expired"
 )
 
 var errTestFallback = errors.New("test: authentication required")
@@ -716,8 +722,8 @@ func fakeOIDCServerRejecting(t *testing.T, status int, errorCode string) *httpte
 			return
 		}
 		_, _ = fmt.Fprintf(w,
-			`{"error":%q,"error_description":"the refresh token is invalid or has expired","secret":"rt-should-not-leak"}`,
-			errorCode)
+			`{"error":%q,"error_description":%q,"secret":%q}`,
+			errorCode, testErrorDescription, testResponseBodySecret)
 	})
 
 	srv = httptest.NewServer(mux)
@@ -748,7 +754,7 @@ func storedRefreshTokenOnly(t *testing.T) *secretsmocks.MockProvider {
 // only an interactive login can replace it. Callers keyed on FallbackErr to
 // render their re-login remediation must therefore see FallbackErr, not the raw
 // OAuth error, which reads like a transient provider fault.
-func TestToken_NonInteractive_PermanentVerdict_ReportsFallbackErr(t *testing.T) {
+func TestToken_NonInteractive_RejectedGrant_ReportsFallbackErr(t *testing.T) {
 	t.Parallel()
 
 	srv := fakeOIDCServerRejecting(t, http.StatusBadRequest, "invalid_grant")
@@ -762,26 +768,9 @@ func TestToken_NonInteractive_PermanentVerdict_ReportsFallbackErr(t *testing.T) 
 }
 
 // The cause stays reachable underneath the sentinel so diagnostics can still
-// identify which verdict the IdP rendered.
-func TestToken_NonInteractive_PermanentVerdict_KeepsCauseReachable(t *testing.T) {
-	t.Parallel()
-
-	srv := fakeOIDCServerRejecting(t, http.StatusBadRequest, "invalid_client")
-	opts := optsWithFakeOIDC(srv, storedRefreshTokenOnly(t))
-
-	_, err := tokensource.New(opts).Token(context.Background())
-
-	require.Error(t, err)
-	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
-	require.True(t, ok, "the underlying *oauth2.RetrieveError must stay reachable via errors.As")
-	assert.Equal(t, "invalid_client", retrieveErr.ErrorCode)
-	assert.Contains(t, err.Error(), "invalid_client", "the safe RFC 6749 code belongs in the message")
-}
-
-// An *oauth2.RetrieveError's own Error() embeds the raw token-endpoint response
-// body, which can echo back bearer material. The rendered message must carry
-// only the sentinel and the error code.
-func TestToken_NonInteractive_PermanentVerdict_MessageOmitsResponseBody(t *testing.T) {
+// identify which verdict the IdP rendered, even though the rendered message
+// deliberately says nothing about it.
+func TestToken_NonInteractive_RejectedGrant_KeepsCauseReachable(t *testing.T) {
 	t.Parallel()
 
 	srv := fakeOIDCServerRejecting(t, http.StatusBadRequest, "invalid_grant")
@@ -790,8 +779,81 @@ func TestToken_NonInteractive_PermanentVerdict_MessageOmitsResponseBody(t *testi
 	_, err := tokensource.New(opts).Token(context.Background())
 
 	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "rt-should-not-leak",
+	retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
+	require.True(t, ok, "the underlying *oauth2.RetrieveError must stay reachable via errors.As")
+	assert.Equal(t, "invalid_grant", retrieveErr.ErrorCode)
+}
+
+// Everything the token endpoint sends back is untrusted: an
+// *oauth2.RetrieveError's own Error() embeds the raw body, which can echo back
+// bearer material, and the parsed 'error' and 'error_description' fields are
+// arbitrary server-chosen strings. The rendered message must therefore
+// interpolate nothing but the caller's own sentinel.
+func TestToken_NonInteractive_RejectedGrant_MessageCarriesNoServerText(t *testing.T) {
+	t.Parallel()
+
+	srv := fakeOIDCServerRejecting(t, http.StatusBadRequest, "invalid_grant")
+	opts := optsWithFakeOIDC(srv, storedRefreshTokenOnly(t))
+
+	_, err := tokensource.New(opts).Token(context.Background())
+
+	require.Error(t, err)
+	assert.Equal(t,
+		errTestFallback.Error()+" (the identity provider rejected the stored credential)",
+		err.Error(),
+		"the message must be the sentinel plus fixed text, with nothing from the token endpoint")
+	assert.NotContains(t, err.Error(), testResponseBodySecret,
 		"the raw token-endpoint response body must never reach the rendered message")
+	assert.NotContains(t, err.Error(), testErrorDescription,
+		"the server-supplied error_description must never reach the rendered message")
+}
+
+// invalid_client, unauthorized_client, and invalid_scope are permanent, but they
+// indict the client registration or the requested scopes rather than the stored
+// refresh token. A fresh login reproduces them unchanged, so reporting them as
+// the re-login sentinel would send the user in a circle and hide the code that
+// names the real problem.
+func TestToken_NonInteractive_ClientVerdict_SurfacesVerbatim(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []string{"invalid_client", "unauthorized_client", "invalid_scope"} {
+		t.Run(code, func(t *testing.T) {
+			t.Parallel()
+
+			srv := fakeOIDCServerRejecting(t, http.StatusUnauthorized, code)
+			opts := optsWithFakeOIDC(srv, storedRefreshTokenOnly(t))
+
+			_, err := tokensource.New(opts).Token(context.Background())
+
+			require.Error(t, err)
+			assert.False(t, errors.Is(err, errTestFallback),
+				"a verdict on the client, not the credential, must not report as re-login required")
+			retrieveErr, ok := errors.AsType[*oauth2.RetrieveError](err)
+			require.True(t, ok, "the OAuth error must still surface so the operator sees the code")
+			assert.Equal(t, code, retrieveErr.ErrorCode)
+		})
+	}
+}
+
+// The RFC 6749 'error' field is attacker-influenceable text from whatever
+// answered the token endpoint. Only the literal invalid_grant builds the
+// sentinel error, so a hostile code cannot reach that rendered message at all —
+// there is no interpolation path for it to travel down.
+func TestToken_NonInteractive_HostileErrorCode_NeverReachesSentinel(t *testing.T) {
+	t.Parallel()
+
+	hostile := "invalid_grant\r\nAuthorization: Bearer " + testResponseBodySecret
+
+	srv := fakeOIDCServerRejecting(t, http.StatusBadRequest, hostile)
+	opts := optsWithFakeOIDC(srv, storedRefreshTokenOnly(t))
+
+	_, err := tokensource.New(opts).Token(context.Background())
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, errTestFallback),
+		"only the literal invalid_grant may build the sentinel error")
+	assert.NotContains(t, err.Error(), "the identity provider rejected the stored credential",
+		"untrusted text must never be interpolated into the sentinel message")
 }
 
 // A 5xx is the IdP having a bad day, not a verdict on the credential. It must

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -14,12 +14,14 @@ import (
 	"github.com/stacklok/toolhive/pkg/secrets"
 )
 
-// ErrTokenRequired is returned when a fresh token is needed but no cached or
-// refreshable token exists and the caller is non-interactive (browser flow
-// disabled). The user must first complete an interactive login so that a
-// refresh token is persisted for subsequent non-interactive calls.
+// ErrTokenRequired is returned when a fresh token is needed but no USABLE
+// cached credential exists and the caller is non-interactive (browser flow
+// disabled). That covers both an empty cache and a stored refresh token the
+// identity provider has since rejected (expired, revoked, or rotated out from
+// under us) — the two are one outcome to the user, because both are fixed only
+// by an interactive login that persists a new refresh token.
 var ErrTokenRequired = errors.New(
-	"LLM gateway authentication required: no cached credentials found; " +
+	"LLM gateway authentication required: no usable cached credentials; " +
 		"run \"thv llm setup\" to log in",
 )
 


### PR DESCRIPTION
## Summary

A non-interactive token source that had exhausted every cache tier returned its last error verbatim. For a refresh token the IdP had rejected (expired, revoked, or rotated out from under us) that meant a raw `invalid_grant` surfaced instead of the caller's `FallbackErr` sentinel.

That inverts the two outcomes:

- A cache **miss** gets `ErrTokenRequired`, the actionable "you must log in again" error.
- A **dead credential**, the case that genuinely requires an interactive login, gets an opaque OAuth error that every downstream consumer reads as a transient provider fault.

Concretely, `pkg/llm/proxy` keys off `ErrTokenRequired` to return a 401 naming `thv llm setup`, and everything else becomes a 502 `server_error`. So a user whose refresh token died was told the gateway was having a problem, with nothing to act on, and retry loops kept hammering the token endpoint with a credential the IdP had already refused.

This was found while diagnosing a real incident: an agent lost gateway access for nearly three hours because the only error it could show was "provider unhealthy, retry in 30s", while the underlying `invalid_grant` never surfaced.

What changed:

- `Token()` now classifies the terminal error. An RFC 6749 `invalid_grant` is reported as `FallbackErr` with the cause still reachable via `errors.As`; everything else keeps surfacing verbatim so callers can retry or fix the real problem.
- The sentinel is built for `invalid_grant` alone. `invalid_client`, `unauthorized_client`, and `invalid_scope` are just as permanent and just as pointless to retry, but they indict the client registration or the requested scopes rather than the refresh token, so a fresh login reproduces them unchanged. Reporting them as `FallbackErr` would send the user in a circle while hiding the code that names the real problem.
- The rendered message interpolates nothing from the token endpoint. Both the raw response body (an `*oauth2.RetrieveError`'s own `Error()` embeds it, and a token endpoint can echo back bearer material) and the parsed `error` field (arbitrary server-chosen text that may carry secrets or control characters) are untrusted. Since the sentinel is only ever built for `invalid_grant`, the code conveys nothing the fixed sentence does not. There are tests pinning this.
- The transient/permanent rules move to a new leaf package, `pkg/auth/oautherr`, so the token source and the workload auth monitor share one implementation. The monitor keeps the broad `IsPermanentCredentialError` ("should I stop retrying"); the token source uses the narrower `IsRejectedRefreshGrant` ("is the stored credential dead"). The monitor's behaviour and tests are unchanged.
- `ErrTokenRequired`'s wording widens from "no cached credentials found" to "no usable cached credentials", which is accurate for both an empty cache and a rejected one.

Deliberately **not** done: the rejected credential is not deleted from the secrets provider. With an IdP that rotates refresh tokens, a sibling process may have just written a newer token under the same key, and the next `Token()` call re-reads the provider. Deleting on a rejection would destroy that cross-process recovery. Throttling comes from callers no longer treating the failure as retryable.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

`go test -race ./pkg/auth/...` and `go test ./pkg/llm/...` are green; `task lint-fix` reports 0 issues.

New tests in `pkg/auth/tokensource`, each verified to fail before the fix:

| Test | Asserts |
|------|---------|
| `RejectedGrant_ReportsFallbackErr` | `invalid_grant` reports as `FallbackErr` |
| `RejectedGrant_KeepsCauseReachable` | the `*oauth2.RetrieveError` stays reachable via `errors.As` |
| `RejectedGrant_MessageCarriesNoServerText` | the rendered message is the sentinel plus fixed text, with no response body and no `error_description` |
| `ClientVerdict_SurfacesVerbatim` | `invalid_client`, `unauthorized_client`, and `invalid_scope` are not reported as a dead credential |
| `HostileErrorCode_NeverReachesSentinel` | an `error` field carrying CRLF and a secret cannot reach the sentinel message |
| `TransientVerdict_SurfacesVerbatim` | a 5xx is not reported as a dead credential |
| `UnparseableRejection_SurfacesVerbatim` | a 4xx with no OAuth error code is not either |

Plus table-driven suites for the new `pkg/auth/oautherr` package covering both predicates.

## API Compatibility

- [x] This PR does not break the `v1beta1` API.

## Changes

| File | Change |
|------|--------|
| `pkg/auth/oautherr/oautherr.go` | New leaf package: the transient/permanent rules plus the narrower `IsRejectedRefreshGrant` |
| `pkg/auth/tokensource/tokensource.go` | `classifyTerminalError` + `credentialRejectedError` |
| `pkg/auth/monitored_token_source.go` | Private helpers delegate to `oautherr`; no behaviour change |
| `pkg/llm/tokensource.go` | `ErrTokenRequired` wording covers a rejected credential |

## Does this introduce a user-facing change?

Yes. A user whose stored LLM gateway credential has expired or been revoked now gets "authentication required, run `thv llm setup`" instead of an opaque OAuth error, and the LLM proxy returns a 401 with that remediation rather than a 502 `server_error`.

## Special notes for reviewers

The one judgement call worth scrutiny is the boundary of "the stored credential is dead". It is deliberately narrow: only the literal RFC 6749 `invalid_grant`, and only on a response the transient classifier does not already excuse (so a 429 or 5xx claiming `invalid_grant` still surfaces verbatim). Everything else, including the other permanent codes, keeps its own error so the operator sees what the IdP actually said.

That narrowness is also what removes the last untrusted interpolation from the message: with only one possible code, there is nothing left to render. Note that on the verbatim path an `*oauth2.RetrieveError` still prints its response body, which is pre-existing behaviour this PR does not change.

Note also that a locked keyring intentionally still surfaces verbatim rather than as `ErrTokenRequired`. "Unlock your keyring" and "log in again" are different remediations, and an existing test pins that distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
