### PR TITLE
Guard OIDC discovery against private IPs

### DIFF
--- a/pkg/auth/discovery/discovery.go
+++ b/pkg/auth/discovery/discovery.go
@@ -943,6 +943,7 @@ func createOAuthConfig(ctx context.Context, issuer string, config *OAuthFlowConf
 		true, // Enable PKCE by default for security
 		config.CallbackPort,
 		config.Resource,
+		!config.AllowPrivateIPs,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/auth/discovery/discovery_test.go
+++ b/pkg/auth/discovery/discovery_test.go
@@ -1391,6 +1391,29 @@ func startIssuerServer(t *testing.T, tokenEndpoint func(issuerURL string) string
 	return server.URL
 }
 
+// TestCreateOAuthConfig_BlocksPrivateIssuerDiscoveryFallback verifies that the
+// OIDC fallback preserves OAuthFlowConfig's private-IP policy.
+func TestCreateOAuthConfig_BlocksPrivateIssuerDiscoveryFallback(t *testing.T) {
+	t.Parallel()
+
+	var discoveryHits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		discoveryHits.Add(1)
+		http.Error(w, "unexpected discovery request", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	config, err := createOAuthConfig(context.Background(), server.URL, &OAuthFlowConfig{
+		ClientID:        "test-client",
+		AllowPrivateIPs: false,
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, networking.ErrPrivateIpAddress)
+	assert.Nil(t, config)
+	assert.Zero(t, discoveryHits.Load(), "OIDC fallback must not reach a private issuer")
+}
+
 // TestCreateOAuthConfig_DiscoveredTokenEndpoint is the regression test for
 // GHSA-3768-rwj3-38p2. An operator-configured issuer that names its own
 // authority in its metadata keeps the operator's trust; one that names a
@@ -1440,6 +1463,7 @@ func TestCreateOAuthConfig_DiscoveredTokenEndpoint(t *testing.T) {
 				ClientID:             "test-client",
 				IssuerTrusted:        true,
 				TokenEndpointTrusted: true,
+				AllowPrivateIPs:      true,
 			})
 			require.NoError(t, err)
 

--- a/pkg/auth/oauth/oidc.go
+++ b/pkg/auth/oauth/oidc.go
@@ -238,8 +238,11 @@ func CreateOAuthConfigFromOIDC(
 	usePKCE bool,
 	callbackPort int,
 	resource string,
+	blockPrivateIPs bool,
 ) (*Config, error) {
-	return createOAuthConfigFromOIDCWithClient(ctx, issuer, clientID, clientSecret, scopes, usePKCE, callbackPort, resource, nil)
+	return createOAuthConfigFromOIDCWithClient(
+		ctx, issuer, clientID, clientSecret, scopes, usePKCE, callbackPort, resource, nil, blockPrivateIPs,
+	)
 }
 
 // createOAuthConfigFromOIDCWithClient creates an OAuth config from OIDC discovery with a custom HTTP client (private for testing)
@@ -251,11 +254,10 @@ func createOAuthConfigFromOIDCWithClient(
 	callbackPort int,
 	resource string,
 	client networking.HTTPClient,
+	blockPrivateIPs bool,
 ) (*Config, error) {
 	// Discover OIDC endpoints (insecureAllowHTTP is false for OAuth config creation).
-	// blockPrivateIPs=false here preserves this call path's existing behavior;
-	// it is unrelated to the CLI DCR fallback fixed in DiscoverOIDCEndpoints.
-	doc, err := discoverOIDCEndpointsWithClient(ctx, issuer, client, false, false)
+	doc, err := discoverOIDCEndpointsWithClient(ctx, issuer, client, false, blockPrivateIPs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover OIDC endpoints: %w", err)
 	}

--- a/pkg/auth/oauth/oidc_test.go
+++ b/pkg/auth/oauth/oidc_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1258,6 +1259,7 @@ func TestCreateOAuthConfigFromOIDC_Production(t *testing.T) {
 				0,  // Use auto-select port for tests
 				"", // No resource
 				client,
+				false,
 			)
 
 			if tt.expectError {
@@ -1273,6 +1275,58 @@ func TestCreateOAuthConfigFromOIDC_Production(t *testing.T) {
 			if tt.validate != nil {
 				tt.validate(t, config)
 			}
+		})
+	}
+}
+
+func TestCreateOAuthConfigFromOIDC_PrivateIPPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		blockPrivateIPs bool
+		wantErr         bool
+	}{
+		{name: "blocks loopback issuer", blockPrivateIPs: true, wantErr: true},
+		{name: "allows loopback issuer", blockPrivateIPs: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var hits atomic.Int32
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				hits.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(oauthproto.OIDCDiscoveryDocument{
+					AuthorizationServerMetadata: oauthproto.AuthorizationServerMetadata{
+						Issuer:                server.URL,
+						AuthorizationEndpoint: server.URL + "/authorize",
+						TokenEndpoint:         server.URL + "/token",
+						JWKSURI:               server.URL + "/jwks",
+						RegistrationEndpoint:  server.URL + "/register",
+					},
+				})
+			}))
+			t.Cleanup(server.Close)
+
+			config, err := CreateOAuthConfigFromOIDC(
+				context.Background(), server.URL, "test-client", "", nil, true, 0, "", tt.blockPrivateIPs,
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, networking.ErrPrivateIpAddress)
+				assert.Nil(t, config)
+				assert.Zero(t, hits.Load(), "blocked issuer must not reach the listener")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, server.URL+"/authorize", config.AuthURL)
+			assert.Equal(t, server.URL+"/token", config.TokenURL)
+			assert.Equal(t, int32(1), hits.Load())
 		})
 	}
 }

--- a/pkg/auth/tokensource/tokensource.go
+++ b/pkg/auth/tokensource/tokensource.go
@@ -402,6 +402,7 @@ func (t *OAuthTokenSource) buildFlowConfig(ctx context.Context) (*oauth.Config, 
 		true, // always use PKCE
 		t.opts.OIDC.CallbackPort,
 		t.opts.OIDC.Audience,
+		false, // issuer is operator-configured
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Remote MCP servers could supply an OIDC realm on a private address and reach it through an unguarded OAuth configuration fallback after the guarded preliminary discovery failed. This closes that SSRF path by carrying the existing private-IP policy into the fallback discovery request.
- Thread `blockPrivateIPs` through OIDC configuration creation, apply `!AllowPrivateIPs` to remote OAuth discovery, and preserve private issuer support for operator-configured registry/token-source OIDC flows.
- Add behavioral regression coverage that verifies blocked discovery never reaches a loopback listener and that explicitly permitted discovery still succeeds.

Security advisory: GHSA-cvhc-p56v-qm9r

Reported by [Yanhaoxi](https://github.com/Yanhaoxi).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`) — attempted, but the complete repository suite did not finish within the local timeout
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Changes

| File | Change |
|------|--------|
| `pkg/auth/oauth/oidc.go` | Accept and enforce the caller's private-IP discovery policy. |
| `pkg/auth/discovery/discovery.go` | Apply `OAuthFlowConfig.AllowPrivateIPs` to fallback OIDC discovery. |
| `pkg/auth/tokensource/tokensource.go` | Preserve private issuer support for operator-configured token sources. |
| `pkg/auth/oauth/oidc_test.go` | Verify blocked and permitted loopback discovery using listener hit counts. |
| `pkg/auth/discovery/discovery_test.go` | Verify the vulnerable fallback cannot reach a private issuer. |

## Does this introduce a user-facing change?

Remote authentication now refuses server-derived OIDC discovery requests to private, loopback, and link-local addresses unless the configured remote target permits private upstreams.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

1. Thread `blockPrivateIPs` through `CreateOAuthConfigFromOIDC` and its private helper, replacing the hardcoded `false`.
2. Pass `!config.AllowPrivateIPs` from the remote discovery fallback and `false` from the trusted operator-configured token-source path.
3. Update the existing private-helper test call.
4. Add behavioral tests for blocked/permitted loopback discovery and the exact fallback branch.
5. Leave best-effort discovery error handling, registry helpers, advisory metadata, docs, and unrelated security behavior unchanged.
6. Run linting, tests, and a focused final code/security review.

</details>

## Special notes for reviewers

The preliminary discovery errors in `pkg/auth/remote/handler.go` remain best-effort CIMD enrichment. Once this fallback uses the same private-IP policy, a failed guarded request cannot fall through to an unguarded retry. The complete `task test` invocation exceeded the local execution window; CI should provide the full unit-test result.