### PR TITLE
Fail LLM setup when callback port is busy

### DIFF
--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -129,12 +129,17 @@ func NewFlow(config *Config) (*Flow, error) {
 	}
 
 	requestedPort := config.CallbackPort
-	port, err := networking.FindOrUsePort(requestedPort)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find available port: %w", err)
-	}
-	if config.RequireExactCallbackPort && requestedPort != 0 && port != requestedPort {
-		return nil, &networking.CallbackPortInUseError{Port: requestedPort}
+	port := requestedPort
+	if config.RequireExactCallbackPort && requestedPort != 0 {
+		if !networking.IsAvailable(requestedPort) {
+			return nil, &networking.CallbackPortInUseError{Port: requestedPort}
+		}
+	} else {
+		var err error
+		port, err = networking.FindOrUsePort(requestedPort)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find available port: %w", err)
+		}
 	}
 
 	// Set default redirect URL if not provided

--- a/pkg/auth/oauth/flow.go
+++ b/pkg/auth/oauth/flow.go
@@ -54,6 +54,10 @@ type Config struct {
 	// CallbackPort is the port for the OAuth callback server (optional, 0 means auto-select)
 	CallbackPort int
 
+	// RequireExactCallbackPort prevents fallback when CallbackPort is unavailable.
+	// Use it when the callback URI is pre-registered with the identity provider.
+	RequireExactCallbackPort bool
+
 	// IntrospectionEndpoint is the optional introspection endpoint for validating tokens
 	IntrospectionEndpoint string
 
@@ -124,10 +128,13 @@ func NewFlow(config *Config) (*Flow, error) {
 		return nil, errors.New("token URL is required")
 	}
 
-	// Use specified callback port or find an available port for the local server
-	port, err := networking.FindOrUsePort(config.CallbackPort)
+	requestedPort := config.CallbackPort
+	port, err := networking.FindOrUsePort(requestedPort)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find available port: %w", err)
+	}
+	if config.RequireExactCallbackPort && requestedPort != 0 && port != requestedPort {
+		return nil, &networking.CallbackPortInUseError{Port: requestedPort}
 	}
 
 	// Set default redirect URL if not provided

--- a/pkg/auth/oauth/flow_test.go
+++ b/pkg/auth/oauth/flow_test.go
@@ -150,6 +150,48 @@ func TestNewFlow(t *testing.T) {
 	}
 }
 
+func TestNewFlow_CallbackPortInUse(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	flow, err := NewFlow(&Config{
+		ClientID:                 "test-client",
+		AuthURL:                  "https://example.com/auth",
+		TokenURL:                 "https://example.com/token",
+		CallbackPort:             port,
+		RequireExactCallbackPort: true,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, flow)
+	var portErr *networking.CallbackPortInUseError
+	require.ErrorAs(t, err, &portErr)
+	assert.Equal(t, port, portErr.Port)
+}
+
+func TestNewFlow_CallbackPortFallback(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	flow, err := NewFlow(&Config{
+		ClientID:     "test-client",
+		AuthURL:      "https://example.com/auth",
+		TokenURL:     "https://example.com/token",
+		CallbackPort: port,
+	})
+
+	require.NoError(t, err)
+	assert.NotEqual(t, port, flow.port)
+}
+
 func TestGeneratePKCEParams(t *testing.T) {
 	t.Parallel()
 	flow := &Flow{}

--- a/pkg/auth/tokensource/tokensource.go
+++ b/pkg/auth/tokensource/tokensource.go
@@ -50,11 +50,12 @@ const preemptiveRefreshWindow = 30 * time.Second
 
 // OIDCParams holds the OIDC connection parameters for a token source.
 type OIDCParams struct {
-	Issuer       string
-	ClientID     string
-	Scopes       []string // "offline_access" is appended automatically if absent
-	Audience     string
-	CallbackPort int
+	Issuer                   string
+	ClientID                 string
+	Scopes                   []string // "offline_access" is appended automatically if absent
+	Audience                 string
+	CallbackPort             int
+	RequireExactCallbackPort bool
 }
 
 // ConfigPersister is called when the refresh token key or expiry changes —
@@ -406,6 +407,7 @@ func (t *OAuthTokenSource) buildFlowConfig(ctx context.Context) (*oauth.Config, 
 		return nil, err
 	}
 	config.TokenEndpointTrusted = true
+	config.RequireExactCallbackPort = t.opts.OIDC.RequireExactCallbackPort
 	return config, nil
 }
 

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -83,7 +83,7 @@ func Setup(
 	// and tool patching succeed, so a failed login leaves no persisted state.
 	if err := llmCfg.SetFields(inlineOpts); err != nil {
 		if portErr := setupCallbackPortError(err); portErr != nil {
-			return portErr
+			return fmt.Errorf("invalid inline flag values: %w", portErr)
 		}
 		return fmt.Errorf("invalid inline flag values: %w", err)
 	}
@@ -124,7 +124,7 @@ func Setup(
 		_, _ = fmt.Fprintln(out, "Ensuring you are logged in to the LLM gateway…")
 		if err := login(ctx, &llmCfg); err != nil {
 			if portErr := setupCallbackPortError(err); portErr != nil {
-				return portErr
+				return fmt.Errorf("OIDC login failed: %w", portErr)
 			}
 			return fmt.Errorf("OIDC login failed: %s", SanitizeTokenError(err))
 		}
@@ -189,7 +189,7 @@ func setupCallbackPortError(err error) error {
 		return nil
 	}
 	return fmt.Errorf(
-		"OIDC login failed: requested callback port %d is already in use; "+
+		"requested callback port %d is already in use; "+
 			"stop the process using it or choose another provider-registered port with "+
 			`"thv llm setup --callback-port <port>"`,
 		portErr.Port,

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -6,6 +6,7 @@ package llm
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stacklok/toolhive/pkg/llmgateway"
+	"github.com/stacklok/toolhive/pkg/networking"
 	pkgsecrets "github.com/stacklok/toolhive/pkg/secrets"
 )
 
@@ -80,6 +82,9 @@ func Setup(
 	// config without touching disk. Persistence happens below, only after login
 	// and tool patching succeed, so a failed login leaves no persisted state.
 	if err := llmCfg.SetFields(inlineOpts); err != nil {
+		if portErr := setupCallbackPortError(err); portErr != nil {
+			return portErr
+		}
 		return fmt.Errorf("invalid inline flag values: %w", err)
 	}
 
@@ -118,6 +123,9 @@ func Setup(
 	} else {
 		_, _ = fmt.Fprintln(out, "Ensuring you are logged in to the LLM gateway…")
 		if err := login(ctx, &llmCfg); err != nil {
+			if portErr := setupCallbackPortError(err); portErr != nil {
+				return portErr
+			}
 			return fmt.Errorf("OIDC login failed: %s", SanitizeTokenError(err))
 		}
 		_, _ = fmt.Fprintln(out, "Login successful.")
@@ -173,6 +181,19 @@ func Setup(
 	}
 
 	return nil
+}
+
+func setupCallbackPortError(err error) error {
+	var portErr *networking.CallbackPortInUseError
+	if !errors.As(err, &portErr) {
+		return nil
+	}
+	return fmt.Errorf(
+		"OIDC login failed: requested callback port %d is already in use; "+
+			"stop the process using it or choose another provider-registered port with "+
+			`"thv llm setup --callback-port <port>"`,
+		portErr.Port,
+	)
 }
 
 // Teardown removes LLM gateway configuration from all (or one) configured tools.

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -6,6 +6,9 @@ package llm
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +19,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/stacklok/toolhive/pkg/llmgateway"
+	"github.com/stacklok/toolhive/pkg/networking"
 	"github.com/stacklok/toolhive/pkg/secrets"
 	secretsmocks "github.com/stacklok/toolhive/pkg/secrets/mocks"
 )
@@ -573,6 +577,88 @@ func TestSetup_NonLazy_InvokesLogin(t *testing.T) {
 
 	assert.True(t, loginCalled, "non-lazy mode must invoke the OIDC login")
 	require.Len(t, provider.cfg.ConfiguredTools, 1)
+}
+
+func TestSetup_NonLazy_LoginFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		loginErr        error
+		wantContains    []string
+		wantNotContains string
+	}{
+		{
+			name:     "callback port in use includes remediation",
+			loginErr: &networking.CallbackPortInUseError{Port: 8666},
+			wantContains: []string{
+				"OIDC login failed",
+				"requested callback port 8666 is already in use",
+				"stop the process using it",
+				"thv llm setup --callback-port <port>",
+			},
+		},
+		{
+			name:            "other login errors keep generic handling",
+			loginErr:        errors.New("login unavailable"),
+			wantContains:    []string{"OIDC login failed", "login unavailable"},
+			wantNotContains: "--callback-port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gm := &setupGatewayManager{detected: []string{"cursor"}, mode: "proxy"}
+			provider := configuredSetupProvider()
+			login := func(_ context.Context, _ *Config) error { return tt.loginErr }
+
+			var stdout, stderr bytes.Buffer
+			err := Setup(
+				context.Background(), &stdout, &stderr, gm, provider, login,
+				SetOptions{}, "", true, "", false,
+			)
+
+			require.Error(t, err)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, err.Error(), want)
+			}
+			if tt.wantNotContains != "" {
+				assert.NotContains(t, err.Error(), tt.wantNotContains)
+			}
+			assert.Empty(t, provider.cfg.ConfiguredTools)
+		})
+	}
+}
+
+func TestSetup_CallbackPortInUseBeforeLogin(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, listener.Close()) })
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	provider := configuredSetupProvider()
+	provider.cfg.OIDC.CallbackPort = port
+	loginCalled := false
+	login := func(_ context.Context, _ *Config) error {
+		loginCalled = true
+		return nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = Setup(
+		context.Background(), &stdout, &stderr,
+		&setupGatewayManager{detected: []string{"cursor"}, mode: "proxy"}, provider, login,
+		SetOptions{}, "", true, "", false,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("requested callback port %d is already in use", port))
+	assert.Contains(t, err.Error(), "thv llm setup --callback-port <port>")
+	assert.False(t, loginCalled)
 }
 
 // ── AnthropicPathPrefix / configureDetectedTools ──────────────────────────────

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -656,6 +656,8 @@ func TestSetup_CallbackPortInUseBeforeLogin(t *testing.T) {
 	)
 
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid inline flag values")
+	assert.NotContains(t, err.Error(), "OIDC login failed")
 	assert.Contains(t, err.Error(), fmt.Sprintf("requested callback port %d is already in use", port))
 	assert.Contains(t, err.Error(), "thv llm setup --callback-port <port>")
 	assert.False(t, loginCalled)

--- a/pkg/llm/tokensource.go
+++ b/pkg/llm/tokensource.go
@@ -53,11 +53,12 @@ func NewTokenSource(
 ) *TokenSource {
 	return tokensource.New(tokensource.Options{
 		OIDC: tokensource.OIDCParams{
-			Issuer:       cfg.OIDC.Issuer,
-			ClientID:     cfg.OIDC.ClientID,
-			Scopes:       cfg.OIDC.EffectiveScopes(),
-			Audience:     cfg.OIDC.Audience,
-			CallbackPort: cfg.OIDC.CallbackPort,
+			Issuer:                   cfg.OIDC.Issuer,
+			ClientID:                 cfg.OIDC.ClientID,
+			Scopes:                   cfg.OIDC.EffectiveScopes(),
+			Audience:                 cfg.OIDC.Audience,
+			CallbackPort:             cfg.OIDC.CallbackPort,
+			RequireExactCallbackPort: true,
 		},
 		SecretsProvider: secretsProvider,
 		Interactive:     interactive,

--- a/pkg/networking/port.go
+++ b/pkg/networking/port.go
@@ -26,6 +26,15 @@ const (
 	MaxAttempts = 10
 )
 
+// CallbackPortInUseError reports that a requested OAuth callback port is unavailable.
+type CallbackPortInUseError struct {
+	Port int
+}
+
+func (e *CallbackPortInUseError) Error() string {
+	return fmt.Sprintf("OAuth callback port %d is already in use", e.Port)
+}
+
 // IsAvailable checks if a port is available
 func IsAvailable(port int) bool {
 	// Check TCP
@@ -135,7 +144,7 @@ func ValidateCallbackPort(callbackPort int, clientID string) error {
 		// For pre-registered clients, the port must be available
 		// The user likely configured this port in their IdP/app
 		if !IsAvailable(callbackPort) {
-			return fmt.Errorf("OAuth callback port %d is not available - please choose a different port", callbackPort)
+			return &CallbackPortInUseError{Port: callbackPort}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- OAuth providers require callback URLs to match their registered redirect URIs. Silently replacing a busy callback port with a random one causes authentication to fail at the provider and hides the local port conflict.
- Require the LLM authentication flow to keep its requested callback port and return an actionable error when that port is occupied.
- Preserve automatic port fallback for OAuth consumers that support dynamically selected callback ports.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Does this introduce a user-facing change?

`thv llm setup` now fails immediately when its requested OIDC callback port is occupied. The error tells users to stop the process using that port or choose another redirect URI registered with their identity provider using `thv llm setup --callback-port <port>`.

## Special notes for reviewers

Strict callback-port behavior is opt-in at the shared OAuth layer and enabled for the LLM token source only, so existing OAuth flows that support dynamic callback ports retain their fallback behavior.
