### PR TITLE
fix(operator): warn when VirtualMCPServer inline telemetry is ignored

### DIFF
--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -791,6 +791,27 @@ func (r *VirtualMCPServerReconciler) emitPrimaryUpstreamProviderDeprecatedEvent(
 			"move the value to spec.authServerConfig.primaryUpstreamProvider")
 }
 
+// emitInlineTelemetryIgnoredEvent emits a Warning when VirtualMCPServer still
+// sets the deprecated spec.config.telemetry field without telemetryConfigRef.
+// The operator does not apply inline telemetry; GET /metrics then falls through
+// to the MCP handler (HTTP 406). One-shot per spec generation.
+func (r *VirtualMCPServerReconciler) emitInlineTelemetryIgnoredEvent(
+	vmcp *mcpv1beta1.VirtualMCPServer,
+	usesIgnoredInline bool,
+) {
+	if !usesIgnoredInline || r.Recorder == nil {
+		return
+	}
+	if vmcp.Generation == vmcp.Status.ObservedGeneration {
+		return
+	}
+	r.Recorder.Eventf(vmcp, nil, corev1.EventTypeWarning,
+		"InlineTelemetryIgnored", "ConvertTelemetry",
+		"spec.config.telemetry is ignored by the operator; set spec.telemetryConfigRef "+
+			"to an MCPTelemetryConfig. Without that, GET /metrics is not registered and "+
+			"returns HTTP 406 from the MCP streamable handler.")
+}
+
 func (r *VirtualMCPServerReconciler) validateAuthzUpstreamAvailable(
 	ctx context.Context,
 	vmcp *mcpv1beta1.VirtualMCPServer,

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -794,7 +794,12 @@ func (r *VirtualMCPServerReconciler) emitPrimaryUpstreamProviderDeprecatedEvent(
 // emitInlineTelemetryIgnoredEvent emits a Warning when VirtualMCPServer still
 // sets the deprecated spec.config.telemetry field without telemetryConfigRef.
 // The operator does not apply inline telemetry; GET /metrics then falls through
-// to the MCP handler (HTTP 406). One-shot per spec generation.
+// to the MCP handler (HTTP 406).
+//
+// The generation==observedGeneration guard suppresses the event after a
+// successful reconcile advances status. Retries that fail before
+// observedGeneration is updated can re-emit; Kubernetes event aggregation
+// is the practical dedupe in that window.
 func (r *VirtualMCPServerReconciler) emitInlineTelemetryIgnoredEvent(
 	vmcp *mcpv1beta1.VirtualMCPServer,
 ) {

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller.go
@@ -797,8 +797,8 @@ func (r *VirtualMCPServerReconciler) emitPrimaryUpstreamProviderDeprecatedEvent(
 // to the MCP handler (HTTP 406). One-shot per spec generation.
 func (r *VirtualMCPServerReconciler) emitInlineTelemetryIgnoredEvent(
 	vmcp *mcpv1beta1.VirtualMCPServer,
-	usesIgnoredInline bool,
 ) {
+	usesIgnoredInline := vmcp.Spec.Config.Telemetry != nil && vmcp.Spec.TelemetryConfigRef == nil
 	if !usesIgnoredInline || r.Recorder == nil {
 		return
 	}

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -43,6 +43,7 @@ import (
 	ctrlutil "github.com/stacklok/toolhive/cmd/thv-operator/pkg/controllerutil"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/runconfig/configmap/checksum"
 	"github.com/stacklok/toolhive/cmd/thv-operator/pkg/virtualmcpserverstatus"
+	"github.com/stacklok/toolhive/pkg/telemetry"
 	vmcpconfig "github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
 )
@@ -3965,6 +3966,95 @@ func TestVirtualMCPServerValidateAuthzUpstreamAvailable_DeprecationEvent(t *test
 			case <-time.After(50 * time.Millisecond):
 				if tt.wantEvent {
 					t.Errorf("expected AuthzPrimaryUpstreamProviderDeprecated event, none recorded")
+				}
+			}
+		})
+	}
+}
+
+func TestVirtualMCPServerEmitInlineTelemetryIgnoredEvent(t *testing.T) {
+	t.Parallel()
+
+	inlineTelemetry := vmcpconfig.Config{
+		Telemetry: &telemetry.Config{Endpoint: "otlp-collector:4317"},
+	}
+
+	tests := []struct {
+		name               string
+		config             vmcpconfig.Config
+		withTelemetryRef   bool
+		observedGeneration int64
+		nilRecorder        bool
+		wantEvent          bool
+	}{
+		{
+			name:      "inline telemetry without ref emits the warning",
+			config:    inlineTelemetry,
+			wantEvent: true,
+		},
+		{
+			name:               "inline telemetry suppresses event when generation already observed",
+			config:             inlineTelemetry,
+			observedGeneration: 1,
+			wantEvent:          false,
+		},
+		{
+			name:             "inline telemetry with telemetryConfigRef does not emit",
+			config:           inlineTelemetry,
+			withTelemetryRef: true,
+			wantEvent:        false,
+		},
+		{
+			name:      "no inline telemetry does not emit",
+			wantEvent: false,
+		},
+		{
+			name:        "no-op when recorder is nil",
+			config:      inlineTelemetry,
+			nilRecorder: true,
+			wantEvent:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := []v1beta1test.VirtualMCPServerOption{
+				v1beta1test.WithVMCPGroupRef(testGroupName),
+				v1beta1test.WithVMCPConfig(tt.config),
+				v1beta1test.WithVMCPStatus(mcpv1beta1.VirtualMCPServerStatus{
+					ObservedGeneration: tt.observedGeneration,
+				}),
+				v1beta1test.MutateVMCP(func(v *mcpv1beta1.VirtualMCPServer) {
+					v.Generation = 1
+				}),
+			}
+			if tt.withTelemetryRef {
+				opts = append(opts, v1beta1test.WithVMCPTelemetryConfigRef("otel"))
+			}
+			vmcp := v1beta1test.NewVirtualMCPServer(testVmcpName, "default", opts...)
+
+			recorder := events.NewFakeRecorder(10)
+			r := &VirtualMCPServerReconciler{}
+			if !tt.nilRecorder {
+				r.Recorder = recorder
+			}
+
+			r.emitInlineTelemetryIgnoredEvent(vmcp)
+
+			select {
+			case event := <-recorder.Events:
+				if !tt.wantEvent {
+					t.Errorf("expected no event, got %q", event)
+					return
+				}
+				assert.Contains(t, event, "Warning")
+				assert.Contains(t, event, "InlineTelemetryIgnored")
+				assert.Contains(t, event, "spec.config.telemetry is ignored by the operator")
+			case <-time.After(50 * time.Millisecond):
+				if tt.wantEvent {
+					t.Errorf("expected InlineTelemetryIgnored event, none recorded")
 				}
 			}
 		})

--- a/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_controller_test.go
@@ -4052,7 +4052,7 @@ func TestVirtualMCPServerEmitInlineTelemetryIgnoredEvent(t *testing.T) {
 				assert.Contains(t, event, "Warning")
 				assert.Contains(t, event, "InlineTelemetryIgnored")
 				assert.Contains(t, event, "spec.config.telemetry is ignored by the operator")
-			case <-time.After(50 * time.Millisecond):
+			default:
 				if tt.wantEvent {
 					t.Errorf("expected InlineTelemetryIgnored event, none recorded")
 				}

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
@@ -47,8 +47,7 @@ func (r *VirtualMCPServerReconciler) ensureVmcpConfigConfigMap(
 		return fmt.Errorf("failed to create vmcp converter: %w", err)
 	}
 	config, authServerRC, err := converter.Convert(ctx, vmcp, telemetryCfg)
-	usesIgnoredInline := vmcp.Spec.Config.Telemetry != nil && vmcp.Spec.TelemetryConfigRef == nil
-	r.emitInlineTelemetryIgnoredEvent(vmcp, usesIgnoredInline)
+	r.emitInlineTelemetryIgnoredEvent(vmcp)
 	if err != nil {
 		var delegateErr *operatorvmcpconfig.DelegateClientConfigValidationError
 		if stderrors.As(err, &delegateErr) {

--- a/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
+++ b/cmd/thv-operator/controllers/virtualmcpserver_vmcpconfig.go
@@ -47,6 +47,8 @@ func (r *VirtualMCPServerReconciler) ensureVmcpConfigConfigMap(
 		return fmt.Errorf("failed to create vmcp converter: %w", err)
 	}
 	config, authServerRC, err := converter.Convert(ctx, vmcp, telemetryCfg)
+	usesIgnoredInline := vmcp.Spec.Config.Telemetry != nil && vmcp.Spec.TelemetryConfigRef == nil
+	r.emitInlineTelemetryIgnoredEvent(vmcp, usesIgnoredInline)
 	if err != nil {
 		var delegateErr *operatorvmcpconfig.DelegateClientConfigValidationError
 		if stderrors.As(err, &delegateErr) {

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -166,11 +166,11 @@ spec:
 See [`examples/operator/mcp-servers/mcpserver_fetch_otel.yaml`](../examples/operator/mcp-servers/mcpserver_fetch_otel.yaml)
 for a complete example.
 
-**Inline (deprecated)**: The inline `spec.telemetry` (MCPServer, MCPRemoteProxy)
-and `spec.config.telemetry` (VirtualMCPServer) fields still work but are
-deprecated and will be removed in a future API version. They are mutually exclusive with
-`telemetryConfigRef` (CEL enforced). All three resource types now support
-`spec.telemetryConfigRef`.
+**Inline (deprecated)**: `spec.telemetry` on MCPServer and MCPRemoteProxy still
+works but is deprecated. `spec.config.telemetry` on VirtualMCPServer is ignored
+by the operator (standalone CLI only); set `spec.telemetryConfigRef` or `/metrics`
+is not registered. These inline fields are mutually exclusive with
+`telemetryConfigRef` (CEL enforced).
 
 For VirtualMCPServer telemetry, see the
 [vMCP observability docs](./operator/virtualmcpserver-observability.md).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -169,8 +169,8 @@ for a complete example.
 **Inline (deprecated)**: `spec.telemetry` on MCPServer and MCPRemoteProxy still
 works but is deprecated. `spec.config.telemetry` on VirtualMCPServer is ignored
 by the operator (standalone CLI only); set `spec.telemetryConfigRef` or `/metrics`
-is not registered. These inline fields are mutually exclusive with
-`telemetryConfigRef` (CEL enforced).
+is not registered. Prefer `telemetryConfigRef` over inline telemetry; the CRD
+does not CEL-reject setting both.
 
 For VirtualMCPServer telemetry, see the
 [vMCP observability docs](./operator/virtualmcpserver-observability.md).

--- a/docs/operator/virtualmcpserver-observability.md
+++ b/docs/operator/virtualmcpserver-observability.md
@@ -201,8 +201,9 @@ for a complete example with an MCPGroup and backend MCPServer.
 the operator. It remains valid for standalone CLI deployments only. If it is set
 without `spec.telemetryConfigRef`, the operator emits a Warning event
 (`InlineTelemetryIgnored`) and does not register `/metrics` — Prometheus scrapes
-then receive HTTP 406 from the MCP handler. Use `telemetryConfigRef`. CEL still
-rejects setting both fields.
+then receive HTTP 406 from the MCP handler. Use `telemetryConfigRef`. Setting
+both fields is not CEL-rejected; `telemetryConfigRef` is the operator source of
+truth and inline telemetry is ignored.
 
 ```yaml
 # Deprecated — use telemetryConfigRef instead

--- a/docs/operator/virtualmcpserver-observability.md
+++ b/docs/operator/virtualmcpserver-observability.md
@@ -197,10 +197,12 @@ spec:
 See [`examples/operator/virtual-mcps/vmcp_with_telemetry_ref.yaml`](../../examples/operator/virtual-mcps/vmcp_with_telemetry_ref.yaml)
 for a complete example with an MCPGroup and backend MCPServer.
 
-**Inline (deprecated)**: The inline `spec.config.telemetry` field still works
-but is deprecated and will be removed in a future API version. It is mutually exclusive with
-`telemetryConfigRef` (CEL enforced). Migrate to `telemetryConfigRef` to use the
-shared MCPTelemetryConfig pattern.
+**Inline (deprecated, operator no-op)**: `spec.config.telemetry` is ignored by
+the operator. It remains valid for standalone CLI deployments only. If it is set
+without `spec.telemetryConfigRef`, the operator emits a Warning event
+(`InlineTelemetryIgnored`) and does not register `/metrics` — Prometheus scrapes
+then receive HTTP 406 from the MCP handler. Use `telemetryConfigRef`. CEL still
+rejects setting both fields.
 
 ```yaml
 # Deprecated — use telemetryConfigRef instead


### PR DESCRIPTION
Follow-up from #6276 after closing #6277. Operator ignores spec.config.telemetry and emits a one-shot Warning (InlineTelemetryIgnored) when it is set without telemetryConfigRef. Docs no longer claim inline still works for operator vMCP. /metrics stays unregistered without the ref (HTTP 406).