### PR TITLE
Report key-signed artifacts as such at install

### DIFF
--- a/cmd/thv/app/skill_push.go
+++ b/cmd/thv/app/skill_push.go
@@ -35,7 +35,10 @@ func init() {
 	skillPushCmd.Flags().StringVar(&skillPushKey, "key", "",
 		"Path to a cosign private key to sign the pushed artifact. "+
 			"Encrypted keys are decrypted with COSIGN_PASSWORD read from the 'thv serve' process, "+
-			"which performs the signing")
+			"which performs the signing. NOTE: ToolHive cannot verify key-pair signatures at "+
+			"install time, so a project-scoped install of the result is refused and "+
+			"--allow-unsigned does not override it — use keyless signing for artifacts that "+
+			"need to be installable")
 	skillPushCmd.Flags().StringVar(&skillPushIdentityToken, "identity-token", "",
 		"OIDC identity token (or a path to a file containing one) for keyless signing. "+
 			"Mutually exclusive with --key. If omitted, one is acquired automatically: from the "+

--- a/docs/arch/12-skills-system.md
+++ b/docs/arch/12-skills-system.md
@@ -426,6 +426,8 @@ What is still trusted on faith, deliberately and visibly:
 
 Publishing is signed by default: `thv skill push` requires `--key` (a cosign private key), an OIDC identity token for keyless signing (supplied with `--identity-token` or acquired automatically), or an explicit `--no-sign`. Either signing path attaches the signature manifest next to the artifact, and the bundle is retrievable at install. See [Publishing](#3-publishing) for the full ladder.
 
+Only the **keyless** path produces an installable artifact. Install-time verification checks the keyless (Fulcio) trust root, and a cosign key pair carries no certificate to chain to it — nor is the signing public key recoverable from the artifact, since the cosign manifest defines no annotation for it. A project-scoped install of a `--key`-signed artifact is therefore refused, and `--allow-unsigned` does **not** override the refusal: the artifact *is* signed, so it never produces the unsigned verdict that exception applies to. Tracked as [#6442](https://github.com/stacklok/toolhive/issues/6442).
+
 ### Schema
 
 ```yaml

--- a/docs/cli/thv_skill_push.md
+++ b/docs/cli/thv_skill_push.md
@@ -26,7 +26,7 @@ thv skill push [reference] [flags]
 ```
   -h, --help                    help for push
       --identity-token string   OIDC identity token (or a path to a file containing one) for keyless signing. Mutually exclusive with --key. If omitted, one is acquired automatically: from the ambient CI OIDC token when running with id-token: write permission, otherwise via an interactive browser sign-in
-      --key string              Path to a cosign private key to sign the pushed artifact. Encrypted keys are decrypted with COSIGN_PASSWORD read from the 'thv serve' process, which performs the signing
+      --key string              Path to a cosign private key to sign the pushed artifact. Encrypted keys are decrypted with COSIGN_PASSWORD read from the 'thv serve' process, which performs the signing. NOTE: ToolHive cannot verify key-pair signatures at install time, so a project-scoped install of the result is refused and --allow-unsigned does not override it — use keyless signing for artifacts that need to be installable
       --no-sign                 Push without signing (consumers will need an explicit unsigned exception to install project-scoped)
 ```
 

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -1703,6 +1703,7 @@ const docTemplate = `{
                     "signature-invalid",
                     "signer-mismatch",
                     "provenance-field-mismatch",
+                    "key-signed-unverifiable",
                     "unsigned-rejected",
                     "unknown"
                 ],
@@ -1715,6 +1716,7 @@ const docTemplate = `{
                     "FailureReasonSignatureInvalid",
                     "FailureReasonSignerMismatch",
                     "FailureReasonProvenanceFieldMismatch",
+                    "FailureReasonKeySigned",
                     "FailureReasonUnsignedRejected",
                     "FailureReasonUnknown"
                 ]

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -1696,6 +1696,7 @@
                     "signature-invalid",
                     "signer-mismatch",
                     "provenance-field-mismatch",
+                    "key-signed-unverifiable",
                     "unsigned-rejected",
                     "unknown"
                 ],
@@ -1708,6 +1709,7 @@
                     "FailureReasonSignatureInvalid",
                     "FailureReasonSignerMismatch",
                     "FailureReasonProvenanceFieldMismatch",
+                    "FailureReasonKeySigned",
                     "FailureReasonUnsignedRejected",
                     "FailureReasonUnknown"
                 ]

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -1808,6 +1808,7 @@ components:
       - signature-invalid
       - signer-mismatch
       - provenance-field-mismatch
+      - key-signed-unverifiable
       - unsigned-rejected
       - unknown
       type: string
@@ -1819,6 +1820,7 @@ components:
       - FailureReasonSignatureInvalid
       - FailureReasonSignerMismatch
       - FailureReasonProvenanceFieldMismatch
+      - FailureReasonKeySigned
       - FailureReasonUnsignedRejected
       - FailureReasonUnknown
     github_com_stacklok_toolhive_pkg_skills.InstallStatus:

--- a/pkg/plugins/options.go
+++ b/pkg/plugins/options.go
@@ -194,6 +194,7 @@ const (
 	FailureReasonLockWriteFailed     = skills.FailureReasonLockWriteFailed
 	FailureReasonSignatureInvalid    = skills.FailureReasonSignatureInvalid
 	FailureReasonSignerMismatch      = skills.FailureReasonSignerMismatch
+	FailureReasonKeySigned           = skills.FailureReasonKeySigned
 	FailureReasonUnsignedRejected    = skills.FailureReasonUnsignedRejected
 	FailureReasonUnknown             = skills.FailureReasonUnknown
 

--- a/pkg/plugins/pluginsvc/verify.go
+++ b/pkg/plugins/pluginsvc/verify.go
@@ -321,6 +321,17 @@ func classifyInstallVerifyError(
 				pluginName, verifyErr),
 			http.StatusForbidden,
 		)
+	// Reported before the default arm so a key-signed artifact is named as
+	// such rather than as a failed verification. allow_unsigned is
+	// deliberately no remedy here: the artifact IS signed, and recording it
+	// as an unsigned exception would file a false trust decision in the lock.
+	case errors.Is(verifyErr, verifier.ErrKeySigned):
+		return httperr.WithCode(
+			fmt.Errorf("plugin %q: %w; re-publish it with keyless signing"+
+				" (allow_unsigned does not apply — the artifact is signed)",
+				pluginName, verifyErr),
+			http.StatusForbidden,
+		)
 	default:
 		return httperr.WithCode(
 			fmt.Errorf("signature verification failed for %q: %w", pluginName, verifyErr),
@@ -341,6 +352,8 @@ func classifySignatureError(err error) plugins.FailureReason {
 		return plugins.FailureReasonSignerMismatch
 	case errors.Is(err, verifier.ErrUnsigned):
 		return plugins.FailureReasonUnsignedRejected
+	case errors.Is(err, verifier.ErrKeySigned):
+		return plugins.FailureReasonKeySigned
 	case errors.Is(err, verifier.ErrSignatureInvalid):
 		return plugins.FailureReasonSignatureInvalid
 	default:

--- a/pkg/plugins/pluginsvc/verify_test.go
+++ b/pkg/plugins/pluginsvc/verify_test.go
@@ -481,3 +481,45 @@ func TestInstallVerification_OversizedBundleIsNotStored(t *testing.T) {
 	})
 	require.Error(t, err, "an oversized bundle must not produce a DB record")
 }
+
+// TestClassifyInstallVerifyErrorNamesKeySigned pins the user-facing half of
+// #6442: a key-signed artifact must be diagnosed as key-signed, must not be
+// reported as a verification failure, and must say plainly that allow_unsigned
+// is no remedy — the artifact is signed, so recording an unsigned exception
+// would file a false trust decision in the lock.
+func TestClassifyInstallVerifyErrorNamesKeySigned(t *testing.T) {
+	t.Parallel()
+
+	err := classifyInstallVerifyError(verifier.ErrKeySigned, "some-plugin", nil)
+	assert.Contains(t, err.Error(), "cosign key pair")
+	assert.Contains(t, err.Error(), "re-publish it with keyless signing",
+		"the message must state the remedy, not merely the refusal")
+	assert.Contains(t, err.Error(), "allow_unsigned does not apply")
+	assert.NotContains(t, err.Error(), "signature verification failed for",
+		"the generic invalid-signature wording is the misdiagnosis this replaces")
+}
+
+// TestClassifySignatureErrorNamesKeySigned keeps the sync/upgrade failure
+// reason distinct from signature-invalid for the same reason.
+func TestClassifySignatureErrorNamesKeySigned(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, plugins.FailureReasonKeySigned, classifySignatureError(verifier.ErrKeySigned))
+	assert.Equal(t, plugins.FailureReasonSignatureInvalid,
+		classifySignatureError(verifier.ErrSignatureInvalid),
+		"the pre-existing mapping must be unaffected")
+}
+
+// TestIsAllowedUnsignedRejectsKeySigned is the guard that closes #6442's
+// actual escape-hatch gap: --allow-unsigned must not rescue a key-signed
+// artifact even on true first use with the flag explicitly set.
+func TestIsAllowedUnsignedRejectsKeySigned(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isAllowedUnsigned(verifier.ErrKeySigned,
+		plugins.InstallOptions{AllowUnsigned: true}, nil),
+		"a signed artifact must never be recordable as an unsigned exception")
+	assert.True(t, isAllowedUnsigned(verifier.ErrUnsigned,
+		plugins.InstallOptions{AllowUnsigned: true}, nil),
+		"the genuine unsigned case must still be allowed through")
+}

--- a/pkg/skills/options.go
+++ b/pkg/skills/options.go
@@ -315,6 +315,11 @@ const (
 	// is pinned — a narrower case than FailureReasonSignerMismatch, whose
 	// remediation (--allow-signer-change) is nonetheless the same.
 	FailureReasonProvenanceFieldMismatch FailureReason = "provenance-field-mismatch"
+	// FailureReasonKeySigned means the artifact carries only cosign
+	// key-pair signatures, which install-time verification cannot check.
+	// Distinct from FailureReasonSignatureInvalid: nothing is wrong with
+	// the signature, there is simply no trust anchor to check it against.
+	FailureReasonKeySigned FailureReason = "key-signed-unverifiable"
 	// FailureReasonUnsignedRejected means the artifact is unsigned and the
 	// operation did not permit unsigned installs.
 	FailureReasonUnsignedRejected FailureReason = "unsigned-rejected"

--- a/pkg/skills/skillsvc/verify.go
+++ b/pkg/skills/skillsvc/verify.go
@@ -292,6 +292,17 @@ func classifyInstallVerifyError(
 				" and reinstall, or upgrade with allow_signer_change)", skillName, verifyErr),
 			http.StatusForbidden,
 		)
+	// Reported before the default arm so a key-signed artifact is named as
+	// such rather than as a failed verification. allow_unsigned is
+	// deliberately no remedy here: the artifact IS signed, and recording it
+	// as an unsigned exception would file a false trust decision in the lock.
+	case errors.Is(verifyErr, verifier.ErrKeySigned):
+		return httperr.WithCode(
+			fmt.Errorf("skill %q: %w; re-publish it with keyless signing"+
+				" (allow_unsigned does not apply — the artifact is signed)",
+				skillName, verifyErr),
+			http.StatusForbidden,
+		)
 	default:
 		return httperr.WithCode(
 			fmt.Errorf("signature verification failed for %q: %w", skillName, verifyErr),
@@ -327,6 +338,8 @@ func classifySignatureError(err error) skills.FailureReason {
 		return skills.FailureReasonSignerMismatch
 	case errors.Is(err, verifier.ErrUnsigned):
 		return skills.FailureReasonUnsignedRejected
+	case errors.Is(err, verifier.ErrKeySigned):
+		return skills.FailureReasonKeySigned
 	case errors.Is(err, verifier.ErrSignatureInvalid):
 		return skills.FailureReasonSignatureInvalid
 	default:

--- a/pkg/skills/skillsvc/verify.go
+++ b/pkg/skills/skillsvc/verify.go
@@ -297,12 +297,7 @@ func classifyInstallVerifyError(
 	// deliberately no remedy here: the artifact IS signed, and recording it
 	// as an unsigned exception would file a false trust decision in the lock.
 	case errors.Is(verifyErr, verifier.ErrKeySigned):
-		return httperr.WithCode(
-			fmt.Errorf("skill %q: %w; re-publish it with keyless signing"+
-				" (allow_unsigned does not apply — the artifact is signed)",
-				skillName, verifyErr),
-			http.StatusForbidden,
-		)
+		return keySignedInstallError(skillName, verifyErr)
 	default:
 		return httperr.WithCode(
 			fmt.Errorf("signature verification failed for %q: %w", skillName, verifyErr),
@@ -320,8 +315,31 @@ func classifyCatalogVerifyError(verifyErr error, skillName string) error {
 			http.StatusForbidden,
 		)
 	}
+	// A key-signed artifact is not a provenance mismatch — nothing was
+	// compared, because the keyless policy cannot check a key-pair signature
+	// at all. The catalog constraint is beside the point, so this reports the
+	// same diagnosis and remedy the non-catalog route does.
+	if errors.Is(verifyErr, verifier.ErrKeySigned) {
+		return keySignedInstallError(skillName, verifyErr)
+	}
 	return httperr.WithCode(
 		fmt.Errorf("skill %q does not match its catalog-declared provenance: %w", skillName, verifyErr),
+		http.StatusForbidden,
+	)
+}
+
+// keySignedInstallError reports a key-signed artifact identically wherever it
+// is detected. A lock-constrained install and a catalog-constrained first
+// install reach classification by different routes, but neither could verify
+// the artifact and both have the same remedy, so the wording is shared rather
+// than duplicated — including the note that allow_unsigned is not a way out,
+// since the artifact IS signed and recording it as an unsigned exception
+// would file a false trust decision in the lock.
+func keySignedInstallError(skillName string, verifyErr error) error {
+	return httperr.WithCode(
+		fmt.Errorf("skill %q: %w; re-publish it with keyless signing"+
+			" (allow_unsigned does not apply — the artifact is signed)",
+			skillName, verifyErr),
 		http.StatusForbidden,
 	)
 }

--- a/pkg/skills/skillsvc/verify_test.go
+++ b/pkg/skills/skillsvc/verify_test.go
@@ -991,3 +991,45 @@ func TestClassifyInstallVerifyErrorDistinguishesProvenanceField(t *testing.T) {
 	assert.Contains(t, identityMismatch.Error(), "signer identity mismatch for",
 		"a genuine signer-identity mismatch keeps its existing wording")
 }
+
+// TestClassifyInstallVerifyErrorNamesKeySigned pins the user-facing half of
+// #6442: a key-signed artifact must be diagnosed as key-signed, must not be
+// reported as a verification failure, and must say plainly that allow_unsigned
+// is no remedy — the artifact is signed, so recording an unsigned exception
+// would file a false trust decision in the lock.
+func TestClassifyInstallVerifyErrorNamesKeySigned(t *testing.T) {
+	t.Parallel()
+
+	err := classifyInstallVerifyError(verifier.ErrKeySigned, "some-skill", nil)
+	assert.Contains(t, err.Error(), "cosign key pair")
+	assert.Contains(t, err.Error(), "re-publish it with keyless signing",
+		"the message must state the remedy, not merely the refusal")
+	assert.Contains(t, err.Error(), "allow_unsigned does not apply")
+	assert.NotContains(t, err.Error(), "signature verification failed for",
+		"the generic invalid-signature wording is the misdiagnosis this replaces")
+}
+
+// TestClassifySignatureErrorNamesKeySigned keeps the sync/upgrade failure
+// reason distinct from signature-invalid for the same reason.
+func TestClassifySignatureErrorNamesKeySigned(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, skills.FailureReasonKeySigned, classifySignatureError(verifier.ErrKeySigned))
+	assert.Equal(t, skills.FailureReasonSignatureInvalid,
+		classifySignatureError(verifier.ErrSignatureInvalid),
+		"the pre-existing mapping must be unaffected")
+}
+
+// TestIsAllowedUnsignedRejectsKeySigned is the guard that closes #6442's
+// actual escape-hatch gap: --allow-unsigned must not rescue a key-signed
+// artifact even on true first use with the flag explicitly set.
+func TestIsAllowedUnsignedRejectsKeySigned(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isAllowedUnsigned(verifier.ErrKeySigned,
+		skills.InstallOptions{AllowUnsigned: true}, nil),
+		"a signed artifact must never be recordable as an unsigned exception")
+	assert.True(t, isAllowedUnsigned(verifier.ErrUnsigned,
+		skills.InstallOptions{AllowUnsigned: true}, nil),
+		"the genuine unsigned case must still be allowed through")
+}

--- a/pkg/skills/skillsvc/verify_test.go
+++ b/pkg/skills/skillsvc/verify_test.go
@@ -1033,3 +1033,37 @@ func TestIsAllowedUnsignedRejectsKeySigned(t *testing.T) {
 		skills.InstallOptions{AllowUnsigned: true}, nil),
 		"the genuine unsigned case must still be allowed through")
 }
+
+// TestCatalogInstallNamesKeySignedArtifact covers the second route to
+// classification. A first install resolved from a catalog entry that declares
+// provenance is classified by classifyCatalogVerifyError, not
+// classifyInstallVerifyError, so a key-signed artifact arriving that way would
+// otherwise be reported as failing to match its catalog-declared provenance —
+// which is doubly wrong: nothing was compared, because the keyless policy
+// cannot check a key-pair signature at all, and the report would carry neither
+// the re-publish remedy nor the note that allow_unsigned cannot help.
+func TestCatalogInstallNamesKeySignedArtifact(t *testing.T) {
+	t.Parallel()
+
+	projectRoot := makeProjectRoot(t)
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	svc := &service{sigVerifier: mv}
+	opts := skills.InstallOptions{
+		ProjectRoot:       projectRoot,
+		CatalogProvenance: &regtypes.Provenance{SignerIdentity: testSignerIdentity},
+	}
+	mv.EXPECT().VerifyOCI(
+		gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Eq(verifier.NewCatalogExpectation(opts.CatalogProvenance))).
+		Return(nil, verifier.ErrKeySigned)
+
+	_, err := svc.verifyOCIInstall(
+		t.Context(), opts, "catalog-skill", "ghcr.io/test/catalog-skill:v1", "sha256:digest")
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusForbidden, httperr.Code(err))
+	assert.Contains(t, err.Error(), "re-publish it with keyless signing")
+	assert.Contains(t, err.Error(), "allow_unsigned does not apply")
+	assert.NotContains(t, err.Error(), "does not match its catalog-declared provenance",
+		"a key-signed artifact was never compared against the catalog constraint")
+}

--- a/pkg/skills/verifier/errors.go
+++ b/pkg/skills/verifier/errors.go
@@ -15,6 +15,21 @@ var (
 	// ErrSignerMismatch indicates the signature verifies, but against an
 	// identity other than the expected one.
 	ErrSignerMismatch = errors.New("signer identity mismatch")
+	// ErrKeySigned indicates the artifact carries only cosign key-pair
+	// signatures, which install-time verification cannot check: the keyless
+	// (Fulcio) trust root has nothing to chain them to, and the signing
+	// public key is recoverable neither from the artifact nor from the
+	// attached bundle — cosign's manifest defines no annotation carrying it,
+	// and the reconstructed bundle holds a fixed placeholder hint in its
+	// place.
+	//
+	// Deliberately NOT wrapping ErrSignatureInvalid, unlike
+	// ErrProvenanceFieldMismatch below: the signature may be perfectly
+	// valid, so reporting it as a verification failure is precisely the
+	// misclassification this sentinel exists to end. That narrowing cannot
+	// fail open, because no caller treats ErrSignatureInvalid as permission
+	// to proceed — it only selects a failure reason.
+	ErrKeySigned = errors.New("artifact is signed with a cosign key pair, which cannot be verified at install time")
 	// ErrProvenanceFieldMismatch indicates the signature verifies against
 	// the expected signer identity and issuer, but a certificate field the
 	// Sigstore policy cannot itself express — the repository ref or runner

--- a/pkg/skills/verifier/oci.go
+++ b/pkg/skills/verifier/oci.go
@@ -217,7 +217,33 @@ func classifyVerifyFailure(
 			return signerMismatchError(vr, expected)
 		}
 	}
+	// Every bundle being certificate-less is the cosign key-pair layout, not
+	// a broken keyless signature — the keyless policy could never have
+	// accepted it. Falling through to wrapInvalid would report
+	// ErrSignatureInvalid, sending the user hunting a corrupt signature; and
+	// because --allow-unsigned only overrides ErrUnsigned, it would leave
+	// them a 403 with no available remedy. A mixed artifact keeps the
+	// keyless diagnosis: one of its bundles genuinely failed the policy.
+	if onlyKeySigned(bundles) {
+		return ErrKeySigned
+	}
 	return wrapInvalid(lastErr)
+}
+
+// onlyKeySigned reports whether every retrieved bundle uses the cosign
+// key-pair layout. An empty slice is not key-signed: retrieveBundles already
+// reports having found no signature material as ErrUnsigned, so classify is
+// never reached with one.
+func onlyKeySigned(bundles []coreverifier.Bundle) bool {
+	if len(bundles) == 0 {
+		return false
+	}
+	for _, b := range bundles {
+		if b.HasCertificate() {
+			return false
+		}
+	}
+	return true
 }
 
 // signerMismatchError builds the ErrSignerMismatch error, naming both the

--- a/pkg/skills/verifier/verifier_test.go
+++ b/pkg/skills/verifier/verifier_test.go
@@ -152,11 +152,22 @@ func TestVerifyOCIKeylessRejectsKeySignedArtifact(t *testing.T) {
 	ref, digest := pushTestArtifact(t, host)
 	signArtifact(t, ref, digest)
 
-	// The keyless flow requires a certificate chain to Fulcio; a key-signed
-	// bundle has none, so this must fail as an invalid signature — not as
-	// unsigned, and never as a panic.
+	// The keyless flow requires a certificate chain to Fulcio and a
+	// key-signed bundle has none, so this must fail — but as the key-pair
+	// layout it is, never as unsigned, and never as a panic.
+	//
+	// This assertion was ErrSignatureInvalid until #6442: that was the only
+	// classification available, not a claim the signature was bad. It is a
+	// real signature referrer, so retrieveBundles finds it and ErrUnsigned
+	// never fires; blaming the signature then sent users hunting a
+	// corruption that was not there, and --allow-unsigned could not override
+	// it because that exception only applies to ErrUnsigned.
 	_, err := NewDefault(nil).VerifyOCI(t.Context(), ref, digest, nil)
-	require.ErrorIs(t, err, ErrSignatureInvalid)
+	require.ErrorIs(t, err, ErrKeySigned)
+	require.NotErrorIs(t, err, ErrSignatureInvalid,
+		"the signature is intact; the missing piece is a trust anchor to check it against")
+	require.NotErrorIs(t, err, ErrUnsigned,
+		"the artifact is signed, so --allow-unsigned must not be able to record an unsigned exception")
 }
 
 func TestVerifyBundleOffline(t *testing.T) {
@@ -528,4 +539,25 @@ func TestFirstVerifiedBundleReturnsEveryRejection(t *testing.T) {
 	require.Len(t, errs, 2)
 	assert.EqualError(t, errs[0], "first")
 	assert.EqualError(t, errs[1], "second")
+}
+
+// TestVerifyOCIReportsKeySignedAgainstLockedIdentity covers a key-signed
+// artifact arriving at an entry already pinned to a keyless identity. The expectation
+// cannot be satisfied and cannot even be compared — there is no certificate to
+// read an observed identity from — so the key-pair diagnosis must win rather
+// than a signer-mismatch report naming an identity nothing produced.
+func TestVerifyOCIReportsKeySignedAgainstLockedIdentity(t *testing.T) {
+	t.Parallel()
+	host := startTestRegistry(t)
+	ref, digest := pushTestArtifact(t, host)
+	signArtifact(t, ref, digest)
+
+	expected := NewLockExpectation(&lockfile.Provenance{
+		SignerIdentity: "org/repo/.github/workflows/publish.yml",
+		CertIssuer:     "https://token.actions.githubusercontent.com",
+	})
+	_, err := NewDefault(nil).VerifyOCI(t.Context(), ref, digest, expected)
+	require.ErrorIs(t, err, ErrKeySigned)
+	require.NotErrorIs(t, err, ErrSignerMismatch,
+		"no certificate exists to compare, so reporting a signer mismatch would invent an observation")
 }


### PR DESCRIPTION
## Summary

`thv skill push --key` and `thv ai-plugin push --key` produce a validly key-signed artifact, but install-time verification is keyless-only — so the result cannot be installed project-scoped. Worse than failing as "unsigned", it failed *inexplicably*:

- A key-pair signature is a real signature referrer, so `retrieveBundles` finds it and `ErrUnsigned` never fires — that sentinel means *no signature material at all*.
- `verifyKeylessBundles` then fails for want of a Fulcio certificate chain, and `classifyVerifyFailure` fell through to `wrapInvalid` → **`ErrSignatureInvalid`**.
- `isAllowedUnsigned` requires `errors.Is(err, ErrUnsigned)`, so **`--allow-unsigned` could not override it.**

Net effect: a hard `403` blaming the signature for what is actually a missing trust anchor, with no flag that could resolve it.

This PR makes the diagnosis truthful. It does **not** yet add key verification — that needs a lock-schema change and is the rest of the stack.

- Adds `verifier.ErrKeySigned`, classified when **every** retrieved bundle is certificate-less (via core's already-exported `Bundle.HasCertificate()`, which had zero callers here).
- Install now names the key-pair layout, states that keyless signing is the remedy, and says plainly that `allow_unsigned` does not apply — for **both** skills and plugins.
- Both classification routes share one formatter. A catalog-constrained first install (`classifyCatalogVerifyError`) is classified separately from a lock-constrained one, and previously reported anything other than unsigned as a mismatch against catalog-declared provenance — wrong twice over for a key-signed artifact, since nothing was compared and the remedy was lost.
- Adds `FailureReasonKeySigned` for sync/upgrade, distinct from `signature-invalid` because nothing is wrong with the signature.
- Documents the gap on `thv skill push --key`, which advertised key signing with no caveat while the equivalent plugin warning shipped separately in #6438.

Refs #6442 (first of ~7 PRs; the issue stays open).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Full unit suite passes for every package this PR touches. Two caveats, stated plainly:

- One unrelated failure persists — `pkg/transport/proxy/streamable`'s `TestMCPGoClientInitializeAndPing`, caused by a stray local process holding `:8096`. Confirmed pre-existing on clean `main` in a detached worktree; untouched by this PR.
- `task lint-fix` reports issues only in `cmd/thv-operator/` files this PR does not touch (deprecated `ctrl.Result{Requeue}` / `PrimaryUpstreamProvider`). All 15 files here are clean.

New coverage: a real key-signed artifact (pushed to an in-process registry via the existing `signArtifact` helper) classifying as `ErrKeySigned` and **not** as `ErrSignatureInvalid` or `ErrUnsigned`; the same artifact against a keyless-pinned lock entry; the 403 wording; the failure-reason mapping; and `isAllowedUnsigned` refusing to rescue a key-signed artifact even with `AllowUnsigned: true`.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

No operator API surface is touched. The `docs/server/*` churn is the skills `FailureReason` enum, which is swagger-documented — an additive enum value.

## Changes

| File | Change |
|------|--------|
| `pkg/skills/verifier/errors.go` | New `ErrKeySigned` sentinel, with the rationale for not wrapping `ErrSignatureInvalid` |
| `pkg/skills/verifier/oci.go` | `onlyKeySigned()` helper; classified before the generic invalid verdict |
| `pkg/skills/skillsvc/verify.go` | 403 naming the key-pair layout; failure-reason mapping |
| `pkg/plugins/pluginsvc/verify.go` | Same, for plugins |
| `pkg/skills/options.go` | `FailureReasonKeySigned` |
| `pkg/plugins/options.go` | Alias, per the shared THV-0080 contract |
| `cmd/thv/app/skill_push.go` | The missing `--key` caveat |
| `docs/arch/12-skills-system.md` | Why only the keyless path yields an installable artifact |
| `docs/cli/*`, `docs/server/*` | Regenerated (`task docs`) |
| 3 × `*_test.go` | New coverage; one pre-existing test refined (see notes) |
| `pkg/skills/skillsvc/verify.go` | `keySignedInstallError`, shared by both classification routes |

## Does this introduce a user-facing change?

Yes. Installing a key-signed artifact project-scoped still fails — that is unchanged and needs the rest of the stack — but the error now explains *why* and what to do, instead of reporting a signature verification failure. `thv skill push --key` also now warns at the point of use that its output is not installable. Sync and upgrade report `key-signed-unverifiable` rather than `signature-invalid`.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

Resolved through a design interview covering the whole of #6442. The chosen arm is **support key verification, install-only for v1**; `--key` stays on push. Full write-up posted to the issue: https://github.com/stacklok/toolhive/issues/6442#issuecomment-5436525763

Decisions relevant to this PR:

- **Lock-first dispatch** — the expectation picks the verify path, never the artifact. A key-signed artifact must never be able to dodge an identity pin by choosing its own policy.
- **New `ErrKeySigned` sentinel**, and `--allow-unsigned` must **not** override it: the artifact *is* signed, so recording it as an unsigned exception would file a false trust decision in the lock.
- **Detection via `HasCertificate()`** — no toolhive-core change or release is needed anywhere in this stack.

Facts established while planning that shaped later PRs, and explain why this one stops where it does:

1. **Key signing writes no Rekor entry** (`toolhive-core/container/signer/signer.go:99`). A `--key` bundle is a bare detached signature: no certificate, no transparency log, no signing time, no revocation.
2. **The public key is not recoverable from the artifact or the bundle.** `signatureAnnotations` writes no annotation for it, and the retrieve side reconstructs with a fixed placeholder hint (`keySignedPublicKeyHint = "cosign-keypair"`). So a `sha256:` digest in the lock is impossible, `resultFromKey` must not grow an observed-key field, and "wrong key" vs "broken signature" are genuinely indistinguishable.
3. **`lockfile.CurrentVersion` must not be bumped** — `validation.go:35` compares `!=`, not `<=`, so a bump makes every existing v1 lock unreadable. Unnecessary regardless: `validateProvenance` already requires `signerIdentity`, so an older thv fails a future key-pinned entry closed for free.

Remaining sequence: (2) lock schema `Provenance.publicKey`, identity XOR key; (3) skills install `--public-key`; (4) skills sync/upgrade; (5–6) plugins mirrors; (7) E2E + docs.

</details>

## Special notes for reviewers

**`ErrKeySigned` deliberately does not wrap `ErrSignatureInvalid`**, unlike the `ErrProvenanceFieldMismatch` precedent directly below it. Reporting a valid signature as a verification failure is the exact misclassification being removed. I checked the narrowing cannot fail open: every consumer of `ErrSignatureInvalid` is either one of the two `classifySignatureError` switches or a `sync.go` message construction — nothing treats it as permission to proceed.

**A pre-existing test pinned the old behavior.** `TestVerifyOCIKeylessRejectsKeySignedArtifact` asserted `ErrSignatureInvalid`. Its comment showed the intent was only *"not as unsigned, and never as a panic"* — `ErrSignatureInvalid` was simply the classification available at the time, not a claim the signature was bad. I refined it in place (keeping both original invariants as explicit negative assertions) rather than treating it as a contract, and folded my duplicate test into it.

**Mixed artifacts keep the keyless diagnosis.** `onlyKeySigned` requires *every* bundle to be certificate-less; if one carries a certificate, that bundle genuinely failed the keyless policy and the existing error is correct.

**Two adjacent paths are already broken for key-signed artifacts** and are addressed in PR 4/6, not here — worth knowing they are not regressions: `probeCandidateSigner` (`upgrade.go:275`) is keyless-only, so a key-signed upgrade candidate reports `UpgradeStatusFailed` rather than `SignerChangeBlocked`; and `adoptSkill`/`adoptLocked` back-fill via `ResultFromBundle`, which requires a certificate, so a key-signed install cannot be adopted at all.

Generated with [Claude Code](https://claude.com/claude-code)

