### PR TITLE
Register and harden static SPIFFE clients

### DIFF
--- a/pkg/auth/dcr/resolver.go
+++ b/pkg/auth/dcr/resolver.go
@@ -262,6 +262,8 @@ const (
 	dcrStepSelectAuthMethod = "select_auth_method"
 	dcrStepRegister         = "dcr_call"
 	dcrStepCacheWrite       = "cache_write"
+	//nolint:gosec // G101: this is a log/error "step" tag, not a credential value.
+	dcrStepExpiredCredential = "expired_credential"
 )
 
 // dcrStepError annotates a resolver error with the phase it was produced
@@ -484,6 +486,22 @@ func registerAndCache(
 		return nil, newDCRStepError(dcrStepCacheWrite, req.Issuer, redirectURI,
 			fmt.Errorf("cache put: %w", err))
 	}
+
+	// The authoritative row can be a concurrent claimant's stable-but-expired
+	// registration: when both the existing stored row and this replica's
+	// fresh registration are already expired, dcrClaimOrReturnWinner
+	// (pkg/authserver/storage/redis.go) deliberately returns the existing
+	// row without error rather than retrying forever. That's the right call
+	// at the storage layer, but "expired means unusable" is DCR policy, not
+	// storage policy, so it belongs here: treat an already-expired
+	// authoritative credential as a resolution failure instead of handing
+	// callers a dead client_secret disguised as a success.
+	if !authoritative.ClientSecretExpiresAt.IsZero() && time.Now().After(authoritative.ClientSecretExpiresAt) {
+		return nil, newDCRStepError(dcrStepExpiredCredential, req.Issuer, redirectURI,
+			fmt.Errorf("authoritative credential is already expired (client_secret_expires_at=%s)",
+				authoritative.ClientSecretExpiresAt.UTC().Format(time.RFC3339)))
+	}
+
 	if authoritative.ClientID != resolution.ClientID {
 		//nolint:gosec // G706: client_id is public metadata per RFC 7591.
 		slog.Debug("dcr: registration superseded by concurrent winner",

--- a/pkg/auth/dcr/resolver.go
+++ b/pkg/auth/dcr/resolver.go
@@ -470,9 +470,29 @@ func registerAndCache(
 	// failure leaves no in-memory state diverging from the cache: the
 	// next call simply re-resolves rather than reading a value the cache
 	// never saw.
-	if err := cache.Put(ctx, key, resolution); err != nil {
+	//
+	// authoritative may differ from resolution: RFC 7591 dynamic
+	// registration mints a brand-new, unique client_id/client_secret on
+	// every call, so if another replica raced this one to register against
+	// the same Key and won the durable claim first, cache.PutIfAbsent
+	// returns THAT replica's credentials — the only ones the shared cache
+	// (and hence any other replica or a future restart) will agree this
+	// caller holds. Returning resolution here instead would leave this
+	// process using a client_id the durable store does not recognize.
+	authoritative, err := cache.PutIfAbsent(ctx, key, resolution)
+	if err != nil {
 		return nil, newDCRStepError(dcrStepCacheWrite, req.Issuer, redirectURI,
 			fmt.Errorf("cache put: %w", err))
+	}
+	if authoritative.ClientID != resolution.ClientID {
+		//nolint:gosec // G706: client_id is public metadata per RFC 7591.
+		slog.Debug("dcr: registration superseded by concurrent winner",
+			"local_issuer", req.Issuer,
+			"upstream_id", key.UpstreamID,
+			"redirect_uri", redirectURI,
+			"registered_client_id", resolution.ClientID,
+			"authoritative_client_id", authoritative.ClientID,
+		)
 	}
 
 	//nolint:gosec // G706: client_id is public metadata per RFC 7591.
@@ -480,9 +500,9 @@ func registerAndCache(
 		"local_issuer", req.Issuer,
 		"upstream_id", key.UpstreamID,
 		"redirect_uri", redirectURI,
-		"client_id", resolution.ClientID,
+		"client_id", authoritative.ClientID,
 	)
-	return resolution, nil
+	return authoritative, nil
 }
 
 // LogStepError emits the single boundary slog.Error record for a DCR

--- a/pkg/auth/dcr/resolver_test.go
+++ b/pkg/auth/dcr/resolver_test.go
@@ -170,7 +170,8 @@ func TestResolveDCRCredentials_CacheHitShortCircuits(t *testing.T) {
 		AuthorizationEndpoint: "https://preloaded/authorize",
 		TokenEndpoint:         "https://preloaded/token",
 	}
-	require.NoError(t, cache.Put(context.Background(), key, preloaded))
+	_, err := cache.PutIfAbsent(context.Background(), key, preloaded)
+	require.NoError(t, err)
 
 	req := &Request{
 		Issuer:       issuer,
@@ -1510,8 +1511,8 @@ func (c *countingStore) Get(ctx context.Context, key Key) (*Resolution, bool, er
 	return res, ok, err
 }
 
-func (c *countingStore) Put(ctx context.Context, key Key, res *Resolution) error {
-	return c.inner.Put(ctx, key, res)
+func (c *countingStore) PutIfAbsent(ctx context.Context, key Key, res *Resolution) (*Resolution, error) {
+	return c.inner.PutIfAbsent(ctx, key, res)
 }
 
 // TestResolveDCRCredentials_SingleflightCoalescesConcurrentCallers pins the
@@ -1790,8 +1791,11 @@ func (f failingDCRStore) Get(_ context.Context, _ Key) (*Resolution, bool, error
 	return nil, false, nil
 }
 
-func (f failingDCRStore) Put(_ context.Context, _ Key, _ *Resolution) error {
-	return f.putErr
+func (f failingDCRStore) PutIfAbsent(_ context.Context, _ Key, res *Resolution) (*Resolution, error) {
+	if f.putErr != nil {
+		return nil, f.putErr
+	}
+	return res, nil
 }
 
 // TestResolveDCRCredentials_CacheGetFailureWrapped covers PR #5042 review
@@ -2017,7 +2021,7 @@ func (panickingPutDCRStore) Get(_ context.Context, _ Key) (*Resolution, bool, er
 	return nil, false, nil
 }
 
-func (s panickingPutDCRStore) Put(_ context.Context, _ Key, _ *Resolution) error {
+func (s panickingPutDCRStore) PutIfAbsent(_ context.Context, _ Key, _ *Resolution) (*Resolution, error) {
 	panic(s.panicValue)
 }
 

--- a/pkg/auth/dcr/resolver_test.go
+++ b/pkg/auth/dcr/resolver_test.go
@@ -1851,6 +1851,59 @@ func TestResolveDCRCredentials_CachePutFailureWrapped(t *testing.T) {
 		"the wrap message is part of the operator-debugging contract")
 }
 
+// expiredWinnerDCRStore simulates a concurrent claimant that already won the
+// durable claim with a credential that is already expired. This mirrors
+// dcrClaimOrReturnWinner (pkg/authserver/storage/redis.go) when both the
+// existing stored row and the incoming registration are already expired: it
+// deliberately returns the existing row without error rather than retrying
+// forever. PutIfAbsent here returns winner regardless of the resolution the
+// caller tried to store, exactly as a real "someone else already claimed
+// this key" response would.
+type expiredWinnerDCRStore struct {
+	winner *Resolution
+}
+
+func (expiredWinnerDCRStore) Get(_ context.Context, _ Key) (*Resolution, bool, error) {
+	return nil, false, nil
+}
+
+func (s expiredWinnerDCRStore) PutIfAbsent(_ context.Context, _ Key, _ *Resolution) (*Resolution, error) {
+	return s.winner, nil
+}
+
+// TestResolveDCRCredentials_ExpiredAuthoritativeCredentialErrors covers the
+// case a human reviewer flagged on PR #6474: cache.PutIfAbsent can return an
+// authoritative credential that is already expired (the storage layer
+// deliberately returns the stable expired row rather than erroring when both
+// claimants are expired). Treating that as a successful resolution would
+// hand the caller a client_secret the upstream will already reject.
+// registerAndCache must instead surface it as a failure.
+func TestResolveDCRCredentials_ExpiredAuthoritativeCredentialErrors(t *testing.T) {
+	t.Parallel()
+
+	server := newDCRTestServer(t, dcrTestHandlerConfig{})
+
+	store := expiredWinnerDCRStore{
+		winner: &Resolution{
+			ClientID:              "winner-client-id",
+			ClientSecret:          "winner-client-secret",
+			ClientSecretExpiresAt: time.Now().Add(-time.Hour),
+		},
+	}
+
+	req := &Request{
+		Issuer:       server.URL,
+		Scopes:       []string{"openid"},
+		DiscoveryURL: server.URL + "/.well-known/oauth-authorization-server",
+	}
+
+	res, err := ResolveCredentials(context.Background(), req, store)
+	require.Error(t, err, "an already-expired authoritative credential must not be returned as a success")
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), dcrStepExpiredCredential,
+		"step identifier is part of the operator-debugging contract")
+}
+
 // TestBuildResolution_PopulatesRFC7591ExpiryFields covers the conversion of
 // the int64 epoch fields client_id_issued_at and client_secret_expires_at
 // into time.Time on Resolution. The wire convention "0 means absent /
@@ -1918,10 +1971,12 @@ func TestBuildResolution_PopulatesRFC7591ExpiryFields(t *testing.T) {
 // TestResolveDCRCredentials_RefetchesOnExpiredCachedSecret pins the fix for
 // the cache-serves-expired-secrets bug: when an entry's
 // ClientSecretExpiresAt has passed, lookupCachedResolution treats it as a
-// miss so registerAndCache re-runs and overwrites the stale entry. Without
-// this, the cached secret would be served indefinitely past the upstream-
-// asserted expiry and every token-endpoint call would 401 with no signal
-// back to the resolver.
+// miss so registerAndCache re-runs rather than serving the stale entry
+// indefinitely. Since the upstream in this test always issues an
+// already-expired secret, every call re-registers AND — per the
+// expired-authoritative-credential check in registerAndCache — every call
+// also fails, rather than handing the caller a client_secret the upstream
+// has already invalidated.
 func TestResolveDCRCredentials_RefetchesOnExpiredCachedSecret(t *testing.T) {
 	t.Parallel()
 
@@ -1929,7 +1984,8 @@ func TestResolveDCRCredentials_RefetchesOnExpiredCachedSecret(t *testing.T) {
 	server := newDCRTestServer(t, dcrTestHandlerConfig{
 		// Issue a secret that expired one minute ago. Every fresh
 		// registration call will produce an already-expired entry; the
-		// resolver will refetch on every Resolve as a result.
+		// resolver will refetch (and, per the expired-credential check,
+		// fail) on every Resolve as a result.
 		clientSecretExpiresAt: time.Now().Add(-time.Minute).Unix(),
 		observeRegistration: func(_ *http.Request, _ []byte) {
 			atomic.AddInt32(&registrationCalls, 1)
@@ -1944,20 +2000,20 @@ func TestResolveDCRCredentials_RefetchesOnExpiredCachedSecret(t *testing.T) {
 		DiscoveryURL: issuer + "/.well-known/oauth-authorization-server",
 	}
 
-	// First call: registers, populates cache with already-expired entry.
+	// First call: registers, but the issued secret is already expired, so
+	// the resolver must not report success.
 	res1, err := ResolveCredentials(context.Background(), req, cache)
-	require.NoError(t, err)
-	require.NotNil(t, res1)
-	require.False(t, res1.ClientSecretExpiresAt.IsZero(),
-		"upstream advertised an expiry — the resolution must echo it")
-	require.True(t, time.Now().After(res1.ClientSecretExpiresAt),
-		"test setup should have produced an already-expired secret")
+	require.Error(t, err)
+	assert.Nil(t, res1)
+	assert.Contains(t, err.Error(), dcrStepExpiredCredential)
 	require.EqualValues(t, 1, atomic.LoadInt32(&registrationCalls))
 
-	// Second call: the cached entry is expired, so the resolver must refetch.
+	// Second call: the cached entry is expired, so the resolver must
+	// refetch — and fail again, since the upstream keeps issuing
+	// already-expired secrets.
 	res2, err := ResolveCredentials(context.Background(), req, cache)
-	require.NoError(t, err)
-	require.NotNil(t, res2)
+	require.Error(t, err)
+	assert.Nil(t, res2)
 	assert.EqualValues(t, 2, atomic.LoadInt32(&registrationCalls),
 		"expired cache entry must trigger a re-registration; got %d total calls",
 		atomic.LoadInt32(&registrationCalls))

--- a/pkg/auth/dcr/store.go
+++ b/pkg/auth/dcr/store.go
@@ -50,11 +50,20 @@ type CredentialStore interface {
 	// key is not present. An error is returned only on backend failure.
 	Get(ctx context.Context, key Key) (*Resolution, bool, error)
 
-	// Put stores the resolution for key, overwriting any existing entry.
+	// PutIfAbsent claims key for resolution. Returns the authoritative
+	// durable value: the caller's own resolution on a successful claim, the
+	// concurrent winner's otherwise. Callers MUST use the returned value,
+	// not their input resolution — RFC 7591 dynamic registration mints a
+	// unique client_id/client_secret on every call, so a caller that lost
+	// the race and kept using its own resolution would hold credentials the
+	// durable store does not agree it owns.
+	//
 	// Implementations must reject a nil resolution with an error rather
 	// than silently succeeding — a no-op would leave callers with no
 	// debug trail for the subsequent Get miss.
-	Put(ctx context.Context, key Key, resolution *Resolution) error
+	//
+	// The returned *Resolution is always non-nil when err is nil.
+	PutIfAbsent(ctx context.Context, key Key, resolution *Resolution) (*Resolution, error)
 }
 
 // NewStorageBackedStore returns a CredentialStore that delegates to a
@@ -154,15 +163,19 @@ func (s *inMemoryStore) Get(ctx context.Context, key Key) (*Resolution, bool, er
 	return credentialsToResolution(creds), true, nil
 }
 
-// Put implements CredentialStore by delegating to the embedded
+// PutIfAbsent implements CredentialStore by delegating to the embedded
 // *storage.MemoryStorage. The nil-resolution rejection matches
-// storageBackedStore.Put; see that method for the rationale.
-func (s *inMemoryStore) Put(ctx context.Context, key Key, resolution *Resolution) error {
+// storageBackedStore.PutIfAbsent; see that method for the rationale.
+func (s *inMemoryStore) PutIfAbsent(ctx context.Context, key Key, resolution *Resolution) (*Resolution, error) {
 	if resolution == nil {
-		return fmt.Errorf("dcr: resolution must not be nil")
+		return nil, fmt.Errorf("dcr: resolution must not be nil")
 	}
 	creds := resolutionToCredentials(key, resolution)
-	return s.mem.StoreDCRCredentials(ctx, creds)
+	authoritative, err := s.mem.StoreDCRCredentialsIfAbsent(ctx, creds)
+	if err != nil {
+		return nil, err
+	}
+	return credentialsToResolution(authoritative), nil
 }
 
 // Close releases the embedded MemoryStorage cleanup goroutine. Safe to
@@ -201,18 +214,27 @@ func (s *storageBackedStore) Get(ctx context.Context, key Key) (*Resolution, boo
 	return credentialsToResolution(creds), true, nil
 }
 
-// Put implements CredentialStore.
+// PutIfAbsent implements CredentialStore.
 //
 // A nil resolution is rejected rather than silently no-oped: a caller
 // passing nil would otherwise get a successful return, observe a miss on
 // the next Get, and have no error trail to debug from. Failing loudly at
 // the boundary makes such bugs visible at the first call.
-func (s *storageBackedStore) Put(ctx context.Context, key Key, resolution *Resolution) error {
+//
+// The returned *Resolution is the authoritative durable value —
+// s.backend.StoreDCRCredentialsIfAbsent's own contract — so a caller whose
+// registration lost a concurrent claim on this key gets back the winner's
+// credentials, not its own.
+func (s *storageBackedStore) PutIfAbsent(ctx context.Context, key Key, resolution *Resolution) (*Resolution, error) {
 	if resolution == nil {
-		return fmt.Errorf("dcr: resolution must not be nil")
+		return nil, fmt.Errorf("dcr: resolution must not be nil")
 	}
 	creds := resolutionToCredentials(key, resolution)
-	return s.backend.StoreDCRCredentials(ctx, creds)
+	authoritative, err := s.backend.StoreDCRCredentialsIfAbsent(ctx, creds)
+	if err != nil {
+		return nil, err
+	}
+	return credentialsToResolution(authoritative), nil
 }
 
 // resolutionToCredentials converts a resolver-side *Resolution into the

--- a/pkg/auth/dcr/store_test.go
+++ b/pkg/auth/dcr/store_test.go
@@ -40,7 +40,10 @@ func TestStorageBackedStore_PutGet_RoundTrip(t *testing.T) {
 		CreatedAt:               time.Now(),
 	}
 
-	require.NoError(t, store.Put(ctx, key, resolution))
+	authoritative, err := store.PutIfAbsent(ctx, key, resolution)
+	require.NoError(t, err)
+	assert.Equal(t, resolution.ClientID, authoritative.ClientID,
+		"an uncontested claim must return the caller's own resolution")
 
 	got, ok, err := store.Get(ctx, key)
 	require.NoError(t, err)
@@ -119,11 +122,15 @@ func TestStorageBackedStore_DistinctKeysDoNotCollide(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, store.Put(ctx, keyA, resolution("a")))
-	require.NoError(t, store.Put(ctx, keyB, resolution("b")))
-	require.NoError(t, store.Put(ctx, keyC, resolution("c")))
-	require.NoError(t, store.Put(ctx, keyD, resolution("d")))
-	require.NoError(t, store.Put(ctx, keyE, resolution("e")))
+	for _, put := range []struct {
+		key      Key
+		clientID string
+	}{
+		{keyA, "a"}, {keyB, "b"}, {keyC, "c"}, {keyD, "d"}, {keyE, "e"},
+	} {
+		_, err := store.PutIfAbsent(ctx, put.key, resolution(put.clientID))
+		require.NoError(t, err)
+	}
 
 	for _, tc := range []struct {
 		key      Key
@@ -142,7 +149,15 @@ func TestStorageBackedStore_DistinctKeysDoNotCollide(t *testing.T) {
 	}
 }
 
-func TestStorageBackedStore_Put_OverwritesExisting(t *testing.T) {
+// TestStorageBackedStore_PutIfAbsent_FirstClaimWins pins the create-if-absent
+// contract that replaced unconditional overwrite (see PutIfAbsent doc): a
+// second PutIfAbsent for a key that already holds a value must NOT overwrite
+// it. Instead it returns the existing (first) resolution as the authoritative
+// value, and the store keeps holding the first entry. This is the fix for the
+// concurrent-replica bug where two callers independently register distinct
+// RFC 7591 clients for the same key — only one registration may ever become
+// the durable, agreed-upon value.
+func TestStorageBackedStore_PutIfAbsent_FirstClaimWins(t *testing.T) {
 	t.Parallel()
 
 	store := newMemoryDCRStore(t)
@@ -161,21 +176,27 @@ func TestStorageBackedStore_Put_OverwritesExisting(t *testing.T) {
 		Authorization: "https://idp.example.com/authorize",
 		Token:         "https://idp.example.com/token",
 	}
-	require.NoError(t, store.Put(ctx, key, &Resolution{
+	first, err := store.PutIfAbsent(ctx, key, &Resolution{
 		ClientID:              "first",
 		AuthorizationEndpoint: endpoints.Authorization,
 		TokenEndpoint:         endpoints.Token,
-	}))
-	require.NoError(t, store.Put(ctx, key, &Resolution{
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "first", first.ClientID, "the uncontested first claim returns its own resolution")
+
+	second, err := store.PutIfAbsent(ctx, key, &Resolution{
 		ClientID:              "second",
 		AuthorizationEndpoint: endpoints.Authorization,
 		TokenEndpoint:         endpoints.Token,
-	}))
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "first", second.ClientID,
+		"the loser must get back the winner's resolution, not its own")
 
 	got, ok, err := store.Get(ctx, key)
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, "second", got.ClientID)
+	assert.Equal(t, "first", got.ClientID, "the store must keep the first-claimed entry, not overwrite it")
 }
 
 // TestStorageBackedStore_Put_RejectsNilResolution pins the
@@ -189,7 +210,7 @@ func TestStorageBackedStore_Put_RejectsNilResolution(t *testing.T) {
 	ctx := context.Background()
 	key := Key{Issuer: "https://idp.example.com", RedirectURI: "https://x.example.com/cb"}
 
-	err := store.Put(ctx, key, nil)
+	_, err := store.PutIfAbsent(ctx, key, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not be nil")
 
@@ -211,11 +232,12 @@ func TestStorageBackedStore_GetReturnsDefensiveCopy(t *testing.T) {
 		RedirectURI: "https://x.example.com/cb",
 		ScopesHash:  storage.ScopesHash([]string{"openid"}),
 	}
-	require.NoError(t, store.Put(ctx, key, &Resolution{
+	_, err := store.PutIfAbsent(ctx, key, &Resolution{
 		ClientID:              "orig",
 		AuthorizationEndpoint: "https://idp.example.com/authorize",
 		TokenEndpoint:         "https://idp.example.com/token",
-	}))
+	})
+	require.NoError(t, err)
 
 	got, ok, err := store.Get(ctx, key)
 	require.NoError(t, err)
@@ -289,14 +311,14 @@ func TestStorageBackedStore_ConcurrentAccess(t *testing.T) {
 					CreatedAt:             time.Now(),
 				}
 				if i%2 == 0 {
-					if err := store.Put(ctx, overlappingKey(i), resolution); err != nil {
+					if _, err := store.PutIfAbsent(ctx, overlappingKey(i), resolution); err != nil {
 						atomic.AddInt32(&errCount, 1)
 					}
 					if _, _, err := store.Get(ctx, overlappingKey(i)); err != nil {
 						atomic.AddInt32(&errCount, 1)
 					}
 				} else {
-					if err := store.Put(ctx, disjointKey(worker, i), resolution); err != nil {
+					if _, err := store.PutIfAbsent(ctx, disjointKey(worker, i), resolution); err != nil {
 						atomic.AddInt32(&errCount, 1)
 					}
 					if _, _, err := store.Get(ctx, disjointKey(worker, i)); err != nil {
@@ -508,18 +530,19 @@ func TestInMemoryStore_PutGetCloseShareBackend(t *testing.T) {
 		TokenEndpoint:         "https://idp.example.com/token",
 	}
 
-	require.NoError(t, store.Put(ctx, key, resolution))
+	_, err := store.PutIfAbsent(ctx, key, resolution)
+	require.NoError(t, err)
 
 	got, ok, err := store.Get(ctx, key)
 	require.NoError(t, err)
-	require.True(t, ok, "Get must see the value Put just wrote — confirms Put and Get share a backend")
+	require.True(t, ok, "Get must see the value PutIfAbsent just wrote — confirms Put and Get share a backend")
 	assert.Equal(t, "client-abc", got.ClientID)
 }
 
 // TestInMemoryStore_PutRejectsNilResolution mirrors the contract pinned
-// for storageBackedStore.Put: a nil resolution is rejected at the
+// for storageBackedStore.PutIfAbsent: a nil resolution is rejected at the
 // adapter boundary rather than silently no-oped, so the next Get miss
-// surfaces with a debug trail. inMemoryStore implements Put directly
+// surfaces with a debug trail. inMemoryStore implements PutIfAbsent directly
 // (not via embedding) — this test guards against a delegation
 // regression that omitted the nil check.
 func TestInMemoryStore_PutRejectsNilResolution(t *testing.T) {
@@ -528,7 +551,7 @@ func TestInMemoryStore_PutRejectsNilResolution(t *testing.T) {
 	store := NewInMemoryStore()
 	t.Cleanup(func() { _ = store.Close() })
 
-	err := store.Put(context.Background(), Key{Issuer: "https://idp.example.com"}, nil)
+	_, err := store.PutIfAbsent(context.Background(), Key{Issuer: "https://idp.example.com"}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "resolution must not be nil")
 }

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -144,6 +144,7 @@ func prepareInboundGrantConfiguration(
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("normalize inbound grants: %w", err)
 	}
+
 	if delegateClients == nil && len(normalized.DelegateClients) > 0 {
 		delegateClients, err = resolveDelegateClients(normalized.DelegateClients)
 		if err != nil {
@@ -160,7 +161,18 @@ func prepareInboundGrantConfiguration(
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("build SPIFFE trust config: %w", err)
 	}
+	// SPIFFE client authentication exclusively uses the token-exchange grant
+	// (validateSPIFFEGrants enforces this), so configuring any SPIFFE
+	// association implies token-exchange capability independent of
+	// legacy/canonical token-exchange enablement.
+	normalized.Capabilities.TokenExchange = normalized.Capabilities.TokenExchange || hasSPIFFEClientAuth(cfg)
 	return normalized, delegateClients, spiffeTrust, nil
+}
+
+// hasSPIFFEClientAuth reports whether cfg declares any SPIFFE client-auth
+// association.
+func hasSPIFFEClientAuth(cfg *authserver.RunConfig) bool {
+	return cfg.InboundGrants != nil && len(cfg.InboundGrants.SPIFFEClientAuth) > 0
 }
 
 func newEmbeddedAuthServerWithStorage(
@@ -169,6 +181,12 @@ func newEmbeddedAuthServerWithStorage(
 	stor storage.Storage,
 	delegateClients []authserver.DelegateClient,
 ) (retEAS *EmbeddedAuthServer, retErr error) {
+	// Validate required inputs before the deferred cleanup is installed: cfg is
+	// dereferenced during validation and stor is closed by that cleanup.
+	if err := validateEmbeddedAuthServerInputs(cfg, stor); err != nil {
+		return nil, err
+	}
+
 	// From here on, any error must close stor before returning.
 	//
 	// Both errors are passed through dcr.SanitizeErrorForLog before being
@@ -198,15 +216,16 @@ func newEmbeddedAuthServerWithStorage(
 	// otherwise skip the check. Placed inside the deferred-cleanup gate above so
 	// a validation failure still closes the caller-supplied storage per the
 	// resource-ownership contract.
-	if cfg == nil {
-		return nil, fmt.Errorf("config is required")
-	}
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid run config: %w", err)
 	}
 	normalized, delegateClients, spiffeTrust, err := prepareInboundGrantConfiguration(cfg, delegateClients)
 	if err != nil {
 		return nil, err
+	}
+
+	if err := authserver.PreflightSPIFFEStaticClientCollisions(ctx, stor, spiffeTrust); err != nil {
+		return nil, fmt.Errorf("preflight SPIFFE static client collisions: %w", err)
 	}
 
 	// 1. Create key provider from RunConfig.SigningKeyConfig
@@ -248,12 +267,9 @@ func newEmbeddedAuthServerWithStorage(
 	}
 
 	// 6. Parse delegation token lifespan if configured.
-	var delegationLifespan time.Duration
-	if cfg.DelegationTokenLifespan != "" {
-		delegationLifespan, err = time.ParseDuration(cfg.DelegationTokenLifespan)
-		if err != nil {
-			return nil, fmt.Errorf("invalid delegation token lifespan: %w", err)
-		}
+	delegationLifespan, err := parseOptionalDuration(cfg.DelegationTokenLifespan, "delegation token lifespan")
+	if err != nil {
+		return nil, err
 	}
 
 	// 7. Build the resolved Config.
@@ -297,8 +313,11 @@ func newEmbeddedAuthServerWithStorage(
 		// slice is still shared with cfg. NewMultiIssuerTokenValidator's
 		// constructor clones AllowedActors per issuer before use, so the
 		// authorization-critical data is protected without a deep copy here.
-		TrustedIssuers:       trustedIssuers,
-		DelegateClients:      delegateClients,
+		TrustedIssuers:  trustedIssuers,
+		DelegateClients: delegateClients,
+		// SPIFFE client authentication factors into Capabilities.TokenExchange
+		// already (see prepareInboundGrantConfiguration): it exclusively uses
+		// the token-exchange grant, independent of legacy/canonical enablement.
 		DisableTokenExchange: !normalized.Capabilities.TokenExchange,
 		SPIFFETrust:          spiffeTrust,
 	}
@@ -413,6 +432,18 @@ func (e *EmbeddedAuthServer) RegisterHandlers(mux *http.ServeMux) {
 	}
 }
 
+// validateEmbeddedAuthServerInputs rejects required inputs before construction
+// can dereference cfg or install cleanup that closes stor.
+func validateEmbeddedAuthServerInputs(cfg *authserver.RunConfig, stor storage.Storage) error {
+	if cfg == nil {
+		return fmt.Errorf("config is required")
+	}
+	if stor == nil {
+		return fmt.Errorf("storage is required")
+	}
+	return nil
+}
+
 // createKeyProvider creates a KeyProvider from SigningKeyRunConfig.
 // Returns a GeneratingProvider if config is nil or empty (development mode).
 func createKeyProvider(cfg *authserver.SigningKeyRunConfig) (keys.KeyProvider, error) {
@@ -474,6 +505,17 @@ func loadHMACSecrets(files []string) (*servercrypto.HMACSecrets, error) {
 	}
 
 	return secrets, nil
+}
+
+func parseOptionalDuration(value, name string) (time.Duration, error) {
+	if value == "" {
+		return 0, nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	return duration, nil
 }
 
 // parseTokenLifespans parses duration strings from TokenLifespanRunConfig.

--- a/pkg/authserver/runner/embeddedauthserver_integration_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_integration_test.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ory/fosite"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/stacklok/toolhive/pkg/authserver"
+	"github.com/stacklok/toolhive/pkg/authserver/storage"
+)
+
+func TestIntegration_EmbeddedAuthServer_SPIFFERedisRestartAndCollision(t *testing.T) {
+	t.Skip("RunConfig.Validate() now hard-rejects any non-empty spiffe_trust_domains " +
+		"(config.go's validateSPIFFENotYetEnforced, per PR #6467 review) until a real " +
+		"SVID-verification consumer lands, so a server can no longer be constructed with " +
+		"a SPIFFE association configured at all -- there is no way to exercise the " +
+		"Redis-backed restart/collision behavior this test proved through " +
+		"NewEmbeddedAuthServerWithStorage without routing around cfg.Validate() in " +
+		"production code. Re-enable this test -- unmodified -- when the future PR that " +
+		"adds real SVID verification removes the hard-reject.")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(cancel)
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "redis:7-alpine",
+			ExposedPorts: []string{"6379/tcp"},
+			WaitingFor:   wait.ForListeningPort("6379/tcp"),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, container.Terminate(context.Background())) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "6379/tcp")
+	require.NoError(t, err)
+	newStorage := func() *storage.RedisStorage {
+		return storage.NewRedisStorageWithClient(redis.NewClient(&redis.Options{
+			Addr: fmt.Sprintf("%s:%s", host, port.Port()),
+		}), "integration:spiffe:")
+	}
+	config := func(includeAssociation bool) authserver.RunConfig {
+		cfg := authserver.RunConfig{
+			SchemaVersion:    authserver.CurrentSchemaVersion,
+			Issuer:           "https://auth.example.com",
+			ScopesSupported:  []string{"openid"},
+			AllowedAudiences: []string{"https://mcp.example.com"},
+			// A static OAuth2 upstream satisfies runtime configuration validation
+			// without discovery or DCR network I/O during server construction.
+			Upstreams: []authserver.UpstreamRunConfig{{
+				Name: "static-upstream",
+				Type: authserver.UpstreamProviderTypeOAuth2,
+				OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+					AuthorizationEndpoint: "https://upstream.example.com/authorize",
+					TokenEndpoint:         "https://upstream.example.com/token",
+					ClientID:              "test-client-id",
+					RedirectURI:           "https://auth.example.com/oauth/callback",
+				},
+			}},
+		}
+		if !includeAssociation {
+			return cfg
+		}
+		cfg.SPIFFETrustDomains = []authserver.SPIFFETrustDomainRunConfig{{
+			Name: "production", TrustDomain: "example.org",
+			Methods: []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+			BundleSource: authserver.SPIFFEBundleSourceRunConfig{
+				Type:        authserver.SPIFFEBundleSourceTypeWorkloadAPI,
+				WorkloadAPI: &authserver.SPIFFEWorkloadAPIBundleSourceRunConfig{},
+			},
+		}}
+		cfg.InboundGrants = &authserver.InboundGrantsRunConfig{
+			SPIFFEClientAuth: []authserver.SPIFFEClientAuthRunConfig{{
+				TrustDomainRef:   "production",
+				PrincipalPattern: "spiffe://example.org/ns/default/agent",
+				ClientID:         "spiffe-client",
+				Methods:          []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+				Scopes:           []string{"openid"},
+				Audiences:        []string{"https://mcp.example.com"},
+				GrantTypes:       []string{authserver.SPIFFEGrantTypeTokenExchange},
+			}},
+		}
+		return cfg
+	}
+
+	firstStorage := newStorage()
+	require.NoError(t, firstStorage.RegisterClient(ctx, &fosite.DefaultClient{ID: "dynamic-client"}))
+	initial := config(true)
+	first, err := NewEmbeddedAuthServerWithStorage(ctx, &initial, firstStorage)
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	secondStorage := newStorage()
+	removed := config(false)
+	second, err := NewEmbeddedAuthServerWithStorage(ctx, &removed, secondStorage)
+	require.NoError(t, err)
+	_, err = secondStorage.GetClient(ctx, "dynamic-client")
+	require.NoError(t, err)
+	_, err = secondStorage.GetClient(ctx, "spiffe-client")
+	require.ErrorIs(t, err, storage.ErrNotFound)
+	require.NoError(t, second.Close())
+
+	collisionStorage := newStorage()
+	require.NoError(t, collisionStorage.RegisterClient(ctx, &fosite.DefaultClient{ID: "spiffe-client"}))
+	collision := config(true)
+	_, err = NewEmbeddedAuthServerWithStorage(ctx, &collision, collisionStorage)
+	require.ErrorIs(t, err, storage.ErrAlreadyExists)
+}

--- a/pkg/authserver/runner/embeddedauthserver_integration_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_integration_test.go
@@ -54,6 +54,11 @@ func TestIntegration_EmbeddedAuthServer_SPIFFERedisRestartAndCollision(t *testin
 			Addr: fmt.Sprintf("%s:%s", host, port.Port()),
 		}), "integration:spiffe:")
 	}
+	newStorageWithPrefix := func(prefix string) *storage.RedisStorage {
+		return storage.NewRedisStorageWithClient(redis.NewClient(&redis.Options{
+			Addr: fmt.Sprintf("%s:%s", host, port.Port()),
+		}), prefix)
+	}
 	config := func(includeAssociation bool) authserver.RunConfig {
 		cfg := authserver.RunConfig{
 			SchemaVersion:    authserver.CurrentSchemaVersion,
@@ -111,11 +116,25 @@ func TestIntegration_EmbeddedAuthServer_SPIFFERedisRestartAndCollision(t *testin
 	require.NoError(t, err)
 	_, err = secondStorage.GetClient(ctx, "dynamic-client")
 	require.NoError(t, err)
-	_, err = secondStorage.GetClient(ctx, "spiffe-client")
-	require.ErrorIs(t, err, storage.ErrNotFound)
+	// The static association is gone from the current config, but the earlier
+	// SPIFFE-enabled boot durably claimed "spiffe-client" in this same Redis
+	// keyspace to close the cross-replica registration race; that durable
+	// claim is not retracted just because a later boot's config no longer
+	// configures the association. The claim must remain unauthenticatable:
+	// no secret and not a public client, so it can never pass client
+	// authentication for any grant. (fosite.DefaultClient.GetGrantTypes
+	// applies its own single-grant default when the underlying field reads
+	// back empty from Redis, so "no grant types" is asserted directly
+	// against MemoryStorage in storage/spiffe_decorator_test.go instead.)
+	claimed, err := secondStorage.GetClient(ctx, "spiffe-client")
+	require.NoError(t, err, "the earlier durable claim for spiffe-client must persist")
+	require.Nil(t, claimed.GetHashedSecret())
+	require.False(t, claimed.IsPublic())
 	require.NoError(t, second.Close())
 
-	collisionStorage := newStorage()
+	// Isolated keyspace so this collision seed isn't itself rejected by the
+	// durable claim the earlier steps above left behind.
+	collisionStorage := newStorageWithPrefix("integration:spiffe-collision:")
 	require.NoError(t, collisionStorage.RegisterClient(ctx, &fosite.DefaultClient{ID: "spiffe-client"}))
 	collision := config(true)
 	_, err = NewEmbeddedAuthServerWithStorage(ctx, &collision, collisionStorage)

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -2248,13 +2248,30 @@ func TestEmbeddedAuthServer_SPIFFEAssociationDoesNotAuthenticateClient(t *testin
 	require.NoError(t, err)
 	_, err = redisStorage.GetClient(context.Background(), "dynamic-client")
 	require.NoError(t, err)
-	_, err = redisStorage.GetClient(context.Background(), "spiffe-client")
-	require.ErrorIs(t, err, storage.ErrNotFound)
+	// The static association is gone from the current config, but the earlier
+	// SPIFFE-enabled boot durably claimed "spiffe-client" to close the
+	// cross-replica registration race; that durable claim is not retracted
+	// just because a later boot's config no longer configures the
+	// association. The claim must remain structurally unauthenticatable: no
+	// secret and not a public client, so it can never pass client
+	// authentication for any grant. (fosite.DefaultClient.GetGrantTypes
+	// applies its own single-grant default when the underlying field reads
+	// back empty from Redis — see storedClientFingerprintsEqual in redis.go
+	// — so the "no grant types" property is asserted directly against
+	// MemoryStorage in storage/spiffe_decorator_test.go instead of here.)
+	claimed, err := redisStorage.GetClient(context.Background(), "spiffe-client")
+	require.NoError(t, err, "the earlier durable claim for spiffe-client must persist")
+	assert.Nil(t, claimed.GetHashedSecret())
+	assert.False(t, claimed.IsPublic())
 	require.NoError(t, embedded.Close())
 
 	// A durable row with a currently static ID is a startup collision, rather
-	// than authority that can be silently shadowed by configuration.
-	collisionStorage := newRedisStorage()
+	// than authority that can be silently shadowed by configuration. Uses an
+	// isolated Redis keyspace so the collision seed isn't itself rejected by
+	// the durable claim left behind by the earlier steps above.
+	collisionRedis := miniredis.RunT(t)
+	collisionStorage := storage.NewRedisStorageWithClient(
+		redis.NewClient(&redis.Options{Addr: collisionRedis.Addr()}), "test:spiffe-collision:")
 	require.NoError(t, collisionStorage.RegisterClient(context.Background(), &fosite.DefaultClient{ID: "spiffe-client"}))
 	_, err = NewEmbeddedAuthServerWithStorage(context.Background(), &initial, collisionStorage)
 	require.ErrorIs(t, err, storage.ErrAlreadyExists)

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -17,15 +17,21 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/ory/fosite"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/stacklok/toolhive/pkg/authserver"
 	servercrypto "github.com/stacklok/toolhive/pkg/authserver/server/crypto"
@@ -1702,7 +1708,558 @@ func newMockAuthorizationServer(t *testing.T) (*httptest.Server, *int32) {
 	return server, &total
 }
 
-// TestBuildUpstreamConfigs_DCR verifies the end-to-end DCR wiring inside
+func TestNewEmbeddedAuthServerWithStorage_RequiredInputs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config returns error without panic or cleanup", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := &closeTrackingStorage{Storage: storage.NewMemoryStorage()}
+		t.Cleanup(func() { require.NoError(t, tracker.Storage.Close()) })
+
+		server, err := NewEmbeddedAuthServerWithStorage(context.Background(), nil, tracker)
+		require.Nil(t, server)
+		require.EqualError(t, err, "config is required")
+		assert.Zero(t, tracker.closeCount.Load())
+	})
+
+	t.Run("nil storage returns error", func(t *testing.T) {
+		t.Parallel()
+
+		server, err := NewEmbeddedAuthServerWithStorage(context.Background(), &authserver.RunConfig{}, nil)
+		require.Nil(t, server)
+		require.EqualError(t, err, "storage is required")
+	})
+}
+
+// TestNewEmbeddedAuthServer_SPIFFEAndJWTBearerGrant ensures the two independent
+// inbound token-exchange configurations construct together through RunConfig.
+func TestNewEmbeddedAuthServer_SPIFFEAndJWTBearerGrant(t *testing.T) {
+	t.Parallel()
+	t.Skip("RunConfig.Validate() now hard-rejects any non-empty spiffe_trust_domains " +
+		"(config.go's validateSPIFFENotYetEnforced, per PR #6467 review) until a real " +
+		"SVID-verification consumer lands, so a server can no longer be constructed with " +
+		"a SPIFFE association configured at all -- there is no way to exercise this " +
+		"combination through NewEmbeddedAuthServer without routing around cfg.Validate() " +
+		"in production code. Re-enable this test -- unmodified -- when the future PR that " +
+		"adds real SVID verification removes the hard-reject.")
+
+	cfg := &authserver.RunConfig{
+		SchemaVersion:    authserver.CurrentSchemaVersion,
+		Issuer:           "https://auth.example.com",
+		ScopesSupported:  []string{"openid", "profile"},
+		AllowedAudiences: []string{"https://mcp.example.com"},
+		Upstreams: []authserver.UpstreamRunConfig{{
+			Name: "static-upstream",
+			Type: authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+				AuthorizationEndpoint: "https://upstream.example.com/authorize",
+				TokenEndpoint:         "https://upstream.example.com/token",
+				ClientID:              "test-client-id",
+				RedirectURI:           "https://auth.example.com/oauth/callback",
+			},
+		}},
+		SPIFFETrustDomains: []authserver.SPIFFETrustDomainRunConfig{{
+			Name:        "production",
+			TrustDomain: "example.org",
+			Methods:     []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+			BundleSource: authserver.SPIFFEBundleSourceRunConfig{
+				Type:        authserver.SPIFFEBundleSourceTypeWorkloadAPI,
+				WorkloadAPI: &authserver.SPIFFEWorkloadAPIBundleSourceRunConfig{},
+			},
+		}},
+		InboundGrants: &authserver.InboundGrantsRunConfig{
+			SPIFFEClientAuth: []authserver.SPIFFEClientAuthRunConfig{{
+				TrustDomainRef:   "production",
+				PrincipalPattern: "spiffe://example.org/ns/default/agent",
+				ClientID:         "spiffe-client",
+				Methods:          []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+				Scopes:           []string{"openid"},
+				Audiences:        []string{"https://mcp.example.com"},
+				GrantTypes:       []string{authserver.SPIFFEGrantTypeTokenExchange},
+			}},
+		},
+		TrustedIssuers: []tokenexchange.TrustedIssuer{{
+			IssuerURL: "https://issuer.example.com",
+			JWTBearerGrant: &tokenexchange.JWTBearerGrantPolicy{
+				MaxAssertionAge: "5m",
+				SubjectBindings: []tokenexchange.JWTBearerSubjectBinding{{
+					Subject:          "workload",
+					AllowedResources: []string{"https://mcp.example.com"},
+				}},
+			},
+		}},
+	}
+
+	srv, err := NewEmbeddedAuthServer(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+}
+
+// TestNewEmbeddedAuthServer_SPIFFEAndCIMD exercises the RunConfig conversion
+// and the production storage-decoration order with both features enabled.
+func TestNewEmbeddedAuthServer_SPIFFEAndCIMD(t *testing.T) {
+	t.Parallel()
+	t.Skip("RunConfig.Validate() now hard-rejects any non-empty spiffe_trust_domains " +
+		"(config.go's validateSPIFFENotYetEnforced, per PR #6467 review) until a real " +
+		"SVID-verification consumer lands, so a server can no longer be constructed with " +
+		"a SPIFFE association configured at all -- there is no way to exercise this " +
+		"combination through NewEmbeddedAuthServer without routing around cfg.Validate() " +
+		"in production code. Re-enable this test -- unmodified -- when the future PR that " +
+		"adds real SVID verification removes the hard-reject.")
+
+	cfg := &authserver.RunConfig{
+		SchemaVersion:    authserver.CurrentSchemaVersion,
+		Issuer:           "https://auth.example.com",
+		ScopesSupported:  []string{"openid", "profile"},
+		AllowedAudiences: []string{"https://mcp.example.com"},
+		CIMD: &authserver.CIMDRunConfig{
+			Enabled:          true,
+			CacheMaxSize:     16,
+			CacheFallbackTTL: "5m",
+		},
+		Upstreams: []authserver.UpstreamRunConfig{{
+			Name: "static-upstream",
+			Type: authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+				AuthorizationEndpoint: "https://upstream.example.com/authorize",
+				TokenEndpoint:         "https://upstream.example.com/token",
+				ClientID:              "test-client-id",
+				RedirectURI:           "https://auth.example.com/oauth/callback",
+			},
+		}},
+		SPIFFETrustDomains: []authserver.SPIFFETrustDomainRunConfig{{
+			Name:        "production",
+			TrustDomain: "example.org",
+			Methods:     []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+			BundleSource: authserver.SPIFFEBundleSourceRunConfig{
+				Type:        authserver.SPIFFEBundleSourceTypeWorkloadAPI,
+				WorkloadAPI: &authserver.SPIFFEWorkloadAPIBundleSourceRunConfig{},
+			},
+		}},
+		InboundGrants: &authserver.InboundGrantsRunConfig{
+			SPIFFEClientAuth: []authserver.SPIFFEClientAuthRunConfig{{
+				TrustDomainRef:   "production",
+				PrincipalPattern: "spiffe://example.org/ns/default/agent",
+				ClientID:         "spiffe-client",
+				Methods:          []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+				Scopes:           []string{"openid"},
+				Audiences:        []string{"https://mcp.example.com"},
+				GrantTypes:       []string{authserver.SPIFFEGrantTypeTokenExchange},
+			}},
+		},
+	}
+
+	srv, err := NewEmbeddedAuthServer(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srv.Close()) })
+}
+
+// TestNewEmbeddedAuthServerWithStorage_SPIFFECollisionPrecedesDCR verifies that
+// the deterministic static-ID collision gate runs before upstream DCR can issue
+// a registration request.
+func TestNewEmbeddedAuthServerWithStorage_SPIFFECollisionPrecedesDCR(t *testing.T) {
+	t.Parallel()
+	t.Skip("RunConfig.Validate() now hard-rejects any non-empty spiffe_trust_domains " +
+		"(config.go's validateSPIFFENotYetEnforced, per PR #6467 review) before " +
+		"construction ever reaches the SPIFFE storage decorator, so the collision-vs-DCR " +
+		"ordering this test proved is no longer observable through NewEmbeddedAuthServerWithStorage " +
+		"-- it now fails even earlier, for a different reason, without the ordering property " +
+		"itself being tested. Re-enable this test -- unmodified -- when the future PR that " +
+		"adds real SVID verification removes the hard-reject.")
+
+	upstreamServer, requestCount := newMockAuthorizationServer(t)
+	stor := storage.NewMemoryStorage()
+	require.NoError(t, stor.RegisterClient(context.Background(), &fosite.DefaultClient{ID: "spiffe-client"}))
+
+	cfg := &authserver.RunConfig{
+		SchemaVersion:     authserver.CurrentSchemaVersion,
+		Issuer:            upstreamServer.URL,
+		InsecureAllowHTTP: true,
+		ScopesSupported:   []string{"openid", "profile"},
+		AllowedAudiences:  []string{"https://mcp.example.com"},
+		SPIFFETrustDomains: []authserver.SPIFFETrustDomainRunConfig{{
+			Name:        "production",
+			TrustDomain: "example.org",
+			Methods:     []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+			BundleSource: authserver.SPIFFEBundleSourceRunConfig{
+				Type:        authserver.SPIFFEBundleSourceTypeWorkloadAPI,
+				WorkloadAPI: &authserver.SPIFFEWorkloadAPIBundleSourceRunConfig{},
+			},
+		}},
+		InboundGrants: &authserver.InboundGrantsRunConfig{
+			SPIFFEClientAuth: []authserver.SPIFFEClientAuthRunConfig{{
+				TrustDomainRef:   "production",
+				PrincipalPattern: "spiffe://example.org/ns/default/agent",
+				ClientID:         "spiffe-client",
+				Methods:          []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+				Scopes:           []string{"openid"},
+				Audiences:        []string{"https://mcp.example.com"},
+				GrantTypes:       []string{authserver.SPIFFEGrantTypeTokenExchange},
+			}},
+		},
+		Upstreams: []authserver.UpstreamRunConfig{{
+			Name: "dcr-upstream",
+			Type: authserver.UpstreamProviderTypeOAuth2,
+			OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+				AuthorizationEndpoint: upstreamServer.URL + "/authorize",
+				TokenEndpoint:         upstreamServer.URL + "/token",
+				Scopes:                []string{"openid", "profile"},
+				DCRConfig:             &authserver.DCRUpstreamConfig{DiscoveryURL: upstreamServer.URL + "/.well-known/oauth-authorization-server"},
+			},
+		}},
+	}
+
+	_, err := NewEmbeddedAuthServerWithStorage(context.Background(), cfg, stor)
+	require.ErrorIs(t, err, storage.ErrAlreadyExists)
+	assert.Zero(t, atomic.LoadInt32(requestCount), "static collision must precede DCR network I/O")
+}
+
+func TestEmbeddedAuthServer_SPIFFESerializedRestartPolicy(t *testing.T) {
+	t.Parallel()
+
+	newConfig := func(scope string, includeAssociation bool) authserver.RunConfig {
+		cfg := authserver.RunConfig{
+			SchemaVersion:    authserver.CurrentSchemaVersion,
+			Issuer:           "https://auth.example.com",
+			ScopesSupported:  []string{"openid", "profile"},
+			AllowedAudiences: []string{"https://mcp.example.com"},
+			// A static OAuth2 upstream satisfies runtime configuration validation
+			// without discovery or DCR network I/O during server construction.
+			Upstreams: []authserver.UpstreamRunConfig{{
+				Name: "static-upstream",
+				Type: authserver.UpstreamProviderTypeOAuth2,
+				OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+					AuthorizationEndpoint: "https://upstream.example.com/authorize",
+					TokenEndpoint:         "https://upstream.example.com/token",
+					ClientID:              "test-client-id",
+					RedirectURI:           "https://auth.example.com/oauth/callback",
+				},
+			}},
+		}
+		if !includeAssociation {
+			return cfg
+		}
+		cfg.SPIFFETrustDomains = []authserver.SPIFFETrustDomainRunConfig{{
+			Name:        "production",
+			TrustDomain: "example.org",
+			Methods:     []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+			BundleSource: authserver.SPIFFEBundleSourceRunConfig{
+				Type:        authserver.SPIFFEBundleSourceTypeWorkloadAPI,
+				WorkloadAPI: &authserver.SPIFFEWorkloadAPIBundleSourceRunConfig{},
+			},
+		}}
+		cfg.InboundGrants = &authserver.InboundGrantsRunConfig{
+			SPIFFEClientAuth: []authserver.SPIFFEClientAuthRunConfig{{
+				TrustDomainRef:   "production",
+				PrincipalPattern: "spiffe://example.org/ns/default/agent",
+				ClientID:         "spiffe-client",
+				Methods:          []authserver.SPIFFEAuthenticationMethod{authserver.SPIFFEAuthenticationMethodX509},
+				Scopes:           []string{scope},
+				Audiences:        []string{"https://mcp.example.com"},
+				GrantTypes:       []string{authserver.SPIFFEGrantTypeTokenExchange},
+			}},
+		}
+		return cfg
+	}
+	decode := func(t *testing.T, cfg authserver.RunConfig, yamlFormat bool) authserver.RunConfig {
+		t.Helper()
+		var encoded []byte
+		var err error
+		if yamlFormat {
+			encoded, err = yaml.Marshal(cfg)
+		} else {
+			encoded, err = json.Marshal(cfg)
+		}
+		require.NoError(t, err)
+
+		var decoded authserver.RunConfig
+		if yamlFormat {
+			err = yaml.Unmarshal(encoded, &decoded)
+		} else {
+			err = json.Unmarshal(encoded, &decoded)
+		}
+		require.NoError(t, err)
+		return decoded
+	}
+	assertAuthority := func(t *testing.T, cfg authserver.RunConfig, scope string) {
+		t.Helper()
+		trust, err := authserver.NewSPIFFETrustConfig(
+			cfg.SPIFFETrustDomains, cfg.InboundGrants, cfg.ScopesSupported, cfg.AllowedAudiences,
+		)
+		require.NoError(t, err)
+		associations := trust.Associations()
+		require.Len(t, associations, 1)
+		assert.Equal(t, []string{scope}, associations[0].AuthorizationPolicy().Scopes())
+	}
+
+	for _, yamlFormat := range []bool{false, true} {
+		yamlFormat := yamlFormat
+		format := "JSON"
+		if yamlFormat {
+			format = "YAML"
+		}
+		t.Run(format, func(t *testing.T) {
+			t.Parallel()
+
+			// A non-empty spiffe_trust_domains is hard-rejected by
+			// RunConfig.Validate() until a real SVID-verification consumer
+			// lands (see config.go's validateSPIFFENotYetEnforced), so the
+			// "initial"/"changed" cases below prove serialization fidelity
+			// and authority reconstruction directly against
+			// NewSPIFFETrustConfig -- unaffected by that policy-layer
+			// rejection -- and separately confirm the rejection itself
+			// survives a JSON/YAML round trip, rather than constructing a
+			// full server.
+			initial := decode(t, newConfig("openid", true), yamlFormat)
+			assertAuthority(t, initial, "openid")
+			require.ErrorContains(t, initial.Validate(), "not yet enforced",
+				"a decoded non-empty SPIFFE configuration must still be hard-rejected")
+
+			changed := decode(t, newConfig("profile", true), yamlFormat)
+			assertAuthority(t, changed, "profile")
+			require.ErrorContains(t, changed.Validate(), "not yet enforced",
+				"a decoded non-empty SPIFFE configuration must still be hard-rejected")
+
+			removed := decode(t, newConfig("", false), yamlFormat)
+			trust, err := authserver.NewSPIFFETrustConfig(
+				removed.SPIFFETrustDomains, nil, removed.ScopesSupported, removed.AllowedAudiences,
+			)
+			require.NoError(t, err)
+			assert.Empty(t, trust.Associations())
+			registry, err := authserver.NewSPIFFEAssociationRegistry(trust)
+			require.NoError(t, err)
+			require.NotNil(t, registry)
+			// Every restart uses fresh memory; an empty (SPIFFE-removed)
+			// configuration is the only shape in this test that can still
+			// build a full server, since it does not trip the hard-reject.
+			for range 2 {
+				stor := storage.NewMemoryStorage()
+				server, err := NewEmbeddedAuthServerWithStorage(context.Background(), &removed, stor)
+				require.NoError(t, err)
+				require.NoError(t, server.Close())
+			}
+		})
+	}
+}
+
+// sessionRecordingStorage observes token-session writes without adding a test
+// hook to production storage. It embeds the real memory backend so every
+// unoverridden storage operation retains its production behavior.
+type sessionRecordingStorage struct {
+	*storage.MemoryStorage
+	authorizeCodeSessions atomic.Int32
+	accessTokenSessions   atomic.Int32
+	refreshTokenSessions  atomic.Int32
+}
+
+func (s *sessionRecordingStorage) CreateAuthorizeCodeSession(ctx context.Context, code string, request fosite.Requester) error {
+	s.authorizeCodeSessions.Add(1)
+	return s.MemoryStorage.CreateAuthorizeCodeSession(ctx, code, request)
+}
+
+func (s *sessionRecordingStorage) CreateAccessTokenSession(ctx context.Context, signature string, request fosite.Requester) error {
+	s.accessTokenSessions.Add(1)
+	return s.MemoryStorage.CreateAccessTokenSession(ctx, signature, request)
+}
+
+func (s *sessionRecordingStorage) CreateRefreshTokenSession(
+	ctx context.Context,
+	signature string,
+	accessSignature string,
+	request fosite.Requester,
+) error {
+	s.refreshTokenSessions.Add(1)
+	return s.MemoryStorage.CreateRefreshTokenSession(ctx, signature, accessSignature, request)
+}
+
+func TestEmbeddedAuthServer_SPIFFEAssociationDoesNotAuthenticateClient(t *testing.T) {
+	t.Parallel()
+	t.Skip("RunConfig.Validate() now hard-rejects any non-empty spiffe_trust_domains " +
+		"(config.go's validateSPIFFENotYetEnforced, per PR #6467 review) until a real " +
+		"SVID-verification consumer lands, so a live server can no longer be constructed " +
+		"with a SPIFFE association configured at all -- there is no path to this HTTP-level " +
+		"proof that does not route around cfg.Validate() in production code, which would " +
+		"reopen exactly the loophole that hard-reject exists to close. The underlying " +
+		"mechanism this test proved end-to-end (a SPIFFE client carries no secret and is " +
+		"never public, so fosite's own credential checks reject it, spoofed X-SPIFFE-ID " +
+		"header or not) is still covered at the unit level by " +
+		"registration.TestNewSPIFFEClient (GetHashedSecret is nil, IsPublic is false). " +
+		"Re-enable this test -- unmodified -- when the future PR that adds real SVID " +
+		"verification removes the hard-reject.")
+
+	newConfig := func(scope string, includeAssociation bool) authserver.RunConfig {
+		cfg := authserver.RunConfig{
+			SchemaVersion:    authserver.CurrentSchemaVersion,
+			Issuer:           "https://auth.example.com",
+			ScopesSupported:  []string{"openid", "profile"},
+			AllowedAudiences: []string{"https://mcp.example.com"},
+			Upstreams: []authserver.UpstreamRunConfig{{
+				Name: "static-upstream",
+				Type: authserver.UpstreamProviderTypeOAuth2,
+				OAuth2Config: &authserver.OAuth2UpstreamRunConfig{
+					AuthorizationEndpoint: "https://upstream.example.com/authorize",
+					TokenEndpoint:         "https://upstream.example.com/token",
+					ClientID:              "upstream-client",
+					RedirectURI:           "https://auth.example.com/oauth/callback",
+				},
+			}},
+		}
+		if !includeAssociation {
+			return cfg
+		}
+		cfg.SPIFFETrustDomains = []authserver.SPIFFETrustDomainRunConfig{{
+			Name:        "production",
+			TrustDomain: "example.org",
+			Methods: []authserver.SPIFFEAuthenticationMethod{
+				authserver.SPIFFEAuthenticationMethodX509,
+				authserver.SPIFFEAuthenticationMethodJWT,
+			},
+			BundleSource: authserver.SPIFFEBundleSourceRunConfig{
+				Type:        authserver.SPIFFEBundleSourceTypeWorkloadAPI,
+				WorkloadAPI: &authserver.SPIFFEWorkloadAPIBundleSourceRunConfig{},
+			},
+		}}
+		cfg.InboundGrants = &authserver.InboundGrantsRunConfig{
+			SPIFFEClientAuth: []authserver.SPIFFEClientAuthRunConfig{{
+				TrustDomainRef:   "production",
+				PrincipalPattern: "spiffe://example.org/ns/default/agent",
+				ClientID:         "spiffe-client",
+				Methods: []authserver.SPIFFEAuthenticationMethod{
+					authserver.SPIFFEAuthenticationMethodX509,
+					authserver.SPIFFEAuthenticationMethodJWT,
+				},
+				Scopes:     []string{scope},
+				Audiences:  []string{"https://mcp.example.com"},
+				GrantTypes: []string{authserver.SPIFFEGrantTypeTokenExchange},
+			}},
+		}
+		return cfg
+	}
+	serialize := func(t *testing.T, cfg authserver.RunConfig) authserver.RunConfig {
+		t.Helper()
+		encoded, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		var decoded authserver.RunConfig
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		require.NoError(t, decoded.Validate())
+		return decoded
+	}
+	assertStaticAuthority := func(t *testing.T, cfg authserver.RunConfig, scope string) {
+		t.Helper()
+		trust, err := authserver.NewSPIFFETrustConfig(
+			cfg.SPIFFETrustDomains, cfg.InboundGrants, cfg.ScopesSupported, cfg.AllowedAudiences,
+		)
+		require.NoError(t, err)
+		associations := trust.Associations()
+		require.Len(t, associations, 1)
+		association := associations[0]
+		assert.Equal(t, "spiffe-client", association.ClientID())
+		policy := association.AuthorizationPolicy()
+		assert.Equal(t, []string{scope}, policy.Scopes())
+		assert.Equal(t, []string{"https://mcp.example.com"}, policy.Audiences())
+	}
+
+	newServer := func(t *testing.T, cfg authserver.RunConfig) (*sessionRecordingStorage, *httptest.Server) {
+		t.Helper()
+		stor := &sessionRecordingStorage{MemoryStorage: storage.NewMemoryStorage()}
+		embedded, err := NewEmbeddedAuthServerWithStorage(context.Background(), &cfg, stor)
+		require.NoError(t, err)
+		httpServer := httptest.NewServer(embedded.Handler())
+		t.Cleanup(func() {
+			httpServer.Close()
+			require.NoError(t, embedded.Close())
+		})
+		return stor, httpServer
+	}
+	assertUnauthenticated := func(t *testing.T, serverURL string, stor *sessionRecordingStorage, spoofedHeader bool) {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, serverURL+"/oauth/token", strings.NewReader(url.Values{
+			"grant_type":         {authserver.SPIFFEGrantTypeTokenExchange},
+			"subject_token":      {"unvalidated-subject-token"},
+			"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
+			"client_id":          {"spiffe-client"},
+			"scope":              {"openid"},
+			"resource":           {"https://mcp.example.com"},
+		}.Encode()))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if spoofedHeader {
+			req.Header.Set("X-SPIFFE-ID", "spiffe://example.org/ns/default/agent")
+		}
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, "invalid_client", body["error"])
+		assert.NotContains(t, body, "access_token")
+		assert.NotContains(t, body, "refresh_token")
+		assert.NotContains(t, body, "id_token")
+		assert.Zero(t, stor.authorizeCodeSessions.Load())
+		assert.Zero(t, stor.accessTokenSessions.Load())
+		assert.Zero(t, stor.refreshTokenSessions.Load())
+	}
+
+	initial := serialize(t, newConfig("openid", true))
+	assertStaticAuthority(t, initial, "openid")
+	stor, httpServer := newServer(t, initial)
+	assertUnauthenticated(t, httpServer.URL, stor, false)
+	assertUnauthenticated(t, httpServer.URL, stor, true)
+
+	// A fresh-memory restart reconstructs the static association from the same
+	// serialized operator-equivalent configuration and still does not authenticate it.
+	restarted := serialize(t, initial)
+	stor, httpServer = newServer(t, restarted)
+	assertStaticAuthority(t, restarted, "openid")
+	assertUnauthenticated(t, httpServer.URL, stor, true)
+
+	changed := serialize(t, newConfig("profile", true))
+	_, _ = newServer(t, changed)
+	assertStaticAuthority(t, changed, "profile")
+
+	removed := serialize(t, newConfig("", false))
+	_, _ = newServer(t, removed)
+	trust, err := authserver.NewSPIFFETrustConfig(
+		removed.SPIFFETrustDomains, nil, removed.ScopesSupported, removed.AllowedAudiences,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, trust.Associations())
+	registry, err := authserver.NewSPIFFEAssociationRegistry(trust)
+	require.NoError(t, err)
+	require.NotNil(t, registry)
+
+	// Redis restarts retain dynamic registrations but reconstruct static authority
+	// exclusively from the current serialized configuration.
+	redisServer := miniredis.RunT(t)
+	newRedisStorage := func() storage.Storage {
+		client := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+		return storage.NewRedisStorageWithClient(client, "test:spiffe:")
+	}
+	redisStorage := newRedisStorage()
+	require.NoError(t, redisStorage.RegisterClient(context.Background(), &fosite.DefaultClient{ID: "dynamic-client"}))
+	embedded, err := NewEmbeddedAuthServerWithStorage(context.Background(), &initial, redisStorage)
+	require.NoError(t, err)
+	require.NoError(t, embedded.Close())
+
+	redisStorage = newRedisStorage()
+	embedded, err = NewEmbeddedAuthServerWithStorage(context.Background(), &removed, redisStorage)
+	require.NoError(t, err)
+	_, err = redisStorage.GetClient(context.Background(), "dynamic-client")
+	require.NoError(t, err)
+	_, err = redisStorage.GetClient(context.Background(), "spiffe-client")
+	require.ErrorIs(t, err, storage.ErrNotFound)
+	require.NoError(t, embedded.Close())
+
+	// A durable row with a currently static ID is a startup collision, rather
+	// than authority that can be silently shadowed by configuration.
+	collisionStorage := newRedisStorage()
+	require.NoError(t, collisionStorage.RegisterClient(context.Background(), &fosite.DefaultClient{ID: "spiffe-client"}))
+	_, err = NewEmbeddedAuthServerWithStorage(context.Background(), &initial, collisionStorage)
+	require.ErrorIs(t, err, storage.ErrAlreadyExists)
+}
+
 // buildUpstreamConfigs: on first call it registers with the mock AS and
 // overlays the resolved client_id/client_secret; on second call it hits the
 // in-memory store and issues zero additional HTTP requests; and neither call

--- a/pkg/authserver/server/handlers/authorize.go
+++ b/pkg/authserver/server/handlers/authorize.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
 	"github.com/stacklok/toolhive/pkg/authserver/storage"
 	"github.com/stacklok/toolhive/pkg/authserver/upstream"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 // upstreamAuthSecrets holds cryptographic values needed for upstream IDP authorization.
@@ -47,6 +48,14 @@ func newUpstreamAuthSecrets() *upstreamAuthSecrets {
 // It validates the client's authorization request and redirects to the upstream IDP.
 func (h *Handler) AuthorizeHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+
+	// Back-channel-only clients must be indistinguishable from unknown clients
+	// at this unauthenticated endpoint. This runs before redirect URI matching
+	// (including the loopback matcher below), which would otherwise expose that
+	// the client is configured through an invalid_request response.
+	if h.rejectBackChannelOnlyAuthorizeClient(ctx, w, req) {
+		return
+	}
 
 	// See rewriteLoopbackRedirectURI's doc comment for what this does and why.
 	rewrittenFrom := h.rewriteLoopbackRedirectURI(ctx, req)
@@ -142,6 +151,38 @@ func (h *Handler) AuthorizeHandler(w http.ResponseWriter, req *http.Request) {
 
 	// Redirect user to upstream IDP
 	http.Redirect(w, req, upstreamURL, http.StatusFound)
+}
+
+// rejectBackChannelOnlyAuthorizeClient rejects a configured client that has no
+// authorization response types before fosite validates redirect_uri. It returns
+// false for unknown clients so fosite retains responsibility for its normal
+// client lookup and error handling.
+func (h *Handler) rejectBackChannelOnlyAuthorizeClient(ctx context.Context, w http.ResponseWriter, req *http.Request) bool {
+	if err := req.ParseForm(); err != nil {
+		return false
+	}
+	clientID := req.Form.Get("client_id")
+	if clientID == "" {
+		return false
+	}
+	client, err := h.storage.GetClient(ctx, clientID)
+	if err != nil || client == nil || !isBackChannelOnlyClient(client) {
+		return false
+	}
+	authorizeRequest := fosite.NewAuthorizeRequest()
+	authorizeRequest.Client = client
+	h.provider.WriteAuthorizeError(
+		ctx,
+		w,
+		authorizeRequest,
+		fosite.ErrInvalidClient.WithHint("The requested OAuth 2.0 Client does not exist."),
+	)
+	return true
+}
+
+func isBackChannelOnlyClient(client fosite.Client) bool {
+	return len(client.GetResponseTypes()) == 0 ||
+		client.GetGrantTypes().ExactOne(oauthproto.GrantTypeTokenExchange)
 }
 
 // loopbackAuthorizeRequester wraps a fosite.AuthorizeRequester to make the

--- a/pkg/authserver/server/handlers/authorize.go
+++ b/pkg/authserver/server/handlers/authorize.go
@@ -180,8 +180,17 @@ func (h *Handler) rejectBackChannelOnlyAuthorizeClient(ctx context.Context, w ht
 	return true
 }
 
+// isBackChannelOnlyClient reports whether client has no interactive
+// /authorize flow. It checks the explicit registration.BackChannelOnly
+// marker first -- the authoritative answer for client types that carry it
+// (registration.SPIFFEClient and the SPIFFE storage decorator's durable
+// placeholder) -- and falls back to the pre-existing metadata-shape
+// inference (empty response types, or grant types exactly
+// token-exchange) for every other client type, such as a delegate client,
+// so their current /authorize-hiding behaviour is unchanged.
 func isBackChannelOnlyClient(client fosite.Client) bool {
-	return len(client.GetResponseTypes()) == 0 ||
+	return registration.BackChannelOnly(client) ||
+		len(client.GetResponseTypes()) == 0 ||
 		client.GetGrantTypes().ExactOne(oauthproto.GrantTypeTokenExchange)
 }
 

--- a/pkg/authserver/server/handlers/authorize_test.go
+++ b/pkg/authserver/server/handlers/authorize_test.go
@@ -4,6 +4,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/ory/fosite"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
@@ -19,6 +22,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/authserver/server"
 	servercrypto "github.com/stacklok/toolhive/pkg/authserver/server/crypto"
 	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
+	"github.com/stacklok/toolhive/pkg/authserver/storage"
 	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
@@ -70,6 +74,100 @@ func TestAuthorizeHandler_ClientNotFound(t *testing.T) {
 	// fosite returns 401 with invalid_client for unknown clients
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Contains(t, rec.Body.String(), "invalid_client")
+}
+
+func TestAuthorizeHandler_BackChannelOnlyClientsMatchMissingClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		client func(t *testing.T) fosite.Client
+	}{
+		{
+			name: "SPIFFE client",
+			client: func(t *testing.T) fosite.Client {
+				t.Helper()
+				client, err := registration.NewSPIFFEClient(
+					"spiffe-client",
+					[]string{"openid"},
+					[]string{"https://mcp.example.com"},
+				)
+				require.NoError(t, err)
+				return client
+			},
+		},
+		{
+			name: "delegate client",
+			client: func(t *testing.T) fosite.Client {
+				t.Helper()
+				client, err := registration.NewStaticDelegateClient(registration.Config{
+					ID:         "delegate-client",
+					Secret:     "test-secret",
+					GrantTypes: []string{"urn:ietf:params:oauth:grant-type:token-exchange"},
+					Scopes:     []string{"openid"},
+					Audience:   []string{"https://mcp.example.com"},
+				})
+				require.NoError(t, err)
+				return client
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, state, _ := handlerTestSetup(t)
+			client := tt.client(t)
+			state.clients[client.GetID()] = client
+
+			missing := httptest.NewRecorder()
+			handler.AuthorizeHandler(missing, httptest.NewRequest(http.MethodGet,
+				"/oauth/authorize?client_id=missing-client&redirect_uri=https://invalid.example/callback", nil))
+
+			configured := httptest.NewRecorder()
+			handler.AuthorizeHandler(configured, httptest.NewRequest(http.MethodGet,
+				"/oauth/authorize?client_id="+client.GetID()+"&redirect_uri=https://invalid.example/callback", nil))
+
+			require.Equal(t, http.StatusUnauthorized, configured.Code)
+			assert.Equal(t, missing.Code, configured.Code)
+			assert.Equal(t, missing.Body.String(), configured.Body.String())
+			assert.Contains(t, configured.Body.String(), "invalid_client")
+		})
+	}
+}
+
+func TestAuthorizeHandler_RedisLoadedDelegateClientMatchesMissingClient(t *testing.T) {
+	t.Parallel()
+
+	handler, _, _ := handlerTestSetup(t)
+	mr := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	stor := storage.NewRedisStorageWithClient(redisClient, "test:authorize:")
+	t.Cleanup(func() { _ = stor.Close() })
+
+	client, err := registration.NewStaticDelegateClient(registration.Config{
+		ID:         "delegate-client",
+		Secret:     "test-secret",
+		GrantTypes: []string{oauthproto.GrantTypeTokenExchange},
+		Scopes:     []string{"openid"},
+		Audience:   []string{"https://mcp.example.com"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, stor.RegisterClient(context.Background(), client))
+	handler.storage = stor
+
+	missing := httptest.NewRecorder()
+	handler.AuthorizeHandler(missing, httptest.NewRequest(http.MethodGet,
+		"/oauth/authorize?client_id=missing-client&redirect_uri=https://invalid.example/callback", nil))
+
+	configured := httptest.NewRecorder()
+	handler.AuthorizeHandler(configured, httptest.NewRequest(http.MethodGet,
+		"/oauth/authorize?client_id=delegate-client&redirect_uri=https://invalid.example/callback", nil))
+
+	require.Equal(t, http.StatusUnauthorized, configured.Code)
+	assert.Equal(t, missing.Code, configured.Code)
+	assert.Equal(t, missing.Body.String(), configured.Body.String())
+	assert.Contains(t, configured.Body.String(), "invalid_client")
 }
 
 func TestAuthorizeHandler_InvalidRedirectURI(t *testing.T) {

--- a/pkg/authserver/server/handlers/authorize_test.go
+++ b/pkg/authserver/server/handlers/authorize_test.go
@@ -80,8 +80,9 @@ func TestAuthorizeHandler_BackChannelOnlyClientsMatchMissingClient(t *testing.T)
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		client func(t *testing.T) fosite.Client
+		name           string
+		client         func(t *testing.T) fosite.Client
+		explicitMarker bool
 	}{
 		{
 			name: "SPIFFE client",
@@ -95,6 +96,7 @@ func TestAuthorizeHandler_BackChannelOnlyClientsMatchMissingClient(t *testing.T)
 				require.NoError(t, err)
 				return client
 			},
+			explicitMarker: true,
 		},
 		{
 			name: "delegate client",
@@ -110,6 +112,11 @@ func TestAuthorizeHandler_BackChannelOnlyClientsMatchMissingClient(t *testing.T)
 				require.NoError(t, err)
 				return client
 			},
+			// A delegate client is rejected via the pre-existing metadata-shape
+			// inference (isBackChannelOnlyClient's fallback), not the explicit
+			// registration.BackChannelOnly marker -- delegate clients are out of
+			// scope for that marker and must keep their current behaviour.
+			explicitMarker: false,
 		},
 	}
 
@@ -119,6 +126,12 @@ func TestAuthorizeHandler_BackChannelOnlyClientsMatchMissingClient(t *testing.T)
 			handler, state, _ := handlerTestSetup(t)
 			client := tt.client(t)
 			state.clients[client.GetID()] = client
+
+			// Prove classification for this client type is directional: the
+			// explicit marker is set (SPIFFE) or is not (delegate), rather than
+			// both client types happening to reach the same /authorize outcome
+			// via the same mechanism.
+			assert.Equal(t, tt.explicitMarker, registration.BackChannelOnly(client))
 
 			missing := httptest.NewRecorder()
 			handler.AuthorizeHandler(missing, httptest.NewRequest(http.MethodGet,

--- a/pkg/authserver/server/registration/client.go
+++ b/pkg/authserver/server/registration/client.go
@@ -200,6 +200,32 @@ type dcrIssuedMarker struct{}
 
 func (dcrIssuedMarker) dcrIssued() {}
 
+// backChannelOnly marks a client with no interactive /authorize flow -- it
+// must never be resolvable there, regardless of what its response types or
+// grant types happen to look like. Explicit, not inferred, so a future
+// client class does not get silently hidden from /authorize just because it
+// happens to share metadata shape with a back-channel-only client.
+type backChannelOnly interface {
+	backChannelOnly()
+}
+
+// BackChannelOnly reports whether client is explicitly marked as having no
+// interactive /authorize flow.
+func BackChannelOnly(client fosite.Client) bool {
+	_, ok := client.(backChannelOnly)
+	return ok
+}
+
+// BackChannelOnlyMarker is embedded anonymously by a client type -- in this
+// package or any other -- to mark it as never resolvable at /authorize. The
+// backChannelOnly method it carries is unexported, but Go resolves interface
+// satisfaction for a promoted method by the method's defining package, not
+// the embedder's, so embedding this exported struct is sufficient for the
+// embedding type to satisfy the unexported backChannelOnly interface above.
+type BackChannelOnlyMarker struct{}
+
+func (BackChannelOnlyMarker) backChannelOnly() {}
+
 // publicClient is the DCR-issued public client shape: an OIDC client (so the
 // "none" method is recorded and enforced). RFC 8252 Section 7.3 loopback
 // dynamic-port matching for native apps is provided separately by

--- a/pkg/authserver/server/registration/spiffe_client.go
+++ b/pkg/authserver/server/registration/spiffe_client.go
@@ -18,6 +18,7 @@ import (
 // credentials; this configuration-only implementation does not authenticate
 // any credentials.
 type SPIFFEClient struct {
+	BackChannelOnlyMarker
 	id         string
 	grantTypes fosite.Arguments
 	scopes     fosite.Arguments

--- a/pkg/authserver/server/registration/spiffe_client.go
+++ b/pkg/authserver/server/registration/spiffe_client.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registration
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/ory/fosite"
+
+	"github.com/stacklok/toolhive/pkg/oauthproto"
+)
+
+// SPIFFEClient is the immutable OAuth client representation of a configured
+// SPIFFE principal association. It is neither public nor secret-bearing. A
+// future credential-validation implementation will authenticate its SPIFFE
+// credentials; this configuration-only implementation does not authenticate
+// any credentials.
+type SPIFFEClient struct {
+	id         string
+	grantTypes fosite.Arguments
+	scopes     fosite.Arguments
+	audiences  []string
+}
+
+// NewSPIFFEClient creates an immutable, secretless, non-public client for a
+// configured SPIFFE association. GetAudience returns the configured allowlist;
+// token exchange checks both audience and resource request parameters against it.
+func NewSPIFFEClient(id string, scopes, audiences []string) (*SPIFFEClient, error) {
+	if id == "" {
+		return nil, fmt.Errorf("SPIFFE client ID is required")
+	}
+	if len(scopes) == 0 || len(audiences) == 0 {
+		return nil, fmt.Errorf("SPIFFE client scopes and audiences are required")
+	}
+
+	return &SPIFFEClient{
+		id:         id,
+		grantTypes: fosite.Arguments{oauthproto.GrantTypeTokenExchange},
+		scopes:     slices.Clone(scopes),
+		audiences:  slices.Clone(audiences),
+	}, nil
+}
+
+// GetID returns the configured association client ID.
+func (c *SPIFFEClient) GetID() string { return c.id }
+
+// GetHashedSecret returns nil because no OAuth client secret is assigned. Future
+// SPIFFE credential validation is outside this configuration-only implementation.
+func (*SPIFFEClient) GetHashedSecret() []byte { return nil }
+
+// GetRedirectURIs returns nil because SPIFFE clients do not use authorization redirects.
+func (*SPIFFEClient) GetRedirectURIs() []string { return nil }
+
+// GetGrantTypes returns a copy of the configured grant types.
+func (c *SPIFFEClient) GetGrantTypes() fosite.Arguments { return slices.Clone(c.grantTypes) }
+
+// GetResponseTypes returns nil because SPIFFE clients do not use authorization responses.
+func (*SPIFFEClient) GetResponseTypes() fosite.Arguments { return nil }
+
+// GetScopes returns a copy of the configured scopes.
+func (c *SPIFFEClient) GetScopes() fosite.Arguments { return slices.Clone(c.scopes) }
+
+// Audiences returns a copy of the allowed token-exchange target identifiers.
+func (c *SPIFFEClient) Audiences() []string { return slices.Clone(c.audiences) }
+
+// GetAudience returns the allowed token-exchange target identifiers. The token
+// exchange handler checks both the RFC 8693 audience and RFC 8707 resource
+// request parameters against this Fosite client field.
+func (c *SPIFFEClient) GetAudience() fosite.Arguments { return slices.Clone(c.audiences) }
+
+// IsPublic returns false so Fosite does not treat unauthenticated requests as
+// public-client requests. Future SPIFFE credential validation remains separate.
+func (*SPIFFEClient) IsPublic() bool { return false }
+
+var _ fosite.Client = (*SPIFFEClient)(nil)

--- a/pkg/authserver/server/registration/spiffe_client_test.go
+++ b/pkg/authserver/server/registration/spiffe_client_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSPIFFEClient(t *testing.T) {
+	t.Parallel()
+
+	scopes := []string{"openid"}
+	audiences := []string{"https://api.example.com"}
+	client, err := NewSPIFFEClient("spiffe-client", scopes, audiences)
+	require.NoError(t, err)
+
+	scopes[0] = "changed"
+	audiences[0] = "changed"
+
+	assert.Equal(t, "spiffe-client", client.GetID())
+	assert.Nil(t, client.GetHashedSecret())
+	assert.Nil(t, client.GetRedirectURIs())
+	assert.Nil(t, client.GetResponseTypes())
+	assert.False(t, client.IsPublic())
+	assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", client.GetGrantTypes()[0])
+	assert.Equal(t, "openid", client.GetScopes()[0])
+	assert.Equal(t, []string{"https://api.example.com"}, client.Audiences())
+	assert.Equal(t, []string{"https://api.example.com"}, []string(client.GetAudience()))
+
+	client.GetScopes()[0] = "mutated"
+	client.Audiences()[0] = "mutated"
+	client.GetAudience()[0] = "mutated"
+	assert.Equal(t, "openid", client.GetScopes()[0])
+	assert.Equal(t, []string{"https://api.example.com"}, client.Audiences())
+	assert.Equal(t, []string{"https://api.example.com"}, []string(client.GetAudience()))
+
+	_, err = NewSPIFFEClient("disabled-exchange", nil, nil)
+	require.Error(t, err)
+}
+
+func TestNewSPIFFEClient_RequiresID(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSPIFFEClient("", nil, nil)
+	require.Error(t, err)
+}
+
+func TestNewSPIFFEClient_RequiresAudiences(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSPIFFEClient(
+		"spiffe-client",
+		[]string{"openid"},
+		nil,
+	)
+	require.EqualError(t, err, "SPIFFE client scopes and audiences are required")
+}

--- a/pkg/authserver/server/tokenexchange/jwt_bearer_handler.go
+++ b/pkg/authserver/server/tokenexchange/jwt_bearer_handler.go
@@ -443,17 +443,21 @@ func JWTBearerIssuanceFactory(trustedIssuers []TrustedIssuer, shared *MultiIssue
 	}, nil
 }
 
+// assertionJWTConsumer resolves rawStorage's AssertionJWTConsumer capability.
+// Every decorator in the actual composition chain must itself implement (and
+// forward, one level down) AssertionJWTConsumer for this to succeed -- there
+// is no automatic bypass via storage.Unwrap. That is deliberate: a decorator
+// that sits between rawStorage and the innermost backend gets an explicit,
+// visible opportunity to intercept or audit assertion-JWT consumption, rather
+// than being silently skipped past. See CIMDStorageDecorator.ConsumeAssertionJWT
+// and SPIFFEStorageDecorator.ConsumeAssertionJWT for the two production
+// decorators that forward it today. A future decorator that omits this method
+// breaks visibly, right here, with an error naming the offending type -- not
+// silently, by having its ConsumeAssertionJWT logic (if any) never run.
 func assertionJWTConsumer(rawStorage fosite.Storage) (storage.AssertionJWTConsumer, error) {
-	baseStorage := rawStorage
-	// Peel every storage decorator, not just one: the SPIFFE static-client
-	// overlay wraps the CIMD decorator, and AssertionJWTConsumer is not part
-	// of storage.Storage, so it is not promoted through an embedded decorator.
-	if stor, ok := rawStorage.(storage.Storage); ok {
-		baseStorage = storage.Unwrap(stor)
-	}
-	consumer, ok := baseStorage.(storage.AssertionJWTConsumer)
+	consumer, ok := rawStorage.(storage.AssertionJWTConsumer)
 	if !ok {
-		return nil, fmt.Errorf("JWT-bearer storage %T does not implement storage.AssertionJWTConsumer", baseStorage)
+		return nil, fmt.Errorf("JWT-bearer storage %T does not implement storage.AssertionJWTConsumer", rawStorage)
 	}
 	return consumer, nil
 }

--- a/pkg/authserver/server/tokenexchange/jwt_bearer_handler.go
+++ b/pkg/authserver/server/tokenexchange/jwt_bearer_handler.go
@@ -445,8 +445,11 @@ func JWTBearerIssuanceFactory(trustedIssuers []TrustedIssuer, shared *MultiIssue
 
 func assertionJWTConsumer(rawStorage fosite.Storage) (storage.AssertionJWTConsumer, error) {
 	baseStorage := rawStorage
-	if decorated, ok := rawStorage.(*storage.CIMDStorageDecorator); ok {
-		baseStorage = decorated.Unwrap()
+	// Peel every storage decorator, not just one: the SPIFFE static-client
+	// overlay wraps the CIMD decorator, and AssertionJWTConsumer is not part
+	// of storage.Storage, so it is not promoted through an embedded decorator.
+	if stor, ok := rawStorage.(storage.Storage); ok {
+		baseStorage = storage.Unwrap(stor)
 	}
 	consumer, ok := baseStorage.(storage.AssertionJWTConsumer)
 	if !ok {

--- a/pkg/authserver/server/tokenexchange/jwt_bearer_handler_test.go
+++ b/pkg/authserver/server/tokenexchange/jwt_bearer_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/toolhive/pkg/authserver/server"
+	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
 	"github.com/stacklok/toolhive/pkg/authserver/server/session"
 	"github.com/stacklok/toolhive/pkg/authserver/storage"
 	"github.com/stacklok/toolhive/pkg/oauthproto"
@@ -381,23 +382,46 @@ func (assertionConsumerStorage) ConsumeAssertionJWT(context.Context, string, str
 	return nil
 }
 
-func TestAssertionJWTConsumer_UnwrapsCIMDAtConstruction(t *testing.T) {
+func TestAssertionJWTConsumer(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name    string
-		base    storage.Storage
+		build   func(t *testing.T) fosite.Storage
 		wantErr string
 	}{
-		{name: "unsupported backend fails", base: storageWithoutAssertionConsumer{}, wantErr: "does not implement"},
-		{name: "supported backend succeeds", base: assertionConsumerStorage{}},
+		{
+			name:    "bare storage without the capability fails",
+			build:   func(*testing.T) fosite.Storage { return storageWithoutAssertionConsumer{} },
+			wantErr: "does not implement",
+		},
+		{
+			name:  "storage implementing the capability directly succeeds",
+			build: func(*testing.T) fosite.Storage { return assertionConsumerStorage{} },
+		},
+		{
+			// CIMDStorageDecorator itself always implements
+			// storage.AssertionJWTConsumer (it forwards one level down to
+			// whatever it wraps), so it satisfies the interface here
+			// regardless of what its wrapped backend supports -- a wrapped
+			// backend lacking the capability only surfaces as an error when
+			// ConsumeAssertionJWT is actually called (see
+			// TestCIMDStorageDecorator_ConsumeAssertionJWTFailsClosedWithoutBackendCapability
+			// in the storage package).
+			name: "CIMD decorator satisfies the interface via its own forwarding method",
+			build: func(t *testing.T) fosite.Storage {
+				t.Helper()
+				decorated, err := storage.NewCIMDStorageDecorator(storageWithoutAssertionConsumer{},
+					storage.CIMDDecoratorConfig{Enabled: true, CacheMaxSize: 1, FallbackTTL: time.Minute})
+				require.NoError(t, err)
+				return decorated
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			decorated, err := storage.NewCIMDStorageDecorator(tt.base, storage.CIMDDecoratorConfig{Enabled: true, CacheMaxSize: 1, FallbackTTL: time.Minute})
-			require.NoError(t, err)
-			consumer, err := assertionJWTConsumer(decorated)
+			consumer, err := assertionJWTConsumer(tt.build(t))
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -408,6 +432,46 @@ func TestAssertionJWTConsumer_UnwrapsCIMDAtConstruction(t *testing.T) {
 			assert.NotNil(t, consumer)
 		})
 	}
+}
+
+// TestAssertionJWTConsumer_ForwardsThroughFullSPIFFEDecoratorChain is an
+// end-to-end positive proof, against the real production chain shape
+// (SPIFFEStorageDecorator wrapping CIMDStorageDecorator wrapping
+// MemoryStorage), that JWT-bearer replay protection still resolves and
+// functions correctly after the storage.Unwrap bypass fix (PR #6474 review).
+// It does not by itself distinguish "forwarded one level at a time" from
+// "unwrapped straight to the base" -- both reach the same MemoryStorage here.
+// The actual regression gate for that distinction is the
+// "CIMD decorator satisfies the interface via its own forwarding method"
+// subtest of TestAssertionJWTConsumer above, which uses a backend that only
+// a correct one-level forward (not a full Unwrap) can resolve.
+func TestAssertionJWTConsumer_ForwardsThroughFullSPIFFEDecoratorChain(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	base := storage.NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+
+	cimdDecorated, err := storage.NewCIMDStorageDecorator(base, storage.CIMDDecoratorConfig{
+		Enabled: true, CacheMaxSize: 1, FallbackTTL: time.Minute,
+	})
+	require.NoError(t, err)
+
+	spiffeClient, err := registration.NewSPIFFEClient(
+		"spiffe-client", []string{"openid"}, []string{"https://mcp.example.com"})
+	require.NoError(t, err)
+	chain, err := storage.NewSPIFFEStorageDecorator(
+		ctx, cimdDecorated, map[string]fosite.Client{spiffeClient.GetID(): spiffeClient})
+	require.NoError(t, err)
+
+	consumer, err := assertionJWTConsumer(chain)
+	require.NoError(t, err)
+
+	exp := time.Now().Add(time.Hour)
+	require.NoError(t, consumer.ConsumeAssertionJWT(ctx, "jwt-bearer", "https://issuer.example", "chain-jti", exp))
+	require.ErrorIs(t,
+		consumer.ConsumeAssertionJWT(ctx, "jwt-bearer", "https://issuer.example", "chain-jti", exp),
+		fosite.ErrJTIKnown)
 }
 
 type storageWithoutAssertionConsumer struct{ storage.Storage }

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -146,10 +146,15 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage) (_ *server
 	// provably safe for the production backends; surfacing a bad backend as
 	// a constructor error keeps misconfiguration fail-loud at boot rather
 	// than at first DCR resolve.
-	baseStore := unwrapStorage(stor)
+	baseStore := storage.Unwrap(stor)
 	dcrStore, ok := baseStore.(storage.DCRCredentialStore)
 	if !ok {
 		return nil, fmt.Errorf("storage backend %T does not implement storage.DCRCredentialStore", baseStore)
+	}
+
+	stor, err := decorateStorageForSPIFFE(ctx, cfg, stor)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := registerDelegateClients(ctx, stor, cfg.DelegateClients); err != nil {
@@ -219,15 +224,7 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage) (_ *server
 		return nil, err
 	}
 
-	// Wrap storage with the CIMD decorator before constructing the fosite provider
-	// so that GetClient calls for HTTPS client_id values are intercepted at the
-	// fosite level (not just the handler level).
-	stor, err = decorateStorageForCIMD(cfg, stor)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create fosite provider with the (possibly decorated) storage.
+	// Create fosite provider with the configured storage decorators.
 	slog.Debug("creating fosite OAuth2 provider")
 	fositeProvider, err := buildProvider(cfg, authServerConfig, stor)
 	if err != nil {
@@ -286,6 +283,33 @@ func registerDelegateClients(ctx context.Context, stor storage.Storage, delegate
 	return nil
 }
 
+// decorateStorageForSPIFFE resolves the immutable association registry from the
+// validated SPIFFE trust model and installs the static overlay outside CIMD.
+// A nil cfg.SPIFFETrust means no SPIFFE associations are configured, which
+// yields a nil registry and leaves the storage chain unchanged.
+func decorateStorageForSPIFFE(ctx context.Context, cfg Config, stor storage.Storage) (storage.Storage, error) {
+	registry, err := NewSPIFFEAssociationRegistry(cfg.SPIFFETrust)
+	if err != nil {
+		return nil, fmt.Errorf("create SPIFFE association registry: %w", err)
+	}
+
+	// Install dynamic CIMD lookup before the static SPIFFE overlay so configured
+	// clients always take precedence over remotely resolved HTTPS client IDs.
+	stor, err = decorateStorageForCIMD(cfg, stor)
+	if err != nil {
+		return nil, err
+	}
+	clients, err := registry.staticClients()
+	if err != nil {
+		return nil, fmt.Errorf("build SPIFFE static clients: %w", err)
+	}
+	stor, err = storage.NewSPIFFEStorageDecorator(ctx, stor, clients)
+	if err != nil {
+		return nil, fmt.Errorf("initialize SPIFFE client overlay: %w", err)
+	}
+	return stor, nil
+}
+
 // decorateStorageForCIMD wraps stor with the CIMD decorator when CIMD is
 // enabled, so GetClient calls for HTTPS client_id values are intercepted at
 // the fosite level (not just the handler level).
@@ -340,8 +364,8 @@ func buildProvider(
 	}
 	jwtBearerEnabled := JWTBearerGrantEnabled(cfg.TrustedIssuers)
 
-	// Built once, up front, and handed to enabled factories below when the
-	// JWT-bearer grant is enabled: otherwise each factory would build
+	// Built once, up front, and handed to both factories below when the
+	// JWT-bearer grant is also enabled: otherwise each factory would build
 	// its own MultiIssuerTokenValidator over the same trusted issuers,
 	// doubling every issuer's JWKS cache and background refresh goroutines
 	// for no benefit. authServerConfig is the exact *AuthorizationServerConfig
@@ -518,21 +542,11 @@ func createProvider(
 	)
 }
 
-// unwrapStorage peels off one decorator layer if the storage implements
-// Unwrap(), returning the concrete backend. Both newServer (DCRCredentialStore
-// assertion) and runLegacyMigration (RedisStorage type assertion) need this.
-func unwrapStorage(stor storage.Storage) storage.Storage {
-	if unwrapper, ok := stor.(interface{ Unwrap() storage.Storage }); ok {
-		return unwrapper.Unwrap()
-	}
-	return stor
-}
-
 // runLegacyMigration runs one-shot Redis data migrations before handlers are
 // constructed. It is a no-op for non-Redis backends and passes through any
 // decorator wrapping so the concrete type can be reached.
 func runLegacyMigration(ctx context.Context, stor storage.Storage, upstreams []UpstreamConfig) error {
-	base := unwrapStorage(stor)
+	base := storage.Unwrap(stor)
 	rs, ok := base.(*storage.RedisStorage)
 	if !ok {
 		return nil

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -272,7 +272,7 @@ func registerDelegateClients(ctx context.Context, stor storage.Storage, delegate
 		if err != nil {
 			return fmt.Errorf("failed to create delegate client %q: %w", delegateClient.ClientID, err)
 		}
-		if err := stor.RegisterClient(ctx, client); err != nil {
+		if err := stor.ReconcileConfiguredClient(ctx, client); err != nil {
 			return fmt.Errorf("failed to register delegate client %q: %w", delegateClient.ClientID, err)
 		}
 		slog.Warn("delegate client has blanket self-issued token exchange rights: "+

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -533,6 +533,15 @@ func TestNewServer_RegistersDelegateClientsBeforeUpstreamConstruction(t *testing
 	ctx := t.Context()
 	stor := storage.NewMemoryStorage()
 	t.Cleanup(func() { _ = stor.Close() })
+
+	// Seed a DCR-issued client under the same ID as the configured delegate
+	// client. The static delegate client is authoritative, so registering it
+	// must replace this DCR registration rather than being rejected as a
+	// duplicate.
+	dcrClient, err := registration.NewConfidentialPlain(registration.Config{ID: "delegate", Secret: "old-secret"})
+	require.NoError(t, err)
+	require.NoError(t, stor.RegisterClient(ctx, dcrClient))
+
 	cfg := Config{
 		Issuer:           "https://example.com",
 		KeyProvider:      keys.NewGeneratingProvider(keys.DefaultAlgorithm),
@@ -555,19 +564,21 @@ func TestNewServer_RegistersDelegateClientsBeforeUpstreamConstruction(t *testing
 	}
 
 	cfg.UpstreamFactory = factory
-	_, err := newServer(ctx, cfg, stor)
-	require.ErrorIs(t, err, assert.AnError)
 
-	// Startup registration is an upsert. Replacing a same-ID DCR client makes
-	// it permanent and unmarked rather than retaining DCR eviction semantics.
-	dcrClient, err := registration.NewConfidentialPlain(registration.Config{ID: "delegate", Secret: "old-secret"})
-	require.NoError(t, err)
-	require.NoError(t, stor.RegisterClient(ctx, dcrClient))
-	_, err = newServer(ctx, cfg, stor)
+	// First boot: static registration is an upsert. Replacing a same-ID DCR
+	// client makes it permanent and unmarked rather than retaining DCR
+	// eviction semantics.
+	_, err := newServer(ctx, cfg, stor)
 	require.ErrorIs(t, err, assert.AnError)
 	client, err := stor.GetClient(ctx, "delegate")
 	require.NoError(t, err)
 	assert.False(t, registration.DCRIssued(client))
+
+	// Second boot: registerDelegateClients runs on every startup, so
+	// re-registering the same static client (not a DCR duplicate) must not
+	// fail the server on restart.
+	_, err = newServer(ctx, cfg, stor)
+	require.ErrorIs(t, err, assert.AnError)
 }
 
 // closeCountingProvider is an OAuth2Provider that implements the optional

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -420,6 +420,61 @@ func TestNewServer_CIMDEnabled_WrapsStorage(t *testing.T) {
 // A regression that reintroduced per-call allocation would leave the
 // refresher's own singleflight test green, so this asserts instance identity
 // at the server boundary instead.
+func TestNewServer_SPIFFEAndCIMD_WrapStorageInOrder(t *testing.T) {
+	t.Parallel()
+
+	trust, err := NewSPIFFETrustConfig(
+		[]SPIFFETrustDomainRunConfig{{
+			Name:        "production",
+			TrustDomain: "example.org",
+			Methods:     []SPIFFEAuthenticationMethod{SPIFFEAuthenticationMethodX509},
+			BundleSource: SPIFFEBundleSourceRunConfig{
+				Type:        SPIFFEBundleSourceTypeWorkloadAPI,
+				WorkloadAPI: &SPIFFEWorkloadAPIBundleSourceRunConfig{},
+			},
+		}},
+		&InboundGrantsRunConfig{SPIFFEClientAuth: []SPIFFEClientAuthRunConfig{{
+			TrustDomainRef:   "production",
+			PrincipalPattern: "spiffe://example.org/ns/default/agent",
+			ClientID:         "spiffe-client",
+			Methods:          []SPIFFEAuthenticationMethod{SPIFFEAuthenticationMethodX509},
+			Scopes:           []string{"openid"},
+			Audiences:        []string{"https://mcp.example.com"},
+			GrantTypes:       []string{SPIFFEGrantTypeTokenExchange},
+		}}},
+		[]string{"openid", "profile"},
+		[]string{"https://mcp.example.com"},
+	)
+	require.NoError(t, err)
+
+	stor := storage.NewMemoryStorage()
+	t.Cleanup(func() { _ = stor.Close() })
+	cfg := Config{
+		CIMDEnabled:          true,
+		CIMDCacheMaxSize:     16,
+		CIMDCacheFallbackTTL: 5 * time.Minute,
+		SPIFFETrust:          trust,
+	}
+
+	// decorateStorageForSPIFFE is exercised directly, not through newServer,
+	// because Config.SPIFFETrust is hard-rejected by Config.Validate() (and
+	// therefore by newServer, which calls it) until a real SVID-verification
+	// consumer lands -- see validateConfigSPIFFENotYetEnforced. This test's
+	// actual subject, the storage-decoration order, lives entirely below
+	// that policy gate.
+	decorated, err := decorateStorageForSPIFFE(context.Background(), cfg, stor)
+	require.NoError(t, err)
+
+	spiffeStorage, ok := decorated.(*storage.SPIFFEStorageDecorator)
+	require.True(t, ok, "SPIFFE static clients must wrap the CIMD storage layer")
+	_, ok = spiffeStorage.Unwrap().(*storage.CIMDStorageDecorator)
+	assert.True(t, ok, "CIMD must remain below the SPIFFE static client overlay")
+
+	client, err := decorated.GetClient(context.Background(), "spiffe-client")
+	require.NoError(t, err)
+	assert.Equal(t, "spiffe-client", client.GetID())
+}
+
 func TestNewServer_UpstreamRefresherSharedInstance(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -527,20 +527,13 @@ func TestNewUpstreamTokenRefresher_NilWhenNoUpstreams(t *testing.T) {
 	}
 }
 
-func TestNewServer_RegistersDelegateClientsBeforeUpstreamConstruction(t *testing.T) {
+// TestNewServer_DelegateClientReconciliation covers registerDelegateClients'
+// use of ReconcileConfiguredClient: registering a delegate client is
+// create-only against a DCR-issued collision (the security fix -- an
+// operator-declared client must never silently overwrite a DCR
+// registration), and idempotent across a restart with unchanged config.
+func TestNewServer_DelegateClientReconciliation(t *testing.T) {
 	t.Parallel()
-
-	ctx := t.Context()
-	stor := storage.NewMemoryStorage()
-	t.Cleanup(func() { _ = stor.Close() })
-
-	// Seed a DCR-issued client under the same ID as the configured delegate
-	// client. The static delegate client is authoritative, so registering it
-	// must replace this DCR registration rather than being rejected as a
-	// duplicate.
-	dcrClient, err := registration.NewConfidentialPlain(registration.Config{ID: "delegate", Secret: "old-secret"})
-	require.NoError(t, err)
-	require.NoError(t, stor.RegisterClient(ctx, dcrClient))
 
 	cfg := Config{
 		Issuer:           "https://example.com",
@@ -555,30 +548,56 @@ func TestNewServer_RegistersDelegateClientsBeforeUpstreamConstruction(t *testing
 		}},
 	}
 
-	factory := func(ctx context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
+	t.Run("refuses to overwrite a DCR-issued collision, before upstream construction", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		stor := storage.NewMemoryStorage()
+		t.Cleanup(func() { _ = stor.Close() })
+
+		dcrClient, err := registration.NewConfidentialPlain(registration.Config{ID: "delegate", Secret: "old-secret"})
+		require.NoError(t, err)
+		require.NoError(t, stor.RegisterClient(ctx, dcrClient))
+
+		factoryCalled := false
+		factory := func(context.Context, *UpstreamConfig) (upstream.OAuth2Provider, error) {
+			factoryCalled = true
+			return nil, assert.AnError
+		}
+		subCfg := cfg
+		subCfg.UpstreamFactory = factory
+
+		_, err = newServer(ctx, subCfg, stor)
+		require.ErrorIs(t, err, storage.ErrAlreadyExists)
+		assert.False(t, factoryCalled, "delegate client registration must run before upstream construction")
+
+		client, err := stor.GetClient(ctx, "delegate")
+		require.NoError(t, err, "the original DCR-issued registration must be untouched")
+		assert.True(t, registration.DCRIssued(client))
+	})
+
+	t.Run("restart with unchanged config is idempotent", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		stor := storage.NewMemoryStorage()
+		t.Cleanup(func() { _ = stor.Close() })
+
+		factory := func(context.Context, *UpstreamConfig) (upstream.OAuth2Provider, error) {
+			return nil, assert.AnError
+		}
+		subCfg := cfg
+		subCfg.UpstreamFactory = factory
+
+		// registerDelegateClients runs on every startup; re-registering the
+		// same static client across a simulated restart must not fail.
+		_, err := newServer(ctx, subCfg, stor)
+		require.ErrorIs(t, err, assert.AnError)
+		_, err = newServer(ctx, subCfg, stor)
+		require.ErrorIs(t, err, assert.AnError)
+
 		client, err := stor.GetClient(ctx, "delegate")
 		require.NoError(t, err)
 		assert.False(t, registration.DCRIssued(client))
-		assert.False(t, client.IsPublic())
-		return nil, assert.AnError
-	}
-
-	cfg.UpstreamFactory = factory
-
-	// First boot: static registration is an upsert. Replacing a same-ID DCR
-	// client makes it permanent and unmarked rather than retaining DCR
-	// eviction semantics.
-	_, err := newServer(ctx, cfg, stor)
-	require.ErrorIs(t, err, assert.AnError)
-	client, err := stor.GetClient(ctx, "delegate")
-	require.NoError(t, err)
-	assert.False(t, registration.DCRIssued(client))
-
-	// Second boot: registerDelegateClients runs on every startup, so
-	// re-registering the same static client (not a DCR duplicate) must not
-	// fail the server on restart.
-	_, err = newServer(ctx, cfg, stor)
-	require.ErrorIs(t, err, assert.AnError)
+	})
 }
 
 // closeCountingProvider is an OAuth2Provider that implements the optional

--- a/pkg/authserver/spiffe_association_registry.go
+++ b/pkg/authserver/spiffe_association_registry.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package authserver
+
+import (
+	"fmt"
+
+	"github.com/ory/fosite"
+
+	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
+)
+
+// SPIFFEAssociationRegistry is the immutable runtime index of validated SPIFFE
+// associations. It selects policy only; it neither accepts nor authenticates a
+// SPIFFE credential.
+type SPIFFEAssociationRegistry struct {
+	byPattern  map[string]SPIFFEClientAuthConfig
+	byClientID map[string]SPIFFEClientAuthConfig
+}
+
+// NewSPIFFEAssociationRegistry creates an immutable lookup registry from a
+// trust configuration. A nil trust configuration represents an absent SPIFFE
+// configuration and returns nil without enabling SPIFFE clients.
+func NewSPIFFEAssociationRegistry(trust *SPIFFETrustConfig) (*SPIFFEAssociationRegistry, error) {
+	if trust == nil {
+		return nil, nil
+	}
+
+	associations := trust.Associations()
+	registry := &SPIFFEAssociationRegistry{
+		byPattern:  make(map[string]SPIFFEClientAuthConfig, len(associations)),
+		byClientID: make(map[string]SPIFFEClientAuthConfig, len(associations)),
+	}
+	for _, association := range associations {
+		if _, exists := registry.byPattern[association.Principal()]; exists {
+			return nil, fmt.Errorf("duplicate SPIFFE association pattern %q", association.Principal())
+		}
+		if _, exists := registry.byClientID[association.ClientID()]; exists {
+			return nil, fmt.Errorf("duplicate SPIFFE association client ID %q", association.ClientID())
+		}
+		registry.byPattern[association.Principal()] = association.clone()
+		registry.byClientID[association.ClientID()] = association.clone()
+	}
+	return registry, nil
+}
+
+// staticClients builds immutable OAuth clients for all configured associations.
+func (r *SPIFFEAssociationRegistry) staticClients() (map[string]fosite.Client, error) {
+	if r == nil {
+		return nil, nil
+	}
+	clients := make(map[string]fosite.Client, len(r.byClientID))
+	for clientID, association := range r.byClientID {
+		policy := association.AuthorizationPolicy()
+		client, err := registration.NewSPIFFEClient(
+			association.ClientID(), policy.Scopes(), policy.Audiences(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("SPIFFE client %q: %w", clientID, err)
+		}
+		clients[clientID] = client
+	}
+	return clients, nil
+}

--- a/pkg/authserver/spiffe_association_registry_test.go
+++ b/pkg/authserver/spiffe_association_registry_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package authserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSPIFFEAssociationRegistryRebuildsChangedAndRemovedAuthority(t *testing.T) {
+	t.Parallel()
+
+	initial := newTestSPIFFEAssociationRegistry(t, []SPIFFEClientAuthRunConfig{testSPIFFEAssociation("client", "openid")})
+	changed := newTestSPIFFEAssociationRegistry(t, []SPIFFEClientAuthRunConfig{testSPIFFEAssociation("client", "profile")})
+	removedTrust, err := NewSPIFFETrustConfig(nil, nil, []string{"openid", "profile"}, []string{"https://resource.example.com"})
+	require.NoError(t, err)
+	assert.Empty(t, removedTrust.Associations())
+	removed, err := NewSPIFFEAssociationRegistry(removedTrust)
+	require.NoError(t, err)
+
+	initialClients, err := initial.staticClients()
+	require.NoError(t, err)
+	initialClient, found := initialClients["client"]
+	require.True(t, found)
+	assert.Equal(t, []string{"openid"}, []string(initialClient.GetScopes()))
+
+	changedClients, err := changed.staticClients()
+	require.NoError(t, err)
+	changedClient, found := changedClients["client"]
+	require.True(t, found)
+	assert.Equal(t, []string{"profile"}, []string(changedClient.GetScopes()))
+
+	removedClients, err := removed.staticClients()
+	require.NoError(t, err)
+	assert.Empty(t, removedClients)
+}
+
+func TestSPIFFEAssociationRegistryKeepsClientAudiencesIsolated(t *testing.T) {
+	t.Parallel()
+
+	first := testSPIFFEAssociation("first-client", "openid")
+	first.Audiences = []string{"https://resource.example.com"}
+	second := testSPIFFEAssociation("second-client", "profile")
+	second.PrincipalPattern = "spiffe://example.org/ns/default/other-agent"
+	second.Audiences = []string{"https://audience.example.com"}
+
+	registry := newTestSPIFFEAssociationRegistry(t, []SPIFFEClientAuthRunConfig{first, second})
+	clients, err := registry.staticClients()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"https://resource.example.com"}, []string(clients["first-client"].GetAudience()))
+	assert.Equal(t, []string{"https://audience.example.com"}, []string(clients["second-client"].GetAudience()))
+}
+
+func newTestSPIFFEAssociationRegistry(t *testing.T, associations []SPIFFEClientAuthRunConfig) *SPIFFEAssociationRegistry {
+	t.Helper()
+
+	trust, err := NewSPIFFETrustConfig([]SPIFFETrustDomainRunConfig{{
+		Name:        "production",
+		TrustDomain: "example.org",
+		Methods:     []SPIFFEAuthenticationMethod{SPIFFEAuthenticationMethodX509, SPIFFEAuthenticationMethodJWT},
+		BundleSource: SPIFFEBundleSourceRunConfig{
+			Type:        SPIFFEBundleSourceTypeWorkloadAPI,
+			WorkloadAPI: &SPIFFEWorkloadAPIBundleSourceRunConfig{},
+		},
+	}}, &InboundGrantsRunConfig{SPIFFEClientAuth: associations}, []string{"openid", "profile"},
+		[]string{"https://resource.example.com", "https://audience.example.com"})
+	require.NoError(t, err)
+	registry, err := NewSPIFFEAssociationRegistry(trust)
+	require.NoError(t, err)
+	return registry
+}
+
+func testSPIFFEAssociation(clientID, scope string) SPIFFEClientAuthRunConfig {
+	return SPIFFEClientAuthRunConfig{
+		TrustDomainRef:   "production",
+		PrincipalPattern: "spiffe://example.org/ns/default/agent",
+		ClientID:         clientID,
+		Methods:          []SPIFFEAuthenticationMethod{SPIFFEAuthenticationMethodX509},
+		Scopes:           []string{scope},
+		Audiences:        []string{"https://audience.example.com"},
+		GrantTypes:       []string{SPIFFEGrantTypeTokenExchange},
+	}
+}

--- a/pkg/authserver/spiffe_preflight.go
+++ b/pkg/authserver/spiffe_preflight.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package authserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stacklok/toolhive/pkg/authserver/storage"
+)
+
+// PreflightSPIFFEStaticClientCollisions rejects static client IDs that already
+// exist in durable storage. It runs before upstream DCR registration so a
+// collision cannot leave an orphaned upstream registration.
+func PreflightSPIFFEStaticClientCollisions(ctx context.Context, base storage.Storage, trust *SPIFFETrustConfig) error {
+	registry, err := NewSPIFFEAssociationRegistry(trust)
+	if err != nil {
+		return fmt.Errorf("create SPIFFE association registry: %w", err)
+	}
+	clients, err := registry.staticClients()
+	if err != nil {
+		return err
+	}
+	return storage.PreflightSPIFFEStaticClientCollisions(ctx, base, clients)
+}

--- a/pkg/authserver/storage/cimd_decorator.go
+++ b/pkg/authserver/storage/cimd_decorator.go
@@ -276,10 +276,14 @@ func (d *CIMDStorageDecorator) fetch(ctx context.Context, id string) (fosite.Cli
 	// issue #6187). The client carries the DCR-issued marker (above) so the
 	// row gets the same anti-bloat TTL as DCR registrations: unauthenticated
 	// /oauth/authorize traffic can mint these rows, so they must never be
-	// permanent. Re-persisting on every fresh fetch keeps the snapshot
-	// current with the document. A persistence failure only degrades
-	// token-path rehydration, so it must not fail the resolution itself.
-	if err := d.RegisterClient(ctx, client); err != nil {
+	// permanent. UpsertDCRIssuedClient (not RegisterClient) is used because
+	// RegisterClient is strictly create-only and would fail every fetch after
+	// the first for the same client_id -- this method re-persists on every
+	// fresh fetch, keeping the stored snapshot current with the document,
+	// while still refusing to clobber a configured/SPIFFE-reconciled client
+	// at the same ID. A persistence failure only degrades token-path
+	// rehydration, so it must not fail the resolution itself.
+	if err := d.UpsertDCRIssuedClient(ctx, client); err != nil {
 		slog.WarnContext(ctx, "failed to persist resolved CIMD client",
 			"client_id", id, "error", err)
 	}

--- a/pkg/authserver/storage/cimd_decorator_test.go
+++ b/pkg/authserver/storage/cimd_decorator_test.go
@@ -950,14 +950,15 @@ func TestCIMDStorageDecorator_PersistsLoopbackResolvedClient(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// registerFailingStorage wraps a Storage and fails every RegisterClient call,
-// for testing that a write-through persistence failure does not fail the
+// registerFailingStorage wraps a Storage and fails every UpsertDCRIssuedClient
+// call -- the write-through persistence path fetch() actually calls -- for
+// testing that a write-through persistence failure does not fail the
 // resolution itself.
 type registerFailingStorage struct {
 	Storage
 }
 
-func (*registerFailingStorage) RegisterClient(context.Context, fosite.Client) error {
+func (*registerFailingStorage) UpsertDCRIssuedClient(context.Context, fosite.Client) error {
 	return errors.New("register failed")
 }
 
@@ -976,4 +977,51 @@ func TestCIMDStorageDecorator_PersistFailureDoesNotFailResolution(t *testing.T) 
 	client, err := dec.fetchOrCached(context.Background(), srv.URL+"/meta.json")
 	require.NoError(t, err, "a write-through persistence failure must not fail the resolution")
 	assert.NotNil(t, client)
+}
+
+// TestCIMDStorageDecorator_RepeatFetchRenewsPersistedClient closes the gap
+// that let the RegisterClient/UpsertDCRIssuedClient bug go undetected:
+// nothing previously asserted the persisted row's state after a repeat
+// fetch of the same client_id. Two fetches of the same CIMD document, whose
+// served content changes between them, must both succeed, and the second
+// fetch's write-through must actually replace the stored row's data rather
+// than silently failing with ErrAlreadyExists (as it would have with the old
+// RegisterClient-only call, whose failure fetch() only logs).
+func TestCIMDStorageDecorator_RepeatFetchRenewsPersistedClient(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	srv := serveCIMDDocWithFields(t, func(doc *cimd.ClientMetadataDocument) {
+		// Change the served document between the first and second fetch so a
+		// real re-persist is distinguishable from a no-op.
+		if callCount.Add(1) == 1 {
+			doc.RedirectURIs = []string{"https://example.com/callback-v1"}
+		} else {
+			doc.RedirectURIs = []string{"https://example.com/callback-v2"}
+		}
+	})
+	base := newTestBase(t)
+	dec := newEnabledDecorator(t, base, 10, time.Minute)
+	id := srv.URL + "/meta.json"
+	ctx := context.Background()
+
+	// Call fetch() directly (bypassing the in-process LRU cache) to force two
+	// real write-through persistence attempts, exactly as two independent
+	// process replicas resolving the same client_id would.
+	first, err := dec.fetch(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://example.com/callback-v1"}, first.GetRedirectURIs())
+
+	stored, err := base.GetClient(ctx, id)
+	require.NoError(t, err, "first fetch must persist the row")
+	assert.Equal(t, []string{"https://example.com/callback-v1"}, stored.GetRedirectURIs())
+
+	second, err := dec.fetch(ctx, id)
+	require.NoError(t, err, "second fetch for the same client_id must not fail")
+	assert.Equal(t, []string{"https://example.com/callback-v2"}, second.GetRedirectURIs())
+
+	stored, err = base.GetClient(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://example.com/callback-v2"}, stored.GetRedirectURIs(),
+		"the persisted row must be renewed with the newly-fetched document, not left stale")
 }

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -476,6 +476,38 @@ func (s *MemoryStorage) RegisterClient(_ context.Context, client fosite.Client) 
 	return s.insertClientLocked(id, client)
 }
 
+// UpsertDCRIssuedClient creates or replaces a DCR-issued client at
+// client.GetID(). Unlike RegisterClient, an existing row is replaced (and its
+// eviction position refreshed) rather than rejected -- but only when the
+// existing row is itself DCR-issued; a configured/SPIFFE-reconciled row at
+// the same ID is protected and refuses with ErrAlreadyExists. See the
+// ClientRegistry interface doc for the full contract.
+func (s *MemoryStorage) UpsertDCRIssuedClient(_ context.Context, client fosite.Client) error {
+	if !registration.DCRIssued(client) {
+		return fmt.Errorf("client %q must carry the DCR-issued marker to use UpsertDCRIssuedClient", client.GetID())
+	}
+	id := client.GetID()
+	if err := ValidateRegisterableClientID(id); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, exists := s.clients[id]
+	if !exists {
+		return s.insertClientLocked(id, client)
+	}
+	if !registration.DCRIssued(existing) {
+		return fmt.Errorf("%w: client %q", ErrAlreadyExists, id)
+	}
+
+	s.clientOrder = slices.DeleteFunc(s.clientOrder, func(e clientOrderEntry) bool { return e.id == id })
+	s.clientOrder = append(s.clientOrder, clientOrderEntry{id: id, touchedAt: time.Now()})
+	s.clients[id] = client
+	return nil
+}
+
 // ReconcileConfiguredClient applies an operator-declared client: creates it
 // if absent, idempotently replaces a matching-fingerprint configured client
 // (the restart-with-unchanged-config case), or refuses with ErrAlreadyExists

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -74,6 +74,13 @@ type MemoryStorage struct {
 	mu sync.RWMutex
 
 	// clients maps client_id -> Client for client lookup (fosite.ClientManager).
+	// A SPIFFE static-client durable placeholder (see staticClientPlaceholder
+	// in spiffe_decorator.go) is stored here as the live inertPlaceholderClient
+	// Go value, so its overridden GetGrantTypes/GetResponseTypes are called
+	// directly on every read — unlike RedisStorage, which serializes the
+	// client's fields and must re-derive the same guarantee on read-back via
+	// storedClient.Reserved (see clientFromStored in redis.go). No equivalent
+	// marker is needed here.
 	clients map[string]fosite.Client
 
 	// clientOrder is the least-recently-proven-used order of clients: a
@@ -449,11 +456,11 @@ func getExpirationFromRequester(request fosite.Requester, tokenType fosite.Token
 	return expTime
 }
 
-// RegisterClient creates or replaces a client in storage. A DCR-issued
-// registration is create-only and returns ErrAlreadyExists when a client with
-// the same ID is already registered; an operator-declared static/delegate
-// client is authoritative and always replaces any existing registration,
-// including one DCR issued.
+// RegisterClient creates a client in storage. Always create-only: it returns
+// ErrAlreadyExists when a client with the same ID is already registered,
+// regardless of the new client's origin. /oauth/register is unauthenticated,
+// so this must never clobber an existing client; operator-declared clients
+// reconcile through ReconcileConfiguredClient instead.
 func (s *MemoryStorage) RegisterClient(_ context.Context, client fosite.Client) error {
 	id := client.GetID()
 	if err := ValidateRegisterableClientID(id); err != nil {
@@ -463,21 +470,56 @@ func (s *MemoryStorage) RegisterClient(_ context.Context, client fosite.Client) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now()
 	if _, exists := s.clients[id]; exists {
-		// DCR is unauthenticated (the /register endpoint has no caller
-		// identity), so a DCR-issued registration must never clobber an
-		// existing client. Operator-declared static/delegate clients are
-		// authoritative and may replace any existing registration, including
-		// one DCR issued: this is how a static overlay promotes a client that
-		// first appeared via DCR into permanent configuration.
-		if registration.DCRIssued(client) {
-			return fmt.Errorf("%w: client %q", ErrAlreadyExists, id)
-		}
-		// Refresh the eviction position: the replacing registration is not
-		// the oldest, and clientOrder must not carry a stale duplicate entry.
-		s.clientOrder = slices.DeleteFunc(s.clientOrder, func(e clientOrderEntry) bool { return e.id == id })
-	} else if s.maxClients > 0 && len(s.clients) >= s.maxClients {
+		return fmt.Errorf("%w: client %q", ErrAlreadyExists, id)
+	}
+	return s.insertClientLocked(id, client)
+}
+
+// ReconcileConfiguredClient applies an operator-declared client: creates it
+// if absent, idempotently replaces a matching-fingerprint configured client
+// (the restart-with-unchanged-config case), or refuses with ErrAlreadyExists
+// when the existing record is DCR-issued or a different configured client.
+// See the ClientRegistry interface doc for the full contract.
+func (s *MemoryStorage) ReconcileConfiguredClient(_ context.Context, client fosite.Client) error {
+	if registration.DCRIssued(client) {
+		return fmt.Errorf("configured client %q must not carry the DCR-issued marker", client.GetID())
+	}
+	id := client.GetID()
+	if err := ValidateRegisterableClientID(id); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, exists := s.clients[id]
+	if !exists {
+		return s.insertClientLocked(id, client)
+	}
+	if registration.DCRIssued(existing) {
+		return fmt.Errorf("%w: client %q is DCR-issued, refusing to overwrite with a configured client",
+			ErrAlreadyExists, id)
+	}
+	if !clientFingerprintsEqual(existing, client) {
+		return fmt.Errorf("%w: client %q is already registered as a different configured client",
+			ErrAlreadyExists, id)
+	}
+
+	// Idempotent restart with unchanged config: refresh the eviction position
+	// and replace the stored value so secret rotation still takes effect.
+	s.clientOrder = slices.DeleteFunc(s.clientOrder, func(e clientOrderEntry) bool { return e.id == id })
+	s.clientOrder = append(s.clientOrder, clientOrderEntry{id: id, touchedAt: time.Now()})
+	s.clients[id] = client
+	return nil
+}
+
+// insertClientLocked inserts client under id, evicting the oldest eligible
+// DCR-issued client if the map is at capacity. Callers must hold s.mu and
+// must have already verified that no client currently exists at id.
+func (s *MemoryStorage) insertClientLocked(id string, client fosite.Client) error {
+	now := time.Now()
+	if s.maxClients > 0 && len(s.clients) >= s.maxClients {
 		if idx := s.oldestEvictableClientIndex(now); idx >= 0 {
 			victim := s.clientOrder[idx].id
 			s.clientOrder = append(s.clientOrder[:idx], s.clientOrder[idx+1:]...)

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -157,7 +157,7 @@ type MemoryStorage struct {
 	// dcrCredentials maps DCRKey -> DCRCredentials for RFC 7591 Dynamic Client
 	// Registration credentials. These entries come from OUTBOUND DCR: ToolHive
 	// acting as a DCR client to register itself against a configured upstream
-	// IdP (see pkg/auth/dcr/store.go, the only caller of StoreDCRCredentials).
+	// IdP (see pkg/auth/dcr/store.go, the only caller of StoreDCRCredentialsIfAbsent).
 	// This is not reachable from the inbound, unauthenticated /oauth/register
 	// handler, so unlike clients (bounded by maxClients/clientOrder because
 	// every inbound registration call mints an entry), growth here is bounded
@@ -1538,29 +1538,46 @@ func cloneDCRCredentials(c *DCRCredentials) *DCRCredentials {
 	return &cp
 }
 
-// StoreDCRCredentials persists DCR credentials for the given key.
-// The credentials are stored under their own Key field; callers must populate
-// it before calling. A defensive copy is made so subsequent caller mutations
-// do not affect persisted state.
+// StoreDCRCredentialsIfAbsent claims creds.Key for creds. The credentials
+// are stored under their own Key field; callers must populate it before
+// calling. A defensive copy is made so subsequent caller mutations do not
+// affect persisted state.
 //
-// Overwrites any existing entry for the same Key. The in-memory backend
-// applies no native TTL — DCR registrations are long-lived and bounded by
-// the operator-configured upstream count, and ClientSecretExpiresAt is
-// retained verbatim for callers to re-check on read (see the interface
-// docstring's "TTL handling" section).
+// Create-if-absent, not overwrite: a single process's dcrFlight singleflight
+// (see pkg/auth/dcr) already prevents concurrent same-key writers within
+// this process, so the check below is not closing a live race here — it is
+// contract symmetry with RedisStorage.StoreDCRCredentialsIfAbsent, which
+// DOES need it to prevent two replicas from independently registering RFC
+// 7591 clients for the same Key and racing on which write wins.
+//
+// The in-memory backend has no native TTL, so "absent" cannot be a plain
+// map-presence check: the Redis backend's rows self-evict via TTL derived
+// from ClientSecretExpiresAt, so a claim there naturally succeeds again once
+// the old row expires. To keep behaviour symmetric, an existing entry whose
+// ClientSecretExpiresAt is non-zero and already in the past is treated as
+// absent — the claim proceeds and overwrites it — so a secret's expiry does
+// not permanently block re-registration on this backend the way a naive
+// presence check would.
 //
 // Validation is delegated to validateDCRCredentialsForStore so the rejection
 // set stays in sync with sibling backends.
-func (s *MemoryStorage) StoreDCRCredentials(_ context.Context, creds *DCRCredentials) error {
+func (s *MemoryStorage) StoreDCRCredentialsIfAbsent(_ context.Context, creds *DCRCredentials) (*DCRCredentials, error) {
 	if err := validateDCRCredentialsForStore(creds); err != nil {
-		return err
+		return nil, err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if existing, ok := s.dcrCredentials[creds.Key]; ok {
+		expired := !existing.ClientSecretExpiresAt.IsZero() && time.Now().After(existing.ClientSecretExpiresAt)
+		if !expired {
+			return cloneDCRCredentials(existing), nil
+		}
+	}
+
 	s.dcrCredentials[creds.Key] = cloneDCRCredentials(creds)
-	return nil
+	return cloneDCRCredentials(creds), nil
 }
 
 // GetDCRCredentials retrieves DCR credentials by key.

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -449,15 +449,11 @@ func getExpirationFromRequester(request fosite.Requester, tokenType fosite.Token
 	return expTime
 }
 
-// RegisterClient adds or updates a client in the storage.
-// This is useful for setting up test clients.
-//
-// When the client map is at maxClients, the oldest DCR-issued registration
-// that has aged past minClientAge is evicted to make room. A pre-provisioned
-// client (no registration.DCRIssued marker) is never evicted; if no current
-// DCR-issued client is old enough to evict, RegisterClient returns
-// ErrClientCapacity. Re-registering an existing ID moves it to the back of the
-// eviction queue.
+// RegisterClient creates or replaces a client in storage. A DCR-issued
+// registration is create-only and returns ErrAlreadyExists when a client with
+// the same ID is already registered; an operator-declared static/delegate
+// client is authoritative and always replaces any existing registration,
+// including one DCR issued.
 func (s *MemoryStorage) RegisterClient(_ context.Context, client fosite.Client) error {
 	id := client.GetID()
 	if err := ValidateRegisterableClientID(id); err != nil {
@@ -469,8 +465,17 @@ func (s *MemoryStorage) RegisterClient(_ context.Context, client fosite.Client) 
 
 	now := time.Now()
 	if _, exists := s.clients[id]; exists {
-		// Refresh the eviction position: an actively re-registering client is
-		// not the oldest.
+		// DCR is unauthenticated (the /register endpoint has no caller
+		// identity), so a DCR-issued registration must never clobber an
+		// existing client. Operator-declared static/delegate clients are
+		// authoritative and may replace any existing registration, including
+		// one DCR issued: this is how a static overlay promotes a client that
+		// first appeared via DCR into permanent configuration.
+		if registration.DCRIssued(client) {
+			return fmt.Errorf("%w: client %q", ErrAlreadyExists, id)
+		}
+		// Refresh the eviction position: the replacing registration is not
+		// the oldest, and clientOrder must not carry a stale duplicate entry.
 		s.clientOrder = slices.DeleteFunc(s.clientOrder, func(e clientOrderEntry) bool { return e.id == id })
 	} else if s.maxClients > 0 && len(s.clients) >= s.maxClients {
 		if idx := s.oldestEvictableClientIndex(now); idx >= 0 {

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -251,23 +251,132 @@ func TestMemoryStorage_RegisterClient_RejectsSyntheticPrefix(t *testing.T) {
 	})
 }
 
-func TestMemoryStorage_StaticClientReplacesDCRClient(t *testing.T) {
-	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
-		dcrClient := dcrClient(t, "delegate")
-		require.True(t, registration.DCRIssued(dcrClient))
-		require.NoError(t, s.RegisterClient(ctx, dcrClient))
+// TestMemoryStorage_RegisterClient_AlwaysCreateOnly pins the security fix:
+// RegisterClient never overwrites an existing client, regardless of whether
+// the existing registration is DCR-issued or pre-provisioned. A caller that
+// needs authoritative replacement of an operator-declared client must use
+// ReconcileConfiguredClient instead.
+func TestMemoryStorage_RegisterClient_AlwaysCreateOnly(t *testing.T) {
+	t.Parallel()
 
-		staticClient, err := registration.NewStaticDelegateClient(registration.Config{
-			ID: "delegate", Secret: "new-secret", GrantTypes: []string{"urn:ietf:params:oauth:grant-type:token-exchange"},
-			Scopes: []string{"openid"}, Audience: []string{"https://mcp.example"},
+	tests := []struct {
+		name     string
+		existing fosite.Client
+	}{
+		{"existing is DCR-issued", nil}, // replaced with dcrClient(t, id) below
+		{"existing is pre-provisioned", &mockClient{id: "existing"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			s := NewMemoryStorage()
+			defer s.Close()
+
+			existing := tt.existing
+			if existing == nil {
+				existing = dcrClient(t, "existing")
+			}
+			require.NoError(t, s.RegisterClient(ctx, existing))
+
+			err := s.RegisterClient(ctx, &mockClient{id: "existing", public: true})
+			require.ErrorIs(t, err, ErrAlreadyExists)
+
+			// The original registration must be untouched.
+			retrieved, err := s.GetClient(ctx, "existing")
+			require.NoError(t, err)
+			assert.Equal(t, existing, retrieved)
 		})
-		require.NoError(t, err)
-		require.NoError(t, s.RegisterClient(ctx, staticClient))
+	}
+}
 
-		retrieved, err := s.GetClient(ctx, "delegate")
+// TestMemoryStorage_ReconcileConfiguredClient covers the create/idempotent/
+// reject matrix ReconcileConfiguredClient must implement: create when
+// absent, no-op (replace with an equivalent record) when the existing record
+// is itself configured and fingerprint-equal, and refuse with
+// ErrAlreadyExists when the existing record is DCR-issued or a different
+// configured client.
+func TestMemoryStorage_ReconcileConfiguredClient(t *testing.T) {
+	t.Parallel()
+
+	newConfigured := func(id string, scopes []string) fosite.Client {
+		return &mockClient{id: id, scopes: scopes, public: false}
+	}
+
+	t.Run("creates when absent", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		s := NewMemoryStorage()
+		defer s.Close()
+
+		client := newConfigured("configured", []string{"openid"})
+		require.NoError(t, s.ReconcileConfiguredClient(ctx, client))
+
+		retrieved, err := s.GetClient(ctx, "configured")
 		require.NoError(t, err)
-		assert.False(t, registration.DCRIssued(retrieved))
-		assert.NoError(t, registration.SHA256Hasher.Compare(ctx, retrieved.GetHashedSecret(), []byte("new-secret")))
+		assert.Equal(t, client, retrieved)
+	})
+
+	t.Run("idempotent on matching fingerprint", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		s := NewMemoryStorage()
+		defer s.Close()
+
+		first := newConfigured("configured", []string{"openid"})
+		require.NoError(t, s.ReconcileConfiguredClient(ctx, first))
+
+		// A second call with an equivalent (but not identical) client value --
+		// simulating a restart re-deriving the same configuration -- succeeds.
+		second := newConfigured("configured", []string{"openid"})
+		require.NoError(t, s.ReconcileConfiguredClient(ctx, second))
+
+		retrieved, err := s.GetClient(ctx, "configured")
+		require.NoError(t, err)
+		assert.Equal(t, second, retrieved)
+	})
+
+	t.Run("refuses to overwrite a DCR-issued client", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		s := NewMemoryStorage()
+		defer s.Close()
+
+		require.NoError(t, s.RegisterClient(ctx, dcrClient(t, "configured")))
+
+		err := s.ReconcileConfiguredClient(ctx, newConfigured("configured", []string{"openid"}))
+		require.ErrorIs(t, err, ErrAlreadyExists)
+	})
+
+	t.Run("refuses a different configured client at the same ID", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		s := NewMemoryStorage()
+		defer s.Close()
+
+		first := newConfigured("configured", []string{"openid"})
+		require.NoError(t, s.ReconcileConfiguredClient(ctx, first))
+
+		different := newConfigured("configured", []string{"profile"})
+		err := s.ReconcileConfiguredClient(ctx, different)
+		require.ErrorIs(t, err, ErrAlreadyExists)
+
+		// The original registration must be untouched.
+		retrieved, err := s.GetClient(ctx, "configured")
+		require.NoError(t, err)
+		assert.Equal(t, first, retrieved)
+	})
+
+	t.Run("rejects a client carrying the DCR-issued marker", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		s := NewMemoryStorage()
+		defer s.Close()
+
+		err := s.ReconcileConfiguredClient(ctx, dcrClient(t, "configured"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not carry the DCR-issued marker")
 	})
 }
 

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -274,8 +273,7 @@ func TestMemoryStorage_StaticClientReplacesDCRClient(t *testing.T) {
 
 // TestMemoryStorage_RegisterClient_Bounded pins the anti-DoS cap: the client
 // map is bounded by maxClients with oldest-first eviction among DCR-issued
-// clients only, a re-registered client refreshes its eviction position, and
-// the survivors still authenticate.
+// clients only, and duplicate registrations fail without changing stored state.
 func TestMemoryStorage_RegisterClient_Bounded(t *testing.T) {
 	t.Parallel()
 
@@ -290,31 +288,20 @@ func TestMemoryStorage_RegisterClient_Bounded(t *testing.T) {
 		require.NoError(t, s.RegisterClient(ctx, dcrClient(t, id)))
 	}
 
-	// Re-register client-1: it is no longer the oldest, so the next overflow
-	// evicts client-2 instead.
-	require.NoError(t, s.RegisterClient(ctx, dcrClient(t, "client-1")))
+	// A duplicate does not update the original registration or eviction order.
+	require.ErrorIs(t, s.RegisterClient(ctx, dcrClient(t, "client-1")), ErrAlreadyExists)
 
-	// Overflow: client-2 (now oldest) is evicted; everyone else survives.
+	// Overflow evicts the oldest client.
 	require.NoError(t, s.RegisterClient(ctx, dcrClient(t, "client-4")))
 
-	_, err := s.GetClient(ctx, "client-2")
+	_, err := s.GetClient(ctx, "client-1")
 	requireNotFoundError(t, err)
 
-	for _, id := range []string{"client-1", "client-3", "client-4"} {
+	for _, id := range []string{"client-2", "client-3", "client-4"} {
 		client, err := s.GetClient(ctx, id)
 		require.NoError(t, err, "surviving client %q must still authenticate", id)
 		assert.Equal(t, id, client.GetID())
 	}
-
-	// Capacity is retained under continued registration pressure: the next
-	// registration always evicts the oldest aged DCR-issued client.
-	for i := range 10 {
-		require.NoError(t, s.RegisterClient(ctx, dcrClient(t, "overflow-"+strconv.Itoa(i))))
-	}
-	s.mu.RLock()
-	size := len(s.clients)
-	s.mu.RUnlock()
-	assert.LessOrEqual(t, size, 3, "client map must never exceed maxClients")
 }
 
 // TestMemoryStorage_RegisterClient_MinAgeGraceWindow pins the eviction floor:

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -380,6 +380,99 @@ func TestMemoryStorage_ReconcileConfiguredClient(t *testing.T) {
 	})
 }
 
+// TestMemoryStorage_UpsertDCRIssuedClient covers the create/replace/reject
+// matrix UpsertDCRIssuedClient must implement: create when absent, replace
+// (and renew the eviction position) when the existing record is itself
+// DCR-issued, refuse with ErrAlreadyExists when the existing record is NOT
+// DCR-issued (the critical protection: a configured/SPIFFE client must never
+// be clobbered by this path), and refuse when the incoming client itself does
+// not carry the DCR-issued marker (misuse guard).
+func TestMemoryStorage_UpsertDCRIssuedClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates when absent", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		s := NewMemoryStorage()
+		defer s.Close()
+
+		client := dcrClient(t, "cimd-client")
+		require.NoError(t, s.UpsertDCRIssuedClient(ctx, client))
+
+		retrieved, err := s.GetClient(ctx, "cimd-client")
+		require.NoError(t, err)
+		assert.Equal(t, client, retrieved)
+	})
+
+	t.Run("replaces and renews when existing row is DCR-issued", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		// MinClientAge(0) isolates this test to the replace/renew behaviour;
+		// the age-floor grace window has its own tests above.
+		s := NewMemoryStorage(WithMaxClients(2), WithMinClientAge(0))
+		defer s.Close()
+
+		first := dcrClient(t, "cimd-client")
+		require.NoError(t, s.UpsertDCRIssuedClient(ctx, first))
+		require.NoError(t, s.RegisterClient(ctx, dcrClient(t, "client-b")))
+
+		// A distinguishing field on the replacement proves the replace branch
+		// actually overwrote the stored data rather than being a silent no-op.
+		second, err := registration.New(registration.Config{
+			ID:                      "cimd-client",
+			TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodNone,
+			RedirectURIs:            []string{"https://app.example/cb-v2"},
+		})
+		require.NoError(t, err)
+		require.NoError(t, s.UpsertDCRIssuedClient(ctx, second))
+
+		retrieved, err := s.GetClient(ctx, "cimd-client")
+		require.NoError(t, err)
+		assert.Equal(t, second, retrieved, "second call must replace the stored row")
+
+		// Renewed eviction position: cimd-client was registered first (oldest)
+		// but the upsert must have moved it to the back, so overflow evicts
+		// client-b instead.
+		require.NoError(t, s.RegisterClient(ctx, dcrClient(t, "client-c")))
+		_, err = s.GetClient(ctx, "cimd-client")
+		require.NoError(t, err, "renewed client must survive eviction")
+		_, err = s.GetClient(ctx, "client-b")
+		requireNotFoundError(t, err)
+	})
+
+	t.Run("refuses to overwrite a non-DCR-issued client", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		s := NewMemoryStorage()
+		defer s.Close()
+
+		configured := &mockClient{id: "configured", public: false}
+		require.NoError(t, s.ReconcileConfiguredClient(ctx, configured))
+
+		err := s.UpsertDCRIssuedClient(ctx, dcrClient(t, "configured"))
+		require.ErrorIs(t, err, ErrAlreadyExists)
+
+		// The original registration must be untouched.
+		retrieved, err := s.GetClient(ctx, "configured")
+		require.NoError(t, err)
+		assert.Equal(t, configured, retrieved)
+	})
+
+	t.Run("rejects a client not carrying the DCR-issued marker", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		s := NewMemoryStorage()
+		defer s.Close()
+
+		err := s.UpsertDCRIssuedClient(ctx, &mockClient{id: "not-dcr"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must carry the DCR-issued marker")
+
+		_, err = s.GetClient(ctx, "not-dcr")
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+}
+
 // TestMemoryStorage_RegisterClient_Bounded pins the anti-DoS cap: the client
 // map is bounded by maxClients with oldest-first eviction among DCR-issued
 // clients only, and duplicate registrations fail without changing stored state.

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -2227,7 +2227,9 @@ func TestMemoryStorage_DCRCredentials_RoundTrip(t *testing.T) {
 			ClientSecretExpiresAt:   time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
 		}
 
-		require.NoError(t, s.StoreDCRCredentials(ctx, creds))
+		authoritative, err := s.StoreDCRCredentialsIfAbsent(ctx, creds)
+		require.NoError(t, err)
+		assert.Equal(t, *creds, *authoritative)
 
 		got, err := s.GetDCRCredentials(ctx, key)
 		require.NoError(t, err)
@@ -2267,7 +2269,8 @@ func TestMemoryStorage_DCRCredentials_DistinctKeysDoNotCollide(t *testing.T) {
 			mkCreds(mkKey("https://idp-a.example.com", "https://up-b", "https://x/cb", []string{"openid"}), "e"),
 		}
 		for _, e := range entries {
-			require.NoError(t, s.StoreDCRCredentials(ctx, e))
+			_, err := s.StoreDCRCredentialsIfAbsent(ctx, e)
+			require.NoError(t, err)
 		}
 
 		for _, want := range entries {
@@ -2279,7 +2282,14 @@ func TestMemoryStorage_DCRCredentials_DistinctKeysDoNotCollide(t *testing.T) {
 	})
 }
 
-func TestMemoryStorage_DCRCredentials_OverwriteSemantics(t *testing.T) {
+// TestMemoryStorage_DCRCredentials_FirstClaimWins pins the create-if-absent
+// contract that replaced unconditional overwrite: a second
+// StoreDCRCredentialsIfAbsent for a key that already holds a (non-expired)
+// value must not replace it. It returns the existing entry as the
+// authoritative value instead, mirroring RedisStorage's create-if-absent
+// claim so the two backends behave symmetrically for a concurrent-
+// registration race.
+func TestMemoryStorage_DCRCredentials_FirstClaimWins(t *testing.T) {
 	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 		key := DCRKey{
 			Issuer:      "https://idp.example.com",
@@ -2296,12 +2306,58 @@ func TestMemoryStorage_DCRCredentials_OverwriteSemantics(t *testing.T) {
 			}
 		}
 
-		require.NoError(t, s.StoreDCRCredentials(ctx, mkCreds("first")))
-		require.NoError(t, s.StoreDCRCredentials(ctx, mkCreds("second")))
+		first, err := s.StoreDCRCredentialsIfAbsent(ctx, mkCreds("first"))
+		require.NoError(t, err)
+		assert.Equal(t, "first", first.ClientID)
+
+		second, err := s.StoreDCRCredentialsIfAbsent(ctx, mkCreds("second"))
+		require.NoError(t, err)
+		assert.Equal(t, "first", second.ClientID,
+			"the loser must get back the winner's credentials, not its own")
 
 		got, err := s.GetDCRCredentials(ctx, key)
 		require.NoError(t, err)
-		assert.Equal(t, "second", got.ClientID)
+		assert.Equal(t, "first", got.ClientID, "the store must keep the first-claimed entry")
+	})
+}
+
+// TestMemoryStorage_DCRCredentials_ExpiredEntryCanBeReclaimed pins the
+// TTL-awareness of the in-memory "absent" check: the in-memory backend has
+// no native TTL, so an existing entry whose ClientSecretExpiresAt is already
+// in the past must be treated as absent — otherwise an expired secret would
+// permanently block re-registration, unlike the Redis backend where the row
+// self-evicts.
+func TestMemoryStorage_DCRCredentials_ExpiredEntryCanBeReclaimed(t *testing.T) {
+	withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+		key := DCRKey{
+			Issuer:      "https://idp.example.com",
+			UpstreamID:  "https://upstream.example.com",
+			RedirectURI: "https://x/cb",
+			ScopesHash:  ScopesHash([]string{"openid"}),
+		}
+		expired, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
+			Key:                   key,
+			ClientID:              "expired-client",
+			AuthorizationEndpoint: "https://idp.example.com/auth",
+			TokenEndpoint:         "https://idp.example.com/token",
+			ClientSecretExpiresAt: time.Now().Add(-time.Hour),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "expired-client", expired.ClientID)
+
+		reclaimed, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
+			Key:                   key,
+			ClientID:              "fresh-client",
+			AuthorizationEndpoint: "https://idp.example.com/auth",
+			TokenEndpoint:         "https://idp.example.com/token",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "fresh-client", reclaimed.ClientID,
+			"an expired entry must be treated as absent and reclaimable")
+
+		got, err := s.GetDCRCredentials(ctx, key)
+		require.NoError(t, err)
+		assert.Equal(t, "fresh-client", got.ClientID)
 	})
 }
 
@@ -2401,7 +2457,7 @@ func TestMemoryStorage_DCRCredentials_StoreInvalidInputRejected(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			withStorage(t, func(ctx context.Context, s *MemoryStorage) {
-				err := s.StoreDCRCredentials(ctx, tc.mutator(validCreds()))
+				_, err := s.StoreDCRCredentialsIfAbsent(ctx, tc.mutator(validCreds()))
 				require.Error(t, err)
 				assert.ErrorIs(t, err, fosite.ErrInvalidRequest)
 				// Confirm the rejection did not partially populate the store.
@@ -2423,12 +2479,13 @@ func TestMemoryStorage_DCRCredentials_GetReturnsDefensiveCopy(t *testing.T) {
 			RedirectURI: "https://x/cb",
 			ScopesHash:  ScopesHash([]string{"openid"}),
 		}
-		require.NoError(t, s.StoreDCRCredentials(ctx, &DCRCredentials{
+		_, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
 			Key:                   key,
 			ClientID:              "orig",
 			AuthorizationEndpoint: "https://idp.example.com/auth",
 			TokenEndpoint:         "https://idp.example.com/token",
-		}))
+		})
+		require.NoError(t, err)
 
 		got, err := s.GetDCRCredentials(ctx, key)
 		require.NoError(t, err)
@@ -2457,7 +2514,8 @@ func TestMemoryStorage_DCRCredentials_StoreCopyIsolatesCaller(t *testing.T) {
 			AuthorizationEndpoint: "https://idp.example.com/auth",
 			TokenEndpoint:         "https://idp.example.com/token",
 		}
-		require.NoError(t, s.StoreDCRCredentials(ctx, input))
+		_, err := s.StoreDCRCredentialsIfAbsent(ctx, input)
+		require.NoError(t, err)
 
 		input.ClientID = "tampered-after-store"
 
@@ -2479,13 +2537,14 @@ func TestMemoryStorage_DCRCredentials_ExcludedFromCleanupExpired(t *testing.T) {
 			RedirectURI: "https://x/cb",
 			ScopesHash:  ScopesHash([]string{"openid"}),
 		}
-		require.NoError(t, s.StoreDCRCredentials(ctx, &DCRCredentials{
+		_, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
 			Key:                   key,
 			ClientID:              "abc",
 			AuthorizationEndpoint: "https://idp.example.com/auth",
 			TokenEndpoint:         "https://idp.example.com/token",
 			CreatedAt:             time.Now().Add(-365 * 24 * time.Hour),
-		}))
+		})
+		require.NoError(t, err)
 
 		s.cleanupExpired()
 
@@ -2496,7 +2555,7 @@ func TestMemoryStorage_DCRCredentials_ExcludedFromCleanupExpired(t *testing.T) {
 }
 
 // TestMemoryStorage_DCRCredentials_ConcurrentAccess fans out N goroutines
-// performing alternating StoreDCRCredentials / GetDCRCredentials against
+// performing alternating StoreDCRCredentialsIfAbsent / GetDCRCredentials against
 // overlapping and disjoint keys, exercising the sync.RWMutex guard
 // advertised in the DCRCredentialStore contract. With go test -race this
 // catches a future change that drops the lock or returns an internal
@@ -2553,7 +2612,7 @@ func TestMemoryStorage_DCRCredentials_ConcurrentAccess(t *testing.T) {
 					} else {
 						key = disjointKey(worker, i)
 					}
-					if err := s.StoreDCRCredentials(ctx, mkCreds(key, fmt.Sprintf("worker-%d-op-%d", worker, i))); err != nil {
+					if _, err := s.StoreDCRCredentialsIfAbsent(ctx, mkCreds(key, fmt.Sprintf("worker-%d-op-%d", worker, i))); err != nil {
 						atomic.AddInt32(&errCount, 1)
 					}
 					// The disjoint Get must always hit (the goroutine that

--- a/pkg/authserver/storage/mocks/mock_storage.go
+++ b/pkg/authserver/storage/mocks/mock_storage.go
@@ -230,6 +230,20 @@ func (mr *MockClientRegistryMockRecorder) GetClient(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockClientRegistry)(nil).GetClient), ctx, id)
 }
 
+// ReconcileConfiguredClient mocks base method.
+func (m *MockClientRegistry) ReconcileConfiguredClient(ctx context.Context, client fosite.Client) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileConfiguredClient", ctx, client)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileConfiguredClient indicates an expected call of ReconcileConfiguredClient.
+func (mr *MockClientRegistryMockRecorder) ReconcileConfiguredClient(ctx, client any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileConfiguredClient", reflect.TypeOf((*MockClientRegistry)(nil).ReconcileConfiguredClient), ctx, client)
+}
+
 // RegisterClient mocks base method.
 func (m *MockClientRegistry) RegisterClient(ctx context.Context, client fosite.Client) error {
 	m.ctrl.T.Helper()
@@ -1002,6 +1016,20 @@ func (m *MockStorage) LoadPendingAuthorization(ctx context.Context, state string
 func (mr *MockStorageMockRecorder) LoadPendingAuthorization(ctx, state any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadPendingAuthorization", reflect.TypeOf((*MockStorage)(nil).LoadPendingAuthorization), ctx, state)
+}
+
+// ReconcileConfiguredClient mocks base method.
+func (m *MockStorage) ReconcileConfiguredClient(ctx context.Context, client fosite.Client) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileConfiguredClient", ctx, client)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileConfiguredClient indicates an expected call of ReconcileConfiguredClient.
+func (mr *MockStorageMockRecorder) ReconcileConfiguredClient(ctx, client any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileConfiguredClient", reflect.TypeOf((*MockStorage)(nil).ReconcileConfiguredClient), ctx, client)
 }
 
 // RegisterClient mocks base method.

--- a/pkg/authserver/storage/mocks/mock_storage.go
+++ b/pkg/authserver/storage/mocks/mock_storage.go
@@ -58,18 +58,19 @@ func (mr *MockDCRCredentialStoreMockRecorder) GetDCRCredentials(ctx, key any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDCRCredentials", reflect.TypeOf((*MockDCRCredentialStore)(nil).GetDCRCredentials), ctx, key)
 }
 
-// StoreDCRCredentials mocks base method.
-func (m *MockDCRCredentialStore) StoreDCRCredentials(ctx context.Context, creds *storage.DCRCredentials) error {
+// StoreDCRCredentialsIfAbsent mocks base method.
+func (m *MockDCRCredentialStore) StoreDCRCredentialsIfAbsent(ctx context.Context, creds *storage.DCRCredentials) (*storage.DCRCredentials, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreDCRCredentials", ctx, creds)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "StoreDCRCredentialsIfAbsent", ctx, creds)
+	ret0, _ := ret[0].(*storage.DCRCredentials)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// StoreDCRCredentials indicates an expected call of StoreDCRCredentials.
-func (mr *MockDCRCredentialStoreMockRecorder) StoreDCRCredentials(ctx, creds any) *gomock.Call {
+// StoreDCRCredentialsIfAbsent indicates an expected call of StoreDCRCredentialsIfAbsent.
+func (mr *MockDCRCredentialStoreMockRecorder) StoreDCRCredentialsIfAbsent(ctx, creds any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreDCRCredentials", reflect.TypeOf((*MockDCRCredentialStore)(nil).StoreDCRCredentials), ctx, creds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreDCRCredentialsIfAbsent", reflect.TypeOf((*MockDCRCredentialStore)(nil).StoreDCRCredentialsIfAbsent), ctx, creds)
 }
 
 // MockPendingAuthorizationStorage is a mock of PendingAuthorizationStorage interface.

--- a/pkg/authserver/storage/mocks/mock_storage.go
+++ b/pkg/authserver/storage/mocks/mock_storage.go
@@ -287,6 +287,20 @@ func (mr *MockClientRegistryMockRecorder) SetClientAssertionJWT(ctx, jti, exp an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClientAssertionJWT", reflect.TypeOf((*MockClientRegistry)(nil).SetClientAssertionJWT), ctx, jti, exp)
 }
 
+// UpsertDCRIssuedClient mocks base method.
+func (m *MockClientRegistry) UpsertDCRIssuedClient(ctx context.Context, client fosite.Client) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertDCRIssuedClient", ctx, client)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertDCRIssuedClient indicates an expected call of UpsertDCRIssuedClient.
+func (mr *MockClientRegistryMockRecorder) UpsertDCRIssuedClient(ctx, client any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDCRIssuedClient", reflect.TypeOf((*MockClientRegistry)(nil).UpsertDCRIssuedClient), ctx, client)
+}
+
 // MockUpstreamTokenStorage is a mock of UpstreamTokenStorage interface.
 type MockUpstreamTokenStorage struct {
 	ctrl     *gomock.Controller
@@ -1172,4 +1186,18 @@ func (m *MockStorage) UpdateProviderIdentityLastUsed(ctx context.Context, provid
 func (mr *MockStorageMockRecorder) UpdateProviderIdentityLastUsed(ctx, providerID, providerSubject, lastUsedAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProviderIdentityLastUsed", reflect.TypeOf((*MockStorage)(nil).UpdateProviderIdentityLastUsed), ctx, providerID, providerSubject, lastUsedAt)
+}
+
+// UpsertDCRIssuedClient mocks base method.
+func (m *MockStorage) UpsertDCRIssuedClient(ctx context.Context, client fosite.Client) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertDCRIssuedClient", ctx, client)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertDCRIssuedClient indicates an expected call of UpsertDCRIssuedClient.
+func (mr *MockStorageMockRecorder) UpsertDCRIssuedClient(ctx, client any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDCRIssuedClient", reflect.TypeOf((*MockStorage)(nil).UpsertDCRIssuedClient), ctx, client)
 }

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -201,6 +201,15 @@ type storedClient struct {
 	// is not compensated for — it predates confidential DCR support entirely,
 	// so it cannot be DCR-issued.
 	DCRIssued bool `json:"dcr_issued,omitempty"`
+	// Reserved is true when the row is a SPIFFE static-client durable
+	// placeholder (see staticClientPlaceholder in spiffe_decorator.go) —
+	// never a real, authenticatable client. It is checked before GrantTypes/
+	// ResponseTypes/Secret/Public are trusted on read: clientFromStored
+	// re-wraps a Reserved row in the same inert type the placeholder was
+	// built with, regardless of what those other fields happen to contain,
+	// so the row cannot become issuable via fosite's own zero-value
+	// defaulting (see clientFromStored and inertPlaceholderClient).
+	Reserved bool `json:"reserved,omitempty"`
 	// JSONWebKeys stores only the inline public keys used by private_key_jwt.
 	// JSONWebKeysURI and other assertion material are intentionally not stored.
 	JSONWebKeys                       *jose.JSONWebKeySet `json:"jwks,omitempty"`
@@ -274,6 +283,24 @@ func publicJSONWebKeySet(jwks *jose.JSONWebKeySet) *jose.JSONWebKeySet {
 // never marked regardless of TTL: it predates confidential DCR support
 // entirely and cannot be DCR-issued.
 func clientFromStored(stored storedClient, hasTTL bool) fosite.Client {
+	// A reserved SPIFFE placeholder is re-wrapped in the exact inert type it
+	// was built with, ignoring whatever GrantTypes/ResponseTypes/Secret/
+	// Public happen to be on the row: a bare *fosite.DefaultClient would
+	// otherwise satisfy fosite's own zero-value defaulting for
+	// GetGrantTypes/GetResponseTypes (["authorization_code"] / ["code"]) on
+	// this exact reconstruction path, undoing the guarantee the placeholder
+	// exists to provide. This check must run before the method-based branch
+	// below: a reserved row never carries a TokenEndpointAuthMethod, but even
+	// if it somehow did, Reserved must still win.
+	if stored.Reserved {
+		return inertPlaceholderClient{DefaultClient: &fosite.DefaultClient{
+			ID:       stored.ID,
+			Scopes:   stored.Scopes,
+			Audience: stored.Audience,
+			Public:   false,
+		}}
+	}
+
 	method := stored.TokenEndpointAuthMethod
 	if method == "" {
 		client := &fosite.DefaultClient{
@@ -312,18 +339,15 @@ func clientFromStored(stored storedClient, hasTTL bool) fosite.Client {
 	return oidcClient
 }
 
-// RegisterClient creates or replaces a client in storage. A DCR-issued
-// registration is create-only and atomically returns ErrAlreadyExists when a
-// client with the same ID is already registered; an operator-declared
-// static/delegate client is authoritative and always replaces any existing
-// registration, including one DCR issued.
-func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client) error {
-	if err := ValidateRegisterableClientID(client.GetID()); err != nil {
-		return err
-	}
-
-	key := redisKey(s.keyPrefix, KeyTypeClient, client.GetID())
-
+// buildStoredClient converts client to its serializable form. Record the
+// registered auth method when the client exposes one. Clients that don't
+// implement fosite.OpenIDConnectClient (e.g. pre-provisioned confidential
+// clients built as bare *fosite.DefaultClient) leave the field empty on
+// purpose: Public alone carries the meaning it already carries, and
+// clientFromStored treats the empty method as a legacy row. Do NOT substitute
+// a "none" fallback here — that would silently reclassify a confidential row
+// as public on read-back.
+func buildStoredClient(client fosite.Client) storedClient {
 	stored := storedClient{
 		ID:            client.GetID(),
 		Secret:        client.GetHashedSecret(),
@@ -334,19 +358,29 @@ func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client)
 		Audience:      client.GetAudience(),
 		Public:        client.IsPublic(),
 	}
-	// Record the registered auth method when the client exposes one. Clients
-	// that don't implement fosite.OpenIDConnectClient (e.g. pre-provisioned
-	// confidential clients built as bare *fosite.DefaultClient) leave the field
-	// empty on purpose: Public alone carries the meaning it already carries,
-	// and GetClient treats the empty method as a legacy row. Do NOT substitute
-	// a "none" fallback here — that would silently reclassify a confidential
-	// row as public on read-back.
 	if oidcClient, ok := client.(fosite.OpenIDConnectClient); ok {
 		stored.TokenEndpointAuthMethod = oidcClient.GetTokenEndpointAuthMethod()
 		stored.JSONWebKeys = publicJSONWebKeySet(oidcClient.GetJSONWebKeys())
 		stored.TokenEndpointAuthSigningAlgorithm = oidcClient.GetTokenEndpointAuthSigningAlgorithm()
 	}
 	stored.DCRIssued = registration.DCRIssued(client)
+	stored.Reserved = isReservedPlaceholder(client)
+	return stored
+}
+
+// RegisterClient creates a client in storage. Always create-only via SetNX:
+// it atomically returns ErrAlreadyExists when a client with the same ID is
+// already registered, regardless of the new client's origin. /oauth/register
+// is unauthenticated, so this must never clobber an existing client;
+// operator-declared clients reconcile through ReconcileConfiguredClient
+// instead.
+func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client) error {
+	if err := ValidateRegisterableClientID(client.GetID()); err != nil {
+		return err
+	}
+
+	key := redisKey(s.keyPrefix, KeyTypeClient, client.GetID())
+	stored := buildStoredClient(client)
 
 	data, err := json.Marshal(stored) //nolint:gosec // G117 - internal Redis storage serialization, not exposed to users
 	if err != nil {
@@ -367,27 +401,129 @@ func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client)
 		ttl = DefaultDCRClientTTL
 	}
 
-	// DCR is unauthenticated (the /register endpoint has no caller identity),
-	// so a DCR-issued registration must never clobber an existing client:
-	// SetNX only creates. Operator-declared static/delegate clients are
-	// authoritative and may replace any existing registration, including one
-	// DCR issued: plain Set with ttl 0 always overwrites and also clears an
-	// inherited DCR expiry, which is exactly what promoting a DCR client to
-	// permanent configuration requires.
-	if registration.DCRIssued(client) {
-		created, err := s.client.SetNX(ctx, key, data, ttl).Result()
-		if err != nil {
-			return fmt.Errorf("failed to register client: %w", err)
-		}
-		if !created {
-			return fmt.Errorf("%w: client %q", ErrAlreadyExists, client.GetID())
-		}
-		return nil
-	}
-	if err := s.client.Set(ctx, key, data, ttl).Err(); err != nil {
+	created, err := s.client.SetNX(ctx, key, data, ttl).Result()
+	if err != nil {
 		return fmt.Errorf("failed to register client: %w", err)
 	}
+	if !created {
+		return fmt.Errorf("%w: client %q", ErrAlreadyExists, client.GetID())
+	}
 	return nil
+}
+
+// storedClientFingerprintsEqual mirrors clientFingerprintsEqual but compares
+// the raw serialized fields directly rather than through the fosite.Client
+// interface returned by clientFromStored. This matters because
+// fosite.DefaultClient.GetGrantTypes and GetResponseTypes each silently
+// substitute a single-element default (["authorization_code"] / ["code"])
+// whenever the underlying field is empty (see clientFromStored) — comparing
+// through the reconstructed client would report a false mismatch between
+// two rows that both deliberately carry no grant/response types, such as
+// the SPIFFE static-client placeholder in spiffe_decorator.go reconciling
+// against itself. Comparing the stored bytes directly sidesteps that
+// defaulting entirely.
+func storedClientFingerprintsEqual(a, b storedClient) bool {
+	return sameStringSet(a.Scopes, b.Scopes) &&
+		sameStringSet(a.Audience, b.Audience) &&
+		sameStringSet(a.GrantTypes, b.GrantTypes) &&
+		sameStringSet(a.ResponseTypes, b.ResponseTypes) &&
+		a.Public == b.Public
+}
+
+// maxConfiguredClientReconcileRetries bounds the retry loop
+// ReconcileConfiguredClient runs around its WATCH/MULTI transaction. go-redis
+// does not retry Watch internally: a concurrent write to the watched key aborts
+// the pipelined EXEC with redis.TxFailedErr, which Watch returns to the caller
+// unwrapped (see $GOMODCACHE/github.com/redis/go-redis/v9@*/tx.go). Retrying a
+// small, fixed number of times lets a real concurrent write during the exact
+// race this feature exists to close (see preflightDurableCollisions in
+// spiffe_decorator.go) resolve on its own rather than failing the caller's
+// startup path with a spurious error.
+const maxConfiguredClientReconcileRetries = 5
+
+// ReconcileConfiguredClient applies an operator-declared client: creates it
+// if absent, idempotently replaces a matching-fingerprint configured client
+// (the restart-with-unchanged-config case), or refuses with ErrAlreadyExists
+// when the existing record is DCR-issued or a different configured client.
+// See the ClientRegistry interface doc for the full contract.
+//
+// The read-check-write sequence for an existing key runs inside a Redis
+// WATCH/MULTI transaction so a concurrent writer (e.g. a DCR registration on
+// another replica racing this reconciliation) cannot interleave between the
+// fingerprint check and the write. Redis aborts the transaction if the
+// watched key changed concurrently, and go-redis surfaces that as
+// redis.TxFailedErr rather than retrying it — see
+// maxConfiguredClientReconcileRetries for why this method retries that error
+// itself, up to a bounded count. A configured client is stored with ttl=0
+// (operator-declared clients never expire), clearing any TTL the row might
+// have inherited.
+func (s *RedisStorage) ReconcileConfiguredClient(ctx context.Context, client fosite.Client) error {
+	if registration.DCRIssued(client) {
+		return fmt.Errorf("configured client %q must not carry the DCR-issued marker", client.GetID())
+	}
+	if err := ValidateRegisterableClientID(client.GetID()); err != nil {
+		return err
+	}
+
+	key := redisKey(s.keyPrefix, KeyTypeClient, client.GetID())
+	stored := buildStoredClient(client)
+	data, err := json.Marshal(stored) //nolint:gosec // G117 - internal Redis storage serialization, not exposed to users
+	if err != nil {
+		return fmt.Errorf("failed to marshal client: %w", err)
+	}
+
+	setPipelined := func(tx *redis.Tx) error {
+		_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Set(ctx, key, data, 0)
+			return nil
+		})
+		return err
+	}
+
+	txFn := func(tx *redis.Tx) error {
+		existingData, getErr := tx.Get(ctx, key).Bytes()
+		if errors.Is(getErr, redis.Nil) {
+			return setPipelined(tx)
+		}
+		if getErr != nil {
+			return fmt.Errorf("failed to get existing client: %w", getErr)
+		}
+
+		ttl, ttlErr := tx.TTL(ctx, key).Result()
+		if ttlErr != nil {
+			return fmt.Errorf("failed to get existing client TTL: %w", ttlErr)
+		}
+
+		var existingStored storedClient
+		if unmarshalErr := json.Unmarshal(existingData, &existingStored); unmarshalErr != nil {
+			return fmt.Errorf("failed to unmarshal existing client: %w", unmarshalErr)
+		}
+
+		// DCR-issued detection goes through the reconstructed client (not the
+		// raw existingStored.DCRIssued field) so it inherits clientFromStored's
+		// legacy-row compensation for rows written before the DCRIssued field
+		// existed. The fingerprint comparison below deliberately does NOT go
+		// through the reconstructed client — see storedClientFingerprintsEqual.
+		if registration.DCRIssued(clientFromStored(existingStored, ttl >= 0)) {
+			return fmt.Errorf("%w: client %q is DCR-issued, refusing to overwrite with a configured client",
+				ErrAlreadyExists, client.GetID())
+		}
+		if !storedClientFingerprintsEqual(existingStored, stored) {
+			return fmt.Errorf("%w: client %q is already registered as a different configured client",
+				ErrAlreadyExists, client.GetID())
+		}
+
+		return setPipelined(tx)
+	}
+
+	var watchErr error
+	for attempt := 0; attempt < maxConfiguredClientReconcileRetries; attempt++ {
+		watchErr = s.client.Watch(ctx, txFn, key)
+		if !errors.Is(watchErr, redis.TxFailedErr) {
+			return watchErr
+		}
+	}
+	return watchErr
 }
 
 // GetClient loads the client by its ID.

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -39,6 +39,16 @@ const nullMarker = "null"
 // confuse this row with a healthy long-lived registration.
 const pastExpiryDCRTTL = time.Second
 
+// maxDCRClaimRetries bounds StoreDCRCredentialsIfAbsent's WATCH/MULTI retry
+// loop. go-redis does not retry Watch internally: a concurrent write to the
+// watched key (another replica claiming, refreshing, or evicting the same
+// row) aborts the pipelined EXEC with redis.TxFailedErr, which Watch returns
+// to the caller unwrapped. Retrying a small, fixed number of times lets a
+// real concurrent write during the exact race this method exists to close
+// resolve on its own rather than failing the caller with a spurious error.
+// Mirrors maxConfiguredClientReconcileRetries above for the same reason.
+const maxDCRClaimRetries = 3
+
 // warnOnCleanupErr logs a warning when a best-effort cleanup operation fails.
 //
 // Secondary index cleanup in Redis (SRem from reverse-lookup sets, Del of orphaned
@@ -1628,7 +1638,7 @@ func unmarshalUpstreamTokens(data []byte) (*UpstreamTokens, error) {
 // Time fields use int64 Unix epoch; 0 is the sentinel meaning "not set", matching
 // the storedUpstreamTokens convention. ClientSecretExpiresAt == 0 specifically
 // encodes the RFC 7591 §3.2.1 "client_secret does not expire" semantics, in
-// which case StoreDCRCredentials persists the entry without a Redis TTL.
+// which case StoreDCRCredentialsIfAbsent persists the entry without a Redis TTL.
 type storedDCRCredentials struct {
 	// Embed the canonical key so a row recovered without its lookup key
 	// (e.g. via SCAN during diagnostics) still self-identifies.
@@ -1687,9 +1697,50 @@ func (s *storedDCRCredentials) toDCRCredentials() *DCRCredentials {
 	}
 }
 
-// StoreDCRCredentials persists DCR credentials, overwriting any existing entry
-// for the same Key. Defensive copy is provided implicitly by JSON serialisation —
+// StoreDCRCredentialsIfAbsent claims creds.Key for creds via a Redis
+// WATCH/MULTI compare-and-set (the same pattern ReconcileConfiguredClient
+// uses above), returning the authoritative durable value: creds itself on a
+// successful claim, or the existing winner's credentials when the key
+// already holds a live (non-expired) entry. Callers MUST use the returned
+// value — RFC 7591 dynamic registration mints a unique client_id/client_secret
+// on every call, so two replicas racing a cache miss for the same Key
+// register genuinely different OAuth clients with the upstream, and only the
+// value the durable store agrees to is a credential either replica actually
+// holds. Defensive copy is provided implicitly by JSON serialisation —
 // caller mutations after the call cannot reach the persisted bytes.
+//
+// # Expired existing rows are claimable
+//
+// An existing row whose ClientSecretExpiresAt is non-zero and already in the
+// past is treated as absent, mirroring MemoryStorage.StoreDCRCredentialsIfAbsent:
+// it is overwritten with creds rather than handed back as if it were still
+// the authoritative winner — but only when creds itself is fresher (creds'
+// own ClientSecretExpiresAt is zero or still in the future). When both the
+// existing row and the incoming creds are already expired — the startup
+// case where many replicas independently re-resolve a dead upstream
+// registration and each mints equally-stale credentials — the existing row
+// is returned as-is instead. Overwriting would gain nothing there, and
+// without this guard every concurrent claimant would keep re-observing an
+// expired row and re-entering the write path, risking exhausting
+// maxDCRClaimRetries under contention instead of converging the way the
+// genuinely-absent case does. WATCH still guards the overwrite path: if
+// another replica claims or refreshes the same key between our GET and our
+// SET, EXEC aborts with redis.TxFailedErr and the loop below retries, so
+// this does not reopen the double-registration race the NX-based
+// predecessor of this method was built to close — it only changes what
+// happens when the existing row is provably expired.
+//
+// This means a caller CAN receive an already-expired credential back from
+// this call — deliberately, per the above, rather than as an oversight. The
+// only thing that later re-checks an expiry against ResolveCredentials'
+// cache is lookupCachedResolution, which only runs on a *subsequent*
+// ResolveCredentials call for the same key; nothing currently re-resolves
+// after the one-time boot-time call in embeddedauthserver.go. So a replica
+// that receives an expired credential here keeps it for the rest of its
+// process lifetime, failing cleanly with an upstream invalid_client/
+// invalid_grant on every use until restart. Closing that gap needs
+// revisiting credentials after boot, not another guard in this function —
+// tracked in #6496.
 //
 // # TTL
 //
@@ -1697,7 +1748,7 @@ func (s *storedDCRCredentials) toDCRCredentials() *DCRCredentials {
 // RFC 7591 §3.2.1 client_secret_expires_at), the entry is stored with a Redis
 // TTL derived from time.Until(ClientSecretExpiresAt) so the row evicts before
 // the upstream rejects the secret at the token endpoint. When zero (RFC 7591
-// "never"), Set with TTL=0 is used and the entry is long-lived.
+// "never"), TTL=0 is used and the entry is long-lived.
 //
 // If ClientSecretExpiresAt is already in the past at call time, the entry is
 // written with the bounded TTL pastExpiryDCRTTL (1 second) rather than rejected
@@ -1708,13 +1759,57 @@ func (s *storedDCRCredentials) toDCRCredentials() *DCRCredentials {
 //
 // Validation is delegated to validateDCRCredentialsForStore so the rejection
 // set stays in sync with MemoryStorage and any future backend.
-func (s *RedisStorage) StoreDCRCredentials(ctx context.Context, creds *DCRCredentials) error {
+func (s *RedisStorage) StoreDCRCredentialsIfAbsent(ctx context.Context, creds *DCRCredentials) (*DCRCredentials, error) {
 	if err := validateDCRCredentialsForStore(creds); err != nil {
-		return err
+		return nil, err
 	}
 
 	key := redisDCRKey(s.keyPrefix, creds.Key)
 
+	data, ttl, err := marshalDCRCredentialsForStore(creds)
+	if err != nil {
+		return nil, err
+	}
+
+	// result is set by txFn on every non-error path: either to creds (a
+	// successful claim) or to the decoded existing row (a live winner
+	// already present). It must not be read until s.client.Watch returns nil.
+	var result *DCRCredentials
+	txFn := func(tx *redis.Tx) error {
+		var txErr error
+		result, txErr = dcrClaimOrReturnWinner(ctx, tx, key, data, ttl, creds)
+		return txErr
+	}
+
+	// Retry bound mirrors ReconcileConfiguredClient's maxConfiguredClientReconcileRetries:
+	// go-redis does not retry Watch internally, so a concurrent writer to the
+	// watched key aborts EXEC with redis.TxFailedErr, which must be retried
+	// here for the race this method exists to close to resolve on its own.
+	var watchErr error
+	for attempt := 0; attempt < maxDCRClaimRetries; attempt++ {
+		watchErr = s.client.Watch(ctx, txFn, key)
+		if watchErr == nil {
+			return result, nil
+		}
+		if !errors.Is(watchErr, redis.TxFailedErr) {
+			return nil, fmt.Errorf("failed to store dcr credentials: %w", watchErr)
+		}
+	}
+	return nil, fmt.Errorf("failed to claim dcr credentials after %d attempts: %w", maxDCRClaimRetries, watchErr)
+}
+
+// marshalDCRCredentialsForStore serializes creds to its Redis wire form and
+// derives the TTL to store it with. Split out of StoreDCRCredentialsIfAbsent
+// purely to keep that method's cyclomatic complexity down; it has no
+// transaction-retry concerns of its own.
+//
+// Derive Redis TTL from ClientSecretExpiresAt:
+//   - Zero (unset)  -> TTL=0 (no expiration) per RFC 7591 §3.2.1 "never".
+//   - Future expiry -> TTL = time.Until(expiry).
+//   - Past expiry   -> TTL = pastExpiryDCRTTL (bounded eviction window).
+//
+// See StoreDCRCredentialsIfAbsent's docstring for the past-expiry rationale.
+func marshalDCRCredentialsForStore(creds *DCRCredentials) ([]byte, time.Duration, error) {
 	stored := storedDCRCredentials{
 		KeyIssuer:               creds.Key.Issuer,
 		KeyUpstreamID:           creds.Key.UpstreamID,
@@ -1738,14 +1833,9 @@ func (s *RedisStorage) StoreDCRCredentials(ctx context.Context, creds *DCRCreden
 
 	data, err := json.Marshal(stored) //nolint:gosec // G117 - internal Redis storage serialization, not exposed to users
 	if err != nil {
-		return fmt.Errorf("failed to marshal dcr credentials: %w", err)
+		return nil, 0, fmt.Errorf("failed to marshal dcr credentials: %w", err)
 	}
 
-	// Derive Redis TTL from ClientSecretExpiresAt:
-	//   * Zero (unset)   -> TTL=0 (no expiration) per RFC 7591 §3.2.1 "never".
-	//   * Future expiry  -> TTL = time.Until(expiry).
-	//   * Past expiry    -> TTL = pastExpiryDCRTTL (bounded eviction window).
-	// See the function docstring for the past-expiry rationale.
 	ttl := time.Duration(0)
 	if !creds.ClientSecretExpiresAt.IsZero() {
 		if until := time.Until(creds.ClientSecretExpiresAt); until > 0 {
@@ -1754,11 +1844,73 @@ func (s *RedisStorage) StoreDCRCredentials(ctx context.Context, creds *DCRCreden
 			ttl = pastExpiryDCRTTL
 		}
 	}
+	return data, ttl, nil
+}
 
-	if err := s.client.Set(ctx, key, data, ttl).Err(); err != nil {
-		return fmt.Errorf("failed to store dcr credentials: %w", err)
+// dcrClaimOrReturnWinner runs the read-check-write body of
+// StoreDCRCredentialsIfAbsent's WATCH transaction: an absent row, or an
+// existing row that is expired while creds is fresher, is claimed with
+// (data, ttl) inside MULTI; a live existing row — or one that is expired but
+// no fresher than creds — is decoded and returned as-is, with no write. See
+// StoreDCRCredentialsIfAbsent's "Expired existing rows" doc section for why.
+// Split out purely to keep StoreDCRCredentialsIfAbsent's cyclomatic
+// complexity down.
+func dcrClaimOrReturnWinner(
+	ctx context.Context, tx *redis.Tx, key string, data []byte, ttl time.Duration, creds *DCRCredentials,
+) (*DCRCredentials, error) {
+	claim := func() error {
+		_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Set(ctx, key, data, ttl)
+			return nil
+		})
+		return err
 	}
-	return nil
+
+	existingData, getErr := tx.Get(ctx, key).Bytes()
+	if errors.Is(getErr, redis.Nil) {
+		if err := claim(); err != nil {
+			return nil, err
+		}
+		return creds, nil
+	}
+	if getErr != nil {
+		return nil, fmt.Errorf("failed to get existing dcr credentials: %w", getErr)
+	}
+
+	var existingStored storedDCRCredentials
+	if unmarshalErr := json.Unmarshal(existingData, &existingStored); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to unmarshal existing dcr credentials: %w", unmarshalErr)
+	}
+	existing := existingStored.toDCRCredentials()
+
+	expired := !existing.ClientSecretExpiresAt.IsZero() && time.Now().After(existing.ClientSecretExpiresAt)
+	if !expired {
+		return existing, nil
+	}
+
+	// The existing row is expired. Only overwrite it when the incoming
+	// credentials are actually fresher — a genuine new registration
+	// reclaiming a dead slot. If the incoming credentials are ALSO already
+	// expired (the startup-reconciliation case: many replicas independently
+	// re-resolving a dead upstream registration all mint equally-stale
+	// credentials), overwriting gains nothing and, under contention, every
+	// concurrent claimant would keep re-observing an expired row and
+	// re-entering this write path, burning through maxDCRClaimRetries
+	// instead of converging. Returning the stable existing row lets every
+	// claimant converge without a write, matching the "genuinely absent"
+	// case's self-limiting behaviour.
+	incomingExpired := !creds.ClientSecretExpiresAt.IsZero() && time.Now().After(creds.ClientSecretExpiresAt)
+	if incomingExpired {
+		return existing, nil
+	}
+
+	// The existing row is provably expired: treat it as absent and overwrite
+	// it, matching MemoryStorage's semantics. WATCH still protects this — see
+	// StoreDCRCredentialsIfAbsent's "Expired existing rows" doc section.
+	if err := claim(); err != nil {
+		return nil, err
+	}
+	return creds, nil
 }
 
 // GetDCRCredentials retrieves the credentials previously persisted under key.
@@ -1766,7 +1918,7 @@ func (s *RedisStorage) StoreDCRCredentials(ctx context.Context, creds *DCRCreden
 // fresh struct decoded from JSON, which acts as a defensive copy.
 //
 // An unpopulated key (empty Issuer, UpstreamID, RedirectURI, or ScopesHash) cannot match
-// any stored row because StoreDCRCredentials rejects such keys, so a Get
+// any stored row because StoreDCRCredentialsIfAbsent rejects such keys, so a Get
 // against one is a normal miss — ErrNotFound — matching
 // MemoryStorage.GetDCRCredentials and the DCRCredentialStore interface contract.
 func (s *RedisStorage) GetDCRCredentials(ctx context.Context, key DCRKey) (*DCRCredentials, error) {

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -421,6 +421,81 @@ func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client)
 	return nil
 }
 
+// UpsertDCRIssuedClient creates or replaces a DCR-issued client at
+// client.GetID(). Unlike RegisterClient (create-only via SetNX), an existing
+// row is replaced -- and its TTL refreshed to DefaultDCRClientTTL -- when the
+// existing row is itself DCR-issued; it refuses with ErrAlreadyExists when the
+// existing row is NOT DCR-issued, protecting a configured/SPIFFE-reconciled
+// client from being clobbered. See the ClientRegistry interface doc for the
+// full contract.
+//
+// The read-check-write sequence for an existing key runs inside a Redis
+// WATCH/MULTI transaction, mirroring ReconcileConfiguredClient, so a
+// concurrent writer cannot interleave between the DCR-issued check and the
+// write; see maxConfiguredClientReconcileRetries for why this method retries
+// redis.TxFailedErr itself, up to the same bounded count. Unlike
+// ReconcileConfiguredClient (ttl=0, permanent), the write here always uses
+// DefaultDCRClientTTL: this row is TTL-bounded like any other DCR-issued
+// client.
+func (s *RedisStorage) UpsertDCRIssuedClient(ctx context.Context, client fosite.Client) error {
+	if !registration.DCRIssued(client) {
+		return fmt.Errorf("client %q must carry the DCR-issued marker to use UpsertDCRIssuedClient", client.GetID())
+	}
+	if err := ValidateRegisterableClientID(client.GetID()); err != nil {
+		return err
+	}
+
+	key := redisKey(s.keyPrefix, KeyTypeClient, client.GetID())
+	stored := buildStoredClient(client)
+	data, err := json.Marshal(stored) //nolint:gosec // G117 - internal Redis storage serialization, not exposed to users
+	if err != nil {
+		return fmt.Errorf("failed to marshal client: %w", err)
+	}
+
+	setPipelined := func(tx *redis.Tx) error {
+		_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Set(ctx, key, data, DefaultDCRClientTTL)
+			return nil
+		})
+		return err
+	}
+
+	txFn := func(tx *redis.Tx) error {
+		existingData, getErr := tx.Get(ctx, key).Bytes()
+		if errors.Is(getErr, redis.Nil) {
+			return setPipelined(tx)
+		}
+		if getErr != nil {
+			return fmt.Errorf("failed to get existing client: %w", getErr)
+		}
+
+		ttl, ttlErr := tx.TTL(ctx, key).Result()
+		if ttlErr != nil {
+			return fmt.Errorf("failed to get existing client TTL: %w", ttlErr)
+		}
+
+		var existingStored storedClient
+		if unmarshalErr := json.Unmarshal(existingData, &existingStored); unmarshalErr != nil {
+			return fmt.Errorf("failed to unmarshal existing client: %w", unmarshalErr)
+		}
+
+		if !registration.DCRIssued(clientFromStored(existingStored, ttl >= 0)) {
+			return fmt.Errorf("%w: client %q", ErrAlreadyExists, client.GetID())
+		}
+
+		return setPipelined(tx)
+	}
+
+	var watchErr error
+	for attempt := 0; attempt < maxConfiguredClientReconcileRetries; attempt++ {
+		watchErr = s.client.Watch(ctx, txFn, key)
+		if !errors.Is(watchErr, redis.TxFailedErr) {
+			return watchErr
+		}
+	}
+	return watchErr
+}
+
 // storedClientFingerprintsEqual mirrors clientFingerprintsEqual but compares
 // the raw serialized fields directly rather than through the fosite.Client
 // interface returned by clientFromStored. This matters because

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -312,7 +312,11 @@ func clientFromStored(stored storedClient, hasTTL bool) fosite.Client {
 	return oidcClient
 }
 
-// RegisterClient adds or updates a client in the storage.
+// RegisterClient creates or replaces a client in storage. A DCR-issued
+// registration is create-only and atomically returns ErrAlreadyExists when a
+// client with the same ID is already registered; an operator-declared
+// static/delegate client is authoritative and always replaces any existing
+// registration, including one DCR issued.
 func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client) error {
 	if err := ValidateRegisterableClientID(client.GetID()); err != nil {
 		return err
@@ -363,7 +367,27 @@ func (s *RedisStorage) RegisterClient(ctx context.Context, client fosite.Client)
 		ttl = DefaultDCRClientTTL
 	}
 
-	return s.client.Set(ctx, key, data, ttl).Err()
+	// DCR is unauthenticated (the /register endpoint has no caller identity),
+	// so a DCR-issued registration must never clobber an existing client:
+	// SetNX only creates. Operator-declared static/delegate clients are
+	// authoritative and may replace any existing registration, including one
+	// DCR issued: plain Set with ttl 0 always overwrites and also clears an
+	// inherited DCR expiry, which is exactly what promoting a DCR client to
+	// permanent configuration requires.
+	if registration.DCRIssued(client) {
+		created, err := s.client.SetNX(ctx, key, data, ttl).Result()
+		if err != nil {
+			return fmt.Errorf("failed to register client: %w", err)
+		}
+		if !created {
+			return fmt.Errorf("%w: client %q", ErrAlreadyExists, client.GetID())
+		}
+		return nil
+	}
+	if err := s.client.Set(ctx, key, data, ttl).Err(); err != nil {
+		return fmt.Errorf("failed to register client: %w", err)
+	}
+	return nil
 }
 
 // GetClient loads the client by its ID.

--- a/pkg/authserver/storage/redis_integration_test.go
+++ b/pkg/authserver/storage/redis_integration_test.go
@@ -1443,7 +1443,9 @@ func TestIntegration_DCRCredentials_RoundTrip(t *testing.T) {
 				ClientSecretExpiresAt:   expiresAt,
 			}
 
-			require.NoError(t, s.StoreDCRCredentials(ctx, creds))
+			authoritative, err := s.StoreDCRCredentialsIfAbsent(ctx, creds)
+			require.NoError(t, err)
+			assert.Equal(t, *creds, *authoritative)
 
 			got, err := s.GetDCRCredentials(ctx, creds.Key)
 			require.NoError(t, err)
@@ -1483,7 +1485,8 @@ func TestIntegration_DCRCredentials_DistinctKeysCoexist(t *testing.T) {
 			mk(mkKey("https://idp-a.example.com", "https://up-b", "https://x/cb", []string{"openid"}), "e"),
 		}
 		for _, e := range entries {
-			require.NoError(t, s.StoreDCRCredentials(ctx, e))
+			_, err := s.StoreDCRCredentialsIfAbsent(ctx, e)
+			require.NoError(t, err)
 		}
 
 		for _, want := range entries {
@@ -1495,7 +1498,11 @@ func TestIntegration_DCRCredentials_DistinctKeysCoexist(t *testing.T) {
 	})
 }
 
-func TestIntegration_DCRCredentials_OverwriteSemantics(t *testing.T) {
+// TestIntegration_DCRCredentials_FirstClaimWins pins the create-if-absent
+// WATCH/MULTI claim against a real Redis Sentinel cluster: a second
+// StoreDCRCredentialsIfAbsent for a key that already holds a value must not
+// overwrite it, and the loser must get back the winner's credentials.
+func TestIntegration_DCRCredentials_FirstClaimWins(t *testing.T) {
 	withIntegrationStorage(t, func(ctx context.Context, s *RedisStorage) {
 		key := dcrFixtureKey()
 		mk := func(clientID string) *DCRCredentials {
@@ -1507,12 +1514,18 @@ func TestIntegration_DCRCredentials_OverwriteSemantics(t *testing.T) {
 			}
 		}
 
-		require.NoError(t, s.StoreDCRCredentials(ctx, mk("first")))
-		require.NoError(t, s.StoreDCRCredentials(ctx, mk("second")))
+		first, err := s.StoreDCRCredentialsIfAbsent(ctx, mk("first"))
+		require.NoError(t, err)
+		assert.Equal(t, "first", first.ClientID)
+
+		second, err := s.StoreDCRCredentialsIfAbsent(ctx, mk("second"))
+		require.NoError(t, err)
+		assert.Equal(t, "first", second.ClientID,
+			"the loser must get back the winner's credentials, not its own")
 
 		got, err := s.GetDCRCredentials(ctx, key)
 		require.NoError(t, err)
-		assert.Equal(t, "second", got.ClientID)
+		assert.Equal(t, "first", got.ClientID)
 	})
 }
 
@@ -1529,13 +1542,14 @@ func TestIntegration_DCRCredentials_TTL(t *testing.T) {
 		withIntegrationStorage(t, func(ctx context.Context, s *RedisStorage) {
 			key := dcrFixtureKey()
 			expires := time.Now().Add(24 * time.Hour).Truncate(time.Second)
-			require.NoError(t, s.StoreDCRCredentials(ctx, &DCRCredentials{
+			_, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
 				Key:                   key,
 				ClientID:              "client-with-expiry",
 				AuthorizationEndpoint: "https://idp.example.com/auth",
 				TokenEndpoint:         "https://idp.example.com/token",
 				ClientSecretExpiresAt: expires,
-			}))
+			})
+			require.NoError(t, err)
 
 			ttl, err := s.client.TTL(ctx, redisDCRKey(s.keyPrefix, key)).Result()
 			require.NoError(t, err)
@@ -1551,13 +1565,14 @@ func TestIntegration_DCRCredentials_TTL(t *testing.T) {
 	t.Run("zero expiry means no TTL", func(t *testing.T) {
 		withIntegrationStorage(t, func(ctx context.Context, s *RedisStorage) {
 			key := dcrFixtureKey()
-			require.NoError(t, s.StoreDCRCredentials(ctx, &DCRCredentials{
+			_, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
 				Key:                   key,
 				ClientID:              "client-no-expiry",
 				AuthorizationEndpoint: "https://idp.example.com/auth",
 				TokenEndpoint:         "https://idp.example.com/token",
 				// ClientSecretExpiresAt deliberately zero.
-			}))
+			})
+			require.NoError(t, err)
 
 			ttl, err := s.client.TTL(ctx, redisDCRKey(s.keyPrefix, key)).Result()
 			require.NoError(t, err)

--- a/pkg/authserver/storage/redis_keys.go
+++ b/pkg/authserver/storage/redis_keys.go
@@ -131,7 +131,7 @@ func redisProviderKey(prefix, providerID, providerSubject string) string {
 // format, so entries written by an older binary (without the segment) will
 // miss on lookup and be harmlessly re-registered under the new key. Orphaned
 // old rows self-evict only when the upstream asserted an RFC 7591 §3.2.1
-// client_secret_expires_at (StoreDCRCredentials sets a matching Redis TTL for
+// client_secret_expires_at (StoreDCRCredentialsIfAbsent sets a matching Redis TTL for
 // those); entries for non-expiring secrets — the common §3.2.1 "never" case —
 // carry no TTL and persist indefinitely, so they require manual cleanup.
 // There is no automated one-shot migration for this key-format change today.

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -658,7 +658,7 @@ func TestRedisStorage_DCRClientTTL(t *testing.T) {
 		})
 	})
 
-	t.Run("static client replaces DCR client without TTL", func(t *testing.T) {
+	t.Run("ReconcileConfiguredClient refuses to overwrite a DCR client, TTL untouched", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
 			dcrClient := newDCRClient(t, "delegate", oauthproto.TokenEndpointAuthMethodClientSecretBasic, "old-secret")
 			require.NoError(t, s.RegisterClient(ctx, dcrClient))
@@ -670,13 +670,74 @@ func TestRedisStorage_DCRClientTTL(t *testing.T) {
 				Scopes: []string{"openid"}, Audience: []string{"https://mcp.example"},
 			})
 			require.NoError(t, err)
-			require.NoError(t, s.RegisterClient(ctx, staticClient))
 
+			err = s.ReconcileConfiguredClient(ctx, staticClient)
+			require.ErrorIs(t, err, ErrAlreadyExists)
+
+			// The original DCR-issued registration and its TTL must be untouched.
 			retrieved, err := s.GetClient(ctx, "delegate")
 			require.NoError(t, err)
+			assert.True(t, registration.DCRIssued(retrieved))
+			assert.Positive(t, mr.TTL(key))
+		})
+	})
+}
+
+// TestRedisStorage_ReconcileConfiguredClient covers the create/idempotent/
+// reject matrix ReconcileConfiguredClient must implement over Redis: create
+// when absent (no TTL), no-op when the existing record is itself configured
+// and fingerprint-equal, and refuse with ErrAlreadyExists when the existing
+// record is DCR-issued or a different configured client.
+func TestRedisStorage_ReconcileConfiguredClient(t *testing.T) {
+	t.Parallel()
+
+	newConfigured := func(id, secret string, scopes []string) fosite.Client {
+		client, err := registration.NewStaticDelegateClient(registration.Config{
+			ID: id, Secret: secret, GrantTypes: []string{oauthproto.GrantTypeTokenExchange},
+			Scopes: scopes, Audience: []string{"https://mcp.example"},
+		})
+		require.NoError(t, err)
+		return client
+	}
+
+	t.Run("creates when absent, no TTL", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			client := newConfigured("configured", "secret", []string{"openid"})
+			require.NoError(t, s.ReconcileConfiguredClient(ctx, client))
+
+			retrieved, err := s.GetClient(ctx, "configured")
+			require.NoError(t, err)
 			assert.False(t, registration.DCRIssued(retrieved))
+			key := redisKey(s.keyPrefix, KeyTypeClient, "configured")
 			assert.Equal(t, time.Duration(0), mr.TTL(key))
+		})
+	})
+
+	t.Run("idempotent on matching fingerprint, secret rotation applies", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.ReconcileConfiguredClient(ctx, newConfigured("configured", "old-secret", []string{"openid"})))
+			require.NoError(t, s.ReconcileConfiguredClient(ctx, newConfigured("configured", "new-secret", []string{"openid"})))
+
+			retrieved, err := s.GetClient(ctx, "configured")
+			require.NoError(t, err)
 			assert.NoError(t, registration.SHA256Hasher.Compare(ctx, retrieved.GetHashedSecret(), []byte("new-secret")))
+		})
+	})
+
+	t.Run("refuses a different configured client at the same ID", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.ReconcileConfiguredClient(ctx, newConfigured("configured", "secret", []string{"openid"})))
+
+			err := s.ReconcileConfiguredClient(ctx, newConfigured("configured", "secret", []string{"profile"}))
+			require.ErrorIs(t, err, ErrAlreadyExists)
+		})
+	})
+
+	t.Run("rejects a client carrying the DCR-issued marker", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			err := s.ReconcileConfiguredClient(ctx, newDCRClient(t, "configured", oauthproto.TokenEndpointAuthMethodClientSecretBasic, "secret"))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must not carry the DCR-issued marker")
 		})
 	})
 }

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -3159,7 +3159,9 @@ func TestRedisStorage_DCRCredentials_RoundTrip(t *testing.T) {
 			ClientSecretExpiresAt:   expiresAt,
 		}
 
-		require.NoError(t, s.StoreDCRCredentials(ctx, creds))
+		authoritative, err := s.StoreDCRCredentialsIfAbsent(ctx, creds)
+		require.NoError(t, err)
+		assert.Equal(t, *creds, *authoritative)
 
 		got, err := s.GetDCRCredentials(ctx, creds.Key)
 		require.NoError(t, err)
@@ -3169,7 +3171,14 @@ func TestRedisStorage_DCRCredentials_RoundTrip(t *testing.T) {
 	})
 }
 
-func TestRedisStorage_DCRCredentials_OverwriteSemantics(t *testing.T) {
+// TestRedisStorage_DCRCredentials_FirstClaimWins pins the create-if-absent
+// contract enforced by the Redis WATCH/MULTI claim: a second
+// StoreDCRCredentialsIfAbsent for a key that already holds a value must NOT
+// overwrite it. The loser gets back the winner's credentials as the
+// authoritative value, and the stored row is unchanged. This is the fix for
+// the concurrent-replica bug where two replicas racing a cache miss each
+// independently register a distinct RFC 7591 client for the same key.
+func TestRedisStorage_DCRCredentials_FirstClaimWins(t *testing.T) {
 	withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
 		key := dcrFixtureKey()
 		mk := func(clientID string) *DCRCredentials {
@@ -3181,12 +3190,231 @@ func TestRedisStorage_DCRCredentials_OverwriteSemantics(t *testing.T) {
 			}
 		}
 
-		require.NoError(t, s.StoreDCRCredentials(ctx, mk("first")))
-		require.NoError(t, s.StoreDCRCredentials(ctx, mk("second")))
+		first, err := s.StoreDCRCredentialsIfAbsent(ctx, mk("first"))
+		require.NoError(t, err)
+		assert.Equal(t, "first", first.ClientID)
+
+		second, err := s.StoreDCRCredentialsIfAbsent(ctx, mk("second"))
+		require.NoError(t, err)
+		assert.Equal(t, "first", second.ClientID,
+			"the loser must get back the winner's credentials, not its own")
 
 		got, err := s.GetDCRCredentials(ctx, key)
 		require.NoError(t, err)
-		assert.Equal(t, "second", got.ClientID)
+		assert.Equal(t, "first", got.ClientID, "the stored row must be the first claim, not overwritten")
+	})
+}
+
+// TestRedisStorage_DCRCredentials_ExpiredWinnerIsClaimable is the regression
+// test for the fix to StoreDCRCredentialsIfAbsent's WATCH/MULTI claim: an
+// existing row whose ClientSecretExpiresAt is already in the past must be
+// treated as absent and overwritten, not handed back as if it were still the
+// authoritative winner. This mirrors MemoryStorage's equivalent behaviour
+// (see TestMemoryStorage_DCRCredentials_FirstClaimWins's expired-entry
+// subtest) which the pre-fix Redis implementation diverged from: a SET NX
+// claim against a live-but-expired key fails, and the pre-fix read-back path
+// returned that stale row verbatim.
+func TestRedisStorage_DCRCredentials_ExpiredWinnerIsClaimable(t *testing.T) {
+	withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+		key := dcrFixtureKey()
+		past := time.Now().Add(-time.Hour).Truncate(time.Second)
+
+		expired, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
+			Key:                   key,
+			ClientID:              "expired-client",
+			AuthorizationEndpoint: "https://idp.example.com/auth",
+			TokenEndpoint:         "https://idp.example.com/token",
+			ClientSecretExpiresAt: past,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "expired-client", expired.ClientID)
+
+		// The row was written with the bounded pastExpiryDCRTTL and would
+		// self-evict almost immediately. Force a long TTL directly so the key
+		// stays PRESENT in Redis while ClientSecretExpiresAt is still in the
+		// past — otherwise the row would simply expire out of miniredis (which
+		// deletes a key once its TTL reaches zero) and the claim below would
+		// hit the "genuinely absent" branch instead of the "present but
+		// expired" branch this test exists to exercise.
+		mr.SetTTL(redisDCRKey(s.keyPrefix, key), time.Hour)
+
+		fresh, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
+			Key:                   key,
+			ClientID:              "fresh-client",
+			AuthorizationEndpoint: "https://idp.example.com/auth",
+			TokenEndpoint:         "https://idp.example.com/token",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "fresh-client", fresh.ClientID,
+			"an expired existing row must be claimable, not returned as the authoritative winner")
+
+		got, err := s.GetDCRCredentials(ctx, key)
+		require.NoError(t, err)
+		assert.Equal(t, "fresh-client", got.ClientID, "the stored row must reflect the overwrite")
+	})
+}
+
+// TestRedisStorage_DCRCredentials_LiveWinnerNotOverwritten pins the "present,
+// not expired" branch of the WATCH/MULTI claim: a genuine, non-expired
+// winner is returned as-is and the stored row is left untouched.
+func TestRedisStorage_DCRCredentials_LiveWinnerNotOverwritten(t *testing.T) {
+	withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+		key := dcrFixtureKey()
+		future := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+
+		winner, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
+			Key:                   key,
+			ClientID:              "live-client",
+			AuthorizationEndpoint: "https://idp.example.com/auth",
+			TokenEndpoint:         "https://idp.example.com/token",
+			ClientSecretExpiresAt: future,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "live-client", winner.ClientID)
+
+		loser, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
+			Key:                   key,
+			ClientID:              "challenger-client",
+			AuthorizationEndpoint: "https://idp.example.com/auth",
+			TokenEndpoint:         "https://idp.example.com/token",
+			ClientSecretExpiresAt: future,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "live-client", loser.ClientID,
+			"a non-expired existing row must be returned as the winner, not overwritten")
+
+		got, err := s.GetDCRCredentials(ctx, key)
+		require.NoError(t, err)
+		assert.Equal(t, "live-client", got.ClientID, "the stored row must be unchanged")
+	})
+}
+
+// TestRedisStorage_DCRCredentials_FirstClaimWins_Concurrent proves the
+// create-if-absent race-safety property holds under genuine concurrency, not
+// just the sequential shape of TestRedisStorage_DCRCredentials_FirstClaimWins:
+// goroutines racing to claim the same, genuinely-absent key via the
+// WATCH/MULTI transaction must produce exactly one winner, with every caller
+// (including the losers) getting back that same winner's credentials.
+func TestRedisStorage_DCRCredentials_FirstClaimWins_Concurrent(t *testing.T) {
+	withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+		const goroutines = 8
+		key := dcrFixtureKey()
+
+		start := make(chan struct{})
+		results := make([]*DCRCredentials, goroutines)
+		errs := make([]error, goroutines)
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for g := 0; g < goroutines; g++ {
+			gid := g
+			go func() {
+				defer wg.Done()
+				<-start
+				results[gid], errs[gid] = s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
+					Key:                   key,
+					ClientID:              fmt.Sprintf("client-%d", gid),
+					AuthorizationEndpoint: "https://idp.example.com/auth",
+					TokenEndpoint:         "https://idp.example.com/token",
+				})
+			}()
+		}
+		close(start)
+
+		done := make(chan struct{})
+		go func() { wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timeout waiting for concurrent claim goroutines")
+		}
+
+		winner := ""
+		for i, err := range errs {
+			require.NoError(t, err)
+			require.NotNil(t, results[i])
+			if winner == "" {
+				winner = results[i].ClientID
+			}
+			assert.Equal(t, winner, results[i].ClientID,
+				"every caller must observe the same winner's credentials")
+		}
+
+		got, err := s.GetDCRCredentials(ctx, key)
+		require.NoError(t, err)
+		assert.Equal(t, winner, got.ClientID, "the stored row must be the agreed-upon winner")
+	})
+}
+
+// TestRedisStorage_DCRCredentials_ExpiredVsExpiredConverges pins the
+// contention-avoidance guard in dcrClaimOrReturnWinner: when the existing row
+// is expired AND the incoming credentials being claimed are ALSO already
+// expired (the startup-reconciliation case where many replicas independently
+// re-resolve a dead upstream registration), concurrent claimants must not
+// churn the write and exhaust maxDCRClaimRetries. They should all converge on
+// returning the stable, still-expired existing row without error.
+func TestRedisStorage_DCRCredentials_ExpiredVsExpiredConverges(t *testing.T) {
+	withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+		const goroutines = 8
+		key := dcrFixtureKey()
+		past := time.Now().Add(-time.Hour).Truncate(time.Second)
+
+		seeded, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
+			Key:                   key,
+			ClientID:              "seed-client",
+			AuthorizationEndpoint: "https://idp.example.com/auth",
+			TokenEndpoint:         "https://idp.example.com/token",
+			ClientSecretExpiresAt: past,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "seed-client", seeded.ClientID)
+
+		// Keep the seeded row PRESENT in Redis (see
+		// TestRedisStorage_DCRCredentials_ExpiredWinnerIsClaimable for why
+		// FastForward is the wrong tool here) while its ClientSecretExpiresAt
+		// stays in the past.
+		mr.SetTTL(redisDCRKey(s.keyPrefix, key), time.Hour)
+
+		start := make(chan struct{})
+		results := make([]*DCRCredentials, goroutines)
+		errs := make([]error, goroutines)
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for g := 0; g < goroutines; g++ {
+			gid := g
+			go func() {
+				defer wg.Done()
+				<-start
+				results[gid], errs[gid] = s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
+					Key:                   key,
+					ClientID:              fmt.Sprintf("stale-client-%d", gid),
+					AuthorizationEndpoint: "https://idp.example.com/auth",
+					TokenEndpoint:         "https://idp.example.com/token",
+					ClientSecretExpiresAt: past,
+				})
+			}()
+		}
+		close(start)
+
+		done := make(chan struct{})
+		go func() { wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timeout waiting for concurrent expired-vs-expired claim goroutines")
+		}
+
+		for i, err := range errs {
+			require.NoError(t, err, "an expired-vs-expired claim must not exhaust maxDCRClaimRetries")
+			require.NotNil(t, results[i])
+			assert.Equal(t, "seed-client", results[i].ClientID,
+				"every caller must converge on the stable existing row, not churn a write")
+		}
+
+		got, err := s.GetDCRCredentials(ctx, key)
+		require.NoError(t, err)
+		assert.Equal(t, "seed-client", got.ClientID, "the stored row must be unchanged")
 	})
 }
 
@@ -3254,7 +3482,8 @@ func TestRedisStorage_DCRCredentials_DistinctKeysCoexist(t *testing.T) {
 			mk(mkKey("https://idp-a.example.com", "https://up-b", "https://x/cb", []string{"openid"}), "e"),
 		}
 		for _, e := range entries {
-			require.NoError(t, s.StoreDCRCredentials(ctx, e))
+			_, err := s.StoreDCRCredentialsIfAbsent(ctx, e)
+			require.NoError(t, err)
 		}
 
 		for _, want := range entries {
@@ -3351,7 +3580,7 @@ func TestRedisStorage_DCRCredentials_StoreInvalidInputRejected(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
-				err := s.StoreDCRCredentials(ctx, tc.mutator(validCreds()))
+				_, err := s.StoreDCRCredentialsIfAbsent(ctx, tc.mutator(validCreds()))
 				assert.ErrorIs(t, err, fosite.ErrInvalidRequest)
 				// Pin the fail-loud contract: a rejected Store must not leave
 				// any row behind, even under a partially-populated key. This
@@ -3371,12 +3600,13 @@ func TestRedisStorage_DCRCredentials_StoreInvalidInputRejected(t *testing.T) {
 func TestRedisStorage_DCRCredentials_GetReturnsDefensiveCopy(t *testing.T) {
 	withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
 		key := dcrFixtureKey()
-		require.NoError(t, s.StoreDCRCredentials(ctx, &DCRCredentials{
+		_, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
 			Key:                   key,
 			ClientID:              "orig",
 			AuthorizationEndpoint: "https://idp.example.com/auth",
 			TokenEndpoint:         "https://idp.example.com/token",
-		}))
+		})
+		require.NoError(t, err)
 
 		got, err := s.GetDCRCredentials(ctx, key)
 		require.NoError(t, err)
@@ -3397,7 +3627,7 @@ func TestRedisStorage_DCRCredentials_GetReturnsDefensiveCopy(t *testing.T) {
 //   - When ClientSecretExpiresAt is in the past at write time, the row
 //     is written with the bounded `pastExpiryDCRTTL` (1 second) so an
 //     already-expired secret self-evicts almost immediately rather than
-//     persisting forever (see StoreDCRCredentials docstring).
+//     persisting forever (see StoreDCRCredentialsIfAbsent docstring).
 func TestRedisStorage_DCRCredentials_TTL(t *testing.T) {
 	t.Parallel()
 
@@ -3405,13 +3635,14 @@ func TestRedisStorage_DCRCredentials_TTL(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
 			key := dcrFixtureKey()
 			expires := time.Now().Add(24 * time.Hour).Truncate(time.Second)
-			require.NoError(t, s.StoreDCRCredentials(ctx, &DCRCredentials{
+			_, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
 				Key:                   key,
 				ClientID:              "client-with-expiry",
 				AuthorizationEndpoint: "https://idp.example.com/auth",
 				TokenEndpoint:         "https://idp.example.com/token",
 				ClientSecretExpiresAt: expires,
-			}))
+			})
+			require.NoError(t, err)
 
 			ttl := mr.TTL(redisDCRKey("test:auth:", key))
 			assert.Greater(t, ttl, time.Duration(0), "TTL should be positive when ClientSecretExpiresAt is in the future")
@@ -3423,13 +3654,14 @@ func TestRedisStorage_DCRCredentials_TTL(t *testing.T) {
 	t.Run("zero expiry means no TTL", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
 			key := dcrFixtureKey()
-			require.NoError(t, s.StoreDCRCredentials(ctx, &DCRCredentials{
+			_, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
 				Key:                   key,
 				ClientID:              "client-no-expiry",
 				AuthorizationEndpoint: "https://idp.example.com/auth",
 				TokenEndpoint:         "https://idp.example.com/token",
 				// ClientSecretExpiresAt deliberately zero.
-			}))
+			})
+			require.NoError(t, err)
 
 			// miniredis returns 0 (not -1) for "no TTL"; the integration test
 			// asserts the real Redis -1 behaviour separately.
@@ -3442,13 +3674,14 @@ func TestRedisStorage_DCRCredentials_TTL(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
 			key := dcrFixtureKey()
 			past := time.Now().Add(-time.Hour).Truncate(time.Second)
-			require.NoError(t, s.StoreDCRCredentials(ctx, &DCRCredentials{
+			_, err := s.StoreDCRCredentialsIfAbsent(ctx, &DCRCredentials{
 				Key:                   key,
 				ClientID:              "client-past-expiry",
 				AuthorizationEndpoint: "https://idp.example.com/auth",
 				TokenEndpoint:         "https://idp.example.com/token",
 				ClientSecretExpiresAt: past,
-			}))
+			})
+			require.NoError(t, err)
 
 			// Pin the bounded-TTL contract for past-expiry writes:
 			// the row exists immediately after the write (so a resolver that
@@ -3506,7 +3739,7 @@ const (
 )
 
 // runDCRConcurrentAccess fans out goroutines doing alternating
-// StoreDCRCredentials / GetDCRCredentials and asserts no Store errored and,
+// StoreDCRCredentialsIfAbsent / GetDCRCredentials and asserts no Store errored and,
 // when the keyspace is disjoint, that every Get hit. Shared between the
 // unit-test (miniredis) and integration-test (real Redis) suites — the
 // integration suite passes a longer deadline.
@@ -3561,17 +3794,17 @@ func runDCRConcurrentAccess(
 			defer wg.Done()
 			for i := 0; i < iterations; i++ {
 				key := keyFor(gid, i)
-				if err := s.StoreDCRCredentials(ctx, mkCreds(key, gid, i)); err != nil {
+				if _, err := s.StoreDCRCredentialsIfAbsent(ctx, mkCreds(key, gid, i)); err != nil {
 					atomic.AddInt32(&storeErrCount, 1)
 					continue
 				}
 				if _, err := s.GetDCRCredentials(ctx, key); err != nil {
 					// In the disjoint keyspace, every goroutine just wrote its own
 					// key; a miss is a real error. In the overlapping keyspace,
-					// the immediate Get can race with another goroutine's
-					// rewrite-then-evict only if a TTL expires mid-test, which
-					// none of these credentials use, so a miss there is also an
-					// error to track.
+					// every write after the first is a no-op under first-claim-wins
+					// semantics (StoreDCRCredentialsIfAbsent), so a miss there could
+					// only mean the key evicted via a TTL — none of these credentials
+					// use one — so a miss there is also an error to track.
 					atomic.AddInt32(&getErrCount, 1)
 				}
 			}

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -742,6 +742,89 @@ func TestRedisStorage_ReconcileConfiguredClient(t *testing.T) {
 	})
 }
 
+// TestRedisStorage_UpsertDCRIssuedClient covers the create/replace/reject
+// matrix UpsertDCRIssuedClient must implement: create when absent (with the
+// DCR TTL, not permanent), replace and renew the TTL when the existing row is
+// itself DCR-issued, refuse with ErrAlreadyExists when the existing row is NOT
+// DCR-issued (the critical protection: a configured/SPIFFE client must never
+// be clobbered by this path), and refuse when the incoming client itself does
+// not carry the DCR-issued marker (misuse guard).
+func TestRedisStorage_UpsertDCRIssuedClient(t *testing.T) {
+	t.Parallel()
+
+	newConfigured := func(id, secret string) fosite.Client {
+		client, err := registration.NewStaticDelegateClient(registration.Config{
+			ID: id, Secret: secret, GrantTypes: []string{oauthproto.GrantTypeTokenExchange},
+			Scopes: []string{"openid"}, Audience: []string{"https://mcp.example"},
+		})
+		require.NoError(t, err)
+		return client
+	}
+
+	t.Run("creates when absent, with the DCR TTL", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			client := newDCRClient(t, "cimd-client", oauthproto.TokenEndpointAuthMethodNone, "")
+			require.NoError(t, s.UpsertDCRIssuedClient(ctx, client))
+
+			retrieved, err := s.GetClient(ctx, "cimd-client")
+			require.NoError(t, err)
+			assert.True(t, registration.DCRIssued(retrieved))
+			key := redisKey(s.keyPrefix, KeyTypeClient, "cimd-client")
+			assert.InDelta(t, DefaultDCRClientTTL.Seconds(), mr.TTL(key).Seconds(), 60)
+		})
+	})
+
+	t.Run("replaces and renews when existing row is DCR-issued", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
+			first := newDCRClient(t, "cimd-client", oauthproto.TokenEndpointAuthMethodNone, "")
+			require.NoError(t, s.UpsertDCRIssuedClient(ctx, first))
+
+			key := redisKey(s.keyPrefix, KeyTypeClient, "cimd-client")
+			mr.FastForward(DefaultDCRClientTTL - time.Hour)
+
+			second, err := registration.New(registration.Config{
+				ID:                      "cimd-client",
+				TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodNone,
+				RedirectURIs:            []string{"https://app.example/cb-v2"},
+			})
+			require.NoError(t, err)
+			require.NoError(t, s.UpsertDCRIssuedClient(ctx, second))
+
+			retrieved, err := s.GetClient(ctx, "cimd-client")
+			require.NoError(t, err)
+			assert.Equal(t, []string{"https://app.example/cb-v2"}, retrieved.GetRedirectURIs(),
+				"second call must replace the stored row's data")
+			assert.InDelta(t, DefaultDCRClientTTL.Seconds(), mr.TTL(key).Seconds(), 60,
+				"second call must renew the TTL")
+		})
+	})
+
+	t.Run("refuses to overwrite a non-DCR-issued client", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			configured := newConfigured("configured", "secret")
+			require.NoError(t, s.ReconcileConfiguredClient(ctx, configured))
+
+			err := s.UpsertDCRIssuedClient(ctx, newDCRClient(t, "configured", oauthproto.TokenEndpointAuthMethodNone, ""))
+			require.ErrorIs(t, err, ErrAlreadyExists)
+
+			retrieved, err := s.GetClient(ctx, "configured")
+			require.NoError(t, err)
+			assert.False(t, registration.DCRIssued(retrieved), "the configured client must be untouched")
+		})
+	})
+
+	t.Run("rejects a client not carrying the DCR-issued marker", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			err := s.UpsertDCRIssuedClient(ctx, newConfigured("not-dcr", "secret"))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must carry the DCR-issued marker")
+
+			_, err = s.GetClient(ctx, "not-dcr")
+			require.ErrorIs(t, err, ErrNotFound)
+		})
+	})
+}
+
 // TestRedisStorage_GetClient_SupportsLoopbackRedirectMatching pins that a
 // public client round-tripped through Redis still supports RFC 8252 §7.3
 // loopback dynamic-port redirect_uri matching.

--- a/pkg/authserver/storage/spiffe_decorator.go
+++ b/pkg/authserver/storage/spiffe_decorator.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+
+	"github.com/ory/fosite"
+
+	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
+)
+
+// SPIFFEStorageDecorator resolves immutable configured SPIFFE clients before
+// the dynamic DCR/CIMD storage backend. Static clients exist only in this
+// overlay; they are never persisted or eligible for registration.
+type SPIFFEStorageDecorator struct {
+	Storage
+	clients map[string]fosite.Client
+}
+
+// NewSPIFFEStorageDecorator overlays static SPIFFE clients over base. It checks
+// the durable backend for client-ID collisions before creating the overlay.
+func NewSPIFFEStorageDecorator(ctx context.Context, base Storage, clients map[string]fosite.Client) (Storage, error) {
+	if base == nil {
+		return nil, fmt.Errorf("storage is required")
+	}
+	if len(clients) == 0 {
+		return base, nil
+	}
+	privateClients := maps.Clone(clients)
+	for clientID, client := range privateClients {
+		if client == nil {
+			return nil, fmt.Errorf("static SPIFFE client %q is required", clientID)
+		}
+		if client.GetID() != clientID {
+			return nil, fmt.Errorf("static SPIFFE client map key %q does not match client ID %q", clientID, client.GetID())
+		}
+	}
+	if err := preflightDurableCollisions(ctx, base, privateClients); err != nil {
+		return nil, err
+	}
+	return &SPIFFEStorageDecorator{Storage: base, clients: privateClients}, nil
+}
+
+// PreflightSPIFFEStaticClientCollisions checks configured static client IDs
+// against durable storage without creating a persistent reservation.
+func PreflightSPIFFEStaticClientCollisions(ctx context.Context, base Storage, clients map[string]fosite.Client) error {
+	if base == nil {
+		return fmt.Errorf("storage is required")
+	}
+	return preflightDurableCollisions(ctx, base, clients)
+}
+
+func preflightDurableCollisions(ctx context.Context, base Storage, clients map[string]fosite.Client) error {
+	for clientID := range clients {
+		if client, err := Unwrap(base).GetClient(ctx, clientID); err == nil {
+			kind := "operator-declared"
+			if registration.DCRIssued(client) {
+				kind = "DCR-issued"
+			}
+			return fmt.Errorf(
+				"%w: static SPIFFE client ID %q collides with an existing %s client; "+
+					"remove the stale registration from durable storage before configuring this association",
+				ErrAlreadyExists, clientID, kind,
+			)
+		} else if !errors.Is(err, ErrNotFound) && !errors.Is(err, fosite.ErrNotFound) {
+			return fmt.Errorf("check durable client collision for SPIFFE client ID %q: %w", clientID, err)
+		}
+	}
+	return nil
+}
+
+// GetClient returns a configured SPIFFE client before consulting the dynamic backend.
+func (d *SPIFFEStorageDecorator) GetClient(ctx context.Context, id string) (fosite.Client, error) {
+	if client, ok := d.clients[id]; ok {
+		return client, nil
+	}
+	return d.Storage.GetClient(ctx, id)
+}
+
+// RegisterClient rejects reserved static SPIFFE IDs and delegates other registrations.
+func (d *SPIFFEStorageDecorator) RegisterClient(ctx context.Context, client fosite.Client) error {
+	if client == nil {
+		return fmt.Errorf("register client: client is required")
+	}
+	if _, reserved := d.clients[client.GetID()]; reserved {
+		return fmt.Errorf("%w: client ID %q is reserved for a static SPIFFE client", ErrAlreadyExists, client.GetID())
+	}
+	return d.Storage.RegisterClient(ctx, client)
+}
+
+// Unwrap returns the dynamic DCR/CIMD storage backend.
+func (d *SPIFFEStorageDecorator) Unwrap() Storage { return d.Storage }

--- a/pkg/authserver/storage/spiffe_decorator.go
+++ b/pkg/authserver/storage/spiffe_decorator.go
@@ -5,9 +5,9 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
+	"time"
 
 	"github.com/ory/fosite"
 
@@ -22,8 +22,9 @@ type SPIFFEStorageDecorator struct {
 	clients map[string]fosite.Client
 }
 
-// NewSPIFFEStorageDecorator overlays static SPIFFE clients over base. It checks
-// the durable backend for client-ID collisions before creating the overlay.
+// NewSPIFFEStorageDecorator overlays static SPIFFE clients over base. It
+// durably claims each configured client ID in base's durable backend (see
+// preflightDurableCollisions) before creating the overlay.
 func NewSPIFFEStorageDecorator(ctx context.Context, base Storage, clients map[string]fosite.Client) (Storage, error) {
 	if base == nil {
 		return nil, fmt.Errorf("storage is required")
@@ -46,8 +47,9 @@ func NewSPIFFEStorageDecorator(ctx context.Context, base Storage, clients map[st
 	return &SPIFFEStorageDecorator{Storage: base, clients: privateClients}, nil
 }
 
-// PreflightSPIFFEStaticClientCollisions checks configured static client IDs
-// against durable storage without creating a persistent reservation.
+// PreflightSPIFFEStaticClientCollisions durably claims each configured static
+// client ID in base's durable backend before the caller starts serving static
+// SPIFFE clients from an in-process overlay. See preflightDurableCollisions.
 func PreflightSPIFFEStaticClientCollisions(ctx context.Context, base Storage, clients map[string]fosite.Client) error {
 	if base == nil {
 		return fmt.Errorf("storage is required")
@@ -55,23 +57,110 @@ func PreflightSPIFFEStaticClientCollisions(ctx context.Context, base Storage, cl
 	return preflightDurableCollisions(ctx, base, clients)
 }
 
+// preflightDurableCollisions durably claims each configured static SPIFFE
+// client ID in base's durable backend using an inert placeholder (see
+// staticClientPlaceholder) — never the real SPIFFE client. Reconciliation is
+// idempotent: a restart with unchanged association config reconstructs the
+// identical placeholder and succeeds silently; a collision with a DCR-issued
+// client, or with a durably-claimed placeholder for a *different* association
+// at the same ID, fails loudly.
+//
+// This closes a cross-replica race that a read-only GetClient check cannot:
+// with Redis and multiple replicas, an older/still-rolling replica without
+// this SPIFFE config could otherwise DCR-register the same client ID after a
+// newer replica's read-only check passed, leaving different replicas
+// resolving different clients for the same ID. Durably claiming the ID here
+// makes the reservation visible to every replica's ReconcileConfiguredClient
+// and RegisterClient calls immediately.
 func preflightDurableCollisions(ctx context.Context, base Storage, clients map[string]fosite.Client) error {
-	for clientID := range clients {
-		if client, err := Unwrap(base).GetClient(ctx, clientID); err == nil {
-			kind := "operator-declared"
-			if registration.DCRIssued(client) {
-				kind = "DCR-issued"
-			}
-			return fmt.Errorf(
-				"%w: static SPIFFE client ID %q collides with an existing %s client; "+
-					"remove the stale registration from durable storage before configuring this association",
-				ErrAlreadyExists, clientID, kind,
-			)
-		} else if !errors.Is(err, ErrNotFound) && !errors.Is(err, fosite.ErrNotFound) {
-			return fmt.Errorf("check durable client collision for SPIFFE client ID %q: %w", clientID, err)
+	underlying := Unwrap(base)
+	for clientID, client := range clients {
+		placeholder := staticClientPlaceholder(client)
+		if err := underlying.ReconcileConfiguredClient(ctx, placeholder); err != nil {
+			return fmt.Errorf("claim durable placeholder for static SPIFFE client ID %q: %w", clientID, err)
 		}
 	}
 	return nil
+}
+
+// inertPlaceholderClient wraps a *fosite.DefaultClient to suppress its
+// implicit defaulting: fosite.DefaultClient.GetGrantTypes and
+// GetResponseTypes each return a single-element default
+// (["authorization_code"] / ["code"]) when the underlying field is nil,
+// treating "omitted" as "the interactive default" per the OIDC registration
+// metadata convention they follow. staticClientPlaceholder needs the
+// opposite: a client that can never be issued a token via any grant.
+// Overriding both getters at the type — rather than storing an empty
+// (non-nil) slice on the embedded struct — is required, not just clearer:
+// fosite defaults on len() == 0 regardless of nil vs. non-nil-empty, so an
+// empty slice alone would not suppress the default.
+//
+// This override is only reliable for the live Go value. A round trip through
+// Redis serializes the *fields* (buildStoredClient reads GetGrantTypes() /
+// GetResponseTypes() into JSON, which correctly capture the override's empty
+// result), but clientFromStored ordinarily reconstructs a bare
+// *fosite.DefaultClient on read, which reintroduces the very defaulting this
+// type exists to suppress. storedClient.Reserved closes that gap: it marks a
+// row as this placeholder so clientFromStored re-wraps the reconstructed
+// client in inertPlaceholderClient on every read, independent of backend.
+// See buildStoredClient and clientFromStored in redis.go.
+type inertPlaceholderClient struct {
+	registration.BackChannelOnlyMarker
+	*fosite.DefaultClient
+}
+
+func (inertPlaceholderClient) GetGrantTypes() fosite.Arguments    { return nil }
+func (inertPlaceholderClient) GetResponseTypes() fosite.Arguments { return nil }
+
+// isReservedPlaceholder reports whether client is a staticClientPlaceholder
+// value, letting buildStoredClient (redis.go) mark the persisted row so
+// clientFromStored can restore the same inert wrapper on read-back. Mirrors
+// registration.DCRIssued's marker-detection pattern.
+func isReservedPlaceholder(client fosite.Client) bool {
+	_, ok := client.(inertPlaceholderClient)
+	return ok
+}
+
+// staticClientPlaceholder returns an inert stand-in for a real static SPIFFE
+// client, safe to durably persist. It is never returned to a caller of
+// GetClient — GetClient always resolves a reserved ID from the in-process
+// overlay first (see SPIFFEStorageDecorator.GetClient) — but must still be
+// structurally impossible to authenticate as or exchange a token for, in
+// case that invariant is ever violated: no grant types and no response types
+// mean fosite can never issue it a token via any grant handler this auth
+// server registers, and it carries no secret. This guarantee holds on every
+// backend, including a bare read-back from Redis by a replica with no SPIFFE
+// overlay — see inertPlaceholderClient and storedClient.Reserved. It keeps
+// the real client's Scopes and Audience so the fingerprint comparison in
+// ReconcileConfiguredClient can distinguish "same association, restarted"
+// (idempotent) from "different, colliding association at this ID" (a loud
+// failure).
+// Scopes and Audience are taken directly from actual.GetScopes() /
+// GetAudience() without an extra defensive clone here: the only production
+// caller (registration.SPIFFEClient) already returns a fresh slice.Clone
+// from both getters (see its doc comments), so there is no live backing
+// array to alias.
+func staticClientPlaceholder(actual fosite.Client) fosite.Client {
+	return inertPlaceholderClient{DefaultClient: &fosite.DefaultClient{
+		ID:       actual.GetID(),
+		Scopes:   actual.GetScopes(),
+		Audience: actual.GetAudience(),
+		Public:   false,
+	}}
+}
+
+// ConsumeAssertionJWT delegates assertion replay consumption to the wrapped
+// storage, one level down. Storage intentionally does not include this narrow
+// capability, so this decorator fails closed when its wrapped storage does
+// not provide it, rather than silently skipping past this layer via Unwrap.
+func (d *SPIFFEStorageDecorator) ConsumeAssertionJWT(
+	ctx context.Context, purpose, issuer, jti string, exp time.Time,
+) error {
+	consumer, ok := d.Storage.(AssertionJWTConsumer)
+	if !ok {
+		return fmt.Errorf("wrapped storage %T does not support assertion JWT replay consumption", d.Storage)
+	}
+	return consumer.ConsumeAssertionJWT(ctx, purpose, issuer, jti, exp)
 }
 
 // GetClient returns a configured SPIFFE client before consulting the dynamic backend.
@@ -91,6 +180,18 @@ func (d *SPIFFEStorageDecorator) RegisterClient(ctx context.Context, client fosi
 		return fmt.Errorf("%w: client ID %q is reserved for a static SPIFFE client", ErrAlreadyExists, client.GetID())
 	}
 	return d.Storage.RegisterClient(ctx, client)
+}
+
+// ReconcileConfiguredClient rejects reserved static SPIFFE IDs and delegates
+// other configured-client reconciliation to the base backend.
+func (d *SPIFFEStorageDecorator) ReconcileConfiguredClient(ctx context.Context, client fosite.Client) error {
+	if client == nil {
+		return fmt.Errorf("reconcile configured client: client is required")
+	}
+	if _, reserved := d.clients[client.GetID()]; reserved {
+		return fmt.Errorf("%w: client ID %q is reserved for a static SPIFFE client", ErrAlreadyExists, client.GetID())
+	}
+	return d.Storage.ReconcileConfiguredClient(ctx, client)
 }
 
 // Unwrap returns the dynamic DCR/CIMD storage backend.

--- a/pkg/authserver/storage/spiffe_decorator.go
+++ b/pkg/authserver/storage/spiffe_decorator.go
@@ -194,5 +194,21 @@ func (d *SPIFFEStorageDecorator) ReconcileConfiguredClient(ctx context.Context, 
 	return d.Storage.ReconcileConfiguredClient(ctx, client)
 }
 
+// UpsertDCRIssuedClient rejects reserved static SPIFFE IDs and delegates
+// other DCR-issued upsert-on-fetch calls (e.g. CIMDStorageDecorator) to the
+// base backend. Without this override the guard would be skipped whenever
+// the durable SPIFFE placeholder row is absent (reconciliation hasn't run
+// yet, or persistence failed), letting a DCR row get created at a reserved
+// SPIFFE ID.
+func (d *SPIFFEStorageDecorator) UpsertDCRIssuedClient(ctx context.Context, client fosite.Client) error {
+	if client == nil {
+		return fmt.Errorf("upsert DCR-issued client: client is required")
+	}
+	if _, reserved := d.clients[client.GetID()]; reserved {
+		return fmt.Errorf("%w: client ID %q is reserved for a static SPIFFE client", ErrAlreadyExists, client.GetID())
+	}
+	return d.Storage.UpsertDCRIssuedClient(ctx, client)
+}
+
 // Unwrap returns the dynamic DCR/CIMD storage backend.
 func (d *SPIFFEStorageDecorator) Unwrap() Storage { return d.Storage }

--- a/pkg/authserver/storage/spiffe_decorator_test.go
+++ b/pkg/authserver/storage/spiffe_decorator_test.go
@@ -57,6 +57,32 @@ func TestSPIFFEStorageDecoratorReconcileConfiguredClientRejectsReservedID(t *tes
 	require.ErrorIs(t, err, ErrAlreadyExists)
 }
 
+// TestSPIFFEStorageDecoratorUpsertDCRIssuedClientRejectsReservedID mirrors
+// TestSPIFFEStorageDecoratorStaticClients' RegisterClient assertion, but for
+// UpsertDCRIssuedClient: a DCR-issued client (e.g. from CIMDStorageDecorator's
+// write-through) must not be able to clobber a reserved static SPIFFE client
+// ID either, even though UpsertDCRIssuedClient's own DCR-issued guard alone
+// would otherwise let a create-when-absent slip through if the durable
+// placeholder row were ever missing.
+func TestSPIFFEStorageDecoratorUpsertDCRIssuedClientRejectsReservedID(t *testing.T) {
+	t.Parallel()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+
+	decorated, err := NewSPIFFEStorageDecorator(context.Background(), base, testSPIFFEClients(t))
+	require.NoError(t, err)
+
+	dcrClient, err := registration.New(registration.Config{
+		ID:                      "spiffe-client",
+		TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodNone,
+		RedirectURIs:            []string{"https://app.example/cb"},
+	})
+	require.NoError(t, err)
+
+	err = decorated.UpsertDCRIssuedClient(context.Background(), dcrClient)
+	require.ErrorIs(t, err, ErrAlreadyExists)
+}
+
 // TestSPIFFEStorageDecoratorDurablyClaimsPlaceholder pins the race fix:
 // construction durably claims each configured client ID in the base backend
 // with an inert placeholder (never the real, unauthenticatable-by-design

--- a/pkg/authserver/storage/spiffe_decorator_test.go
+++ b/pkg/authserver/storage/spiffe_decorator_test.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ory/fosite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
+)
+
+func testSPIFFEClients(t *testing.T) map[string]fosite.Client {
+	t.Helper()
+	client, err := registration.NewSPIFFEClient(
+		"spiffe-client",
+		[]string{"openid"},
+		[]string{"https://api.example.com"},
+	)
+	require.NoError(t, err)
+	return map[string]fosite.Client{client.GetID(): client}
+}
+
+func TestSPIFFEStorageDecoratorStaticClients(t *testing.T) {
+	t.Parallel()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+
+	decorated, err := NewSPIFFEStorageDecorator(context.Background(), base, testSPIFFEClients(t))
+	require.NoError(t, err)
+	client, err := decorated.GetClient(context.Background(), "spiffe-client")
+	require.NoError(t, err)
+	assert.Equal(t, "spiffe-client", client.GetID())
+	assert.Empty(t, client.GetResponseTypes())
+	require.ErrorIs(t, decorated.RegisterClient(context.Background(), &fosite.DefaultClient{ID: "spiffe-client"}), ErrAlreadyExists)
+}
+
+func TestSPIFFEStorageDecoratorRejectsInvalidClients(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		clients map[string]fosite.Client
+		wantErr string
+	}{
+		{
+			name:    "nil client",
+			clients: map[string]fosite.Client{"spiffe-client": nil},
+			wantErr: `static SPIFFE client "spiffe-client" is required`,
+		},
+		{
+			name: "map key does not match client ID",
+			clients: map[string]fosite.Client{
+				"map-key": &fosite.DefaultClient{ID: "client-id"},
+			},
+			wantErr: `map key "map-key" does not match client ID "client-id"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			base := NewMemoryStorage()
+			t.Cleanup(func() { _ = base.Close() })
+
+			_, err := NewSPIFFEStorageDecorator(context.Background(), base, tt.clients)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestSPIFFEStorageDecoratorClonesClientMap(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+	clients := testSPIFFEClients(t)
+
+	decorated, err := NewSPIFFEStorageDecorator(ctx, base, clients)
+	require.NoError(t, err)
+	delete(clients, "spiffe-client")
+	clients["added-client"] = &fosite.DefaultClient{ID: "added-client"}
+
+	client, err := decorated.GetClient(ctx, "spiffe-client")
+	require.NoError(t, err)
+	assert.Equal(t, "spiffe-client", client.GetID())
+	require.ErrorIs(t, decorated.RegisterClient(ctx, &fosite.DefaultClient{ID: "spiffe-client"}), ErrAlreadyExists)
+
+	_, err = decorated.GetClient(ctx, "added-client")
+	require.ErrorIs(t, err, ErrNotFound)
+	require.NoError(t, decorated.RegisterClient(ctx, &fosite.DefaultClient{ID: "added-client"}))
+}
+
+func TestSPIFFEStorageDecoratorRejectsDurableCollision(t *testing.T) {
+	t.Parallel()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+	require.NoError(t, base.RegisterClient(context.Background(), &fosite.DefaultClient{ID: "spiffe-client"}))
+
+	_, err := NewSPIFFEStorageDecorator(context.Background(), base, testSPIFFEClients(t))
+	require.ErrorIs(t, err, ErrAlreadyExists)
+	assert.Contains(t, err.Error(), "operator-declared")
+	assert.Contains(t, err.Error(), "remove the stale registration")
+}
+
+func TestSPIFFEStorageDecoratorLeavesEmptyClientsUnchanged(t *testing.T) {
+	t.Parallel()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+	decorated, err := NewSPIFFEStorageDecorator(context.Background(), base, nil)
+	require.NoError(t, err)
+	assert.Same(t, base, decorated)
+}

--- a/pkg/authserver/storage/spiffe_decorator_test.go
+++ b/pkg/authserver/storage/spiffe_decorator_test.go
@@ -6,12 +6,14 @@ package storage
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/ory/fosite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 func testSPIFFEClients(t *testing.T) map[string]fosite.Client {
@@ -37,6 +39,60 @@ func TestSPIFFEStorageDecoratorStaticClients(t *testing.T) {
 	assert.Equal(t, "spiffe-client", client.GetID())
 	assert.Empty(t, client.GetResponseTypes())
 	require.ErrorIs(t, decorated.RegisterClient(context.Background(), &fosite.DefaultClient{ID: "spiffe-client"}), ErrAlreadyExists)
+}
+
+// TestSPIFFEStorageDecoratorReconcileConfiguredClientRejectsReservedID mirrors
+// TestSPIFFEStorageDecoratorStaticClients' RegisterClient assertion, but for
+// ReconcileConfiguredClient: an operator-declared client must not be able to
+// reconcile onto a reserved static SPIFFE client ID either.
+func TestSPIFFEStorageDecoratorReconcileConfiguredClientRejectsReservedID(t *testing.T) {
+	t.Parallel()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+
+	decorated, err := NewSPIFFEStorageDecorator(context.Background(), base, testSPIFFEClients(t))
+	require.NoError(t, err)
+
+	err = decorated.ReconcileConfiguredClient(context.Background(), &fosite.DefaultClient{ID: "spiffe-client"})
+	require.ErrorIs(t, err, ErrAlreadyExists)
+}
+
+// TestSPIFFEStorageDecoratorDurablyClaimsPlaceholder pins the race fix:
+// construction durably claims each configured client ID in the base backend
+// with an inert placeholder (never the real, unauthenticatable-by-design
+// SPIFFE client), so a concurrent DCR registration on another replica cannot
+// claim the same ID after this replica's construction completes.
+func TestSPIFFEStorageDecoratorDurablyClaimsPlaceholder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := NewSPIFFEStorageDecorator(ctx, base, testSPIFFEClients(t))
+	require.NoError(t, err)
+
+	claimed, err := base.GetClient(ctx, "spiffe-client")
+	require.NoError(t, err, "construction must durably claim the client ID in the base backend")
+	assert.Empty(t, claimed.GetGrantTypes(), "the durable placeholder must carry no grant types")
+	assert.Empty(t, claimed.GetResponseTypes(), "the durable placeholder must carry no response types")
+	assert.Nil(t, claimed.GetHashedSecret(), "the durable placeholder must carry no secret")
+	assert.False(t, registration.DCRIssued(claimed))
+}
+
+// TestSPIFFEStorageDecoratorRestartIsIdempotent pins the restart case:
+// reconstructing the decorator with the SAME association config reclaims the
+// identical placeholder and succeeds, rather than colliding with itself.
+func TestSPIFFEStorageDecoratorRestartIsIdempotent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+
+	_, err := NewSPIFFEStorageDecorator(ctx, base, testSPIFFEClients(t))
+	require.NoError(t, err)
+
+	_, err = NewSPIFFEStorageDecorator(ctx, base, testSPIFFEClients(t))
+	require.NoError(t, err, "reconstructing with unchanged association config must be idempotent")
 }
 
 func TestSPIFFEStorageDecoratorRejectsInvalidClients(t *testing.T) {
@@ -98,14 +154,43 @@ func TestSPIFFEStorageDecoratorClonesClientMap(t *testing.T) {
 
 func TestSPIFFEStorageDecoratorRejectsDurableCollision(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 	base := NewMemoryStorage()
 	t.Cleanup(func() { _ = base.Close() })
-	require.NoError(t, base.RegisterClient(context.Background(), &fosite.DefaultClient{ID: "spiffe-client"}))
 
-	_, err := NewSPIFFEStorageDecorator(context.Background(), base, testSPIFFEClients(t))
+	dcrIssued, err := registration.New(registration.Config{
+		ID:                      "spiffe-client",
+		TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodNone,
+		RedirectURIs:            []string{"https://app.example/cb"},
+	})
+	require.NoError(t, err)
+	require.True(t, registration.DCRIssued(dcrIssued), "precondition: seeded client must be DCR-issued")
+	require.NoError(t, base.RegisterClient(ctx, dcrIssued))
+
+	_, err = NewSPIFFEStorageDecorator(ctx, base, testSPIFFEClients(t))
 	require.ErrorIs(t, err, ErrAlreadyExists)
-	assert.Contains(t, err.Error(), "operator-declared")
-	assert.Contains(t, err.Error(), "remove the stale registration")
+	assert.Contains(t, err.Error(), "DCR-issued")
+}
+
+// TestSPIFFEStorageDecoratorRejectsDifferentConfiguredClientCollision covers
+// the case ReconcileConfiguredClient's fingerprint check adds: a *different*
+// configured client (not DCR-issued) already durably claiming a reserved ID
+// -- e.g. a stale placeholder from a prior, differently-scoped association --
+// must still fail construction loudly rather than silently diverging.
+func TestSPIFFEStorageDecoratorRejectsDifferentConfiguredClientCollision(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+
+	// Pre-seed a durably-claimed placeholder with a different fingerprint
+	// (mismatched scopes) than the one the real association will produce.
+	mismatched := &fosite.DefaultClient{ID: "spiffe-client", Scopes: []string{"a-different-scope"}}
+	require.NoError(t, base.ReconcileConfiguredClient(ctx, mismatched))
+
+	_, err := NewSPIFFEStorageDecorator(ctx, base, testSPIFFEClients(t))
+	require.ErrorIs(t, err, ErrAlreadyExists)
+	assert.Contains(t, err.Error(), "different configured client")
 }
 
 func TestSPIFFEStorageDecoratorLeavesEmptyClientsUnchanged(t *testing.T) {
@@ -115,4 +200,115 @@ func TestSPIFFEStorageDecoratorLeavesEmptyClientsUnchanged(t *testing.T) {
 	decorated, err := NewSPIFFEStorageDecorator(context.Background(), base, nil)
 	require.NoError(t, err)
 	assert.Same(t, base, decorated)
+}
+
+// TestSPIFFEStorageDecoratorPlaceholderInertOnRawRedisReadback is the
+// regression test for PR #6474 review finding 1: the durable placeholder
+// written by PreflightSPIFFEStaticClientCollisions must remain unusable even
+// when read back through the RAW, unwrapped Redis storage — simulating an
+// old or mid-rollout replica with no SPIFFE overlay reaching the placeholder
+// through the ordinary fosite.ClientManager.GetClient path.
+// fosite.DefaultClient.GetGrantTypes/GetResponseTypes silently default to a
+// real grant/response type ("authorization_code" / "code") whenever the
+// underlying field is empty, and clientFromStored used to reconstruct a bare
+// *fosite.DefaultClient on every read, reintroducing exactly that defaulting
+// for a row that must never satisfy it. Without the storedClient.Reserved fix
+// in clientFromStored, this test fails with non-empty grant/response types.
+func TestSPIFFEStorageDecoratorPlaceholderInertOnRawRedisReadback(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	raw, mr := newTestRedisStorage(t)
+	t.Cleanup(func() { _ = raw.Close(); mr.Close() })
+
+	require.NoError(t, PreflightSPIFFEStaticClientCollisions(ctx, raw, testSPIFFEClients(t)))
+
+	client, err := raw.GetClient(ctx, "spiffe-client")
+	require.NoError(t, err)
+
+	assert.Empty(t, client.GetGrantTypes(), "placeholder must carry no usable grant type on raw Redis readback")
+	assert.Empty(t, client.GetResponseTypes(), "placeholder must carry no usable response type on raw Redis readback")
+	assert.Nil(t, client.GetHashedSecret(), "placeholder must carry no usable secret on raw Redis readback")
+	assert.False(t, client.IsPublic(), "placeholder must not read back as a public client")
+	assert.True(t, registration.BackChannelOnly(client),
+		"placeholder must carry the explicit back-channel-only marker on raw Redis readback, "+
+			"not rely solely on empty grant/response types")
+}
+
+// TestSPIFFEStorageDecoratorDurableClaimRedisBacked exercises the full
+// durable-claim flow (the point of PR #6474) against a real RedisStorage
+// backend rather than MemoryStorage: the original cross-replica race (review
+// finding 1's precondition) only manifests with a shared backend, since
+// MemoryStorage is per-process.
+func TestSPIFFEStorageDecoratorDurableClaimRedisBacked(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	base, mr := newTestRedisStorage(t)
+	t.Cleanup(func() { _ = base.Close(); mr.Close() })
+
+	_, err := NewSPIFFEStorageDecorator(ctx, base, testSPIFFEClients(t))
+	require.NoError(t, err)
+
+	// Durably written: readable via GetClient on the raw Redis storage.
+	claimed, err := base.GetClient(ctx, "spiffe-client")
+	require.NoError(t, err)
+	assert.Empty(t, claimed.GetGrantTypes())
+
+	// Reconstructing with the same config twice is idempotent (restart case).
+	_, err = NewSPIFFEStorageDecorator(ctx, base, testSPIFFEClients(t))
+	require.NoError(t, err)
+
+	// Reconstructing with a different/conflicting association at the same ID
+	// fails loudly.
+	conflicting, err := registration.NewSPIFFEClient(
+		"spiffe-client", []string{"a-different-scope"}, []string{"https://api.example.com"})
+	require.NoError(t, err)
+	_, err = NewSPIFFEStorageDecorator(ctx, base, map[string]fosite.Client{"spiffe-client": conflicting})
+	require.ErrorIs(t, err, ErrAlreadyExists)
+}
+
+// TestSPIFFEStorageDecorator_ConsumeAssertionJWTDelegatesToWrapped is the
+// regression test for PR #6474 review finding 2: SPIFFEStorageDecorator must
+// forward JWT-bearer assertion-replay consumption to its immediately-wrapped
+// storage (one level down), never by unwrapping past it, so replay protection
+// is actually enforced (not just accidentally reachable) when this decorator
+// sits in the chain. MemoryStorage's own ConsumeAssertionJWT does the real
+// replay bookkeeping here, proving the forward is live rather than a stub.
+func TestSPIFFEStorageDecorator_ConsumeAssertionJWTDelegatesToWrapped(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	base := NewMemoryStorage()
+	t.Cleanup(func() { _ = base.Close() })
+
+	decorated, err := NewSPIFFEStorageDecorator(ctx, base, testSPIFFEClients(t))
+	require.NoError(t, err)
+	consumer, ok := decorated.(AssertionJWTConsumer)
+	require.True(t, ok, "SPIFFEStorageDecorator must implement AssertionJWTConsumer")
+
+	exp := time.Now().Add(time.Hour)
+	require.NoError(t, consumer.ConsumeAssertionJWT(ctx, "jwt-bearer", "https://issuer.example", "jti", exp))
+	require.ErrorIs(t,
+		consumer.ConsumeAssertionJWT(ctx, "jwt-bearer", "https://issuer.example", "jti", exp),
+		fosite.ErrJTIKnown)
+}
+
+// TestSPIFFEStorageDecorator_ConsumeAssertionJWTFailsClosedWithoutBackendCapability
+// mirrors CIMDStorageDecorator's equivalent test: when the wrapped storage
+// does not implement AssertionJWTConsumer, SPIFFEStorageDecorator must fail
+// closed with an error naming the concrete wrapped type, not silently succeed
+// or panic. storageWithoutAssertionJWTConsumer is defined in
+// cimd_decorator_test.go and reused here.
+//
+// The decorator is built directly (not via NewSPIFFEStorageDecorator) because
+// the constructor's preflight durably claims each client ID against the base
+// backend, which would call methods on the embedded nil Storage this fake
+// deliberately doesn't implement.
+func TestSPIFFEStorageDecorator_ConsumeAssertionJWTFailsClosedWithoutBackendCapability(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	decorated := &SPIFFEStorageDecorator{Storage: storageWithoutAssertionJWTConsumer{}, clients: testSPIFFEClients(t)}
+
+	err := decorated.ConsumeAssertionJWT(ctx, "jwt-bearer", "https://issuer.example", "jti", time.Now().Add(time.Hour))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support assertion JWT replay consumption")
 }

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -639,6 +639,19 @@ type ClientRegistry interface {
 	// existing registration.
 	RegisterClient(ctx context.Context, client fosite.Client) error
 
+	// UpsertDCRIssuedClient creates or replaces a DCR-issued client at
+	// client.GetID(). Unlike RegisterClient (create-only, for the unauthenticated
+	// /oauth/register endpoint), this is for callers that independently
+	// re-validate the client's authoritative source on every call -- today only
+	// CIMDStorageDecorator, which re-fetches and re-validates the document at
+	// client.GetID() before calling this. Creates the row if absent. If a row
+	// exists, replaces its data and refreshes its TTL only when the existing row
+	// is itself DCR-issued; refuses with ErrAlreadyExists if the existing row is
+	// NOT DCR-issued (protects a configured/SPIFFE-reconciled client from being
+	// clobbered). client MUST carry registration.DCRIssued -- refuses otherwise
+	// (mirrors ReconcileConfiguredClient's inverse check).
+	UpsertDCRIssuedClient(ctx context.Context, client fosite.Client) error
+
 	// ReconcileConfiguredClient applies an operator-declared (configured)
 	// client: creates it if no client with that ID exists, or idempotently
 	// replaces an existing record with the same ID when that record is itself

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -289,7 +289,7 @@ func validateDCRCredentialsForStore(creds *DCRCredentials) error {
 //
 // Callers receive a defensive copy from the store. Mutations on the returned
 // value do not affect persisted state, and mutations on a value passed to
-// StoreDCRCredentials are not observed by subsequent reads. This matches the
+// StoreDCRCredentialsIfAbsent are not observed by subsequent reads. This matches the
 // UpstreamTokens contract.
 //
 // # Lifetime
@@ -384,8 +384,8 @@ type DCRCredentials struct {
 //
 // # Why the key is embedded in DCRCredentials
 //
-// StoreDCRCredentials takes a single (ctx, creds) argument rather than the
-// (ctx, key, value) shape used by sibling Store* methods on Storage. The
+// StoreDCRCredentialsIfAbsent takes a single (ctx, creds) argument rather
+// than the (ctx, key, value) shape used by sibling Store* methods on Storage. The
 // DCRKey is embedded as DCRCredentials.Key so the persisted blob is
 // self-describing: a Redis SCAN, an admin-tool dump, or a cross-replica
 // reconciliation path can identify a record's logical cache slot
@@ -400,10 +400,16 @@ type DCRCredentialStore interface {
 	// The returned value is a defensive copy.
 	GetDCRCredentials(ctx context.Context, key DCRKey) (*DCRCredentials, error)
 
-	// StoreDCRCredentials persists the credentials, overwriting any existing
-	// entry for the same Key. See the interface-level "TTL handling" section
-	// for the contract on ClientSecretExpiresAt.
-	StoreDCRCredentials(ctx context.Context, creds *DCRCredentials) error
+	// StoreDCRCredentialsIfAbsent claims creds.Key for creds. Returns the
+	// authoritative durable value: the caller's own creds on a successful
+	// claim, the concurrent winner's value otherwise. Callers MUST use the
+	// returned value, not their input creds — RFC 7591 dynamic registration
+	// mints a unique client_id/client_secret on every call, so a caller that
+	// lost the race and kept using its own creds would hold credentials the
+	// durable store does not agree it owns. See the interface-level "TTL
+	// handling" section for the contract on ClientSecretExpiresAt. The
+	// returned *DCRCredentials is always non-nil when err is nil.
+	StoreDCRCredentialsIfAbsent(ctx context.Context, creds *DCRCredentials) (*DCRCredentials, error)
 }
 
 // User represents a user account in the authorization server.
@@ -867,7 +873,7 @@ type Storage interface {
 	// and user management for multi-IDP support.
 	//
 	// DCRCredentialStore is intentionally NOT embedded here: doing so would
-	// promote GetDCRCredentials / StoreDCRCredentials onto every consumer of
+	// promote GetDCRCredentials / StoreDCRCredentialsIfAbsent onto every consumer of
 	// storage.Storage (handlers, server, registration, etc.), broadening the
 	// surface that can read raw client_secret / registration_access_token even
 	// when those consumers have no DCR responsibility. Code that legitimately

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -591,20 +591,60 @@ func ValidateRegisterableClientID(id string) error {
 	return nil
 }
 
+// sameStringSet reports whether a and b contain the same elements as sets:
+// order and duplicate count don't matter, only membership. Canonicalisation
+// (sort, then dedup) mirrors ScopesHash's approach so the two stay consistent.
+func sameStringSet(a, b []string) bool {
+	as := slices.Clone(a)
+	bs := slices.Clone(b)
+	sort.Strings(as)
+	sort.Strings(bs)
+	as = slices.Compact(as)
+	bs = slices.Compact(bs)
+	return slices.Equal(as, bs)
+}
+
+// clientFingerprintsEqual reports whether a and b represent the same logical
+// client configuration: equal scope set, audience set, grant-type set,
+// response-type set, and public/confidential class. Client secrets are
+// deliberately excluded from the comparison — an operator rotating a
+// configured client's secret must still be able to reconcile; a secret
+// rotation is not a different logical client.
+func clientFingerprintsEqual(a, b fosite.Client) bool {
+	return sameStringSet(a.GetScopes(), b.GetScopes()) &&
+		sameStringSet(a.GetAudience(), b.GetAudience()) &&
+		sameStringSet(a.GetGrantTypes(), b.GetGrantTypes()) &&
+		sameStringSet(a.GetResponseTypes(), b.GetResponseTypes()) &&
+		a.IsPublic() == b.IsPublic()
+}
+
 // ClientRegistry provides client registration and lookup operations.
 // It embeds fosite.ClientManager for client lookup (GetClient) and adds
-// RegisterClient for dynamic client registration (RFC 7591).
+// RegisterClient for dynamic client registration (RFC 7591) and
+// ReconcileConfiguredClient for operator-declared clients.
 type ClientRegistry interface {
 	// ClientManager provides client lookup (GetClient)
 	fosite.ClientManager
 
-	// RegisterClient registers a new OAuth client.
-	// This supports both static configuration and dynamic client registration (RFC 7591).
-	// A DCR-issued client is create-only: it returns ErrAlreadyExists if a
-	// client with the same ID already exists. A static/operator-declared
-	// client is authoritative and replaces any existing client with the same
-	// ID, including one that was DCR-issued.
+	// RegisterClient registers a new OAuth client. Always create-only: it
+	// returns ErrAlreadyExists if a client with the same ID already exists,
+	// regardless of the new client's origin. Used by unauthenticated DCR
+	// (RFC 7591) and any other caller that must never silently overwrite an
+	// existing registration.
 	RegisterClient(ctx context.Context, client fosite.Client) error
+
+	// ReconcileConfiguredClient applies an operator-declared (configured)
+	// client: creates it if no client with that ID exists, or idempotently
+	// replaces an existing record with the same ID when that record is itself
+	// operator-declared AND has a matching fingerprint (scopes, audience,
+	// grant types, response types, public/confidential class) — the
+	// restart-with-unchanged-config case. It refuses with ErrAlreadyExists if
+	// the existing record is DCR-issued (registration.DCRIssued), or if it is
+	// a *different* configured client at that ID (fingerprint mismatch — a
+	// misconfiguration, e.g. two colliding associations). The passed client
+	// must not itself carry the registration.DCRIssued marker;
+	// ReconcileConfiguredClient returns an error if it does.
+	ReconcileConfiguredClient(ctx context.Context, client fosite.Client) error
 
 	// RenewClientTTL extends the registration TTL of a DCR-issued client (public or
 	// confidential, gated on the registration.DCRIssued marker) so an actively-used

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -598,18 +598,12 @@ type ClientRegistry interface {
 	// ClientManager provides client lookup (GetClient)
 	fosite.ClientManager
 
-	// RegisterClient registers a new OAuth client. This supports both static
-	// configuration and dynamic client registration (RFC 7591).
-	//
-	// This is an upsert, not an insert: both backends store()/SET the client
-	// unconditionally, overwriting any existing row with the same ID rather
-	// than rejecting it. Re-registering an existing ID is the only mechanism
-	// that renews a DCR-issued client's TTL on the CIMD write-through path
-	// (see CIMDStorageDecorator.fetch), so callers rely on this upsert
-	// behavior, not merely tolerate it. The one exception is the in-memory
-	// backend at capacity: when the client map is full and no DCR-issued
-	// client is old enough to evict, RegisterClient returns ErrClientCapacity
-	// instead of completing the upsert.
+	// RegisterClient registers a new OAuth client.
+	// This supports both static configuration and dynamic client registration (RFC 7591).
+	// A DCR-issued client is create-only: it returns ErrAlreadyExists if a
+	// client with the same ID already exists. A static/operator-declared
+	// client is authoritative and replaces any existing client with the same
+	// ID, including one that was DCR-issued.
 	RegisterClient(ctx context.Context, client fosite.Client) error
 
 	// RenewClientTTL extends the registration TTL of a DCR-issued client (public or

--- a/pkg/authserver/storage/unwrap.go
+++ b/pkg/authserver/storage/unwrap.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+// Unwrap returns the innermost storage backend by recursively peeling storage
+// decorators that expose Unwrap. It is used at construction boundaries that
+// require the durable backend, such as static-client collision checks.
+func Unwrap(stor Storage) Storage {
+	for {
+		unwrapper, ok := stor.(interface{ Unwrap() Storage })
+		if !ok {
+			return stor
+		}
+		stor = unwrapper.Unwrap()
+	}
+}


### PR DESCRIPTION
## Summary

Configured SPIFFE workload associations need restart-safe OAuth client records before either SVID authentication method (X.509 or JWT) can use them — without this, a restart would lose the mapping from a SPIFFE principal to its OAuth client identity and permissions.

Stacked on #6473. Four commits:

- **Register static SPIFFE clients**: builds immutable SPIFFE associations (`SPIFFEAssociationRegistry`) and materializes narrowed static OAuth clients at startup, rejecting collisions instead of silently replacing existing clients.
- **Harden static client registration**: separates configured-client insertion from replacement so restart reconstruction can't overwrite dynamic (DCR) registrations, and enforces duplicate-client behavior consistently across memory and Redis storage.
- **Hide configured back-channel clients**: static workload clients have no interactive redirect flow, so exposing them through authorization-endpoint lookup would permit client enumeration and accidental browser use. Filters them from authorization requests while leaving their token-endpoint registration available.
- **Close remaining client-registration and replay-forwarding gaps**: addresses four review findings — see below.

Fixes #

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

Covers: association-registry construction (duplicate pattern/client-ID rejection, audience isolation between clients), static-client materialization and restart reconstruction (including Redis-backed tests that dynamic registrations survive a restart while static authority is rebuilt exclusively from the current config), that static SPIFFE clients are rejected at the authorization endpoint while still resolving at the token endpoint, uniform create-only registration on both storage backends, durable cross-replica client-ID reservation (Redis-backed), and JWT-bearer replay-protection forwarding through the full storage decorator chain.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Special notes for reviewers

Rebased cleanly onto the fixed `#6467`/`#6473` base, with one fixup: `spiffe_association_registry.go` referenced a `SPIFFETrustConfig.validated` field that was removed in #6467's review pass (the zero value is now documented as intentionally valid instead), and a few tests asserted `nil` for an empty trust config/registry where the corrected constructor now returns a valid-but-empty value. Folded those fixes into the first commit of this branch so the stack stays bisectable.

The fourth commit responds to all four remaining review findings (durable client-ID reservation, create-only registration, JWT-bearer replay-check forwarding, explicit back-channel marker). Each fix was designed with an oauth-expert/go-architect review pair, implemented, and adversarially re-reviewed in two independent rounds before landing — see the reply comment for a finding-by-finding breakdown, including one known, intentionally-deferred limitation (filed as #6477: stale configured-client records — for both delegate and SPIFFE clients — are never removed when dropped from config; pre-existing behavior for delegate clients, inherited rather than introduced here).
