### PR TITLE
Pin golangci-lint to avoid nilness panic on main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: 'stable'
+          # go.mod's directive, not 'stable': golangci-lint is pinned below
+          # v2.13.0 (see the version comment further down), and that older
+          # release's bundled type-checker cannot parse the newer Go
+          # toolchain's stdlib (e.g. a generic-method signature in
+          # math/rand/v2 under Go 1.27), so linting must run on the Go
+          # version the module itself targets.
+          go-version-file: go.mod
           cache: true  # Caches go modules
           cache-dependency-path: go.sum
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,5 +44,10 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
+          # Pin to a known-good release: v2.13.0 bundles honnef.co/go/tools
+          # v0.8.0-rc.1, whose nilness analyzer panics ("unhandled builtin
+          # recover") analyzing github.com/getsentry/sentry-go. Unpin once
+          # upstream ships a fixed release.
+          version: v2.12.2
           # Enable golangci-lint's built-in caching (removes skip-cache: true)
           args: --timeout=5m


### PR DESCRIPTION
## Summary

CI on `main` is failing: `golangci-lint` panics during the `staticcheck` /
`nilness` fact analysis with `internal error: unhandled builtin recover`
while analyzing `github.com/getsentry/sentry-go` (a dependency of
`pkg/sentry`). See the failing run:
https://github.com/stacklok/toolhive/actions/runs/32346960123/job/96357620328

Root cause: `.github/workflows/lint.yml` used to pin
`golangci-lint-action`'s `version` input (`v2.0.1`), but that pin was
silently dropped when the action was bumped to v8.0.0. Since then, CI
floats to golangci-lint's latest release. `v2.13.0` (released
2026-08-19) bundles a release-candidate build of staticcheck
(`honnef.co/go/tools@v0.8.0-rc.1`), which crashes on this codebase.
This is an upstream bug — `pkg/sentry/sentry.go` itself never calls
`recover()`.

- Pin `golangci-lint-action`'s `version` input back to `v2.12.2`, the
  last stable release before the regression, until upstream ships a
  fix.

Fixes #

## Type of change

- [x] Bug fix

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Confirmed via `gh release list` that `v2.12.2` (2026-05-06) predates
the `v2.13.0` (2026-08-19) release that introduced the staticcheck RC
dependency, and that this repo has no `replace` directive affecting
`github.com/getsentry/sentry-go`. This is a CI-only config change;
correctness will be confirmed by this PR's own lint job running
against the pinned version.

## Special notes for reviewers

Once golangci-lint ships a release with a fixed `honnef.co/go/tools`
version, the `version: v2.12.2` pin (and its explanatory comment)
should be removed so CI floats to latest again.

Generated with [Claude Code](https://claude.com/claude-code)