### PR TITLE
Fix Windows unix socket URL round-trip

### DIFF
--- a/pkg/api/socket_unix.go
+++ b/pkg/api/socket_unix.go
@@ -11,9 +11,10 @@ import (
 	"io/fs"
 	"log/slog"
 	"net"
-	"net/url"
 	"os"
 	"path/filepath"
+
+	"github.com/stacklok/toolhive/pkg/server/discovery"
 )
 
 // supportsNamedPipe reports whether the current build target can host a
@@ -59,10 +60,8 @@ func cleanupUnixSocket(address string) {
 }
 
 // socketURL returns the URL form of a Unix-socket address for the discovery
-// file. Non-Windows platforms only ever produce unix:// URLs. Built via
-// (&url.URL{}).String() so the discovery dialer can round-trip the value back
-// through net/url without surprises (matters mostly on Windows but kept here
-// for symmetry).
+// file. Non-Windows platforms only ever produce unix:// URLs. Delegates to
+// discovery.UnixSocketURL so emit and parse stay on the same helper as Windows.
 func socketURL(address string) string {
-	return (&url.URL{Scheme: "unix", Path: address}).String()
+	return discovery.UnixSocketURL(address)
 }

--- a/pkg/api/socket_windows.go
+++ b/pkg/api/socket_windows.go
@@ -16,6 +16,8 @@ import (
 	"path/filepath"
 
 	"github.com/Microsoft/go-winio"
+
+	"github.com/stacklok/toolhive/pkg/server/discovery"
 )
 
 // namedPipeBufferSize is the size of the input/output buffers winio allocates
@@ -97,20 +99,15 @@ func cleanupUnixSocket(address string) {
 // socketURL returns the URL form of a Unix-socket or named-pipe address for
 // the discovery file. Named pipes are emitted as npipe://<name> where <name>
 // is everything after the \\.\pipe\ prefix. AF_UNIX paths are emitted as
-// unix:///<path> so a Windows drive-letter path round-trips through net/url
-// cleanly (the previous concatenation form produced unix://C:\... , which
-// url.Parse rejects with "invalid port").
-//
-// The synthetic leading slash is required: with Host == "" and a Path that
-// does not start with /, url.URL.String() emits only scheme://+path (two
-// slashes), and url.Parse then mis-reads the drive letter as host:port.
-// Forcing the leading slash yields the three-slash form, and the consumer
-// (ParseUnixSocketPath) strips that synthetic slash before the drive letter
-// so the round-trip closes.
+// unix:///<path>. AF_UNIX emit is discovery.UnixSocketURL so POSIX paths keep
+// three slashes (unix:///tmp/...) and drive-letter paths still get the
+// synthetic slash that net/url needs (unix:///C:%5C...). Concatenating
+// unix://+C:\... used to produce an invalid port; prepending / onto an
+// already-absolute POSIX path used to produce four slashes.
 func socketURL(address string) string {
 	if isNamedPipeAddress(address) {
 		name := address[len(namedPipePrefix):]
 		return (&url.URL{Scheme: "npipe", Host: name}).String()
 	}
-	return (&url.URL{Scheme: "unix", Path: "/" + address}).String()
+	return discovery.UnixSocketURL(address)
 }

--- a/pkg/api/socket_windows_test.go
+++ b/pkg/api/socket_windows_test.go
@@ -40,6 +40,8 @@ func TestSocketURL_Windows(t *testing.T) {
 		// (unix://C:\path\thv.sock) was rejected by url.Parse with
 		// "invalid port :\\path\\thv.sock".
 		{"af_unix windows path", `C:\path\thv.sock`, `unix:///C:%5Cpath%5Cthv.sock`},
+		// POSIX-shaped paths must not pick up a second slash (unix:////tmp/...).
+		{"posix path three slashes", `/tmp/test.sock`, `unix:///tmp/test.sock`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,6 +69,14 @@ func TestSocketURL_RoundTrip_NamedPipe(t *testing.T) {
 func TestSocketURL_RoundTrip_AFUnix(t *testing.T) {
 	t.Parallel()
 	addr := `C:\path\thv.sock`
+	got, err := discovery.ParseUnixSocketPath(socketURL(addr))
+	require.NoError(t, err)
+	assert.Equal(t, addr, got)
+}
+
+func TestSocketURL_RoundTrip_POSIXPath(t *testing.T) {
+	t.Parallel()
+	addr := `/tmp/test.sock`
 	got, err := discovery.ParseUnixSocketPath(socketURL(addr))
 	require.NoError(t, err)
 	assert.Equal(t, addr, got)

--- a/pkg/server/discovery/health.go
+++ b/pkg/server/discovery/health.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -181,7 +180,9 @@ func ValidateLoopbackURL(rawURL string) error {
 // authority (unix://host/path) are rejected because the path component would
 // be ambiguous. On Windows, unix:///C:%5Cpath%5Cthv.sock round-trips back to
 // C:\path\thv.sock by stripping the synthetic leading slash that net/url
-// inserts in front of the drive letter.
+// inserts in front of the drive letter. POSIX unix:///tmp/foo.sock stays in
+// slash form even when parsed on Windows; filepath.Clean would otherwise turn
+// it into \tmp\foo.sock, which is not absolute on that GOOS.
 func ParseUnixSocketPath(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -193,31 +194,7 @@ func ParseUnixSocketPath(rawURL string) (string, error) {
 	if u.Host != "" || u.RawQuery != "" || u.Fragment != "" || u.User != nil {
 		return "", fmt.Errorf("unix socket path must be absolute (use unix:///<path>): %s", rawURL)
 	}
-	path := u.Path
-	if path == "" {
-		return "", fmt.Errorf("empty unix socket path")
-	}
-
-	// On Windows AF_UNIX paths, the listener emits unix:///C:%5Cpath%5C..., which
-	// url.Parse returns as Path="/C:\path\..." with a synthetic leading slash.
-	// Strip it before any further validation so filepath.IsAbs sees the actual
-	// drive-letter form.
-	if len(path) >= 3 && path[0] == '/' && isASCIILetter(path[1]) && path[2] == ':' {
-		path = path[1:]
-	}
-
-	// Check for traversal before Clean resolves it away.
-	if strings.Contains(path, "..") {
-		return "", fmt.Errorf("unix socket path must not contain '..': %s", path)
-	}
-
-	path = filepath.Clean(path)
-
-	if !filepath.IsAbs(path) {
-		return "", fmt.Errorf("unix socket path must be absolute: %s", path)
-	}
-
-	return path, nil
+	return parseUnixSocketPath(u.Path)
 }
 
 // ParseNamedPipeURL extracts and validates the pipe name from an npipe:// URL
@@ -256,8 +233,8 @@ func ParseNamedPipeURL(rawURL string) (string, error) {
 	return NamedPipePrefix + name, nil
 }
 
-// isASCIILetter reports whether b is an ASCII letter [A-Za-z]. Used by
-// ParseUnixSocketPath to detect Windows drive-letter prefixes after url.Parse.
+// isASCIILetter reports whether b is an ASCII letter [A-Za-z]. Used to detect
+// Windows drive-letter prefixes in unix:// URL paths.
 func isASCIILetter(b byte) bool {
 	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
 }

--- a/pkg/server/discovery/health_test.go
+++ b/pkg/server/discovery/health_test.go
@@ -26,6 +26,13 @@ func TestParseUnixSocketPath_Valid(t *testing.T) {
 	assert.Equal(t, "/var/run/thv.sock", path)
 }
 
+func TestParseUnixSocketPath_WindowsDriveLetter(t *testing.T) {
+	t.Parallel()
+	path, err := ParseUnixSocketPath(`unix:///C:%5Cpath%5Cthv.sock`)
+	require.NoError(t, err)
+	assert.Equal(t, `C:\path\thv.sock`, path)
+}
+
 func TestParseUnixSocketPath_RelativePathRejected(t *testing.T) {
 	t.Parallel()
 	_, err := ParseUnixSocketPath("unix://relative/path.sock")
@@ -177,7 +184,7 @@ func TestCheckHealth_UnixSocket_Success(t *testing.T) {
 	go func() { _ = srv.Serve(listener) }()
 	defer srv.Close()
 
-	err = CheckHealth(context.Background(), "unix://"+socketPath, expectedNonce)
+	err = CheckHealth(context.Background(), UnixSocketURL(socketPath), expectedNonce)
 	require.NoError(t, err)
 }
 
@@ -242,6 +249,6 @@ func TestValidateLoopbackURL(t *testing.T) {
 func TestCheckHealth_UnixSocket_NotFound(t *testing.T) {
 	t.Parallel()
 	socketPath := filepath.Join(os.TempDir(), "nonexistent-test.sock")
-	err := CheckHealth(context.Background(), "unix://"+socketPath, "")
+	err := CheckHealth(context.Background(), UnixSocketURL(socketPath), "")
 	require.Error(t, err)
 }

--- a/pkg/server/discovery/unix_url.go
+++ b/pkg/server/discovery/unix_url.go
@@ -47,6 +47,11 @@ func isDriveLetterPath(p string) bool {
 	return len(p) >= 2 && isASCIILetter(p[0]) && p[1] == ':'
 }
 
+// Windows current-directory-relative form (C:foo) is not absolute.
+func isAbsoluteDriveLetterPath(p string) bool {
+	return isDriveLetterPath(p) && len(p) >= 3 && (p[2] == '\\' || p[2] == '/')
+}
+
 func isDriveLetterURLPath(p string) bool {
 	if isDriveLetterPath(p) {
 		return true
@@ -62,7 +67,7 @@ func parseDriveLetterSocketPath(p string) (string, error) {
 		return "", fmt.Errorf("unix socket path must not contain '..': %s", p)
 	}
 	cleaned := filepath.Clean(p)
-	if !isDriveLetterPath(cleaned) {
+	if !isAbsoluteDriveLetterPath(cleaned) {
 		return "", fmt.Errorf("unix socket path must be absolute: %s", p)
 	}
 	return cleaned, nil

--- a/pkg/server/discovery/unix_url.go
+++ b/pkg/server/discovery/unix_url.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"fmt"
+	"net/url"
+	urlpath "path"
+	"path/filepath"
+	"strings"
+)
+
+// UnixSocketURL builds a unix:// URL for a filesystem socket path.
+//
+// POSIX absolute paths already start with / and must keep the three-slash
+// form unix:///path. Windows drive-letter paths get a synthetic leading slash
+// so net/url round-trips (unix:///C:%5C... instead of unix://C:\..., which
+// url.Parse rejects as an invalid port).
+func UnixSocketURL(address string) string {
+	return (&url.URL{Scheme: "unix", Path: unixSocketURLPath(address)}).String()
+}
+
+func unixSocketURLPath(address string) string {
+	if isDriveLetterPath(address) {
+		return "/" + address
+	}
+	return address
+}
+
+// parseUnixSocketPath converts the Path from a parsed unix:// URL into a
+// filesystem socket path. Drive-letter forms stay native (C:\...) on every
+// GOOS so a discovery file written on Windows is parseable in tests. POSIX
+// forms stay slash-separated, including the older four-slash alias
+// unix:////tmp/foo.sock (url.Parse Path is //tmp/foo.sock).
+func parseUnixSocketPath(rawPath string) (string, error) {
+	if rawPath == "" {
+		return "", fmt.Errorf("empty unix socket path")
+	}
+	if isDriveLetterURLPath(rawPath) {
+		return parseDriveLetterSocketPath(rawPath)
+	}
+	return parsePOSIXSocketPath(rawPath)
+}
+
+func isDriveLetterPath(p string) bool {
+	return len(p) >= 2 && isASCIILetter(p[0]) && p[1] == ':'
+}
+
+func isDriveLetterURLPath(p string) bool {
+	if isDriveLetterPath(p) {
+		return true
+	}
+	return len(p) >= 3 && p[0] == '/' && isDriveLetterPath(p[1:])
+}
+
+func parseDriveLetterSocketPath(p string) (string, error) {
+	if p[0] == '/' {
+		p = p[1:]
+	}
+	if strings.Contains(p, "..") {
+		return "", fmt.Errorf("unix socket path must not contain '..': %s", p)
+	}
+	cleaned := filepath.Clean(p)
+	if !isDriveLetterPath(cleaned) {
+		return "", fmt.Errorf("unix socket path must be absolute: %s", p)
+	}
+	return cleaned, nil
+}
+
+func parsePOSIXSocketPath(p string) (string, error) {
+	if strings.Contains(p, "..") {
+		return "", fmt.Errorf("unix socket path must not contain '..': %s", p)
+	}
+	cleaned := urlpath.Clean(p)
+	if !strings.HasPrefix(cleaned, "/") {
+		return "", fmt.Errorf("unix socket path must be absolute: %s", p)
+	}
+	return cleaned, nil
+}

--- a/pkg/server/discovery/unix_url_test.go
+++ b/pkg/server/discovery/unix_url_test.go
@@ -56,3 +56,21 @@ func TestParseUnixSocketPath_FourSlashAlias(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/test.sock", got)
 }
+
+func TestParseUnixSocketPath_DriveLetterRejectsDotDot(t *testing.T) {
+	t.Parallel()
+	_, err := ParseUnixSocketPath(`unix:///C:%5Cpath%5C..%5CWindows%5Cthv.sock`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "..")
+}
+
+func TestParseUnixSocketPathHelpers(t *testing.T) {
+	t.Parallel()
+	_, err := parseUnixSocketPath("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+
+	_, err = parseUnixSocketPath("relative.sock")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
+}

--- a/pkg/server/discovery/unix_url_test.go
+++ b/pkg/server/discovery/unix_url_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnixSocketURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{"posix absolute", "/tmp/test.sock", "unix:///tmp/test.sock"},
+		{"windows drive letter", `C:\path\thv.sock`, `unix:///C:%5Cpath%5Cthv.sock`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, UnixSocketURL(tt.address))
+		})
+	}
+}
+
+func TestUnixSocketURL_RoundTrip(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		address string
+	}{
+		{"posix", "/tmp/test.sock"},
+		{"drive letter", `C:\path\thv.sock`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseUnixSocketPath(UnixSocketURL(tt.address))
+			require.NoError(t, err)
+			assert.Equal(t, tt.address, got)
+		})
+	}
+}
+
+func TestParseUnixSocketPath_FourSlashAlias(t *testing.T) {
+	t.Parallel()
+	// Older Windows ListenURL prepended / onto an already-absolute POSIX
+	// path and emitted unix:////tmp/test.sock. New discovery files should
+	// not do that, but the parser still has to accept the old form.
+	got, err := ParseUnixSocketPath("unix:////tmp/test.sock")
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/test.sock", got)
+}

--- a/pkg/server/discovery/unix_url_test.go
+++ b/pkg/server/discovery/unix_url_test.go
@@ -64,6 +64,21 @@ func TestParseUnixSocketPath_DriveLetterRejectsDotDot(t *testing.T) {
 	assert.Contains(t, err.Error(), "..")
 }
 
+func TestParseUnixSocketPath_DriveRelativeRejected(t *testing.T) {
+	t.Parallel()
+	// Drive-relative paths (C:foo) are not absolute; filepath.IsAbs used to
+	// reject them. Keep that contract so the health client cannot dial a
+	// different socket from the process's current directory on C:.
+	for _, raw := range []string{"unix:///C:relative.sock", "unix:///C:"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseUnixSocketPath(raw)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "absolute")
+		})
+	}
+}
+
 func TestParseUnixSocketPathHelpers(t *testing.T) {
 	t.Parallel()
 	_, err := parseUnixSocketPath("")


### PR DESCRIPTION
## Summary

I reproduced this on Windows 11 with `go test ./pkg/api ./pkg/server/discovery`. Drive-letter emit was already `unix:///C:%5C...`. What still failed:

- `ListenURL` for `/tmp/test.sock` came out as `unix:////tmp/test.sock` (extra slash).
- `ParseUnixSocketPath("unix:///var/run/thv.sock")` ran the path through `filepath.Clean`, so Windows turned it into `\var\run\thv.sock` and rejected it as not absolute.
- Health tests built `"unix://"+socketPath`, which `url.Parse` rejects on a drive letter (`invalid port`).

I put emit on one helper (`discovery.UnixSocketURL`) and taught the parser the two absolute forms instead of three one-off patches.

- POSIX paths keep three slashes. Drive-letter paths still get the synthetic leading slash that `net/url` needs.
- POSIX `unix:///` stays slash-form on Windows. The old four-slash alias still parses.
- Health tests call the helper.

Fixes #6291

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Win11, go1.26.5, worktree at `origin/main` `e25de16`. I did not run full `task test` (whole-repo `-race`). Focused:

```
go test -timeout 90s -count=1 ./pkg/server/discovery/
ok  	github.com/stacklok/toolhive/pkg/server/discovery	1.511s

go test -timeout 90s -count=1 ./pkg/api/ -run "TestListenURL|TestSocketURL"
ok  	github.com/stacklok/toolhive/pkg/api	4.847s

go test -timeout 60s -count=1 ./pkg/api/ -run "TestSetupUnixSocket|TestCleanupUnixSocket|TestCreateListener|TestIsNamedPipe"
ok  	github.com/stacklok/toolhive/pkg/api	1.817s
```

`TestListenURL/Unix_socket_returns_unix_URL`, `TestUnixSocketURL`, POSIX/drive-letter round-trip, and `TestParseUnixSocketPath_FourSlashAlias` are in that set.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File | Change |
|------|--------|
| `pkg/server/discovery/unix_url.go` | Shared `UnixSocketURL` plus POSIX vs drive-letter parse |
| `pkg/server/discovery/health.go` | `ParseUnixSocketPath` delegates to that parse |
| `pkg/api/socket_windows.go` / `socket_unix.go` | `socketURL` calls `UnixSocketURL` (npipe branch unchanged) |
| `*_test.go` | Round-trip, four-slash alias, health tests stop concatenating |

## Does this introduce a user-facing change?

Yes, for AF_UNIX discovery URLs. A POSIX socket path on Windows is now `unix:///tmp/...` (three slashes), not `unix:////tmp/...`. Drive-letter URLs are unchanged (`unix:///C:%5C...`). Named pipes are unchanged.

## Special notes for reviewers

I left `pkg/container/docker/sdk/client_unix.go` (`unix://`+docker socket into moby `WithHost`) alone. That is a different host string, unix-only build.

I used Cursor to write the patch after reproducing the failures on this box.

Claimed and assigned on #6291.
