### PR TITLE
Pin golangci-lint below the 2.13.0 nilness crash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,5 +44,11 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
+          # Pinned below v2.13.0: that release bundles honnef.co/go/tools
+          # v0.8.0-rc.1, whose nilness analyzer panics analyzing this repo's
+          # dependency graph (package "sentry") — reproduces deterministically
+          # on a clean checkout, unrelated to any PR's changes. Unpin once
+          # upstream ships a fixed nilness analyzer.
+          version: v2.12.2
           # Enable golangci-lint's built-in caching (removes skip-cache: true)
           args: --timeout=5m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: 'stable'
+          # go.mod's directive, not 'stable': golangci-lint is pinned below
+          # v2.13.0 (see the version comment further down), and that older
+          # release's bundled type-checker cannot parse the newer Go
+          # toolchain's stdlib (e.g. a generic-method signature in
+          # math/rand/v2 under Go 1.27), so linting must run on the Go
+          # version the module itself targets.
+          go-version-file: go.mod
           cache: true  # Caches go modules
           cache-dependency-path: go.sum
 


### PR DESCRIPTION
## Summary

- golangci-lint 2.13.0 bundles `honnef.co/go/tools` v0.8.0-rc.1, whose `nilness` analyzer panics analyzing this repo's dependency graph (specifically `pkg/sentry`), causing `goanalysis_metalinter` to fail with `internal error: unhandled builtin recover`. This currently fails linting on **every** PR, unrelated to the PR's own changes — I reproduced it deterministically on a clean, unmodified checkout of `main`.
- Pins `golangci-lint-action`'s `version` input to `2.12.2`, the last release before the broken analyzer bundle. Verified `2.12.2` runs clean (`0 issues.`) on the current `main` tip.
- No code changes; only `.github/workflows/lint.yml`.

## Type of change

- [x] Bug fix

## Test plan

- [x] Linting (`task lint-fix`) — ran `golangci-lint run --allow-parallel-runners --timeout=5m ./...` locally with both the CI-matching 2.13.0 (reproduces the panic) and the pinned 2.12.2 (`0 issues.`) against a clean `main` checkout.

## API Compatibility

Not applicable — CI workflow only, no operator API surface touched.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

Discovered while investigating an unrelated PR's CI failures — the lint job started failing there with no relevant code changes, no local repro (my locally-cached golangci-lint was 2.12.2 already), and correlated exactly with `golangci-lint-action` picking up 2.13.0. Unpin once upstream ships a fixed `nilness` analyzer.