### PR TITLE
Store plugin sigstore bundles, carry git signature

### DIFF
--- a/pkg/plugins/pluginsvc/install_git.go
+++ b/pkg/plugins/pluginsvc/install_git.go
@@ -50,7 +50,10 @@ func (s *service) installFromGit(
 
 	gitURL := opts.Name
 
-	files, manifest, commitHash, err := s.cloneAndCollectPlugin(ctx, gitRef)
+	// head carries the resolved commit's hash plus its (unverified) gitsign
+	// signature and signed payload. Only the hash is consumed today; the
+	// signature and payload are carried for install-time verification.
+	files, manifest, head, err := s.cloneAndCollectPlugin(ctx, gitRef)
 	if err != nil {
 		return nil, httperr.WithCode(
 			fmt.Errorf("resolving git plugin: %w", err),
@@ -85,7 +88,7 @@ func (s *service) installFromGit(
 	opts.Name = manifest.Name
 	opts.LayerData = layerData
 	opts.Reference = gitURL
-	opts.Digest = commitHash
+	opts.Digest = head.Hash
 	opts.Components = manifestComponentInventory(manifest)
 	opts.Description = manifest.Description
 	if opts.Version == "" && manifest.Version != "" {
@@ -112,10 +115,12 @@ func (s *service) installFromGit(
 // cloneAndCollectPlugin clones the repo referenced by gitRef, reads the plugin
 // manifest, and collects every file under the plugin subdirectory. Returns the
 // files as ociartifact.FileEntry values (ready for CompressTar), the parsed
-// manifest, and the commit hash.
+// manifest, and the HEAD commit. The commit carries its hash (used as the
+// install digest) alongside its UNVERIFIED gitsign signature and the payload
+// that signature covers, so install-time verification can check them.
 func (s *service) cloneAndCollectPlugin(
 	ctx context.Context, gitRef *gitresolver.GitReference,
-) ([]ociartifact.FileEntry, *plugins.PluginManifest, string, error) {
+) ([]ociartifact.FileEntry, *plugins.PluginManifest, git.HeadCommit, error) {
 	ctx, cancel := context.WithTimeout(ctx, gitresolver.CloneTimeout)
 	defer cancel()
 
@@ -124,33 +129,32 @@ func (s *service) cloneAndCollectPlugin(
 	client := gitresolver.ClientForURL(gitRef.URL, s.gitClient)
 	repoInfo, err := client.Clone(ctx, cloneConfig)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("cloning repository: %w", err)
+		return nil, nil, git.HeadCommit{}, fmt.Errorf("cloning repository: %w", err)
 	}
 	defer func() { _ = client.Cleanup(ctx, repoInfo) }()
 
 	head, err := client.HeadCommit(repoInfo)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("getting HEAD commit: %w", err)
+		return nil, nil, git.HeadCommit{}, fmt.Errorf("getting HEAD commit: %w", err)
 	}
-	commitHash := head.Hash
 
 	// Read the plugin manifest. It lives at <path>/.claude-plugin/plugin.json.
 	// We collect the whole file tree first, then locate the manifest among the
 	// collected entries so we don't need a second pass over the repo.
 	fileEntries, err := collectPluginFiles(repoInfo, gitRef.Path)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("collecting plugin files: %w", err)
+		return nil, nil, git.HeadCommit{}, fmt.Errorf("collecting plugin files: %w", err)
 	}
 
 	manifestBytes, err := findManifestBytes(fileEntries)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("reading plugin manifest: %w", err)
+		return nil, nil, git.HeadCommit{}, fmt.Errorf("reading plugin manifest: %w", err)
 	}
 	manifest, err := plugins.ParsePluginManifestFromBytes(manifestBytes)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("parsing plugin manifest: %w", err)
+		return nil, nil, git.HeadCommit{}, fmt.Errorf("parsing plugin manifest: %w", err)
 	}
-	return fileEntries, manifest, commitHash, nil
+	return fileEntries, manifest, head, nil
 }
 
 // collectPluginFiles reads all files from the given path in the repository,

--- a/pkg/plugins/pluginsvc/install_git_test.go
+++ b/pkg/plugins/pluginsvc/install_git_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,13 +99,47 @@ func TestCloneAndCollectPlugin(t *testing.T) {
 		repoDir := createPluginTestRepo(t, "")
 
 		s := &service{gitClient: git.NewDefaultGitClient()}
-		files, manifest, commitHash, err := s.cloneAndCollectPlugin(t.Context(), &gitresolver.GitReference{URL: repoDir})
+		files, manifest, head, err := s.cloneAndCollectPlugin(t.Context(), &gitresolver.GitReference{URL: repoDir})
 		require.NoError(t, err)
 		assert.Equal(t, "my-plugin", manifest.Name)
 		assert.Equal(t, "1.0.0", manifest.Version)
-		assert.NotEmpty(t, commitHash)
+		assert.NotEmpty(t, head.Hash)
+		// The commit is unsigned, but its signed payload is still surfaced so
+		// install-time verification can check a signature when one is present.
+		assert.Empty(t, head.Signature, "test repo commits are unsigned")
+		assert.NotEmpty(t, head.Payload, "the signed commit payload must be surfaced")
 		// Manifest + a command file are collected.
 		assert.GreaterOrEqual(t, len(files), 2)
+	})
+
+	t.Run("signed commit surfaces its signature and payload", func(t *testing.T) {
+		t.Parallel()
+		const armoredSig = "-----BEGIN SIGNED MESSAGE-----\nMIIC(test-signature)\n-----END SIGNED MESSAGE-----\n"
+		repoDir := createPluginTestRepo(t, "")
+
+		// Rewrite HEAD with the signature attached, mimicking gitsign output.
+		repo, err := gogit.PlainOpen(repoDir)
+		require.NoError(t, err)
+		headRef, err := repo.Head()
+		require.NoError(t, err)
+		commit, err := repo.CommitObject(headRef.Hash())
+		require.NoError(t, err)
+		commit.PGPSignature = armoredSig
+		obj := repo.Storer.NewEncodedObject()
+		require.NoError(t, commit.Encode(obj))
+		signedHash, err := repo.Storer.SetEncodedObject(obj)
+		require.NoError(t, err)
+		require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(headRef.Name(), signedHash)))
+
+		s := &service{gitClient: git.NewDefaultGitClient()}
+		_, _, head, err := s.cloneAndCollectPlugin(t.Context(), &gitresolver.GitReference{URL: repoDir})
+		require.NoError(t, err)
+		assert.Equal(t, signedHash.String(), head.Hash)
+		assert.Equal(t, armoredSig, head.Signature)
+		assert.Contains(t, string(head.Payload), "tree ",
+			"the signed payload must accompany the signature")
+		assert.NotContains(t, string(head.Payload), "gpgsig",
+			"the payload must exclude the signature it covers")
 	})
 
 	t.Run("subdir scopes the collected tree", func(t *testing.T) {

--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -100,6 +100,10 @@ type InstalledPlugin struct {
 	// installs. No omitempty: false is an observable state (unmanaged),
 	// not an absence.
 	Managed bool `json:"managed"`
+	// SigstoreBundle is the serialized Sigstore bundle captured at install
+	// time, used for offline re-verification during sync. Nil for unsigned
+	// installs. Never serialized to API responses.
+	SigstoreBundle []byte `json:"-"`
 }
 
 // ComponentInventory summarizes the component types declared by a plugin

--- a/pkg/storage/sqlite/migrations/006_add_plugin_sigstore_bundle.sql
+++ b/pkg/storage/sqlite/migrations/006_add_plugin_sigstore_bundle.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE installed_plugins ADD COLUMN sigstore_bundle BLOB DEFAULT NULL;
+
+-- +goose Down
+
+ALTER TABLE installed_plugins DROP COLUMN sigstore_bundle;

--- a/pkg/storage/sqlite/migrations_test.go
+++ b/pkg/storage/sqlite/migrations_test.go
@@ -300,3 +300,48 @@ func TestMigrations_PluginManagedFlagAppliesOverPriorState(t *testing.T) {
 	assert.Equal(t, 0, count, "managed column should be dropped by 005 Down")
 	assert.True(t, tableExists(t, db.DB(), "installed_plugins"), "installed_plugins table itself must remain")
 }
+
+// TestMigrations_PluginSigstoreBundleAppliesOverPriorState verifies migration
+// 006 adds installed_plugins.sigstore_bundle defaulting to NULL, so rows
+// created by an earlier schema read back as unsigned (nil bundle) once the
+// column appears.
+func TestMigrations_PluginSigstoreBundleAppliesOverPriorState(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := Open(ctx, dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	provider := newGooseProvider(t, db.DB())
+
+	// Roll back to just after migration 005, before plugin "sigstore_bundle" existed.
+	_, err = provider.DownTo(ctx, 5)
+	require.NoError(t, err)
+
+	_, err = db.DB().Exec(`INSERT INTO entries (entry_type, name) VALUES ('plugin', 'pre-migration-plugin')`)
+	require.NoError(t, err)
+	_, err = db.DB().Exec(`INSERT INTO installed_plugins (entry_id, scope) VALUES (1, 'user')`)
+	require.NoError(t, err)
+
+	// Re-apply Up: migration 006 adds the column to the pre-existing row.
+	_, err = provider.Up(ctx)
+	require.NoError(t, err)
+
+	var bundle []byte
+	err = db.DB().QueryRow(`SELECT sigstore_bundle FROM installed_plugins WHERE entry_id = 1`).Scan(&bundle)
+	require.NoError(t, err)
+	assert.Nil(t, bundle, "a row created before migration 006 must default to a NULL bundle")
+
+	// Down for 006 removes the column without disturbing earlier tables.
+	_, err = provider.DownTo(ctx, 5)
+	require.NoError(t, err)
+	var count int
+	err = db.DB().QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('installed_plugins') WHERE name = 'sigstore_bundle'`,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "sigstore_bundle column should be dropped by 006 Down")
+	assert.True(t, tableExists(t, db.DB(), "installed_plugins"), "installed_plugins table itself must remain")
+}

--- a/pkg/storage/sqlite/plugin_store.go
+++ b/pkg/storage/sqlite/plugin_store.go
@@ -45,7 +45,7 @@ var _ storage.PluginStore = (*PluginStore)(nil)
 const pluginColumns = `ip_.id, e.name, ip_.scope, ip_.project_root, ip_.reference, ip_.tag,
 			ip_.digest, ip_.version, ip_.description, ip_.author, ip_.license, json(ip_.keywords),
 			json(ip_.client_apps), json(ip_.components), ip_.signature, ip_.status, ip_.installed_at,
-			ip_.managed`
+			ip_.managed, ip_.sigstore_bundle`
 
 // errPluginManagedRequiresProjectScope is returned by Create/Update when a
 // user-scoped plugin has Managed set. Managed pins a plugin in a project's
@@ -106,8 +106,8 @@ func (s *PluginStore) Create(ctx context.Context, plugin plugins.InstalledPlugin
 		INSERT INTO installed_plugins (
 			entry_id, scope, project_root, reference, tag, digest,
 			version, description, author, license, keywords, client_apps, components,
-			signature, status, managed
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, jsonb(?), jsonb(?), jsonb(?), ?, ?, ?)`,
+			signature, status, managed, sigstore_bundle
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, jsonb(?), jsonb(?), jsonb(?), ?, ?, ?, ?)`,
 		entryID,
 		string(plugin.Scope),
 		plugin.ProjectRoot,
@@ -124,6 +124,7 @@ func (s *PluginStore) Create(ctx context.Context, plugin plugins.InstalledPlugin
 		nullableSignature(plugin.Signature),
 		string(plugin.Status),
 		boolToInt(plugin.Managed),
+		plugin.SigstoreBundle,
 	)
 	if err != nil {
 		if isUniqueViolation(err) {
@@ -297,7 +298,8 @@ func (s *PluginStore) Update(ctx context.Context, plugin plugins.InstalledPlugin
 		UPDATE installed_plugins SET
 			reference = ?, tag = ?, digest = ?, version = ?, description = ?,
 			author = ?, license = ?, keywords = jsonb(?), client_apps = jsonb(?),
-			components = jsonb(?), signature = ?, status = ?, managed = ?
+			components = jsonb(?), signature = ?, status = ?, managed = ?,
+			sigstore_bundle = ?
 		WHERE id = ?`,
 		plugin.Reference,
 		plugin.Tag,
@@ -312,6 +314,7 @@ func (s *PluginStore) Update(ctx context.Context, plugin plugins.InstalledPlugin
 		nullableSignature(plugin.Signature),
 		string(plugin.Status),
 		boolToInt(plugin.Managed),
+		plugin.SigstoreBundle,
 		installedPluginID,
 	); err != nil {
 		return fmt.Errorf("updating installed plugin: %w", err)
@@ -386,9 +389,10 @@ func (s *PluginStore) Delete(ctx context.Context, name string, scope plugins.Sco
 }
 
 // scanPluginFields scans a plugin row into an InstalledPlugin and its DB id.
-// The column list must match pluginColumns (18 fields: id, name, scope,
+// The column list must match pluginColumns (19 fields: id, name, scope,
 // project_root, reference, tag, digest, version, description, author, license,
-// keywords, client_apps, components, signature, status, installed_at, managed).
+// keywords, client_apps, components, signature, status, installed_at, managed,
+// sigstore_bundle).
 func scanPluginFields(sc scanner) (plugins.InstalledPlugin, int64, error) {
 	var (
 		installedPluginID int64
@@ -409,13 +413,14 @@ func scanPluginFields(sc scanner) (plugins.InstalledPlugin, int64, error) {
 		status            string
 		installedAtStr    string
 		managed           int
+		sigstoreBundle    []byte
 	)
 
 	err := sc.Scan(
 		&installedPluginID, &name, &scope, &projectRoot, &reference, &tag,
 		&digest, &version, &description, &author, &license, &keywordsBlob,
 		&clientsBlob, &componentsBlob, &signature, &status, &installedAtStr,
-		&managed,
+		&managed, &sigstoreBundle,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -449,16 +454,17 @@ func scanPluginFields(sc scanner) (plugins.InstalledPlugin, int64, error) {
 			License:     license,
 			Keywords:    keywords,
 		},
-		Scope:       plugins.Scope(scope),
-		ProjectRoot: projectRoot,
-		Reference:   reference,
-		Tag:         tag,
-		Digest:      digest,
-		Status:      plugins.InstallStatus(status),
-		InstalledAt: installedAt,
-		Clients:     clients,
-		Components:  components,
-		Managed:     managed != 0,
+		Scope:          plugins.Scope(scope),
+		ProjectRoot:    projectRoot,
+		Reference:      reference,
+		Tag:            tag,
+		Digest:         digest,
+		Status:         plugins.InstallStatus(status),
+		InstalledAt:    installedAt,
+		Clients:        clients,
+		Components:     components,
+		Managed:        managed != 0,
+		SigstoreBundle: sigstoreBundle,
 	}
 	// signature is nullable — set Signature only when Valid.
 	if signature.Valid {

--- a/pkg/storage/sqlite/plugin_store_test.go
+++ b/pkg/storage/sqlite/plugin_store_test.go
@@ -78,6 +78,36 @@ func TestPluginStore_Create(t *testing.T) {
 
 	assert.False(t, got.InstalledAt.IsZero(), "InstalledAt should not be zero")
 	assert.False(t, got.Managed, "Managed should default to false")
+	assert.Nil(t, got.SigstoreBundle, "SigstoreBundle should default to nil (unsigned)")
+}
+
+func TestPluginStore_SigstoreBundleRoundTrip(t *testing.T) {
+	t.Parallel()
+	store := newPluginTestStore(t)
+
+	bundle := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+	pl := testPlugin("bundle-test")
+	pl.SigstoreBundle = bundle
+	require.NoError(t, store.Create(t.Context(), pl))
+
+	got, err := store.Get(t.Context(), pl.Metadata.Name, pl.Scope, pl.ProjectRoot)
+	require.NoError(t, err)
+	assert.Equal(t, bundle, got.SigstoreBundle)
+
+	// Update replaces the stored bundle (e.g. re-install of a re-signed
+	// artifact), and can clear it back to nil for an unsigned replacement.
+	newBundle := []byte(`{"replaced":true}`)
+	got.SigstoreBundle = newBundle
+	require.NoError(t, store.Update(t.Context(), got))
+	got, err = store.Get(t.Context(), pl.Metadata.Name, pl.Scope, pl.ProjectRoot)
+	require.NoError(t, err)
+	assert.Equal(t, newBundle, got.SigstoreBundle)
+
+	got.SigstoreBundle = nil
+	require.NoError(t, store.Update(t.Context(), got))
+	got, err = store.Get(t.Context(), pl.Metadata.Name, pl.Scope, pl.ProjectRoot)
+	require.NoError(t, err)
+	assert.Nil(t, got.SigstoreBundle, "a cleared bundle must read back as NULL/unsigned")
 }
 
 func TestPluginStore_CreateDuplicate(t *testing.T) {


### PR DESCRIPTION
## Summary

Plugin install-time signature verification (PR7) and offline re-verification in `sync --check` (PR8) both need groundwork that has to land before any verifier does. Two gaps today:

- OCI plugin installs have nowhere to persist the Sigstore bundle captured at install time, so `sync` cannot re-verify a plugin offline without going back to the registry.
- Git plugin installs read the resolved commit but throw away its gitsign signature and the payload that signature covers, so a verifier would have nothing to check.

This PR closes both gaps and nothing else — no verification logic, no verifier imports, no lock-file or API changes. It is the plugin counterpart to #6084, which did the same for skills.

What changed:

- **Migration 006** adds `installed_plugins.sigstore_bundle BLOB DEFAULT NULL`. NULL means unsigned or pre-schema, so rows written by an earlier schema read back as unsigned rather than as a corrupt bundle — same convention as `004_add_skill_sigstore_bundle.sql`.
- **`plugins.InstalledPlugin`** gains `SigstoreBundle []byte` (`json:"-"`, never serialized to API responses), wired through the SQLite plugin store's insert, update, and scan paths.
- **`cloneAndCollectPlugin`** returns the whole `git.HeadCommit` instead of just the hash, so the commit's signature and payload travel with the hash they describe instead of being looked up again against a possibly different commit. `pkg/git.HeadCommit` already carries all three fields (added by #6084); only the plugin caller needed updating.

The signature and payload are carried, not consumed — PR7 hands them to the verifier at the point where `installFromGit` takes the per-plugin lock.

Part of #6300.

## Type of change

- [x] Other (describe): groundwork — schema + type plumbing for a follow-up feature, no behavior change

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New coverage:

- `TestMigrations_PluginSigstoreBundleAppliesOverPriorState` — rolls back to migration 005, inserts an `installed_plugins` row, re-applies Up, and asserts the pre-existing row reads back with a NULL bundle; then asserts 006 Down drops the column while leaving the table intact.
- `TestPluginStore_SigstoreBundleRoundTrip` — Create persists a bundle, Update replaces it, and Update can clear it back to NULL/unsigned.
- `TestPluginStore_Create` now asserts an unset bundle defaults to nil.
- `TestCloneAndCollectPlugin` gains a signed-commit subtest (HEAD rewritten with an armored signature, mimicking gitsign) asserting the signature and its payload are both surfaced and that the payload excludes the `gpgsig` header it covers.

Notes on the local runs:

- `task test` is green except `pkg/transport/proxy/streamable`'s `TestMCPGoClientInitializeAndPing`, which fails identically on a clean checkout of `main` on this machine (hardcoded port 8096 already in use). Unrelated to this PR.
- `task lint-fix` over the whole repo hits the known `nilness` analyzer panic on `getsentry/sentry-go` from golangci-lint v2.13.0 — the exact panic #6393 pinned CI to v2.12.2 to avoid. Linting scoped to `./pkg/storage/sqlite/... ./pkg/plugins/...` reports 0 issues.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

No. The new column is unused until install-time verification lands, and `SigstoreBundle` is tagged `json:"-"` so it never appears in API responses.

## Special notes for reviewers

- `cloneAndCollectPlugin` returning `git.HeadCommit` rather than two extra return slots keeps the signature at four values and guarantees hash/signature/payload always describe the same commit.
- `head` is bound early in `installFromGit` but only `head.Hash` is read today. That is deliberate: PR7 inserts the verify call under the per-plugin lock, where `head` is already in scope.
- Migration 006 is a plain `ADD COLUMN` with a `DROP COLUMN` Down, so it is reversible without a table rebuild.

Generated with [Claude Code](https://claude.com/claude-code)
