### PR TITLE
Re-verify stored plugin signatures during sync

### DIFF
--- a/cmd/thv/app/ai_plugin_sync.go
+++ b/cmd/thv/app/ai_plugin_sync.go
@@ -15,13 +15,14 @@ import (
 )
 
 var (
-	aiPluginSyncProjectRoot string
-	aiPluginSyncClientsRaw  string
-	aiPluginSyncCheck       bool
-	aiPluginSyncAdopt       bool
-	aiPluginSyncPrune       bool
-	aiPluginSyncYes         bool
-	aiPluginSyncFormat      string
+	aiPluginSyncProjectRoot   string
+	aiPluginSyncClientsRaw    string
+	aiPluginSyncCheck         bool
+	aiPluginSyncAdopt         bool
+	aiPluginSyncPrune         bool
+	aiPluginSyncYes           bool
+	aiPluginSyncAllowUnsigned bool
+	aiPluginSyncFormat        string
 )
 
 var aiPluginSyncCmd = &cobra.Command{
@@ -60,6 +61,8 @@ func init() {
 		"Remove installs no longer present in the lock file")
 	aiPluginSyncCmd.Flags().BoolVar(&aiPluginSyncYes, "yes", false,
 		"Skip the confirmation prompt (required when not running interactively)")
+	aiPluginSyncCmd.Flags().BoolVar(&aiPluginSyncAllowUnsigned, "allow-unsigned", false,
+		"Allow adopting plugins whose signature state cannot be established (recorded as unsigned)")
 	AddFormatFlag(aiPluginSyncCmd, &aiPluginSyncFormat)
 }
 
@@ -85,11 +88,12 @@ func aiPluginSyncCmdFunc(cmd *cobra.Command, _ []string) error {
 
 	c := newAIPluginClient(cmd.Context())
 	result, err := c.Sync(cmd.Context(), plugins.SyncOptions{
-		ProjectRoot: projectRoot,
-		Clients:     parseSkillInstallClients(aiPluginSyncClientsRaw),
-		Check:       aiPluginSyncCheck,
-		Adopt:       aiPluginSyncAdopt,
-		Prune:       aiPluginSyncPrune,
+		ProjectRoot:   projectRoot,
+		Clients:       parseSkillInstallClients(aiPluginSyncClientsRaw),
+		Check:         aiPluginSyncCheck,
+		Adopt:         aiPluginSyncAdopt,
+		Prune:         aiPluginSyncPrune,
+		AllowUnsigned: aiPluginSyncAllowUnsigned,
 	})
 	if err != nil {
 		return formatAIPluginError("sync plugins", err)

--- a/cmd/thv/app/ai_plugin_sync_test.go
+++ b/cmd/thv/app/ai_plugin_sync_test.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAIPluginSyncAllowUnsignedFlag pins the flag that carries the unsigned
+// trust decision into sync: adopting an install whose signature state cannot
+// be established is rejected unless the user opts in here, and the flag must
+// be bound to the variable the command threads into plugins.SyncOptions.
+//
+//nolint:paralleltest // sets the command's package-level flag variable
+func TestAIPluginSyncAllowUnsignedFlag(t *testing.T) {
+	flag := aiPluginSyncCmd.Flags().Lookup("allow-unsigned")
+	require.NotNil(t, flag, "thv ai-plugin sync must expose --allow-unsigned")
+	assert.Equal(t, "false", flag.DefValue, "unsigned adoption must never be the default")
+
+	t.Cleanup(func() { aiPluginSyncAllowUnsigned = false })
+	require.NoError(t, flag.Value.Set("true"))
+	assert.True(t, aiPluginSyncAllowUnsigned,
+		"--allow-unsigned must bind to the variable sync passes to the service")
+}

--- a/docs/cli/thv_ai-plugin_sync.md
+++ b/docs/cli/thv_ai-plugin_sync.md
@@ -36,6 +36,7 @@ thv ai-plugin sync [flags]
 
 ```
       --adopt                 Write lock entries for existing unmanaged project-scope installs
+      --allow-unsigned        Allow adopting plugins whose signature state cannot be established (recorded as unsigned)
       --check                 Report drift without installing, writing, or removing anything
       --clients string        Comma-separated target client apps (e.g. claude-code,opencode), or "all" for every available client
       --format string         Output format (json, text) (default "text")

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -3893,6 +3893,10 @@ const docTemplate = `{
                         "description": "Adopt writes lock entries for existing unmanaged project-scope installs",
                         "type": "boolean"
                     },
+                    "allow_unsigned": {
+                        "description": "AllowUnsigned permits adopting plugins whose signature state cannot be\nestablished, recording them as unsigned",
+                        "type": "boolean"
+                    },
                     "check": {
                         "description": "Check verifies on-disk content against the lock file without installing or writing anything",
                         "type": "boolean"

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -3886,6 +3886,10 @@
                         "description": "Adopt writes lock entries for existing unmanaged project-scope installs",
                         "type": "boolean"
                     },
+                    "allow_unsigned": {
+                        "description": "AllowUnsigned permits adopting plugins whose signature state cannot be\nestablished, recording them as unsigned",
+                        "type": "boolean"
+                    },
                     "check": {
                         "description": "Check verifies on-disk content against the lock file without installing or writing anything",
                         "type": "boolean"

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -3623,6 +3623,11 @@ components:
           description: Adopt writes lock entries for existing unmanaged project-scope
             installs
           type: boolean
+        allow_unsigned:
+          description: |-
+            AllowUnsigned permits adopting plugins whose signature state cannot be
+            established, recording them as unsigned
+          type: boolean
         check:
           description: Check verifies on-disk content against the lock file without
             installing or writing anything

--- a/pkg/api/v1/plugins.go
+++ b/pkg/api/v1/plugins.go
@@ -438,11 +438,12 @@ func (s *PluginsRoutes) syncPlugins(w http.ResponseWriter, r *http.Request) erro
 	}
 
 	result, err := s.lockService.Sync(r.Context(), plugins.SyncOptions{
-		ProjectRoot: req.ProjectRoot,
-		Clients:     req.Clients,
-		Prune:       req.Prune,
-		Check:       req.Check,
-		Adopt:       req.Adopt,
+		ProjectRoot:   req.ProjectRoot,
+		Clients:       req.Clients,
+		Prune:         req.Prune,
+		Check:         req.Check,
+		Adopt:         req.Adopt,
+		AllowUnsigned: req.AllowUnsigned,
 	})
 	if err != nil {
 		return err

--- a/pkg/api/v1/plugins_sync_test.go
+++ b/pkg/api/v1/plugins_sync_test.go
@@ -83,6 +83,19 @@ func TestSyncPluginsEndpoint(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name: "allow_unsigned reaches the service",
+			service: &pluginServiceWithSync{
+				PluginService: plugmocks.NewMockPluginService(gomock.NewController(t)),
+				syncFn: func(_ context.Context, opts plugins.SyncOptions) (*plugins.SyncResult, error) {
+					assert.True(t, opts.Adopt)
+					assert.True(t, opts.AllowUnsigned, "allow_unsigned must survive the DTO boundary")
+					return &plugins.SyncResult{}, nil
+				},
+			},
+			body:       `{"project_root":"/tmp/proj","adopt":true,"allow_unsigned":true}`,
+			wantStatus: http.StatusOK,
+		},
+		{
 			name: "sync error is forwarded",
 			service: &pluginServiceWithSync{
 				PluginService: plugmocks.NewMockPluginService(gomock.NewController(t)),

--- a/pkg/api/v1/plugins_types.go
+++ b/pkg/api/v1/plugins_types.go
@@ -96,6 +96,9 @@ type syncPluginsRequest struct {
 	Check bool `json:"check,omitempty"`
 	// Adopt writes lock entries for existing unmanaged project-scope installs
 	Adopt bool `json:"adopt,omitempty"`
+	// AllowUnsigned permits adopting plugins whose signature state cannot be
+	// established, recording them as unsigned
+	AllowUnsigned bool `json:"allow_unsigned,omitempty"`
 }
 
 // upgradePluginsRequest represents the request to upgrade a project's plugins.

--- a/pkg/plugins/client/client.go
+++ b/pkg/plugins/client/client.go
@@ -314,11 +314,12 @@ func (c *Client) GetContent(ctx context.Context, opts plugins.ContentOptions) (*
 // Sync restores a project's installed plugins to match its lock file.
 func (c *Client) Sync(ctx context.Context, opts plugins.SyncOptions) (*plugins.SyncResult, error) {
 	body := syncRequest{
-		ProjectRoot: opts.ProjectRoot,
-		Clients:     opts.Clients,
-		Prune:       opts.Prune,
-		Check:       opts.Check,
-		Adopt:       opts.Adopt,
+		ProjectRoot:   opts.ProjectRoot,
+		Clients:       opts.Clients,
+		Prune:         opts.Prune,
+		Check:         opts.Check,
+		Adopt:         opts.Adopt,
+		AllowUnsigned: opts.AllowUnsigned,
 	}
 
 	var result plugins.SyncResult

--- a/pkg/plugins/client/client_test.go
+++ b/pkg/plugins/client/client_test.go
@@ -1025,3 +1025,26 @@ func TestInstallCarriesAllowUnsigned(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, got.AllowUnsigned, "allow_unsigned must reach the server")
 }
+
+// TestSyncCarriesAllowUnsigned mirrors TestInstallCarriesAllowUnsigned for
+// the sync/adopt path: a flag that dies at the DTO boundary would silently
+// make every adoption of an install with no stored bundle fail.
+func TestSyncCarriesAllowUnsigned(t *testing.T) {
+	t.Parallel()
+
+	var got syncRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(plugins.SyncResult{})
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newTestClient(t, srv).Sync(t.Context(), plugins.SyncOptions{
+		ProjectRoot:   "/tmp/project",
+		Adopt:         true,
+		AllowUnsigned: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, got.AllowUnsigned, "allow_unsigned must reach the server")
+}

--- a/pkg/plugins/client/dto.go
+++ b/pkg/plugins/client/dto.go
@@ -51,6 +51,8 @@ type syncRequest struct {
 	Prune       bool     `json:"prune,omitempty"`
 	Check       bool     `json:"check,omitempty"`
 	Adopt       bool     `json:"adopt,omitempty"`
+	// AllowUnsigned mirrors plugins.SyncOptions.AllowUnsigned for adoption.
+	AllowUnsigned bool `json:"allow_unsigned,omitempty"`
 }
 
 type upgradeRequest struct {

--- a/pkg/plugins/pluginsvc/sync.go
+++ b/pkg/plugins/pluginsvc/sync.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/plugins"
 	"github.com/stacklok/toolhive/pkg/skills/gitresolver"
 	"github.com/stacklok/toolhive/pkg/skills/lockfile"
+	"github.com/stacklok/toolhive/pkg/skills/verifier"
 	"github.com/stacklok/toolhive/pkg/storage"
 )
 
@@ -129,10 +131,11 @@ func (s *service) syncOne(
 }
 
 // syncLockedEntry reconciles one lock file entry against installed state,
-// appending its outcome to result. Missing (dbOK false) and drifted (digest
-// or contentDigest mismatch) entries are reinstalled at the pinned reference
-// unless opts.Check is set, in which case nothing is written — both states
-// are still reported (Missing/Drifted), never as failures.
+// appending its outcome to result. Missing (dbOK false), drifted (digest or
+// contentDigest mismatch) and signature-drifted (the stored bundle no longer
+// verifies against the locked identity) entries are reinstalled at the pinned
+// reference unless opts.Check is set, in which case nothing is written — all
+// three states are still reported (Missing/Drifted), never as failures.
 func (s *service) syncLockedEntry(
 	ctx context.Context,
 	opts plugins.SyncOptions,
@@ -142,7 +145,19 @@ func (s *service) syncLockedEntry(
 	targetClients []string,
 	result *plugins.SyncResult,
 ) {
-	if dbOK && pl.Managed && s.entryMatchesInstalled(ctx, entry, pl, targetClients) {
+	sigOK := true
+	if dbOK {
+		if sigErr := s.verifyStoredSignature(entry, pl); sigErr != nil {
+			// A failed offline re-verification is treated as drift: check
+			// mode reports it, apply mode reinstalls from the pinned
+			// reference — where install-time verification enforces the
+			// locked identity and, on success, heals the stored bundle.
+			sigOK = false
+			slog.Warn("stored signature failed offline re-verification",
+				"plugin", entry.Name, "error", sigErr)
+		}
+	}
+	if dbOK && sigOK && pl.Managed && s.entryMatchesInstalled(ctx, entry, pl, targetClients) {
 		result.AlreadyCurrent = append(result.AlreadyCurrent, entry.Name)
 		return
 	}
@@ -365,7 +380,7 @@ func (s *service) syncUnlockedInstall(
 	if !pl.Managed {
 		result.NeverManaged = append(result.NeverManaged, pl.Metadata.Name)
 		if opts.Adopt && !opts.Check {
-			if err := s.adoptLocked(ctx, pl); err != nil {
+			if err := s.adoptLocked(ctx, opts, pl); err != nil {
 				result.Failed = append(result.Failed, plugins.SyncFailure{
 					Name: pl.Metadata.Name, Reason: classifySyncFailure(err), Error: err.Error(),
 				})
@@ -388,21 +403,41 @@ func (s *service) syncUnlockedInstall(
 	}
 }
 
-// adoptPlugin writes a lock entry for an existing, unmanaged project-scope
-// install, pinning its current on-disk state. The install's own Reference is
-// used as Source: an adopted install predates (or never went through) lock
-// tracking, so the original user-typed request is not recoverable — the
-// concrete resolved reference is the closest available fact to pin against.
-// Adoption is rejected when that reference is not a restorable git:// or OCI
-// pin (a bare local-store tag cannot be re-fetched later).
+// verifyStoredSignature re-verifies the Sigstore bundle stored with an
+// installed plugin against the identity its lock entry records — entirely
+// offline, via the embedded trust root, so sync never contacts a registry to
+// decide whether an entry is current. Entries recorded unsigned or with no
+// provenance have nothing to verify. A recorded identity with no stored
+// bundle fails closed for OCI installs (the bundle should exist); git
+// installs never store a bundle — their signature lives on the commit and is
+// re-verified when content is re-resolved.
+func (s *service) verifyStoredSignature(entry lockfile.Entry, pl plugins.InstalledPlugin) error {
+	if entry.Unsigned || entry.Provenance == nil {
+		return nil
+	}
+	if len(pl.SigstoreBundle) == 0 {
+		if !strings.Contains(entry.Digest, ":") {
+			return nil // git install: no stored bundle by design
+		}
+		return fmt.Errorf("%w: lock entry records signer %q but no bundle is stored",
+			verifier.ErrSignatureInvalid, entry.Provenance.SignerIdentity)
+	}
+	return s.artifactVerifier().VerifyBundleOffline(pl.SigstoreBundle, entry.Digest, entry.Provenance)
+}
+
+// adoptLocked writes a lock entry for an existing, unmanaged project-scope
+// install, pinning its current on-disk state and assuming the per-plugin lock
+// is already held. The install's own Reference is used as Source: an adopted
+// install predates (or never went through) lock tracking, so the original
+// user-typed request is not recoverable — the concrete resolved reference is
+// the closest available fact to pin against. Adoption is rejected when that
+// reference is not a restorable git:// or OCI pin (a bare local-store tag
+// cannot be re-fetched later).
 //
-// Trust state is left unset (no provenance, not unsigned). Plugin Sigstore
-// verification lands in a later PR; requiring --allow-unsigned here would
-// make every adopt fail until then. Lock validation permits an entry with
-// neither provenance nor unsigned.
-// adoptLocked writes a lock entry for an unmanaged install assuming the
-// per-plugin lock is already held.
-func (s *service) adoptLocked(ctx context.Context, pl plugins.InstalledPlugin) error {
+// Trust state is back-filled from the stored Sigstore bundle when one exists;
+// otherwise adoption is the same trust decision as an unsigned install and
+// requires the explicit AllowUnsigned exception.
+func (s *service) adoptLocked(ctx context.Context, opts plugins.SyncOptions, pl plugins.InstalledPlugin) error {
 	current, err := s.store.Get(ctx, pl.Metadata.Name, plugins.ScopeProject, pl.ProjectRoot)
 	if err != nil {
 		return fmt.Errorf("re-reading plugin before adopt: %w", err)
@@ -442,6 +477,11 @@ func (s *service) adoptLocked(ctx context.Context, pl plugins.InstalledPlugin) e
 		prevEntry = &e
 	}
 
+	provenance, unsigned, err := s.adoptionTrust(opts, pl)
+	if err != nil {
+		return err
+	}
+
 	if err := recordLockEntry(pl.ProjectRoot, lockEntryInput{
 		Name:              pl.Metadata.Name,
 		Version:           pl.Metadata.Version,
@@ -449,6 +489,8 @@ func (s *service) adoptLocked(ctx context.Context, pl plugins.InstalledPlugin) e
 		ResolvedReference: resolved,
 		Digest:            pl.Digest,
 		ContentDigest:     contentDigest,
+		Provenance:        provenance,
+		Unsigned:          unsigned,
 	}); err != nil {
 		return fmt.Errorf("writing lock entry: %w", errors.Join(errLockWrite, err))
 	}
@@ -462,7 +504,34 @@ func (s *service) adoptLocked(ctx context.Context, pl plugins.InstalledPlugin) e
 	return nil
 }
 
-// restoreAdoptedLockEntry undoes adoptPlugin's lock write: reinstates the
+// adoptionTrust decides what trust state an adopted install records. A stored
+// Sigstore bundle is the only evidence adoption has to work from: when one
+// exists its identity is back-filled into the lock entry, and when it does not
+// adopting is the same trust decision as an unsigned install — it records an
+// explicit unsigned exception, which the caller must have opted into.
+func (s *service) adoptionTrust(
+	opts plugins.SyncOptions, pl plugins.InstalledPlugin,
+) (*lockfile.Provenance, bool, error) {
+	if len(pl.SigstoreBundle) > 0 {
+		result, err := s.artifactVerifier().ResultFromBundle(pl.SigstoreBundle, pl.Digest)
+		if err != nil {
+			return nil, false, fmt.Errorf("verifying stored bundle for adoption: %w", err)
+		}
+		if provenance := result.ToLockProvenance(); provenance != nil {
+			return provenance, false, nil
+		}
+	}
+	if !opts.AllowUnsigned {
+		return nil, false, httperr.WithCode(
+			fmt.Errorf("%w: adopting %q records it as unsigned; pass --allow-unsigned to accept that",
+				verifier.ErrUnsigned, pl.Metadata.Name),
+			http.StatusForbidden,
+		)
+	}
+	return nil, true, nil
+}
+
+// restoreAdoptedLockEntry undoes adoptLocked's lock write: reinstates the
 // entry observed before adoption, or removes the name if none existed.
 func restoreAdoptedLockEntry(pl plugins.InstalledPlugin, prevEntry *lockfile.Entry) error {
 	if prevEntry != nil {

--- a/pkg/plugins/pluginsvc/sync.go
+++ b/pkg/plugins/pluginsvc/sync.go
@@ -411,11 +411,20 @@ func (s *service) syncUnlockedInstall(
 // bundle fails closed for OCI installs (the bundle should exist); git
 // installs never store a bundle — their signature lives on the commit and is
 // re-verified when content is re-resolved.
+//
+// Local-store pins (isLocalStorePin) also carry an OCI-shaped digest and
+// store no bundle, but they cannot reach the fail-closed branch: a local
+// install is always an unsigned trust decision (verifyLocalInstall refuses
+// outright once an entry is locked to a signer), so its entry records
+// unsigned and returns above. An entry hand-edited into that state is
+// correctly reported as drift here, and the reinstall it triggers is then
+// refused by verifyLocalInstall.
 func (s *service) verifyStoredSignature(entry lockfile.Entry, pl plugins.InstalledPlugin) error {
 	if entry.Unsigned || entry.Provenance == nil {
 		return nil
 	}
 	if len(pl.SigstoreBundle) == 0 {
+		// A bare commit hash has no colon; an OCI digest is "sha256:<hex>".
 		if !strings.Contains(entry.Digest, ":") {
 			return nil // git install: no stored bundle by design
 		}

--- a/pkg/plugins/pluginsvc/sync_test.go
+++ b/pkg/plugins/pluginsvc/sync_test.go
@@ -265,7 +265,19 @@ func TestSync_AdoptsUnmanagedInstall(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"my-plugin"}, result.NeverManaged)
 
+	// Adoption of an install with no stored bundle is an unsigned trust
+	// decision: without the explicit exception it fails...
 	result, err = syncSvc.Sync(t.Context(), plugins.SyncOptions{ProjectRoot: projectRoot, Adopt: true})
+	require.NoError(t, err)
+	require.Len(t, result.Failed, 1)
+	assert.Equal(t, plugins.FailureReasonUnsignedRejected, result.Failed[0].Reason)
+	_, ok := readLockfile(t, projectRoot).GetPlugin("my-plugin")
+	assert.False(t, ok, "adoption without the unsigned exception must not write a lock entry")
+
+	// ...and with it, the entry records the unsigned state.
+	result, err = syncSvc.Sync(t.Context(), plugins.SyncOptions{
+		ProjectRoot: projectRoot, Adopt: true, AllowUnsigned: true,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"my-plugin"}, result.NeverManaged)
 	assert.Empty(t, result.Failed)
@@ -274,7 +286,7 @@ func TestSync_AdoptsUnmanagedInstall(t *testing.T) {
 	entry, ok := lf.GetPlugin("my-plugin")
 	require.True(t, ok, "adopt must write a lock entry for the unmanaged install")
 	assert.NotEmpty(t, entry.ContentDigest)
-	assert.False(t, entry.Unsigned)
+	assert.True(t, entry.Unsigned, "an adoption without verifiable trust must record unsigned")
 	assert.Nil(t, entry.Provenance)
 
 	info, err := svc.Info(t.Context(), plugins.InfoOptions{Name: "my-plugin", Scope: plugins.ScopeProject, ProjectRoot: projectRoot})
@@ -335,7 +347,9 @@ func TestSync_AdoptUpdateFailureRemovesLockEntry(t *testing.T) {
 		},
 	}
 
-	result, err := syncSvc.Sync(t.Context(), plugins.SyncOptions{ProjectRoot: projectRoot, Adopt: true})
+	result, err := syncSvc.Sync(t.Context(), plugins.SyncOptions{
+		ProjectRoot: projectRoot, Adopt: true, AllowUnsigned: true,
+	})
 	require.NoError(t, err)
 	require.Len(t, result.Failed, 1)
 	assert.Equal(t, "my-plugin", result.Failed[0].Name)
@@ -388,7 +402,9 @@ func TestSync_AdoptUpdateFailureRestoresExistingLockEntry(t *testing.T) {
 		},
 	}
 
-	result, err := syncSvc.Sync(t.Context(), plugins.SyncOptions{ProjectRoot: projectRoot, Adopt: true})
+	result, err := syncSvc.Sync(t.Context(), plugins.SyncOptions{
+		ProjectRoot: projectRoot, Adopt: true, AllowUnsigned: true,
+	})
 	require.NoError(t, err)
 	require.Len(t, result.Failed, 1)
 

--- a/pkg/plugins/pluginsvc/sync_verify_test.go
+++ b/pkg/plugins/pluginsvc/sync_verify_test.go
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pluginsvc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive/pkg/plugins"
+	"github.com/stacklok/toolhive/pkg/skills/lockfile"
+	"github.com/stacklok/toolhive/pkg/skills/verifier"
+	verifiermocks "github.com/stacklok/toolhive/pkg/skills/verifier/mocks"
+)
+
+// TestSync_StoredSignatureFailureIsDriftThenHeals proves the offline
+// re-verification path: a stored bundle that no longer verifies reports as
+// drift in check mode, and an apply reinstalls from the pinned reference —
+// where install-time verification enforces the locked identity and heals the
+// stored state.
+//
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestSync_StoredSignatureFailureIsDriftThenHeals(t *testing.T) {
+	repoDir := createPluginTestRepo(t, "")
+
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(signedResult(), nil)
+	// Every offline re-verification of the stored bundle fails.
+	mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(verifier.ErrSignatureInvalid)
+
+	svc, projectRoot := newGitLockTestService(t, repoDir, WithVerifier(mv))
+	require.NoError(t, gitInstall(t, svc, projectRoot, nil))
+
+	syncer := svc.(*service) //nolint:forcetypeassert
+
+	result, err := syncer.Sync(t.Context(), plugins.SyncOptions{ProjectRoot: projectRoot, Check: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"my-plugin"}, result.Drifted,
+		"a failed offline re-verification must report as drift in check mode")
+	assert.Empty(t, result.AlreadyCurrent)
+
+	result, err = syncer.Sync(t.Context(), plugins.SyncOptions{ProjectRoot: projectRoot})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"my-plugin"}, result.Installed,
+		"apply mode must reinstall from the pinned reference, re-verifying the artifact")
+	assert.Empty(t, result.Failed)
+}
+
+func TestVerifyStoredSignature(t *testing.T) {
+	t.Parallel()
+
+	provenance := &lockfile.Provenance{
+		SignerIdentity: testSignerIdentity,
+		CertIssuer:     testCertIssuer,
+	}
+	ociDigest := "sha256:" + strings.Repeat("a", 64)
+	gitDigest := strings.Repeat("b", 40)
+
+	tests := []struct {
+		name       string
+		entry      lockfile.Entry
+		bundle     []byte
+		offlineErr error
+		expectCall bool
+		wantErr    bool
+	}{
+		{
+			name:  "unsigned entry has nothing to verify",
+			entry: lockfile.Entry{Unsigned: true, Digest: ociDigest},
+		},
+		{
+			name:  "no provenance has nothing to verify",
+			entry: lockfile.Entry{Digest: ociDigest},
+		},
+		{
+			name:    "provenance without stored bundle fails closed for OCI",
+			entry:   lockfile.Entry{Provenance: provenance, Digest: ociDigest},
+			wantErr: true,
+		},
+		{
+			name:  "provenance without stored bundle is fine for git",
+			entry: lockfile.Entry{Provenance: provenance, Digest: gitDigest},
+		},
+		{
+			name:       "stored bundle delegates to offline verification",
+			entry:      lockfile.Entry{Provenance: provenance, Digest: ociDigest},
+			bundle:     []byte(`{"bundle":true}`),
+			expectCall: true,
+		},
+		{
+			name:       "offline verification failure propagates",
+			entry:      lockfile.Entry{Provenance: provenance, Digest: ociDigest},
+			bundle:     []byte(`{"bundle":true}`),
+			offlineErr: verifier.ErrSignatureInvalid,
+			expectCall: true,
+			wantErr:    true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+			if tc.expectCall {
+				mv.EXPECT().VerifyBundleOffline(tc.bundle, tc.entry.Digest, tc.entry.Provenance).
+					Return(tc.offlineErr)
+			}
+			svc := &service{sigVerifier: mv}
+			err := svc.verifyStoredSignature(tc.entry, plugins.InstalledPlugin{SigstoreBundle: tc.bundle})
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestVerifyStoredSignature_MissingBundleClassifiesAsSignatureInvalid pins the
+// typed reason a fail-closed missing bundle produces: sync reports it through
+// the same FailureReasonSignatureInvalid channel as a tampered one.
+func TestVerifyStoredSignature_MissingBundleClassifiesAsSignatureInvalid(t *testing.T) {
+	t.Parallel()
+
+	svc := &service{sigVerifier: verifiermocks.NewMockVerifier(gomock.NewController(t))}
+	err := svc.verifyStoredSignature(lockfile.Entry{
+		Provenance: &lockfile.Provenance{SignerIdentity: testSignerIdentity},
+		Digest:     "sha256:" + strings.Repeat("a", 64),
+	}, plugins.InstalledPlugin{})
+	require.Error(t, err)
+	assert.Equal(t, plugins.FailureReasonSignatureInvalid, classifySyncFailure(err))
+}
+
+// TestSync_AdoptBackFillsProvenanceFromStoredBundle proves adoption is a trust
+// decision made from evidence: a stored bundle back-fills the identity into
+// the lock entry, so the adopted entry is signed rather than an unsigned
+// exception.
+//
+//nolint:paralleltest // uses t.Setenv via newLockTestService
+func TestSync_AdoptBackFillsProvenanceFromStoredBundle(t *testing.T) {
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	mv.EXPECT().ResultFromBundle([]byte(`{"bundle":true}`), gomock.Any()).
+		Return(signedResult(), nil)
+	mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(nil)
+
+	svc, projectRoot := newLockTestService(t, true, WithVerifier(mv))
+	installTestPlugin(t, svc, projectRoot, validLockDigest())
+
+	require.NoError(t, lockfile.RemovePluginEntry(mustOpenRoot(t, projectRoot), "my-plugin"))
+	syncSvc := svc.(*service) //nolint:forcetypeassert
+	legacy, err := syncSvc.store.Get(t.Context(), "my-plugin", plugins.ScopeProject, projectRoot)
+	require.NoError(t, err)
+	legacy.Managed = false
+	legacy.Reference = "ghcr.io/org/my-plugin:v1"
+	legacy.SigstoreBundle = []byte(`{"bundle":true}`)
+	require.NoError(t, syncSvc.store.Update(t.Context(), legacy))
+
+	// No AllowUnsigned: the stored bundle is the evidence adoption needs.
+	result, err := syncSvc.Sync(t.Context(), plugins.SyncOptions{ProjectRoot: projectRoot, Adopt: true})
+	require.NoError(t, err)
+	assert.Empty(t, result.Failed)
+
+	entry, ok := readLockfile(t, projectRoot).GetPlugin("my-plugin")
+	require.True(t, ok)
+	require.NotNil(t, entry.Provenance, "adoption must back-fill provenance from the stored bundle")
+	assert.Equal(t, testSignerIdentity, entry.Provenance.SignerIdentity)
+	assert.Equal(t, testCertIssuer, entry.Provenance.CertIssuer)
+	assert.False(t, entry.Unsigned)
+}
+
+// TestSync_AdoptRejectsUnverifiableStoredBundle covers the third adoption
+// outcome: a bundle exists but does not verify, which is a failure rather
+// than a silent fall-through to the unsigned path.
+//
+//nolint:paralleltest // uses t.Setenv via newLockTestService
+func TestSync_AdoptRejectsUnverifiableStoredBundle(t *testing.T) {
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	mv.EXPECT().ResultFromBundle(gomock.Any(), gomock.Any()).
+		Return(nil, verifier.ErrSignatureInvalid)
+	mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(nil)
+
+	svc, projectRoot := newLockTestService(t, true, WithVerifier(mv))
+	installTestPlugin(t, svc, projectRoot, validLockDigest())
+
+	require.NoError(t, lockfile.RemovePluginEntry(mustOpenRoot(t, projectRoot), "my-plugin"))
+	syncSvc := svc.(*service) //nolint:forcetypeassert
+	legacy, err := syncSvc.store.Get(t.Context(), "my-plugin", plugins.ScopeProject, projectRoot)
+	require.NoError(t, err)
+	legacy.Managed = false
+	legacy.Reference = "ghcr.io/org/my-plugin:v1"
+	legacy.SigstoreBundle = []byte(`{"bundle":true}`)
+	require.NoError(t, syncSvc.store.Update(t.Context(), legacy))
+
+	result, err := syncSvc.Sync(t.Context(), plugins.SyncOptions{
+		ProjectRoot: projectRoot, Adopt: true, AllowUnsigned: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Failed, 1)
+	assert.Equal(t, plugins.FailureReasonSignatureInvalid, result.Failed[0].Reason)
+
+	_, ok := readLockfile(t, projectRoot).GetPlugin("my-plugin")
+	assert.False(t, ok, "an unverifiable stored bundle must not produce a lock entry")
+}

--- a/pkg/plugins/pluginsvc/verify.go
+++ b/pkg/plugins/pluginsvc/verify.go
@@ -16,6 +16,20 @@ import (
 	"github.com/stacklok/toolhive/pkg/skills/verifier"
 )
 
+// maxSignatureBlobSize bounds every attacker-influenced blob install-time
+// verification captures: the Sigstore bundle persisted with the install
+// record, and the commit payload and gitsign signature a git install verifies.
+// None is bounded at its source — a registry serves whatever bundle it likes,
+// and git imposes no length limit on a commit message — so without a ceiling a
+// hostile plugin source can push a multi-MB blob into SQLite on every install
+// and make every sync read it back (#6396 review). A real keyless bundle or
+// gitsign signature is a few KB (a certificate chain, a signature, an
+// inclusion proof), so 1 MiB is orders of magnitude above any legitimate
+// value while still refusing the abuse. Over-limit material is rejected, not
+// truncated: a truncated bundle would fail to verify later and be
+// indistinguishable from tampering.
+const maxSignatureBlobSize = 1 << 20 // 1 MiB
+
 // artifactVerifier returns the configured signature verifier, defaulting to
 // the Sigstore verifier with the composite registry keychain. Plugins reuse
 // the skills verifier wholesale: the Sigstore policy, the trust-on-first-use
@@ -58,6 +72,30 @@ func applyDecisionToOpts(opts *plugins.InstallOptions, decision *provenanceDecis
 	opts.SigstoreBundle = decision.bundle
 }
 
+// rejectOversizedBlob rejects signature material over maxSignatureBlobSize.
+// Reported as unprocessable rather than as a signature failure: the artifact
+// may well be correctly signed, but its material is not something ToolHive
+// will store.
+func rejectOversizedBlob(kind, pluginName string, size int) error {
+	if size <= maxSignatureBlobSize {
+		return nil
+	}
+	return httperr.WithCode(
+		fmt.Errorf("%s for plugin %q is %d bytes, over the %d-byte limit",
+			kind, pluginName, size, maxSignatureBlobSize),
+		http.StatusUnprocessableEntity,
+	)
+}
+
+// signedDecision records a successful verification, refusing an oversized
+// bundle before it reaches InstallOptions and the store.
+func signedDecision(result *verifier.Result, pluginName string) (*provenanceDecision, error) {
+	if err := rejectOversizedBlob("sigstore bundle", pluginName, len(result.Bundle)); err != nil {
+		return nil, err
+	}
+	return &provenanceDecision{provenance: result.ToLockProvenance(), bundle: result.Bundle}, nil
+}
+
 // verifyOCIInstall verifies the signature of the OCI artifact at ref/digest
 // before anything is extracted or recorded. The identity expected by the
 // lock file (if any) is enforced inside the verifier's Sigstore policy;
@@ -86,7 +124,7 @@ func (s *service) verifyOCIInstall(
 		}
 		return nil, classifyInstallVerifyError(verifyErr, pluginName, expected)
 	}
-	return &provenanceDecision{provenance: result.ToLockProvenance(), bundle: result.Bundle}, nil
+	return signedDecision(result, pluginName)
 }
 
 // verifyGitInstall verifies the gitsign signature on the resolved commit
@@ -105,6 +143,14 @@ func (s *service) verifyGitInstall(
 	if expectUnsigned {
 		return unsignedLockedDecision(opts, pluginName)
 	}
+	// Checked before verification: both come straight off a remote commit,
+	// so refusing them early keeps a hostile repo from spending our CPU.
+	if err := rejectOversizedBlob("commit payload", pluginName, len(payload)); err != nil {
+		return nil, err
+	}
+	if err := rejectOversizedBlob("commit signature", pluginName, len(signature)); err != nil {
+		return nil, err
+	}
 
 	result, verifyErr := s.artifactVerifier().VerifyGit(
 		ctx, payload, []byte(signature), verifier.NewLockExpectation(expected))
@@ -114,7 +160,7 @@ func (s *service) verifyGitInstall(
 		}
 		return nil, classifyInstallVerifyError(verifyErr, pluginName, expected)
 	}
-	return &provenanceDecision{provenance: result.ToLockProvenance(), bundle: result.Bundle}, nil
+	return signedDecision(result, pluginName)
 }
 
 // verifyLocalInstall handles installs sourced from the local OCI store or

--- a/pkg/plugins/pluginsvc/verify_test.go
+++ b/pkg/plugins/pluginsvc/verify_test.go
@@ -377,3 +377,107 @@ func TestClassifyInstallVerifyErrorDistinguishesProvenanceField(t *testing.T) {
 	assert.Contains(t, identityMismatch.Error(), "signer identity mismatch for",
 		"a genuine signer-identity mismatch keeps its existing wording")
 }
+
+// TestVerify_OversizedSignatureMaterialRejected covers the size ceiling
+// deferred from #6396's review: neither the bundle a registry serves nor the
+// commit payload/signature a repo serves is bounded at its source, so each is
+// refused at capture time rather than written to the store. The git payload
+// and signature are checked before the verifier is consulted, which the
+// mock's missing VerifyGit expectation enforces.
+func TestVerify_OversizedSignatureMaterialRejected(t *testing.T) {
+	t.Parallel()
+
+	oversized := make([]byte, maxSignatureBlobSize+1)
+
+	tests := []struct {
+		name    string
+		arrange func(*verifiermocks.MockVerifier)
+		call    func(*service) error
+	}{
+		{
+			name: "oversized OCI bundle",
+			arrange: func(mv *verifiermocks.MockVerifier) {
+				result := signedResult()
+				result.Bundle = oversized
+				mv.EXPECT().VerifyOCI(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(result, nil)
+			},
+			call: func(svc *service) error {
+				_, err := svc.verifyOCIInstall(t.Context(), plugins.InstallOptions{},
+					"my-plugin", "ghcr.io/org/my-plugin:v1", validLockDigest())
+				return err
+			},
+		},
+		{
+			name: "oversized git bundle",
+			arrange: func(mv *verifiermocks.MockVerifier) {
+				result := signedResult()
+				result.Bundle = oversized
+				mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(result, nil)
+			},
+			call: func(svc *service) error {
+				_, err := svc.verifyGitInstall(t.Context(), plugins.InstallOptions{},
+					"my-plugin", []byte("commit payload"), "signature")
+				return err
+			},
+		},
+		{
+			name:    "oversized commit payload is refused before verification",
+			arrange: func(*verifiermocks.MockVerifier) {},
+			call: func(svc *service) error {
+				_, err := svc.verifyGitInstall(t.Context(), plugins.InstallOptions{},
+					"my-plugin", oversized, "signature")
+				return err
+			},
+		},
+		{
+			name:    "oversized commit signature is refused before verification",
+			arrange: func(*verifiermocks.MockVerifier) {},
+			call: func(svc *service) error {
+				_, err := svc.verifyGitInstall(t.Context(), plugins.InstallOptions{},
+					"my-plugin", []byte("commit payload"), string(oversized))
+				return err
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+			tc.arrange(mv)
+
+			err := tc.call(&service{sigVerifier: mv})
+			require.Error(t, err)
+			assert.Equal(t, http.StatusUnprocessableEntity, httperr.Code(err))
+			assert.Equal(t, plugins.FailureReasonValidationRejected, classifySyncFailure(err))
+		})
+	}
+}
+
+// TestInstallVerification_OversizedBundleIsNotStored proves the ceiling holds
+// end to end: an over-limit bundle fails the install rather than reaching the
+// DB or the lock file.
+//
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestInstallVerification_OversizedBundleIsNotStored(t *testing.T) {
+	repoDir := createPluginTestRepo(t, "")
+	result := signedResult()
+	result.Bundle = make([]byte, maxSignatureBlobSize+1)
+
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(result, nil)
+
+	svc, projectRoot := newGitLockTestService(t, repoDir, WithVerifier(mv))
+	err := gitInstall(t, svc, projectRoot, nil)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnprocessableEntity, httperr.Code(err))
+
+	_, ok := loadPluginLockEntry(t, projectRoot)
+	assert.False(t, ok, "an oversized bundle must not produce a lock entry")
+	_, err = svc.Info(t.Context(), plugins.InfoOptions{
+		Name: "my-plugin", Scope: plugins.ScopeProject, ProjectRoot: projectRoot,
+	})
+	require.Error(t, err, "an oversized bundle must not produce a DB record")
+}

--- a/pkg/plugins/pluginsvc/verify_test.go
+++ b/pkg/plugins/pluginsvc/verify_test.go
@@ -38,14 +38,18 @@ func signedResult() *verifier.Result {
 }
 
 // alwaysSignedVerifier reports every artifact as signed by the fixed test
-// identity, so tests exercising lock/sync/upgrade mechanics don't trip
-// install-time verification.
+// identity — including offline re-verification of stored bundles — so tests
+// exercising lock/sync/upgrade mechanics don't trip verification.
 func alwaysSignedVerifier(t *testing.T) verifier.Verifier {
 	t.Helper()
 	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
 	mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().Return(signedResult(), nil)
 	mv.EXPECT().VerifyOCI(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(signedResult(), nil)
+	mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(nil)
+	mv.EXPECT().ResultFromBundle(gomock.Any(), gomock.Any()).
 		AnyTimes().Return(signedResult(), nil)
 	return mv
 }


### PR DESCRIPTION
## Summary

Sync is where a lock file becomes an enforcement mechanism: it is what CI runs to assert that what is installed is what was pinned. #6397 made install-time verification record a signer identity and persist the Sigstore bundle on the install record, but nothing re-checked either afterwards — an entry whose stored bundle had been tampered with, swapped, or lost still reported as up to date, so the CI gate covered content drift but not signature drift.

**Commit 1 — re-verify stored signatures during sync**

- Sync re-verifies each managed entry's stored bundle against the identity its lock entry records, entirely offline via the embedded trust root — no registry access, so `--check` stays usable in a sandboxed CI runner. A failed re-verification is drift: `--check` reports it and exits 2, apply mode reinstalls from the pinned reference, where #6397's install-time verification enforces the locked identity and heals the stored bundle.
- An OCI entry recording a signer identity with no stored bundle fails closed rather than passing — a recorded identity with nothing backing it cannot be verified. Git entries store no bundle by design (their signature lives on the commit and is re-verified when content is re-resolved) and entries recorded `unsigned: true` have nothing to verify, so both skip the offline check.
- Adoption is a trust decision, so `--adopt` back-fills the entry's provenance from the stored bundle when one exists. With no bundle, adopting is the same trust decision as an unsigned install: it now requires the explicit `--allow-unsigned` exception and records `unsigned: true`. Without the flag it fails typed as `unsigned-rejected`. This tightens `--adopt`, which previously wrote entries with no trust state at all.
- Adds `--allow-unsigned` to `thv ai-plugin sync` and threads the field through the plugins API DTO and the Go HTTP client DTO. `plugins.SyncOptions` already carried the field (it aliases `skills.SyncOptions`); nothing was passing it.
- Signature failures classify through the existing `errors.Is` sentinel mapping to the typed reasons established in Stack 1 (`signature-invalid`, `signer-mismatch`, `unsigned-rejected`). Exit-code semantics are unchanged.

**Commit 2 — bound stored signature material (closes the #6396 review thread)**

@jhrozek flagged on #6396 that nothing caps what gets written into the `sigstore_bundle` column, and that the git `Payload`/`Signature` that PR started carrying are equally unbounded — commit messages have no length limit, so a hostile repo or registry can push a multi-MB blob into SQLite on every install. #6397 deferred the fix here, because this is the PR where sync starts reading those bytes back on every run.

- All three are capped at capture time in `verify.go`, before the bytes reach `InstallOptions` and the store, at 1 MiB — orders of magnitude above a real keyless bundle or gitsign signature (a few KB: certificate chain, signature, inclusion proof).
- Over-limit material is rejected (422), never truncated: a truncated bundle would fail to verify later and be indistinguishable from tampering. The git payload and signature are checked *before* the verifier is consulted, so a hostile repo cannot spend our CPU either.
- The other #6396 comment — nothing binds a stored bundle to the digest it covers — is answered by the two PRs together: capture derives the pair from a single `VerifyOCI`/`VerifyGit` call over that digest (#6397), and commit 1 here re-verifies the stored bundle against the entry's digest on every sync, so a mismatched pair now surfaces as drift instead of sitting unnoticed.

Part of #6300. Mirrors the skills counterpart #6131. Stacked on #6397 — this PR targets `plugins-sig/07-install-verify`.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Sync re-verification tests mirror the skills suite:

- a stored bundle that no longer verifies reports as drift in `--check` and is reinstalled at the pin in apply mode;
- `verifyStoredSignature` table: unsigned and no-provenance entries skip the check, provenance-without-bundle fails closed for OCI and passes for git, a stored bundle delegates to `VerifyBundleOffline` and its failure propagates;
- a missing bundle classifies as `signature-invalid`, not `unknown`;
- adopt back-fills provenance from a stored bundle without needing the flag, rejects an unverifiable bundle rather than silently falling through to unsigned, and without a bundle fails typed `unsigned-rejected` then records `unsigned: true` with `--allow-unsigned`;
- round-trip tests pin the flag at both DTO boundaries (API request → `SyncOptions`, client → wire) and the CLI flag's binding to the variable sync passes to the service.

Size-cap tests: a table over all four rejection paths (OCI bundle, git bundle, oversized commit payload, oversized commit signature) asserting 422 and `validation-rejected`, where the payload/signature cases prove the verifier is never called; plus an end-to-end case showing an oversized bundle leaves neither a lock entry nor a DB record.

`task docs` output verified with `./cmd/help/verify.sh` (exit 0, no diffs).

Two pre-existing conditions on this branch and its base, neither introduced here:

- `TestMCPGoClientInitializeAndPing` (`pkg/transport/proxy/streamable`) fails locally — its server binds a hardcoded `127.0.0.1:8096`, which is in use on this machine.
- `task lint-fix` was run with golangci-lint v2.12.2, the version CI pins in #6393 (v2.13.0 panics in `nilness` on `sentry-go`). It reports one `gci` finding in `pkg/authserver/runner/embeddedauthserver.go:249`, a file this PR does not touch; the repo is otherwise clean.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/plugins/pluginsvc/sync.go` | Offline re-verification in `syncLockedEntry`; adoption trust decision in `adoptLocked` |
| `pkg/plugins/pluginsvc/verify.go` | 1 MiB ceiling on bundle, commit payload and gitsign signature at capture |
| `cmd/thv/app/ai_plugin_sync.go` | `--allow-unsigned` flag |
| `pkg/api/v1/plugins_types.go`, `pkg/api/v1/plugins.go` | `allow_unsigned` on the sync request DTO and handler |
| `pkg/plugins/client/dto.go`, `pkg/plugins/client/client.go` | `allow_unsigned` on the client sync DTO |
| `docs/` | Regenerated CLI docs and swagger |

## Does this introduce a user-facing change?

Yes. `thv ai-plugin sync --check` now also fails when a plugin's stored signature no longer verifies against the identity pinned in the lock file, not just on content drift. `thv ai-plugin sync --adopt` now requires `--allow-unsigned` for installs with no stored Sigstore bundle, and records those entries as `unsigned: true`; adoptions with a stored bundle back-fill the signer identity into the lock entry instead of leaving trust state empty. An install whose signature material exceeds 1 MiB is rejected.

## Special notes for reviewers

- The OCI/git split keys off whether `entry.Digest` contains a `:` — the same discriminator the skills implementation uses. Git digests are bare commit hashes, OCI digests are `sha256:…`. Local-store pins share the OCI digest shape and store no bundle, but cannot reach the fail-closed branch (a local install is always an unsigned trust decision, so its entry returns at the `Unsigned` check); `verifyStoredSignature`'s doc comment reasons through that case and through a hand-edited lock entry.
- In `adoptLocked`, the restorable-pin check deliberately still runs before the trust decision, so adopting a bare local-store tag keeps reporting `validation-rejected` rather than changing to `unsigned-rejected`.
- `ResultFromBundle` returning a nil provenance (a key-signed bundle carries no certificate identity) falls through to the unsigned path rather than recording an empty provenance block.
- The equivalent unbounded-blob exposure exists on the skills side, which has no cap today. Out of scope here (this stack does not touch `pkg/skills`) but worth a follow-up.
- Follow-ups in this stack: the signer-change guard on the upgrade path is PR9; push signing and gate removal are PR10.

Generated with [Claude Code](https://claude.com/claude-code)
