### PR TITLE
Block plugin upgrades that change the signer identity

### DIFF
--- a/cmd/thv/app/ai_plugin_upgrade.go
+++ b/cmd/thv/app/ai_plugin_upgrade.go
@@ -13,13 +13,14 @@ import (
 )
 
 var (
-	aiPluginUpgradeProjectRoot    string
-	aiPluginUpgradeClientsRaw     string
-	aiPluginUpgradePreview        bool
-	aiPluginUpgradeFailOnChanges  bool
-	aiPluginUpgradeAllowRefChange bool
-	aiPluginUpgradeYes            bool
-	aiPluginUpgradeFormat         string
+	aiPluginUpgradeProjectRoot       string
+	aiPluginUpgradeClientsRaw        string
+	aiPluginUpgradePreview           bool
+	aiPluginUpgradeFailOnChanges     bool
+	aiPluginUpgradeAllowRefChange    bool
+	aiPluginUpgradeAllowSignerChange bool
+	aiPluginUpgradeYes               bool
+	aiPluginUpgradeFormat            string
 )
 
 var aiPluginUpgradeCmd = &cobra.Command{
@@ -60,6 +61,8 @@ func init() {
 		"Report what would change without persisting anything (OCI sources are still fetched to compare digests)")
 	aiPluginUpgradeCmd.Flags().BoolVar(&aiPluginUpgradeFailOnChanges, "fail-on-changes", false,
 		"Report what would change without installing anything; a CI freshness gate")
+	aiPluginUpgradeCmd.Flags().BoolVar(&aiPluginUpgradeAllowSignerChange, "allow-signer-change", false,
+		"Permit upgrading to an artifact signed by a different identity; the new identity replaces the recorded one")
 	aiPluginUpgradeCmd.Flags().BoolVar(&aiPluginUpgradeAllowRefChange, "allow-ref-change", false,
 		"Permit the artifact to move to a different repository during upgrade")
 	aiPluginUpgradeCmd.Flags().BoolVar(&aiPluginUpgradeYes, "yes", false,
@@ -89,12 +92,13 @@ func aiPluginUpgradeCmdFunc(cmd *cobra.Command, args []string) error {
 
 	c := newAIPluginClient(cmd.Context())
 	result, err := c.Upgrade(cmd.Context(), plugins.UpgradeOptions{
-		ProjectRoot:    projectRoot,
-		Names:          args,
-		Clients:        parseSkillInstallClients(aiPluginUpgradeClientsRaw),
-		Preview:        aiPluginUpgradePreview,
-		FailOnChanges:  aiPluginUpgradeFailOnChanges,
-		AllowRefChange: aiPluginUpgradeAllowRefChange,
+		ProjectRoot:       projectRoot,
+		Names:             args,
+		Clients:           parseSkillInstallClients(aiPluginUpgradeClientsRaw),
+		Preview:           aiPluginUpgradePreview,
+		FailOnChanges:     aiPluginUpgradeFailOnChanges,
+		AllowRefChange:    aiPluginUpgradeAllowRefChange,
+		AllowSignerChange: aiPluginUpgradeAllowSignerChange,
 	})
 	if err != nil {
 		return formatAIPluginError("upgrade plugins", err)
@@ -109,7 +113,8 @@ func aiPluginUpgradeCmdFunc(cmd *cobra.Command, args []string) error {
 
 func pluginUpgradeExitError(result *plugins.UpgradeResult, preview, failOnChanges bool) error {
 	tally := tallyUpgradeOutcomes(result)
-	failed, refBlocked, wouldChange := tally.failed, tally.refBlocked, tally.wouldChange
+	failed, refBlocked, signerBlocked, wouldChange :=
+		tally.failed, tally.refBlocked, tally.signerBlocked, tally.wouldChange
 	if failed > 0 {
 		return withExitCode(fmt.Errorf("upgrade failed for %d plugin(s)", failed), ExitCodePartialFailure)
 	}
@@ -117,6 +122,12 @@ func pluginUpgradeExitError(result *plugins.UpgradeResult, preview, failOnChange
 		return withExitCode(
 			fmt.Errorf("%d plugin(s) would change; the lock file is stale", wouldChange),
 			ExitCodeCheckFailure,
+		)
+	}
+	if !preview && !failOnChanges && signerBlocked > 0 {
+		return withExitCode(
+			fmt.Errorf("%d plugin(s) blocked by a signer change; use --allow-signer-change", signerBlocked),
+			ExitCodePolicyRejection,
 		)
 	}
 	if !preview && !failOnChanges && refBlocked > 0 {

--- a/cmd/thv/app/ai_plugin_upgrade_test.go
+++ b/cmd/thv/app/ai_plugin_upgrade_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/plugins"
+)
+
+func TestPluginUpgradeExitError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		outcomes      []plugins.UpgradeOutcome
+		preview       bool
+		failOnChanges bool
+		wantCode      int
+	}{
+		{
+			name:     "all up to date",
+			outcomes: []plugins.UpgradeOutcome{{Name: "a", Status: plugins.UpgradeStatusUpToDate}},
+			wantCode: 0,
+		},
+		{
+			name:     "signer change blocked is a policy rejection",
+			outcomes: []plugins.UpgradeOutcome{{Name: "a", Status: plugins.UpgradeStatusSignerChangeBlocked}},
+			wantCode: ExitCodePolicyRejection,
+		},
+		{
+			name:     "signer change blocked in preview is informational",
+			outcomes: []plugins.UpgradeOutcome{{Name: "a", Status: plugins.UpgradeStatusSignerChangeBlocked}},
+			preview:  true,
+			wantCode: 0,
+		},
+		{
+			name:          "signer change blocked counts as would-change under fail-on-changes",
+			outcomes:      []plugins.UpgradeOutcome{{Name: "a", Status: plugins.UpgradeStatusSignerChangeBlocked}},
+			failOnChanges: true,
+			wantCode:      ExitCodeCheckFailure,
+		},
+		{
+			// A genuine failure must never be masked by a guard doing its job.
+			name: "a failure outranks a signer-change block",
+			outcomes: []plugins.UpgradeOutcome{
+				{Name: "a", Status: plugins.UpgradeStatusSignerChangeBlocked},
+				{Name: "b", Status: plugins.UpgradeStatusFailed},
+			},
+			wantCode: ExitCodePartialFailure,
+		},
+		{
+			name:     "ref change blocked is still a policy rejection",
+			outcomes: []plugins.UpgradeOutcome{{Name: "a", Status: plugins.UpgradeStatusRefChangeBlocked}},
+			wantCode: ExitCodePolicyRejection,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := pluginUpgradeExitError(
+				&plugins.UpgradeResult{Outcomes: tc.outcomes}, tc.preview, tc.failOnChanges)
+			if tc.wantCode == 0 {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, tc.wantCode, ExitCodeFromError(err))
+		})
+	}
+}
+
+// TestPluginUpgradeAllowSignerChangeFlag pins the flag name the blocked-status
+// message tells users to pass, and its binding to the variable the upgrade
+// options are built from.
+//
+//nolint:paralleltest // mutates the command's package-level flag state
+func TestPluginUpgradeAllowSignerChangeFlag(t *testing.T) {
+	flag := aiPluginUpgradeCmd.Flags().Lookup("allow-signer-change")
+	require.NotNil(t, flag, "the status message promises --allow-signer-change")
+	assert.Equal(t, "false", flag.DefValue, "a signer rotation is never permitted by default")
+
+	t.Cleanup(func() {
+		aiPluginUpgradeAllowSignerChange = false
+		require.NoError(t, flag.Value.Set("false"))
+		flag.Changed = false
+	})
+	require.NoError(t, aiPluginUpgradeCmd.Flags().Set("allow-signer-change", "true"))
+	assert.True(t, aiPluginUpgradeAllowSignerChange,
+		"the flag must bind to the variable threaded into plugins.UpgradeOptions")
+}

--- a/docs/cli/thv_ai-plugin_upgrade.md
+++ b/docs/cli/thv_ai-plugin_upgrade.md
@@ -41,6 +41,7 @@ thv ai-plugin upgrade [plugin-name...] [flags]
 
 ```
       --allow-ref-change      Permit the artifact to move to a different repository during upgrade
+      --allow-signer-change   Permit upgrading to an artifact signed by a different identity; the new identity replaces the recorded one
       --clients string        Comma-separated target client apps (e.g. claude-code,opencode), or "all" for every available client
       --fail-on-changes       Report what would change without installing anything; a CI freshness gate
       --format string         Output format (json, text) (default "text")

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -4144,6 +4144,10 @@ const docTemplate = `{
                         "description": "AllowRefChange permits resolvedReference changes during upgrade",
                         "type": "boolean"
                     },
+                    "allow_signer_change": {
+                        "description": "AllowSignerChange permits upgrading to an artifact signed by a\ndifferent identity than the recorded one",
+                        "type": "boolean"
+                    },
                     "clients": {
                         "description": "Clients lists target client identifiers. Empty means every\nplugin-supporting client detected on this host.",
                         "items": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -4137,6 +4137,10 @@
                         "description": "AllowRefChange permits resolvedReference changes during upgrade",
                         "type": "boolean"
                     },
+                    "allow_signer_change": {
+                        "description": "AllowSignerChange permits upgrading to an artifact signed by a\ndifferent identity than the recorded one",
+                        "type": "boolean"
+                    },
                     "clients": {
                         "description": "Clients lists target client identifiers. Empty means every\nplugin-supporting client detected on this host.",
                         "items": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -3835,6 +3835,11 @@ components:
         allow_ref_change:
           description: AllowRefChange permits resolvedReference changes during upgrade
           type: boolean
+        allow_signer_change:
+          description: |-
+            AllowSignerChange permits upgrading to an artifact signed by a
+            different identity than the recorded one
+          type: boolean
         clients:
           description: |-
             Clients lists target client identifiers. Empty means every

--- a/pkg/api/v1/plugins.go
+++ b/pkg/api/v1/plugins.go
@@ -485,12 +485,13 @@ func (s *PluginsRoutes) upgradePlugins(w http.ResponseWriter, r *http.Request) e
 	}
 
 	result, err := s.lockService.Upgrade(r.Context(), plugins.UpgradeOptions{
-		ProjectRoot:    req.ProjectRoot,
-		Names:          req.Names,
-		Preview:        req.Preview,
-		FailOnChanges:  req.FailOnChanges,
-		AllowRefChange: req.AllowRefChange,
-		Clients:        req.Clients,
+		ProjectRoot:       req.ProjectRoot,
+		Names:             req.Names,
+		Preview:           req.Preview,
+		FailOnChanges:     req.FailOnChanges,
+		AllowRefChange:    req.AllowRefChange,
+		AllowSignerChange: req.AllowSignerChange,
+		Clients:           req.Clients,
 	})
 	if err != nil {
 		return err

--- a/pkg/api/v1/plugins_sync_test.go
+++ b/pkg/api/v1/plugins_sync_test.go
@@ -157,6 +157,27 @@ func TestUpgradePluginsEndpoint(t *testing.T) {
 			wantContains: `"my-plugin"`,
 		},
 		{
+			// A DTO field that dies at the decode boundary would silently
+			// re-arm the signer-change guard the caller just overrode.
+			name: "allow_signer_change reaches the service",
+			service: &pluginServiceWithSync{
+				PluginService: plugmocks.NewMockPluginService(gomock.NewController(t)),
+				syncFn:        func(context.Context, plugins.SyncOptions) (*plugins.SyncResult, error) { return nil, nil },
+				upgradeFn: func(_ context.Context, opts plugins.UpgradeOptions) (*plugins.UpgradeResult, error) {
+					assert.True(t, opts.AllowSignerChange, "allow_signer_change must reach the service")
+					assert.True(t, opts.AllowRefChange)
+					assert.Equal(t, []string{"my-plugin"}, opts.Names)
+					return &plugins.UpgradeResult{Outcomes: []plugins.UpgradeOutcome{
+						{Name: "my-plugin", Status: plugins.UpgradeStatusUpgraded},
+					}}, nil
+				},
+			},
+			body: `{"project_root":"/tmp/proj","names":["my-plugin"],` +
+				`"allow_ref_change":true,"allow_signer_change":true}`,
+			wantStatus:   http.StatusOK,
+			wantContains: `"upgraded"`,
+		},
+		{
 			name:       "service without Upgrade support returns 501",
 			service:    plugmocks.NewMockPluginService(gomock.NewController(t)),
 			body:       `{"project_root":"/tmp/proj"}`,

--- a/pkg/api/v1/plugins_types.go
+++ b/pkg/api/v1/plugins_types.go
@@ -115,6 +115,9 @@ type upgradePluginsRequest struct {
 	FailOnChanges bool `json:"fail_on_changes,omitempty"`
 	// AllowRefChange permits resolvedReference changes during upgrade
 	AllowRefChange bool `json:"allow_ref_change,omitempty"`
+	// AllowSignerChange permits upgrading to an artifact signed by a
+	// different identity than the recorded one
+	AllowSignerChange bool `json:"allow_signer_change,omitempty"`
 	// Clients lists target client identifiers. Empty means every
 	// plugin-supporting client detected on this host.
 	Clients []string `json:"clients,omitempty"`

--- a/pkg/plugins/client/client.go
+++ b/pkg/plugins/client/client.go
@@ -333,12 +333,13 @@ func (c *Client) Sync(ctx context.Context, opts plugins.SyncOptions) (*plugins.S
 // where available.
 func (c *Client) Upgrade(ctx context.Context, opts plugins.UpgradeOptions) (*plugins.UpgradeResult, error) {
 	body := upgradeRequest{
-		ProjectRoot:    opts.ProjectRoot,
-		Names:          opts.Names,
-		Preview:        opts.Preview,
-		FailOnChanges:  opts.FailOnChanges,
-		AllowRefChange: opts.AllowRefChange,
-		Clients:        opts.Clients,
+		ProjectRoot:       opts.ProjectRoot,
+		Names:             opts.Names,
+		Preview:           opts.Preview,
+		FailOnChanges:     opts.FailOnChanges,
+		AllowRefChange:    opts.AllowRefChange,
+		AllowSignerChange: opts.AllowSignerChange,
+		Clients:           opts.Clients,
 	}
 
 	var result plugins.UpgradeResult

--- a/pkg/plugins/client/client_test.go
+++ b/pkg/plugins/client/client_test.go
@@ -1048,3 +1048,29 @@ func TestSyncCarriesAllowUnsigned(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, got.AllowUnsigned, "allow_unsigned must reach the server")
 }
+
+// TestUpgradeCarriesAllowSignerChange pins the upgrade DTO boundary: a flag
+// that dies here would silently re-arm the signer-change guard the caller
+// just overrode, turning an explicit rotation into a blocked upgrade.
+func TestUpgradeCarriesAllowSignerChange(t *testing.T) {
+	t.Parallel()
+
+	var got upgradeRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(plugins.UpgradeResult{})
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newTestClient(t, srv).Upgrade(t.Context(), plugins.UpgradeOptions{
+		ProjectRoot:       "/tmp/project",
+		Names:             []string{"my-plugin"},
+		AllowRefChange:    true,
+		AllowSignerChange: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, got.AllowSignerChange, "allow_signer_change must reach the server")
+	assert.True(t, got.AllowRefChange)
+	assert.Equal(t, []string{"my-plugin"}, got.Names)
+}

--- a/pkg/plugins/client/dto.go
+++ b/pkg/plugins/client/dto.go
@@ -56,10 +56,12 @@ type syncRequest struct {
 }
 
 type upgradeRequest struct {
-	ProjectRoot    string   `json:"project_root"`
-	Names          []string `json:"names,omitempty"`
-	Preview        bool     `json:"preview,omitempty"`
-	FailOnChanges  bool     `json:"fail_on_changes,omitempty"`
-	AllowRefChange bool     `json:"allow_ref_change,omitempty"`
-	Clients        []string `json:"clients,omitempty"`
+	ProjectRoot string   `json:"project_root"`
+	Names       []string `json:"names,omitempty"`
+	// AllowSignerChange mirrors plugins.UpgradeOptions.AllowSignerChange.
+	AllowSignerChange bool     `json:"allow_signer_change,omitempty"`
+	Preview           bool     `json:"preview,omitempty"`
+	FailOnChanges     bool     `json:"fail_on_changes,omitempty"`
+	AllowRefChange    bool     `json:"allow_ref_change,omitempty"`
+	Clients           []string `json:"clients,omitempty"`
 }

--- a/pkg/plugins/options.go
+++ b/pkg/plugins/options.go
@@ -75,6 +75,11 @@ type InstallOptions struct {
 	// normal "same digest means content is already correct" fast path must
 	// not apply. Internal use only — NOT exposed via HTTP API.
 	SyncRestore bool `json:"-"`
+	// AllowSignerChange lets install-time verification re-record the
+	// observed identity instead of enforcing the lock file's recorded one.
+	// Internal use only — set by upgrade when its signer-change guard was
+	// explicitly overridden. NOT exposed via HTTP API.
+	AllowSignerChange bool `json:"-"`
 	// ExpectedCanonicalName, when set, requires the resolved plugin/manifest name
 	// to equal this value before any install mutation. Used by Sync/Upgrade so a
 	// lock entry cannot be repaired under a different canonical identity.

--- a/pkg/plugins/pluginsvc/upgrade.go
+++ b/pkg/plugins/pluginsvc/upgrade.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/plugins"
 	"github.com/stacklok/toolhive/pkg/skills/gitresolver"
 	"github.com/stacklok/toolhive/pkg/skills/lockfile"
+	"github.com/stacklok/toolhive/pkg/skills/verifier"
 )
 
 // var _ ensures *service continues to satisfy the full lock service surface
@@ -29,9 +30,10 @@ var _ plugins.PluginLockService = (*service)(nil)
 // pinned to an immutable reference (an OCI digest or a full git commit hash)
 // are reported not-upgradable: there is nothing newer to resolve to.
 //
-// Signer-change guarding is intentionally omitted: plugin Sigstore
-// verification lands in a later PR. AllowSignerChange is accepted on the
-// options type (aliased from skills) but not enforced here.
+// An upgrade re-resolves a mutable source, which is exactly when a
+// compromised or transferred publisher would slip a differently-signed
+// artifact into the pinned trust chain, so planning probes the candidate's
+// signer identity before anything is installed — see guardSignerChange.
 func (s *service) Upgrade(ctx context.Context, opts plugins.UpgradeOptions) (*plugins.UpgradeResult, error) {
 	if !plugins.LockFileFeatureEnabled() {
 		return nil, httperr.WithCode(
@@ -147,6 +149,11 @@ type resolvedLatest struct {
 	ref       string
 	digest    string
 	layerData []byte
+	// commitPayload and commitSignature are the git candidate's signature
+	// material, captured during resolution so the signer probe does not
+	// need a second clone. Empty for OCI candidates.
+	commitPayload   []byte
+	commitSignature string
 }
 
 func (s *service) planUpgrade(ctx context.Context, opts plugins.UpgradeOptions, entry lockfile.Entry) upgradePlan {
@@ -196,6 +203,23 @@ func (s *service) planUpgrade(ctx context.Context, opts plugins.UpgradeOptions, 
 		}
 	}
 
+	// Signer-change guard: when the entry records a signer identity, the
+	// candidate must verify with the same one before the upgrade is even
+	// planned. Verification happens here (plan-only modes stay
+	// install-free) with a nil expected identity so a differing signer is
+	// reported as a change rather than a bare failure; blocked plans carry
+	// no pinnedRef, exactly like ref changes.
+	//
+	// Local-store candidates never reach this point — they returned above
+	// with layerData set — because they carry no signature to probe.
+	// verifyLocalInstall refuses them outright at install time when the
+	// entry is locked to a signer, which is the stronger check.
+	if entry.Provenance != nil && !opts.AllowSignerChange {
+		if blocked := s.guardSignerChange(ctx, entry, latest, &outcome); blocked {
+			return upgradePlan{entry: entry, outcome: outcome}
+		}
+	}
+
 	pinnedRef, err := buildPinnedReference(lockfile.Entry{ResolvedReference: latest.ref, Digest: latest.digest})
 	if err != nil {
 		outcome.Status = plugins.UpgradeStatusFailed
@@ -206,6 +230,100 @@ func (s *service) planUpgrade(ctx context.Context, opts plugins.UpgradeOptions, 
 
 	outcome.Status = plugins.UpgradeStatusUpgraded
 	return upgradePlan{entry: entry, outcome: outcome, pinnedRef: pinnedRef, resolvedRef: latest.ref}
+}
+
+// guardSignerChange probes the candidate artifact's signer identity and
+// fills outcome when the upgrade must not proceed: the candidate is signed
+// by a different identity (or unsigned) versus the recorded provenance, its
+// signature cannot be verified at all, or its certificate's repository ref
+// or runner class differs from what is recorded. Returns true when blocked.
+//
+// The repository ref has NO automatic allowance for a tag-shaped rotation.
+// An earlier version of the skills guard this mirrors let a recorded tag
+// ref rotate to any other tag ref, reasoning that a release workflow signs
+// each version on its own tag — but that also let a candidate signed from
+// an attacker's OWN tag (e.g. "refs/tags/attacker-release") on the SAME
+// repository replace a pinned tag, since nothing tied the candidate's tag
+// to the specific version actually being upgraded to. Binding it correctly
+// would need the resolved release source's own tag, which the git resolver
+// does not surface at all (only the resolved commit hash) — so an OCI-only
+// partial fix would leave git-sourced plugins with the identical hole.
+// Every ref change — tag or branch, git or OCI — therefore blocks here
+// exactly like a genuine signer-identity change, and needs the same
+// explicit --allow-signer-change override. See stacklok/toolhive#6315
+// review.
+func (s *service) guardSignerChange(
+	ctx context.Context,
+	entry lockfile.Entry,
+	latest resolvedLatest,
+	outcome *plugins.UpgradeOutcome,
+) bool {
+	probe, probeErr := s.probeCandidateSigner(ctx, entry.Name, latest)
+	switch {
+	case probeErr != nil && errors.Is(probeErr, verifier.ErrUnsigned):
+		outcome.Status = plugins.UpgradeStatusSignerChangeBlocked
+		return true
+	case probeErr != nil:
+		outcome.Status = plugins.UpgradeStatusFailed
+		outcome.Reason = classifySignatureError(probeErr)
+		if outcome.Reason == "" {
+			outcome.Reason = plugins.FailureReasonUnknown
+		}
+		outcome.Error = probeErr.Error()
+		return true
+	case probe.SignerIdentity != entry.Provenance.SignerIdentity ||
+		probe.CertIssuer != entry.Provenance.CertIssuer ||
+		runnerEnvironmentChanged(probe, entry.Provenance) ||
+		repositoryRefChanged(probe, entry.Provenance):
+		outcome.Status = plugins.UpgradeStatusSignerChangeBlocked
+		outcome.NewSignerIdentity = probe.SignerIdentity
+		return true
+	}
+	return false
+}
+
+// runnerEnvironmentChanged reports whether the candidate's runner class
+// differs from the one recorded. An entry that recorded none is
+// unconstrained — lock entries written before the field existed have it
+// empty, as do certificates that carry no such extension.
+func runnerEnvironmentChanged(probe *verifier.Result, recorded *lockfile.Provenance) bool {
+	return recorded.RunnerEnvironment != "" && probe.RunnerEnvironment != recorded.RunnerEnvironment
+}
+
+// repositoryRefChanged reports whether the candidate's certificate ref
+// differs from the one recorded, with the same absent-means-unconstrained
+// rule as runnerEnvironmentChanged. Unlike the runner class, no ref value
+// is treated as an automatically allowed rotation — see guardSignerChange's
+// doc comment for why.
+func repositoryRefChanged(probe *verifier.Result, recorded *lockfile.Provenance) bool {
+	return recorded.RepositoryRef != "" && probe.RepositoryRef != recorded.RepositoryRef
+}
+
+// probeCandidateSigner verifies the candidate artifact chain-of-trust-only
+// (nil expected identity) and returns the observed identity. Git candidates
+// verify the signature material captured while resolving the candidate
+// commit, rather than re-resolving it: skillsvc's probe clones a second
+// time, which for plugins would both double the clone cost and let the
+// probed commit drift from the one being planned.
+//
+// The commit payload and signature are bounded here for the same reason
+// verifyGitInstall bounds them: both come straight off a remote commit, and
+// this probe runs on every guarded upgrade — including --preview and
+// --fail-on-changes, which install nothing — so an unbounded probe would let
+// a hostile repository spend our CPU without ever reaching an install.
+func (s *service) probeCandidateSigner(
+	ctx context.Context, pluginName string, latest resolvedLatest,
+) (*verifier.Result, error) {
+	if len(latest.commitPayload) > 0 {
+		if err := rejectOversizedBlob("commit payload", pluginName, len(latest.commitPayload)); err != nil {
+			return nil, err
+		}
+		if err := rejectOversizedBlob("commit signature", pluginName, len(latest.commitSignature)); err != nil {
+			return nil, err
+		}
+		return s.artifactVerifier().VerifyGit(ctx, latest.commitPayload, []byte(latest.commitSignature), nil)
+	}
+	return s.artifactVerifier().VerifyOCI(ctx, latest.ref, latest.digest, nil)
 }
 
 func (s *service) applyUpgrade(ctx context.Context, opts plugins.UpgradeOptions, plan upgradePlan) plugins.UpgradeOutcome {
@@ -238,6 +356,7 @@ func (s *service) applyUpgrade(ctx context.Context, opts plugins.UpgradeOptions,
 		Clients:               clients,
 		LockSource:            plan.entry.Source,
 		LockResolvedReference: lockResolved,
+		AllowSignerChange:     opts.AllowSignerChange,
 		ExpectedCanonicalName: plan.entry.Name,
 	}); err != nil {
 		outcome := plan.outcome
@@ -259,8 +378,7 @@ func (s *service) applyUpgrade(ctx context.Context, opts plugins.UpgradeOptions,
 // side-effect-free" note.
 func (s *service) resolveLatestState(ctx context.Context, source string) (resolvedLatest, error) {
 	if gitresolver.IsGitReference(source) {
-		ref, digest, err := s.resolveGitLatest(ctx, source)
-		return resolvedLatest{ref: ref, digest: digest}, err
+		return s.resolveGitLatest(ctx, source)
 	}
 
 	ref, isOCI, parseErr := parseOCIReference(source)
@@ -298,10 +416,14 @@ func (s *service) resolvePlainNameLatest(ctx context.Context, source string) (re
 	return resolvedLatest{ref: ref, digest: digest}, err
 }
 
-func (s *service) resolveGitLatest(ctx context.Context, gitURL string) (string, string, error) {
+// resolveGitLatest re-resolves gitURL to its current HEAD commit. The
+// commit's gitsign signature and the payload it covers travel with the
+// result so the signer probe can verify the exact commit being planned
+// without cloning the repository a second time.
+func (s *service) resolveGitLatest(ctx context.Context, gitURL string) (resolvedLatest, error) {
 	gitRef, err := gitresolver.ParseGitReference(gitURL)
 	if err != nil {
-		return "", "", httperr.WithCode(fmt.Errorf("invalid git reference: %w", err), http.StatusBadRequest)
+		return resolvedLatest{}, httperr.WithCode(fmt.Errorf("invalid git reference: %w", err), http.StatusBadRequest)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, gitresolver.CloneTimeout)
@@ -311,15 +433,20 @@ func (s *service) resolveGitLatest(ctx context.Context, gitURL string) (string, 
 	client := gitresolver.ClientForURL(gitRef.URL, s.gitClient)
 	repoInfo, err := client.Clone(ctx, cloneConfig)
 	if err != nil {
-		return "", "", httperr.WithCode(fmt.Errorf("resolving git plugin: %w", err), http.StatusBadGateway)
+		return resolvedLatest{}, httperr.WithCode(fmt.Errorf("resolving git plugin: %w", err), http.StatusBadGateway)
 	}
 	defer func() { _ = client.Cleanup(ctx, repoInfo) }()
 
 	head, err := client.HeadCommit(repoInfo)
 	if err != nil {
-		return "", "", httperr.WithCode(fmt.Errorf("resolving git plugin: %w", err), http.StatusBadGateway)
+		return resolvedLatest{}, httperr.WithCode(fmt.Errorf("resolving git plugin: %w", err), http.StatusBadGateway)
 	}
-	return gitURL, head.Hash, nil
+	return resolvedLatest{
+		ref:             gitURL,
+		digest:          head.Hash,
+		commitPayload:   head.Payload,
+		commitSignature: head.Signature,
+	}, nil
 }
 
 func (s *service) resolveOCILatest(ctx context.Context, ref nameref.Reference) (string, string, error) {

--- a/pkg/plugins/pluginsvc/upgrade_verify_test.go
+++ b/pkg/plugins/pluginsvc/upgrade_verify_test.go
@@ -1,0 +1,546 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package pluginsvc
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive-core/httperr"
+	"github.com/stacklok/toolhive/pkg/plugins"
+	"github.com/stacklok/toolhive/pkg/skills/lockfile"
+	"github.com/stacklok/toolhive/pkg/skills/verifier"
+	verifiermocks "github.com/stacklok/toolhive/pkg/skills/verifier/mocks"
+)
+
+const testRunnerEnvironment = "github-hosted"
+
+// otherSignerResult is a verification result from a different identity than
+// signedResult's.
+func otherSignerResult() *verifier.Result {
+	r := signedResult()
+	r.SignerIdentity = "/.github/workflows/other.yml"
+	return r
+}
+
+// provenanceSignedResult is signedResult with the pinned certificate fields
+// the guard also enforces (repository ref and runner class) populated.
+func provenanceSignedResult(ref, runner string) *verifier.Result {
+	r := signedResult()
+	r.RepositoryRef = ref
+	r.RunnerEnvironment = runner
+	return r
+}
+
+// signerChangeFixture installs a signed git plugin, then adds a commit at the
+// same source so an upgrade is planned, and returns a service whose verifier
+// reports the candidate as candidate() (or unsigned when candidate returns
+// nil, err). The initial install always sees signedResult, so the lock entry
+// is anchored to the fixed test identity.
+func signerChangeFixture(
+	t *testing.T,
+	candidate func() (*verifier.Result, error),
+) (plugins.PluginService, string) {
+	t.Helper()
+	repoDir := createPluginTestRepo(t, "")
+
+	calls := 0
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ any, _, _ []byte, expected *verifier.ProvenanceExpectation) (*verifier.Result, error) {
+			calls++
+			if calls == 1 {
+				return signedResult(), nil // initial install (TOFU)
+			}
+			result, err := candidate()
+			if err != nil {
+				return nil, err
+			}
+			// Stand in for the real verifier's lock-pin enforcement: a
+			// non-nil expectation that does not describe the candidate is a
+			// signer mismatch. The probe always passes nil, so this only
+			// fires on the install applyUpgrade performs.
+			if expected != nil && !assert.ObjectsAreEqual(verifier.NewLockExpectation(result.ToLockProvenance()), expected) {
+				return nil, verifier.ErrSignerMismatch
+			}
+			return result, nil
+		})
+	mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(nil)
+
+	svc, projectRoot := newGitLockTestService(t, repoDir, WithVerifier(mv))
+	installGitTestPlugin(t, svc, projectRoot)
+
+	// Add a commit at the same source so an upgrade is planned.
+	addPluginRepoCommit(t, repoDir, "# hello guarded")
+	return svc, projectRoot
+}
+
+// upgradePlugins runs Upgrade against every entry in projectRoot's lock file.
+func upgradePlugins(t *testing.T, svc plugins.PluginService, opts plugins.UpgradeOptions) plugins.UpgradeOutcome {
+	t.Helper()
+	result, err := svc.(*service).Upgrade(t.Context(), opts) //nolint:forcetypeassert
+	require.NoError(t, err)
+	require.Len(t, result.Outcomes, 1)
+	return result.Outcomes[0]
+}
+
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestUpgrade_SameSignerProceeds(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return signedResult(), nil
+	})
+
+	outcome := upgradePlugins(t, svc, plugins.UpgradeOptions{ProjectRoot: projectRoot})
+	assert.Equal(t, plugins.UpgradeStatusUpgraded, outcome.Status,
+		"a candidate signed by the recorded identity must not be blocked")
+
+	entry, ok := loadPluginLockEntry(t, projectRoot)
+	require.True(t, ok)
+	require.NotNil(t, entry.Provenance)
+	assert.Equal(t, testSignerIdentity, entry.Provenance.SignerIdentity)
+	assert.Equal(t, outcome.NewDigest, entry.Digest)
+}
+
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestUpgrade_SignerChangeBlocked(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return otherSignerResult(), nil
+	})
+
+	outcome := upgradePlugins(t, svc, plugins.UpgradeOptions{ProjectRoot: projectRoot})
+	assert.Equal(t, plugins.UpgradeStatusSignerChangeBlocked, outcome.Status)
+	assert.Equal(t, "/.github/workflows/other.yml", outcome.NewSignerIdentity)
+
+	// Nothing installed, lock unchanged.
+	entry, ok := loadPluginLockEntry(t, projectRoot)
+	require.True(t, ok)
+	require.NotNil(t, entry.Provenance)
+	assert.Equal(t, testSignerIdentity, entry.Provenance.SignerIdentity)
+	assert.Equal(t, outcome.OldDigest, entry.Digest, "a blocked upgrade must not re-pin the entry")
+}
+
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestUpgrade_UnsignedCandidateBlockedAgainstSignedEntry(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return nil, verifier.ErrUnsigned
+	})
+
+	outcome := upgradePlugins(t, svc, plugins.UpgradeOptions{ProjectRoot: projectRoot})
+	assert.Equal(t, plugins.UpgradeStatusSignerChangeBlocked, outcome.Status)
+	assert.Empty(t, outcome.NewSignerIdentity, "an unsigned candidate has no identity to report")
+}
+
+// TestUpgrade_ProvenanceFieldDivergenceBlocked covers the fields beyond the
+// signer identity that the guard pins: a certificate's repository ref and its
+// runner class. A candidate signed by the SAME identity and issuer from a
+// different branch, a different tag, or a different runner class is the exact
+// substitution the pinning exists to catch, so each blocks like a genuine
+// signer change — and must never reach applyUpgrade's install call, leaving
+// the lock untouched.
+//
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestUpgrade_ProvenanceFieldDivergenceBlocked(t *testing.T) {
+	tests := []struct {
+		name            string
+		lockedRef       string
+		lockedRunner    string
+		candidateRef    string
+		candidateRunner string
+		description     string
+	}{
+		{
+			name:      "attacker branch",
+			lockedRef: "refs/heads/main", candidateRef: "refs/heads/attacker",
+			lockedRunner: testRunnerEnvironment, candidateRunner: testRunnerEnvironment,
+			description: "same identity, issuer, and runner, signed from a different branch",
+		},
+		{
+			name:      "plausible tag rotation",
+			lockedRef: "refs/tags/v0.1.0", candidateRef: "refs/tags/v0.2.0",
+			lockedRunner: testRunnerEnvironment, candidateRunner: testRunnerEnvironment,
+			description: "a tag-to-tag rotation has no automatic allowance either",
+		},
+		{
+			name:      "candidate lost its ref extension",
+			lockedRef: "refs/tags/v0.1.0", candidateRef: "",
+			lockedRunner: testRunnerEnvironment, candidateRunner: testRunnerEnvironment,
+			description: "a certificate that stopped carrying a ref extension must not silently unpin one",
+		},
+		{
+			name:      "runner class change",
+			lockedRef: "refs/heads/main", candidateRef: "refs/heads/main",
+			lockedRunner: testRunnerEnvironment, candidateRunner: "self-hosted",
+			description: "a move from a hosted runner to a self-hosted one is a provenance change",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repoDir := createPluginTestRepo(t, "")
+
+			calls := 0
+			mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+			mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				AnyTimes().
+				DoAndReturn(func(_ any, _, _ []byte, expected *verifier.ProvenanceExpectation) (*verifier.Result, error) {
+					calls++
+					if calls == 1 {
+						return provenanceSignedResult(tc.lockedRef, tc.lockedRunner), nil // initial install (TOFU)
+					}
+					if expected == nil {
+						// The upgrade's plan-time signer probe.
+						return provenanceSignedResult(tc.candidateRef, tc.candidateRunner), nil
+					}
+					// A blocked divergence must never reach here: applyUpgrade
+					// only runs when guardSignerChange did not block.
+					t.Fatalf("install-time verification must not run for a blocked upgrade: %s", tc.description)
+					return nil, nil
+				})
+			mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+
+			svc, projectRoot := newGitLockTestService(t, repoDir, WithVerifier(mv))
+			installGitTestPlugin(t, svc, projectRoot)
+
+			entry, ok := loadPluginLockEntry(t, projectRoot)
+			require.True(t, ok)
+			require.NotNil(t, entry.Provenance)
+			require.Equal(t, tc.lockedRef, entry.Provenance.RepositoryRef, "the install must pin the observed ref")
+
+			addPluginRepoCommit(t, repoDir, "# hello divergence")
+			outcome := upgradePlugins(t, svc, plugins.UpgradeOptions{ProjectRoot: projectRoot})
+			assert.Equal(t, plugins.UpgradeStatusSignerChangeBlocked, outcome.Status, tc.description)
+
+			entry, ok = loadPluginLockEntry(t, projectRoot)
+			require.True(t, ok)
+			require.NotNil(t, entry.Provenance)
+			assert.Equal(t, tc.lockedRef, entry.Provenance.RepositoryRef,
+				"a blocked upgrade must leave the locked ref untouched")
+			assert.Equal(t, tc.lockedRunner, entry.Provenance.RunnerEnvironment,
+				"a blocked upgrade must leave the locked runner class untouched")
+		})
+	}
+}
+
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestUpgrade_AllowSignerChangeRecordsNewIdentity(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return otherSignerResult(), nil
+	})
+
+	outcome := upgradePlugins(t, svc, plugins.UpgradeOptions{
+		ProjectRoot: projectRoot, AllowSignerChange: true,
+	})
+	assert.Equal(t, plugins.UpgradeStatusUpgraded, outcome.Status)
+
+	entry, ok := loadPluginLockEntry(t, projectRoot)
+	require.True(t, ok)
+	require.NotNil(t, entry.Provenance)
+	assert.Equal(t, "/.github/workflows/other.yml", entry.Provenance.SignerIdentity,
+		"the explicit override must re-record the new identity")
+	assert.False(t, entry.Unsigned)
+}
+
+// TestUpgrade_AllowSignerChangeRepinsProvenanceFields is the override's other
+// half: a ref/runner divergence is re-pinned to what the candidate actually
+// carries, so the next install enforces the new values rather than the stale
+// ones.
+//
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestUpgrade_AllowSignerChangeRepinsProvenanceFields(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return provenanceSignedResult("refs/tags/v0.2.0", "self-hosted"), nil
+	})
+
+	outcome := upgradePlugins(t, svc, plugins.UpgradeOptions{
+		ProjectRoot: projectRoot, AllowSignerChange: true,
+	})
+	assert.Equal(t, plugins.UpgradeStatusUpgraded, outcome.Status)
+
+	entry, ok := loadPluginLockEntry(t, projectRoot)
+	require.True(t, ok)
+	require.NotNil(t, entry.Provenance)
+	assert.Equal(t, "refs/tags/v0.2.0", entry.Provenance.RepositoryRef)
+	assert.Equal(t, "self-hosted", entry.Provenance.RunnerEnvironment)
+}
+
+// TestUpgrade_SignerChangePreviewAndGateParity pins the two plan-only modes
+// against the blocked outcome: --preview reports the same block without
+// installing, and --fail-on-changes counts it as a change. Neither carries a
+// pinned reference, so neither can install anything.
+//
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestUpgrade_SignerChangePreviewAndGateParity(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return otherSignerResult(), nil
+	})
+
+	before, ok := loadPluginLockEntry(t, projectRoot)
+	require.True(t, ok)
+
+	for _, opts := range []plugins.UpgradeOptions{
+		{ProjectRoot: projectRoot, Preview: true},
+		{ProjectRoot: projectRoot, FailOnChanges: true},
+	} {
+		outcome := upgradePlugins(t, svc, opts)
+		assert.Equal(t, plugins.UpgradeStatusSignerChangeBlocked, outcome.Status,
+			"plan-only modes must report the same signer-change block as apply")
+
+		after, found := loadPluginLockEntry(t, projectRoot)
+		require.True(t, found)
+		assert.Equal(t, before.Digest, after.Digest, "a plan-only run must not rewrite the lock file")
+		assert.Equal(t, testSignerIdentity, after.Provenance.SignerIdentity)
+	}
+}
+
+// TestUpgrade_BlockedOutcomeCarriesNoPinnedReference proves the block happens
+// during planning rather than at install: the plan carries no pinnedRef, which
+// is what makes preview, the CI gate, and apply all agree.
+//
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestUpgrade_BlockedOutcomeCarriesNoPinnedReference(t *testing.T) {
+	svc, projectRoot := signerChangeFixture(t, func() (*verifier.Result, error) {
+		return otherSignerResult(), nil
+	})
+
+	entry, ok := loadPluginLockEntry(t, projectRoot)
+	require.True(t, ok)
+
+	plan := svc.(*service).planUpgrade(t.Context(), //nolint:forcetypeassert
+		plugins.UpgradeOptions{ProjectRoot: projectRoot}, entry)
+	assert.Equal(t, plugins.UpgradeStatusSignerChangeBlocked, plan.outcome.Status)
+	assert.Empty(t, plan.pinnedRef, "a blocked plan must carry no pinned reference to install")
+	assert.Empty(t, plan.layerData)
+}
+
+// TestUpgrade_UnaffectedEntrySkipsSignerProbe covers the entries the guard
+// leaves alone: one recorded `unsigned: true` has no identity to compare
+// against, so no probe runs at all — an extra verification round-trip there
+// would be both wasted work and a new failure mode for a plugin the lock file
+// already accepts as unsigned.
+//
+//nolint:paralleltest // uses t.Setenv via newGitLockTestService
+func TestUpgrade_UnaffectedEntrySkipsSignerProbe(t *testing.T) {
+	repoDir := createPluginTestRepo(t, "")
+
+	calls := 0
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ any, _, _ []byte, _ *verifier.ProvenanceExpectation) (*verifier.Result, error) {
+			calls++
+			return nil, verifier.ErrUnsigned
+		})
+	mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+
+	svc, projectRoot := newGitLockTestService(t, repoDir, WithVerifier(mv))
+	require.NoError(t, gitInstall(t, svc, projectRoot, func(o *plugins.InstallOptions) { o.AllowUnsigned = true }))
+
+	entry, ok := loadPluginLockEntry(t, projectRoot)
+	require.True(t, ok)
+	require.True(t, entry.Unsigned)
+	require.Nil(t, entry.Provenance)
+	require.Equal(t, 1, calls, "only the install itself consulted the verifier")
+
+	addPluginRepoCommit(t, repoDir, "# hello unsigned")
+	outcome := upgradePlugins(t, svc, plugins.UpgradeOptions{ProjectRoot: projectRoot})
+	assert.Equal(t, plugins.UpgradeStatusUpgraded, outcome.Status,
+		"an entry with no recorded signer identity is unaffected by the guard")
+	assert.Equal(t, 1, calls,
+		"the guard must not probe an entry that records no signer identity")
+}
+
+func TestRepositoryRefChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		probe    string
+		recorded string
+		want     bool
+	}{
+		{name: "same ref", probe: "refs/tags/v0.1.0", recorded: "refs/tags/v0.1.0"},
+		{name: "entry recorded none is unconstrained", probe: "refs/heads/attacker"},
+		{name: "tag rotation blocked", probe: "refs/tags/v0.2.0", recorded: "refs/tags/v0.1.0", want: true},
+		{name: "branch change blocked", probe: "refs/heads/attacker", recorded: "refs/heads/main", want: true},
+		{name: "candidate carrying none blocked", recorded: "refs/tags/v0.1.0", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, repositoryRefChanged(
+				&verifier.Result{RepositoryRef: tc.probe},
+				&lockfile.Provenance{RepositoryRef: tc.recorded}))
+		})
+	}
+}
+
+func TestRunnerEnvironmentChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		probe    string
+		recorded string
+		want     bool
+	}{
+		{name: "same runner class", probe: testRunnerEnvironment, recorded: testRunnerEnvironment},
+		{name: "entry recorded none is unconstrained", probe: "self-hosted"},
+		{name: "runner class change blocked", probe: "self-hosted", recorded: testRunnerEnvironment, want: true},
+		{name: "candidate carrying none blocked", recorded: testRunnerEnvironment, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, runnerEnvironmentChanged(
+				&verifier.Result{RunnerEnvironment: tc.probe},
+				&lockfile.Provenance{RunnerEnvironment: tc.recorded}))
+		})
+	}
+}
+
+// TestVerifyInstallHonorsAllowSignerChange pins the install-side half of the
+// override on the OCI path, which the git-sourced upgrade tests above never
+// reach: with AllowSignerChange the recorded identity is not handed to the
+// verifier as the expected one, so the chain of trust is checked and whatever
+// identity is observed gets recorded in its place.
+func TestVerifyInstallHonorsAllowSignerChange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		allowSignerChange bool
+		wantExpected      bool
+	}{
+		{name: "default enforces the recorded identity", wantExpected: true},
+		{name: "override verifies chain of trust only", allowSignerChange: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			projectRoot := writeSignedPluginLockEntry(t)
+
+			mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+			mv.EXPECT().VerifyOCI(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ any, _, _ string, expected *verifier.ProvenanceExpectation) (*verifier.Result, error) {
+					assert.Equal(t, tc.wantExpected, expected != nil,
+						"AllowSignerChange decides whether the recorded identity is enforced")
+					return otherSignerResult(), nil
+				})
+
+			svc := &service{sigVerifier: mv}
+			decision, err := svc.verifyOCIInstall(t.Context(), plugins.InstallOptions{
+				ProjectRoot:       projectRoot,
+				AllowSignerChange: tc.allowSignerChange,
+			}, "my-plugin", "ghcr.io/org/my-plugin:v2", validLockDigest())
+			require.NoError(t, err)
+			require.NotNil(t, decision.provenance)
+			assert.Equal(t, "/.github/workflows/other.yml", decision.provenance.SignerIdentity,
+				"the observed identity is what gets recorded")
+		})
+	}
+}
+
+// writeSignedPluginLockEntry creates a project root whose lock file records
+// the fixture plugin as signed by the fixed test identity.
+func writeSignedPluginLockEntry(t *testing.T) string {
+	t.Helper()
+	projectRoot := makeProjectRoot(t)
+	root := mustOpenRoot(t, projectRoot)
+	lf, err := lockfile.Load(root)
+	require.NoError(t, err)
+	lf.UpsertPlugin(lockfile.Entry{
+		Name:   "my-plugin",
+		Source: "ghcr.io/org/my-plugin",
+		Digest: validLockDigest(),
+		Provenance: &lockfile.Provenance{
+			SignerIdentity: testSignerIdentity,
+			CertIssuer:     testCertIssuer,
+		},
+	})
+	require.NoError(t, lf.Save(root))
+	return projectRoot
+}
+
+// TestProbeCandidateSigner_RejectsOversizedCommitMaterial extends the size
+// ceiling verifyGitInstall enforces (#6396 review) to the plan-time probe,
+// which the install path never covers: the probe runs on every guarded
+// upgrade, including --preview and --fail-on-changes, so an unbounded probe
+// would let a hostile repository spend our CPU without ever reaching an
+// install. Rejection happens before the verifier is consulted at all.
+func TestProbeCandidateSigner_RejectsOversizedCommitMaterial(t *testing.T) {
+	t.Parallel()
+
+	oversized := make([]byte, maxSignatureBlobSize+1)
+
+	tests := []struct {
+		name    string
+		latest  resolvedLatest
+		wantErr bool
+	}{
+		{
+			name:   "material within the limit is verified",
+			latest: resolvedLatest{commitPayload: []byte("commit"), commitSignature: "sig"},
+		},
+		{
+			name:    "oversized payload rejected",
+			latest:  resolvedLatest{commitPayload: oversized, commitSignature: "sig"},
+			wantErr: true,
+		},
+		{
+			name:    "oversized signature rejected",
+			latest:  resolvedLatest{commitPayload: []byte("commit"), commitSignature: string(oversized)},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+			if !tc.wantErr {
+				mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil()).
+					Return(signedResult(), nil)
+			}
+
+			svc := &service{sigVerifier: mv}
+			result, err := svc.probeCandidateSigner(t.Context(), "my-plugin", tc.latest)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, http.StatusUnprocessableEntity, httperr.Code(err),
+					"oversized material is unprocessable, not a signature failure")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testSignerIdentity, result.SignerIdentity)
+		})
+	}
+}
+
+// TestUpgrade_OversizedCommitMaterialFailsRatherThanBlocks pins how the guard
+// reports a rejected probe: an over-limit candidate is a failure with a
+// message, not a silent signer-change block, so the operator sees why.
+func TestUpgrade_OversizedCommitMaterialFailsRatherThanBlocks(t *testing.T) {
+	t.Parallel()
+
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	svc := &service{sigVerifier: mv}
+	outcome := plugins.UpgradeOutcome{Name: "my-plugin"}
+
+	blocked := svc.guardSignerChange(t.Context(),
+		lockfile.Entry{
+			Name:       "my-plugin",
+			Provenance: &lockfile.Provenance{SignerIdentity: testSignerIdentity},
+		},
+		resolvedLatest{commitPayload: make([]byte, maxSignatureBlobSize+1), commitSignature: "sig"},
+		&outcome)
+
+	assert.True(t, blocked, "an unusable probe must stop the upgrade")
+	assert.Equal(t, plugins.UpgradeStatusFailed, outcome.Status)
+	assert.Equal(t, plugins.FailureReasonUnknown, outcome.Reason)
+	assert.Contains(t, outcome.Error, "over the")
+}

--- a/pkg/plugins/pluginsvc/verify.go
+++ b/pkg/plugins/pluginsvc/verify.go
@@ -109,6 +109,11 @@ func (s *service) verifyOCIInstall(
 	if err != nil {
 		return nil, err
 	}
+	if opts.AllowSignerChange {
+		// The signer-change guard was explicitly overridden: verify the
+		// chain of trust only and re-record whatever identity is observed.
+		expected, expectUnsigned = nil, false
+	}
 	if expectUnsigned {
 		return unsignedLockedDecision(opts, pluginName)
 	}
@@ -139,6 +144,9 @@ func (s *service) verifyGitInstall(
 	expected, expectUnsigned, err := expectedLockTrust(opts.ProjectRoot, pluginName)
 	if err != nil {
 		return nil, err
+	}
+	if opts.AllowSignerChange {
+		expected, expectUnsigned = nil, false
 	}
 	if expectUnsigned {
 		return unsignedLockedDecision(opts, pluginName)
@@ -300,13 +308,16 @@ func classifyInstallVerifyError(
 	// misreported as a signer-identity change below.
 	case errors.Is(verifyErr, verifier.ErrProvenanceFieldMismatch):
 		return httperr.WithCode(
-			fmt.Errorf("plugin %q's certificate no longer matches its pinned provenance: %w", pluginName, verifyErr),
+			fmt.Errorf("plugin %q's certificate no longer matches its pinned provenance: %w"+
+				" (if this is an expected publisher-side change, upgrade with allow_signer_change)",
+				pluginName, verifyErr),
 			http.StatusForbidden,
 		)
 	case errors.Is(verifyErr, verifier.ErrSignerMismatch):
 		return httperr.WithCode(
 			fmt.Errorf("signer identity mismatch for %q: %w"+
-				" (if the signer change is intended, remove the plugin's lock entry and reinstall)",
+				" (if the signer change is intended, remove the plugin's lock entry"+
+				" and reinstall, or upgrade with allow_signer_change)",
 				pluginName, verifyErr),
 			http.StatusForbidden,
 		)


### PR DESCRIPTION
## Summary

An upgrade re-resolves a mutable source, which is exactly the moment a compromised or transferred publisher would slip a differently-signed artifact into a plugin's pinned trust chain (RFC THV-0080). Since PR7 the plugin lock file records a signer identity, but upgrade never consulted it — `pkg/plugins/pluginsvc/upgrade.go` carried an explicit "signer-change guarding is intentionally omitted" note, and the `--allow-signer-change` that `thv ai-plugin upgrade`'s blocked-status message already promises did not exist. This PR closes that gap.

- **Guard during planning.** When a lock entry records a signer identity, upgrade planning probes the candidate's signature — chain-of-trust verification only, no install, nil expected identity — and blocks with `signer-change-blocked` when the observed identity differs, when a pinned certificate field (repository ref or runner class) diverges, or when the candidate is unsigned. Blocked plans carry no pinned reference, exactly like ref-change blocks: `--preview` reports them, `--fail-on-changes` counts them as changes, and a plain upgrade exits with the policy-rejection code (4). Entries with no recorded provenance — including those marked `unsigned: true` — are unaffected and skip the probe entirely.
- **The override re-records deliberately.** With `--allow-signer-change` the candidate is verified chain-of-trust-only and the newly observed identity replaces the recorded one in the lock entry, so a rotation is diff-visible rather than silent.
- **Flag wired end to end.** `--allow-signer-change` on the CLI, `allow_signer_change` on the plugins upgrade API DTO, and the matching field on the Go HTTP client DTO, each pinned by a round-trip test.

This mirrors the skills counterpart #6132 as it stands today on `main`, not as originally merged: the hardened shape treats a provenance-field mismatch like a signer change (see the #6315 review) and has no automatic tag-rotation allowance.

**Rebased onto the updated #6399.** Two changes landed down-stack since this PR opened and both reach into it: the verifier now takes a `ProvenanceExpectation` (#6420), so the probe and the test mocks were adapted; and `verify.go` gained a 1 MiB ceiling on captured signature material. The probe calls the verifier directly, so it bypassed that ceiling — it now applies the same bound, with the same rationale sharpened: the probe runs on every guarded upgrade *including the plan-only modes that install nothing*, so an unbounded probe would let a hostile repository spend CPU without ever reaching an install.

Part of #6300. Stacked on #6399 — please review and merge that first; this PR targets `plugins-sig/08-sync-reverify`.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

New coverage in `pkg/plugins/pluginsvc/upgrade_verify_test.go`: oversized commit payload/signature rejected by the probe before the verifier is consulted, and reported as a failure with a message rather than a silent block; same-signer upgrade proceeds; a differing signer blocks; each provenance-field divergence blocks (attacker branch, tag rotation, dropped ref extension, runner-class change) without ever reaching the install call; an unsigned candidate against a locked signer blocks; an entry with no recorded identity skips the probe (asserted by verifier call count); the override re-records both the new identity and the new ref/runner; the blocked plan carries no pinned reference; preview and `--fail-on-changes` report the same block without touching the lock. Plus DTO round-trips at the API and client boundaries, and the exit-code table for `pluginUpgradeExitError`.

Each guard assertion was mutation-checked, and re-checked after the rebase: disabling the guard fails all six blocking tests, dropping the `AllowSignerChange` clause in `verify.go` fails both override tests, and removing the probe's size bound fails the two bound tests.

Two pre-existing local failures, both reproduced on the untouched base branch and unrelated to this diff: `task lint-fix` crashes inside staticcheck's `nilness` analyzer while analyzing the `sentry` dependency, and `TestMCPGoClientInitializeAndPing` fails because a running `thv` process holds the hardcoded port 8096 that test binds. Linting this PR's packages with `--disable=staticcheck` reports 0 issues.

## Changes

| File | Change |
|------|--------|
| `pkg/plugins/pluginsvc/upgrade.go` | Signer-change guard during planning; `resolvedLatest` carries git signature material (size-bounded before verification); `AllowSignerChange` threaded into the install options |
| `pkg/plugins/pluginsvc/verify.go` | OCI/git install verification honors `AllowSignerChange`; mismatch errors now point at the override |
| `pkg/plugins/options.go` | Internal-only `InstallOptions.AllowSignerChange` |
| `cmd/thv/app/ai_plugin_upgrade.go` | `--allow-signer-change` flag; signer-blocked outcomes exit with the policy-rejection code |
| `pkg/api/v1/plugins*.go`, `pkg/plugins/client/*` | `allow_signer_change` DTO field on both sides of the HTTP boundary |

## Does this introduce a user-facing change?

Yes. `thv ai-plugin upgrade` now refuses to upgrade a plugin whose lock entry records a signer identity when the candidate artifact is signed by a different identity, carries a different repository ref or runner class, or is unsigned. Such upgrades exit 4 and name `--allow-signer-change`, which permits the upgrade and records the new identity in the lock file. Plugins with no recorded provenance are unaffected.

## Special notes for reviewers

- **Where the guard sits.** It runs after the ref-change check, so local-store upgrade candidates (which return earlier with layer data) never reach it — they carry no signature to probe, and `verifyLocalInstall` already refuses a local build outright for an entry locked to a signer, which is the stronger check.
- **Divergence from skillsvc.** `probeCandidateSigner` verifies the commit payload/signature captured during resolution instead of re-resolving the git reference the way skills does. That avoids a second clone per guarded entry and removes the window in which the probed commit could drift from the one being planned.
- **After the rebase**, the fixture mock simulates the verifier's lock-pin enforcement by comparing the whole `ProvenanceExpectation` rather than reading a field off it — the type's fields are unexported, and this matches the comparison style #6399 adopted in `verify_test.go`.
- Follow-ups in PR10: push signing, trust display on `ai-plugin info`, and gate removal.

Generated with [Claude Code](https://claude.com/claude-code)

