### PR TITLE
Add CLI identity-token acquisition for keyless skill push

### DIFF
--- a/cmd/thv/app/skill_push.go
+++ b/cmd/thv/app/skill_push.go
@@ -4,14 +4,22 @@
 package app
 
 import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/stacklok/toolhive/pkg/skills"
+	"github.com/stacklok/toolhive/pkg/skills/identitytoken"
 )
 
 var (
-	skillPushKey    string
-	skillPushNoSign bool
+	skillPushKey           string
+	skillPushIdentityToken string
+	skillPushNoSign        bool
 )
 
 var skillPushCmd = &cobra.Command{
@@ -28,21 +36,61 @@ func init() {
 		"Path to a cosign private key to sign the pushed artifact. "+
 			"Encrypted keys are decrypted with COSIGN_PASSWORD read from the 'thv serve' process, "+
 			"which performs the signing")
+	skillPushCmd.Flags().StringVar(&skillPushIdentityToken, "identity-token", "",
+		"OIDC identity token (or a path to a file containing one) for keyless signing. "+
+			"Mutually exclusive with --key. If omitted, one is acquired automatically: from the "+
+			"ambient CI OIDC token when running with id-token: write permission, otherwise via an "+
+			"interactive browser sign-in")
 	skillPushCmd.Flags().BoolVar(&skillPushNoSign, "no-sign", false,
 		"Push without signing (consumers will need an explicit unsigned exception to install project-scoped)")
 }
 
 func skillPushCmdFunc(cmd *cobra.Command, args []string) error {
-	c := newSkillClient(cmd.Context())
+	ctx := cmd.Context()
 
-	err := c.Push(cmd.Context(), skills.PushOptions{
-		Reference: args[0],
+	token, err := identitytoken.Acquire(ctx, identitytoken.Options{
+		FlagValue: skillPushIdentityToken,
 		Key:       skillPushKey,
 		NoSign:    skillPushNoSign,
+		Confirm:   confirmBrowserSignIn,
+	})
+	if err != nil {
+		return formatSkillError("push skill", err)
+	}
+
+	c := newSkillClient(ctx)
+	err = c.Push(ctx, skills.PushOptions{
+		Reference:     args[0],
+		Key:           skillPushKey,
+		IdentityToken: token,
+		NoSign:        skillPushNoSign,
 	})
 	if err != nil {
 		return formatSkillError("push skill", err)
 	}
 
 	return nil
+}
+
+// confirmBrowserSignIn is the identitytoken.Options.Confirm callback for
+// `skill push`: on a non-interactive terminal it declines silently (no
+// error — Acquire falls through to its own actionable failure text), since
+// this command has no --yes escape hatch the way sync/upgrade do. On a TTY
+// it prompts to stderr (stdout is reserved for command output) and reads a
+// y/N response. Deliberately not requireConfirmation (skill_confirm.go):
+// that helper's non-interactive refusal hardcodes "pass --yes to run
+// non-interactively", which doesn't apply to a command with no --yes flag.
+func confirmBrowserSignIn() (bool, error) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) { //nolint:gosec // uintptr fits int on all supported platforms
+		return false, nil
+	}
+
+	fmt.Fprint(os.Stderr, "Sign in with a browser to sign this push keylessly? [y/N]: ")
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("failed to read user input: %w", err)
+	}
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes", nil
 }

--- a/cmd/thv/app/skill_push_test.go
+++ b/cmd/thv/app/skill_push_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfirmBrowserSignInNonInteractiveDeclinesSilently exercises the
+// non-interactive path: in this test process, os.Stdin is not a terminal,
+// so this reaches the decline branch without needing to fake TTY detection
+// (same approach as TestRequireConfirmationNonInteractiveWithoutYesRefuses
+// in skill_confirm_test.go). Unlike requireConfirmation, this must NOT
+// error — skill push has no --yes flag to hint at, so Acquire's own
+// actionable failure text is the only message the user sees.
+func TestConfirmBrowserSignInNonInteractiveDeclinesSilently(t *testing.T) {
+	t.Parallel()
+	confirmed, err := confirmBrowserSignIn()
+	require.NoError(t, err)
+	assert.False(t, confirmed)
+}

--- a/docs/arch/12-skills-system.md
+++ b/docs/arch/12-skills-system.md
@@ -187,6 +187,40 @@ thv skill push ghcr.io/org/my-skill:v1.0.0
 
 **Implementation:** `pkg/skills/skillsvc/build.go` (Push), `toolhive-core/oci/skills` (RegistryClient)
 
+**Signing:** Every push is signed by default — the RFC THV-0080 trust model
+has no unsigned publish path. `thv skill push` requires exactly one of three
+mutually exclusive choices:
+
+- `--key <path>`: sign with a cosign private key (`COSIGN_PASSWORD`
+  decrypts encrypted keys, read server-side by `thv serve`, which performs
+  the signing).
+- `--identity-token <token-or-path>`: sign keylessly. The CLI acquires an
+  OIDC identity token and forwards it in the push request; the server
+  exchanges it with Fulcio for a short-lived certificate, signs, and records
+  a Rekor transparency-log entry (`toolhive-core/container/signer`). The
+  server never handles long-lived credentials — only the already-acquired,
+  short-lived token.
+- `--no-sign`: push unsigned. Consumers installing project-scoped need an
+  explicit unsigned exception.
+
+When none of the three is given, `pkg/skills/identitytoken` runs an
+acquisition ladder before the push request is made, so a failure here never
+leaves an unsigned artifact published:
+
+1. A GitHub Actions ambient OIDC token, when the job has
+   `permissions: id-token: write` (`ACTIONS_ID_TOKEN_REQUEST_URL` /
+   `_TOKEN`, scoped to the `sigstore` audience).
+2. Otherwise, on an interactive terminal only: a y/N prompt, then a browser
+   sign-in against the public-good Sigstore OAuth instance
+   (`oauth2.sigstore.dev`).
+3. If neither yields a token (non-interactive with no ambient token, or the
+   prompt declined): the push fails with an actionable error naming all
+   three signing choices, never silently unsigned.
+
+`--key` and `--identity-token` are mutually exclusive; the identity token,
+once resolved, is always forwarded even alongside `--key` so the server
+reports the conflict rather than the client silently picking one.
+
 ### 4. Installation
 
 ```bash
@@ -506,6 +540,9 @@ The skills system applies defense-in-depth across multiple layers:
 - OCI artifact skill name must match the last path component of the OCI repository
 - Git authentication is host-scoped (GitHub token only sent to github.com)
 - SSRF prevention: rejects localhost and private IPs in git references
+- Push signing is keyless by default; see "3. Publishing" above for the
+  credential ladder and the CLI-acquires / server-signs split
+  (`pkg/skills/identitytoken`, `toolhive-core/container/signer`)
 
 ### Input Validation
 - Skill names: 2-64 chars, lowercase alphanumeric + hyphens, no consecutive hyphens

--- a/docs/cli/thv_skill_push.md
+++ b/docs/cli/thv_skill_push.md
@@ -24,9 +24,10 @@ thv skill push [reference] [flags]
 ### Options
 
 ```
-  -h, --help         help for push
-      --key string   Path to a cosign private key to sign the pushed artifact. Encrypted keys are decrypted with COSIGN_PASSWORD read from the 'thv serve' process, which performs the signing
-      --no-sign      Push without signing (consumers will need an explicit unsigned exception to install project-scoped)
+  -h, --help                    help for push
+      --identity-token string   OIDC identity token (or a path to a file containing one) for keyless signing. Mutually exclusive with --key. If omitted, one is acquired automatically: from the ambient CI OIDC token when running with id-token: write permission, otherwise via an interactive browser sign-in
+      --key string              Path to a cosign private key to sign the pushed artifact. Encrypted keys are decrypted with COSIGN_PASSWORD read from the 'thv serve' process, which performs the signing
+      --no-sign                 Push without signing (consumers will need an explicit unsigned exception to install project-scoped)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/skills/identitytoken/acquire.go
+++ b/pkg/skills/identitytoken/acquire.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package identitytoken
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sigstore/sigstore/pkg/oauthflow"
+)
+
+// ErrNoCredential is returned when Acquire exhausts every rung of the
+// ladder without obtaining a signing credential. The message names every
+// remaining option so the failure is actionable from the CLI alone.
+var ErrNoCredential = errors.New("signing required: no signing credential available. " +
+	"Provide --key, --identity-token, run in CI with id-token: write permission, or pass --no-sign to push unsigned")
+
+// Options configures Acquire.
+type Options struct {
+	// FlagValue is the raw --identity-token flag value, if given.
+	FlagValue string
+	// Key is the --key flag value, if given.
+	Key string
+	// NoSign is the --no-sign flag value.
+	NoSign bool
+	// Confirm is called only when no token was found ambiently, to ask the
+	// user (via the CLI's own TTY-gated prompt) whether to open a browser
+	// for an interactive sign-in. Returning (false, nil) declines or skips
+	// without error. Required.
+	Confirm func() (bool, error)
+}
+
+// Acquire resolves the identity token to sign a skill push with, trying
+// each rung of the ladder in order:
+//
+//  1. An explicit --identity-token is always resolved and forwarded, even
+//     alongside --key — the ambiguity is a conflict for the server to
+//     reject (skillsvc.validateSigningInputs), never something to silently
+//     arbitrate client-side.
+//  2. --key or --no-sign with no --identity-token means the user made an
+//     explicit signing choice; Acquire returns "" without attempting
+//     ambient or interactive acquisition.
+//  3. A GitHub Actions ambient OIDC token, when present.
+//  4. An interactive browser sign-in, gated by opts.Confirm.
+//  5. ErrNoCredential.
+func Acquire(ctx context.Context, opts Options) (string, error) {
+	if opts.Confirm == nil {
+		return "", errors.New("identitytoken: Options.Confirm is required")
+	}
+	if opts.FlagValue != "" {
+		return Resolve(opts.FlagValue)
+	}
+	if opts.Key != "" || opts.NoSign {
+		return "", nil
+	}
+
+	if token, ok, err := Ambient(ctx); err != nil {
+		return "", err
+	} else if ok {
+		return token, nil
+	}
+
+	confirmed, err := opts.Confirm()
+	if err != nil {
+		return "", err
+	}
+	if !confirmed {
+		return "", ErrNoCredential
+	}
+
+	return Interactive(oauthflow.DefaultIDTokenGetter)
+}

--- a/pkg/skills/identitytoken/acquire_test.go
+++ b/pkg/skills/identitytoken/acquire_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package identitytoken
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func alwaysConfirm() (bool, error) { return true, nil }
+func neverConfirm() (bool, error)  { return false, nil }
+
+func TestAcquireExplicitFlagAlwaysWins(t *testing.T) {
+	t.Parallel()
+
+	// Regression case: an explicit --identity-token must be resolved and
+	// forwarded even when --key is also set, so the server (not the
+	// client) reports the conflict. It must never be silently dropped.
+	token, err := Acquire(t.Context(), Options{
+		FlagValue: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig",
+		Key:       "/tmp/cosign.key",
+		Confirm:   neverConfirm,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig", token)
+}
+
+func TestAcquireExplicitKeyOrNoSignSkipsAcquisition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts Options
+	}{
+		{name: "key set", opts: Options{Key: "/tmp/cosign.key"}},
+		{name: "no_sign set", opts: Options{NoSign: true}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.opts.Confirm = func() (bool, error) {
+				t.Fatal("Confirm must not be called when an explicit signing choice was made")
+				return false, nil
+			}
+			token, err := Acquire(t.Context(), tc.opts)
+			require.NoError(t, err)
+			assert.Empty(t, token)
+		})
+	}
+}
+
+// TestAcquireConsultsConfirmWhenNoAmbientToken proves Confirm is only
+// reached once ambient acquisition is unavailable — declining it surfaces
+// ErrNoCredential without ever attempting a real interactive sign-in.
+// Acquire hardcodes oauthflow.DefaultIDTokenGetter for the confirmed=true
+// case, so that branch isn't exercised here — see TestInteractive, which
+// verifies the actual OIDConnect wiring via an injected StaticTokenGetter.
+func TestAcquireConsultsConfirmWhenNoAmbientToken(t *testing.T) {
+	// Not parallel: Ambient reads process env vars via t.Setenv.
+	t.Setenv(envRequestURL, "")
+	t.Setenv(envRequestToken, "")
+
+	called := false
+	confirm := func() (bool, error) {
+		called = true
+		return false, nil
+	}
+
+	_, err := Acquire(t.Context(), Options{Confirm: confirm})
+	require.ErrorIs(t, err, ErrNoCredential)
+	assert.True(t, called, "Confirm must be consulted once ambient acquisition is unavailable")
+}
+
+func TestAcquireConfirmErrorPropagates(t *testing.T) {
+	t.Setenv(envRequestURL, "")
+	t.Setenv(envRequestToken, "")
+
+	wantErr := errors.New("reading stdin failed")
+	_, err := Acquire(t.Context(), Options{
+		Confirm: func() (bool, error) { return false, wantErr },
+	})
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestAcquireRequiresConfirmCallback(t *testing.T) {
+	t.Parallel()
+
+	_, err := Acquire(t.Context(), Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Confirm is required")
+}
+
+func TestAcquireInvalidFlagValuePropagatesResolveError(t *testing.T) {
+	t.Parallel()
+
+	_, err := Acquire(t.Context(), Options{
+		FlagValue: "/does/not/exist/and-not-a-jwt",
+		Confirm:   alwaysConfirm,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "neither a readable file nor a JWT")
+}

--- a/pkg/skills/identitytoken/ambient.go
+++ b/pkg/skills/identitytoken/ambient.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package identitytoken
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+const (
+	// envRequestURL and envRequestToken are set by GitHub Actions when the
+	// job has `permissions: id-token: write` — the ambient OIDC credential
+	// source. Absence of either means the job doesn't have that permission,
+	// not a failure.
+	envRequestURL   = "ACTIONS_ID_TOKEN_REQUEST_URL"
+	envRequestToken = "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+
+	sigstoreAudience = "sigstore"
+
+	ambientRequestTimeout = 10 * time.Second
+)
+
+// Ambient fetches a GitHub Actions ambient OIDC token scoped to the
+// sigstore audience. ok is false with a nil error when the environment
+// doesn't carry the id-token: write request variables — that is simply not
+// running under that permission, not a failure. A request that fails once
+// both variables are present IS an error: the caller expected this to work.
+func Ambient(ctx context.Context) (token string, ok bool, err error) {
+	reqURL := os.Getenv(envRequestURL)
+	reqToken := os.Getenv(envRequestToken)
+	if reqURL == "" || reqToken == "" {
+		return "", false, nil
+	}
+
+	u, err := url.Parse(reqURL)
+	if err != nil {
+		return "", false, fmt.Errorf("parsing %s: %w", envRequestURL, err)
+	}
+	// Merge into the existing query rather than concatenating — the URL GHA
+	// provides already carries its own query parameters.
+	q := u.Query()
+	q.Set("audience", sigstoreAudience)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", false, fmt.Errorf("building ambient OIDC token request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+reqToken)
+
+	client := &http.Client{Timeout: ambientRequestTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("requesting ambient OIDC token: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("ambient OIDC token request returned status %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", false, fmt.Errorf("decoding ambient OIDC token response: %w", err)
+	}
+	if body.Value == "" {
+		return "", false, errors.New("ambient OIDC token response had an empty value")
+	}
+	return body.Value, true, nil
+}

--- a/pkg/skills/identitytoken/ambient_test.go
+++ b/pkg/skills/identitytoken/ambient_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package identitytoken
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAmbient is not run in parallel: it uses t.Setenv, which forbids it.
+func TestAmbient(t *testing.T) {
+	tests := []struct {
+		name        string
+		reqURLSet   bool
+		reqTokenSet bool
+		handler     http.HandlerFunc
+		wantOK      bool
+		wantErr     string
+		wantToken   string
+	}{
+		{
+			name:      "no request URL: unavailable, not an error",
+			reqURLSet: false,
+		},
+		{
+			name:        "no request token: unavailable, not an error",
+			reqURLSet:   true,
+			reqTokenSet: false,
+		},
+		{
+			name:        "success merges audience into existing query",
+			reqURLSet:   true,
+			reqTokenSet: true,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "sigstore", r.URL.Query().Get("audience"))
+				assert.Equal(t, "2.0", r.URL.Query().Get("api-version"))
+				assert.Equal(t, "Bearer test-request-token", r.Header.Get("Authorization"))
+				_ = json.NewEncoder(w).Encode(map[string]string{"value": "the.jwt.token"})
+			},
+			wantOK:    true,
+			wantToken: "the.jwt.token",
+		},
+		{
+			name:        "non-2xx status is an error",
+			reqURLSet:   true,
+			reqTokenSet: true,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+			wantErr: "status 403",
+		},
+		{
+			name:        "malformed body is an error",
+			reqURLSet:   true,
+			reqTokenSet: true,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("not json"))
+			},
+			wantErr: "decoding ambient OIDC token response",
+		},
+		{
+			name:        "empty value is an error",
+			reqURLSet:   true,
+			reqTokenSet: true,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]string{"value": ""})
+			},
+			wantErr: "empty value",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.handler != nil {
+				srv := httptest.NewServer(tc.handler)
+				t.Cleanup(srv.Close)
+				u, err := url.Parse(srv.URL)
+				require.NoError(t, err)
+				q := u.Query()
+				q.Set("api-version", "2.0")
+				u.RawQuery = q.Encode()
+				t.Setenv(envRequestURL, u.String())
+			} else if tc.reqURLSet {
+				t.Setenv(envRequestURL, "https://example.test/token")
+			} else {
+				t.Setenv(envRequestURL, "")
+			}
+			if tc.reqTokenSet {
+				t.Setenv(envRequestToken, "test-request-token")
+			} else {
+				t.Setenv(envRequestToken, "")
+			}
+
+			token, ok, err := Ambient(t.Context())
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.False(t, ok)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantToken, token)
+			}
+		})
+	}
+}

--- a/pkg/skills/identitytoken/interactive.go
+++ b/pkg/skills/identitytoken/interactive.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package identitytoken
+
+import (
+	"fmt"
+
+	"github.com/sigstore/sigstore/pkg/oauthflow"
+)
+
+// Public-good Sigstore OAuth instance (oauth2.sigstore.dev), the same
+// values cosign uses for its interactive `--identity-token` login. There is
+// no toolhive-specific OAuth application — every Sigstore-signing tool
+// authenticates against this same public client.
+const (
+	sigstoreOAuthIssuer   = "https://oauth2.sigstore.dev/auth"
+	sigstoreOAuthClientID = "sigstore"
+)
+
+// Interactive obtains an OIDC identity token via an interactive browser
+// sign-in against the public-good Sigstore OAuth instance. tg is injectable
+// for tests (see oauthflow.StaticTokenGetter); production callers pass
+// oauthflow.DefaultIDTokenGetter.
+//
+// This blocks until the user completes or abandons the browser flow.
+// oauthflow.OIDConnect accepts no context and hardcodes context.Background()
+// internally, so there is no cancellation path to plumb here: the redirect
+// wait self-limits to 120s, but provider discovery, the code exchange, and
+// the out-of-band stdin fallback are all unbounded. That's acceptable
+// because this only runs after an explicit y/N confirmation on a TTY — a
+// human is already present, and Ctrl-C is the exit. Wrapping this in a
+// goroutine would leak one blocked on stdin or a listening socket with no
+// way to cancel it, which is worse than an unbounded wait a human can
+// interrupt themselves.
+func Interactive(tg oauthflow.TokenGetter) (string, error) {
+	tok, err := oauthflow.OIDConnect(sigstoreOAuthIssuer, sigstoreOAuthClientID, "", "", tg)
+	if err != nil {
+		return "", fmt.Errorf("acquiring identity token via browser sign-in: %w", err)
+	}
+	return tok.RawString, nil
+}

--- a/pkg/skills/identitytoken/interactive_test.go
+++ b/pkg/skills/identitytoken/interactive_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package identitytoken
+
+import (
+	"testing"
+
+	josejwt "github.com/go-jose/go-jose/v4"
+	"github.com/sigstore/sigstore/pkg/oauthflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInteractive proves the wiring against oauthflow.OIDConnect end to end
+// without a real OAuth exchange: OIDConnect special-cases
+// oauthflow.StaticTokenGetter and calls its GetIDToken directly, skipping
+// provider discovery and all network calls. The token must still be a
+// structurally valid (if unverified) compact JWS, since StaticTokenGetter
+// parses it to extract a subject.
+func TestInteractive(t *testing.T) {
+	t.Parallel()
+
+	token := signedTestJWT(t, `{"sub":"test-subject"}`)
+
+	got, err := Interactive(&oauthflow.StaticTokenGetter{RawToken: token})
+	require.NoError(t, err)
+	assert.Equal(t, token, got)
+}
+
+func TestInteractivePropagatesGetterError(t *testing.T) {
+	t.Parallel()
+
+	_, err := Interactive(&oauthflow.StaticTokenGetter{RawToken: "not-a-jwt"})
+	require.Error(t, err)
+}
+
+// signedTestJWT builds a real, structurally valid (but unverified) compact
+// JWS over payload using an ephemeral HS256 key — enough for
+// jose.ParseSigned (used internally by StaticTokenGetter) to accept it.
+func signedTestJWT(t *testing.T, payload string) string {
+	t.Helper()
+	signer, err := josejwt.NewSigner(josejwt.SigningKey{
+		Algorithm: josejwt.HS256,
+		Key:       []byte("test-signing-key-not-used-for-anything-real"),
+	}, nil)
+	require.NoError(t, err)
+
+	sig, err := signer.Sign([]byte(payload))
+	require.NoError(t, err)
+
+	compact, err := sig.CompactSerialize()
+	require.NoError(t, err)
+	return compact
+}

--- a/pkg/skills/identitytoken/resolve.go
+++ b/pkg/skills/identitytoken/resolve.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package identitytoken resolves and acquires the OIDC identity token used
+// for keyless skill push signing (RFC THV-0080 / #6307). It is CLI-side
+// only: the server never handles credentials, only the already-acquired
+// token forwarded in the push request (skills.PushOptions.IdentityToken).
+package identitytoken
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Resolve interprets the --identity-token flag value: a path to a file
+// containing the token, or the raw token itself (cosign parity with --key,
+// which already accepts a path). An existing regular file wins; otherwise a
+// JWT-shaped value (two dots) is used as a literal token; otherwise this is
+// an error rather than a guess, so a mistyped path is never silently
+// forwarded to Fulcio as if it were a token.
+func Resolve(value string) (string, error) {
+	if path, ok := existingFile(value); ok {
+		data, err := os.ReadFile(path) //nolint:gosec // path is canonicalized and vetted by existingFile
+		if err != nil {
+			return "", fmt.Errorf("reading identity token file %q: %w", value, err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	if looksLikeJWT(value) {
+		return value, nil
+	}
+	return "", fmt.Errorf("--identity-token %q is neither a readable file nor a JWT", value)
+}
+
+// existingFile reports whether value names a readable regular file,
+// following the same canonicalization core's resolveKeyPath uses for --key:
+// absolute, cleaned, symlinks resolved.
+func existingFile(value string) (string, bool) {
+	if value == "" {
+		return "", false
+	}
+	abs, err := filepath.Abs(value)
+	if err != nil {
+		return "", false
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(abs))
+	if err != nil {
+		return "", false
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", false
+	}
+	return resolved, true
+}
+
+// looksLikeJWT applies the same shape heuristic already used elsewhere in
+// this repo (pkg/authz/authorizers/cedar/core.go) to distinguish a
+// compact-serialized JWT from other input: exactly two dots. This is a
+// disambiguation heuristic, not validation — Fulcio is the real authority
+// on whether the token is valid.
+func looksLikeJWT(s string) bool {
+	return strings.Count(s, ".") == 2
+}

--- a/pkg/skills/identitytoken/resolve_test.go
+++ b/pkg/skills/identitytoken/resolve_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package identitytoken
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+
+	tokenFile := filepath.Join(resolved, "token.jwt")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("  eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig\n"), 0o600))
+
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "readable file wins, trimmed",
+			value: tokenFile,
+			want:  "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig",
+		},
+		{
+			name:  "JWT-shaped literal",
+			value: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig",
+			want:  "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig",
+		},
+		{
+			name:    "neither a file nor JWT-shaped",
+			value:   filepath.Join(resolved, "does-not-exist.jwt"),
+			wantErr: "neither a readable file nor a JWT",
+		},
+		{
+			name:    "empty value",
+			value:   "",
+			wantErr: "neither a readable file nor a JWT",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Resolve(tc.value)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #6385. #6307 (keyless push signing) makes keyless the *default*
signing path, not something to opt into per push — but until now nothing
gave `thv skill push` a way to actually obtain an identity token, so
`PushOptions.IdentityToken` (added in #6385) had no way to become non-empty.

- Add `--identity-token` to `thv skill push`: accepts a raw OIDC token or a
  path to a file containing one (cosign parity with `--key`).
- New `pkg/skills/identitytoken` package implements the acquisition ladder
  when the flag is absent and neither `--key` nor `--no-sign` was given:
  1. A GitHub Actions ambient OIDC token (`ACTIONS_ID_TOKEN_REQUEST_URL` /
     `_TOKEN`, scoped to the `sigstore` audience) — the CI case.
  2. Otherwise, only on an interactive terminal: a y/N prompt, then a
     browser sign-in against the public-good Sigstore OAuth instance
     (`oauth2.sigstore.dev`, via `sigstore/sigstore/pkg/oauthflow` — already
     a direct dependency).
  3. If neither yields a token: an actionable failure naming all three
     signing choices. Never silently unsigned.
- An explicit `--identity-token` is always resolved and forwarded, even
  alongside `--key` — the conflict is the server's to reject
  (`skillsvc.validateSigningInputs`, from #6385), never something the
  client silently arbitrates.
- All of this runs client-side before the push HTTP request, so a failed
  acquisition never leaves an unsigned artifact published.
- `docs/arch/12-skills-system.md`: documents the three signing choices, the
  CLI-acquires/server-signs split, and the ladder, in the same PR that ships
  the UX.

**Consequence worth flagging explicitly**: after this merges, a bare
`thv skill push` with no flags at all stops being a hard 400 and starts
signing keylessly — in CI from the ambient token, or after a browser prompt
locally. That's the intended fix for the CI breakage from #6139 (the
workflow file itself is repaired in the next PR in this stack).

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

`task test` passes for `pkg/skills/identitytoken` (new, thorough table-driven
coverage: `Resolve`'s file/literal/error disambiguation, `Ambient`'s
env-var-absent/success/error-response cases via `httptest`, `Acquire`'s full
precedence table including the regression case where `--key` +
`--identity-token` are both set, and `Interactive`'s wiring via
`oauthflow.StaticTokenGetter` with a structurally-valid unverified JWT
fixture — no real OAuth exchange). One unrelated failure appeared in
`pkg/transport/proxy/streamable` from a stray leftover process holding a
hardcoded test port in this local environment (same pre-existing flake noted
on the earlier PRs in this stack, untouched package).

Manual: built binary, ran `thv skill push <ref>` with stdin from `/dev/null`
(no `--key`/`--no-sign`/`--identity-token`) — fails immediately with the
documented text, no HTTP request attempted (no `thv serve` was even running).
`--identity-token /no/such/file` fails naming both possibilities rather than
being forwarded as a literal token. Did not exercise the real interactive
browser flow or a live Fulcio/Rekor round trip — that's covered by the
staging E2E job in the next PR in this stack, not here.

## Changes

| File | Change |
|------|--------|
| `pkg/skills/identitytoken/{resolve,ambient,interactive,acquire}.go` | New: token resolution, ambient CI fetch, interactive browser flow, ladder orchestration |
| `cmd/thv/app/skill_push.go` | `--identity-token` flag, TTY-gated confirm callback, one `Acquire` call before `Push` |
| `docs/arch/12-skills-system.md` | Document the three signing choices, precedence, and the ladder |
| `docs/cli/thv_skill_push.md` | Regenerated via `task docs` |

## Does this introduce a user-facing change?

Yes — `thv skill push` gains `--identity-token`, and a push with none of
`--key` / `--identity-token` / `--no-sign` now attempts keyless signing
automatically (ambient CI token, or an interactive browser prompt) instead
of unconditionally failing with "signing key required". If no credential can
be acquired, it still fails, with an error naming all three options.

## Special notes for reviewers

Base branch is `skills-keyless/02-push-token-plumbing` (#6385), not `main`.

Two things flagged during design review worth a second look:
- The `sigstore` OAuth client ID used for the interactive flow is cosign's
  well-known public value, but it isn't a constant in any vendored library
  (only the issuer URL, `https://oauth2.sigstore.dev/auth`, is), so it could
  not be confirmed from source alone — worth one real interactive run before
  merge to be certain.
- `oauthflow.OIDConnect` takes no `context.Context` and hardcodes
  `context.Background()` internally, so `Interactive` has no cancellation
  path to plumb. The redirect wait self-limits to 120s, but provider
  discovery, the code exchange, and the out-of-band stdin fallback are
  unbounded. Accepted deliberately (documented in `interactive.go`): this
  only runs after an explicit y/N on a TTY, so a human is present and Ctrl-C
  is the exit — wrapping it in a goroutine would leak one blocked on stdin
  or an open socket with no way to cancel it.

Out of scope, flagged for a separate issue: `thv ai-plugin push` still
declares no `--key` / `--no-sign` / `--identity-token` at all, even though
`plugins.PushOptions` is a type alias of `skills.PushOptions` and already
carries `IdentityToken`. That issue has not been filed yet.
