### PR TITLE
fix(authserver): scope upstream-token callback cleanup to the chain's providers

### DIFF
--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -182,8 +182,13 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 		slog.Error("failed to store upstream tokens",
 			"error", err,
 		)
-		// Clean up any tokens stored by earlier legs of a multi-upstream chain.
-		_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
+		// Clean up any tokens stored by earlier legs of a multi-upstream chain,
+		// scoped per provider so a user-keyed storage decorator that re-keys upstream
+		// tokens by (gateway, user) removes only this chain's providers and never the
+		// user's tokens for connectors outside it. providerID (this leg) is included
+		// even though its store just failed: any partial or carried-forward row is
+		// removed, and an absent row deletes as a no-op.
+		h.cleanupUpstreamTokens(ctx, sessionID, append([]string{providerID}, pending.ChainUpstreams...))
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to store session"))
 		return
 	}
@@ -401,16 +406,18 @@ func (h *Handler) handleUpstreamError(
 			// Clean up any upstream tokens stored by earlier legs of a multi-upstream chain.
 			// On a subsequent leg the resolved user is carried in pending.ResolvedUserID;
 			// place it in ctx via WithPlatformUser so a context-keyed storage decorator can
-			// resolve the canonical user for this delete (DeleteUpstreamTokens takes no tokens
-			// argument). WithPlatformUser, not WithIdentity: there is no authenticated identity
-			// at the callback, only the storage-scoped user. A first-leg error has no resolved
-			// user and no earlier-leg tokens to clean up, so the bare ctx is correct there.
+			// resolve the canonical user for the per-provider cleanup. WithPlatformUser, not
+			// WithIdentity: there is no authenticated identity at the callback, only the
+			// storage-scoped user. The cleanup is scoped to the chain's providers so a
+			// user-keyed decorator does not over-delete the user's other connectors; a
+			// first-leg error carries no ChainUpstreams and no earlier-leg tokens, so nothing
+			// is deleted there.
 			if pending.SessionID != "" {
 				cleanupCtx := ctx
 				if pending.ResolvedUserID != "" {
 					cleanupCtx = auth.WithPlatformUser(ctx, pending.ResolvedUserID)
 				}
-				_ = h.storage.DeleteUpstreamTokens(cleanupCtx, pending.SessionID)
+				h.cleanupUpstreamTokens(cleanupCtx, pending.SessionID, pending.ChainUpstreams)
 			}
 			ar := h.buildAuthorizeRequesterFromPending(ctx, pending)
 			if ar != nil {
@@ -426,6 +433,42 @@ func (h *Handler) handleUpstreamError(
 	// Cannot redirect to client, show generic error page.
 	// Detailed error information is logged above for server-side diagnostics.
 	http.Error(w, "upstream authentication failed", http.StatusBadGateway)
+}
+
+// cleanupUpstreamTokens best-effort removes the upstream tokens an authorization
+// chain has collected, one provider at a time. It is the failure-path counterpart
+// to a successful chain: when a leg fails, the tokens earlier legs stored under this
+// session must not be left mid-chain.
+//
+// It deletes per provider rather than calling the session-wide DeleteUpstreamTokens
+// because that method carries no provider name. A storage decorator that re-keys
+// upstream tokens by (gateway, user) — so a session-independent caller can find a
+// user's tokens — cannot narrow a session-wide delete back to this chain, and would
+// instead delete every connector token the user holds on the gateway. Naming each
+// provider lets such a decorator scope the delete to exactly this chain's providers.
+//
+// providers is the effective chain (or the chain carried forward in the pending on a
+// subsequent leg), optionally including the leg currently being processed. Passing a
+// provider whose leg has not been walked, or whose row is already absent, is a no-op:
+// the storage contract makes a missing-row delete non-fatal. Errors are logged and
+// swallowed — cleanup is best-effort and must not mask the original failure.
+func (h *Handler) cleanupUpstreamTokens(ctx context.Context, sessionID string, providers []string) {
+	seen := make(map[string]struct{}, len(providers))
+	for _, provider := range providers {
+		if provider == "" {
+			continue
+		}
+		if _, dup := seen[provider]; dup {
+			continue
+		}
+		seen[provider] = struct{}{}
+		if err := h.storage.DeleteUpstreamTokensForProvider(ctx, sessionID, provider); err != nil {
+			slog.Warn("failed to clean up upstream token for provider",
+				"provider", provider,
+				"error", err,
+			)
+		}
+	}
 }
 
 // continueChainOrComplete checks whether all upstream providers in the authorization
@@ -476,7 +519,11 @@ func (h *Handler) continueChainOrComplete(
 	chain, err := h.resolveChain(ctx, pending, principal)
 	if err != nil {
 		slog.Error("failed to resolve upstream chain", "error", err)
-		_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
+		// The chain could not be resolved, so scope the cleanup to what is known: this
+		// leg's provider plus any chain carried forward on a subsequent leg. An earlier
+		// leg not named here (e.g. a stale pending with no ChainUpstreams) is left to
+		// expire by TTL rather than risk a user-keyed decorator over-deleting.
+		h.cleanupUpstreamTokens(ctx, sessionID, append([]string{pending.UpstreamProviderName}, pending.ChainUpstreams...))
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to determine authorization chain"))
 		return
 	}
@@ -484,7 +531,7 @@ func (h *Handler) continueChainOrComplete(
 	nextProvider, err := h.nextMissingUpstream(ctx, sessionID, chain)
 	if err != nil {
 		slog.Error("failed to determine next upstream", "error", err)
-		_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
+		h.cleanupUpstreamTokens(ctx, sessionID, chain)
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to check authorization chain state"))
 		return
 	}
@@ -493,7 +540,7 @@ func (h *Handler) continueChainOrComplete(
 		if err := h.verifyChainIdentity(ctx, sessionID, chain, subject); err != nil {
 			// verifyChainIdentity already logged the specific cause (with structured
 			// fields for a mismatch); here we just clean up and fail closed.
-			_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
+			h.cleanupUpstreamTokens(ctx, sessionID, chain)
 			h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("identity verification failed"))
 			return
 		}
@@ -501,7 +548,7 @@ func (h *Handler) continueChainOrComplete(
 		// All upstreams satisfied — issue authorization code
 		if err := h.writeAuthorizationResponse(ctx, w, pending, sessionID, subject, name, email); err != nil {
 			slog.Error("failed to create authorization response", "error", err)
-			_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
+			h.cleanupUpstreamTokens(ctx, sessionID, chain)
 			h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to create authorization code"))
 		}
 		return
@@ -539,7 +586,7 @@ func (h *Handler) continueChainOrComplete(
 
 	if err := h.storage.StorePendingAuthorization(ctx, secrets.State, nextPending); err != nil {
 		slog.Error("failed to store next chain leg", "error", err)
-		_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
+		h.cleanupUpstreamTokens(ctx, sessionID, chain)
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to continue authorization chain"))
 		return
 	}
@@ -553,7 +600,7 @@ func (h *Handler) continueChainOrComplete(
 	if !ok {
 		slog.Error("next upstream provider not found", "provider", nextProvider)
 		_ = h.storage.DeletePendingAuthorization(ctx, secrets.State)
-		_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
+		h.cleanupUpstreamTokens(ctx, sessionID, chain)
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("upstream provider configuration error"))
 		return
 	}
@@ -561,7 +608,7 @@ func (h *Handler) continueChainOrComplete(
 	if err != nil {
 		slog.Error("failed to build next upstream authorization URL", "error", err)
 		_ = h.storage.DeletePendingAuthorization(ctx, secrets.State)
-		_ = h.storage.DeleteUpstreamTokens(ctx, sessionID)
+		h.cleanupUpstreamTokens(ctx, sessionID, chain)
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to build authorization URL"))
 		return
 	}

--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -182,11 +182,10 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 		slog.Error("failed to store upstream tokens",
 			"error", err,
 		)
-		// Clean up tokens stored by earlier legs of a multi-upstream chain (see
-		// cleanupUpstreamTokens for the per-provider scoping rationale). providerID
-		// (this leg) is included even though its store just failed: any partial or
-		// carried-forward row is removed, and an absent row deletes as a no-op.
-		h.cleanupUpstreamTokens(ctx, sessionID, append([]string{providerID}, pending.ChainUpstreams...))
+		// Clean up only this leg's token (see cleanupUpstreamTokens): its store just
+		// failed, so this removes any partial or carried-forward row and is otherwise a
+		// no-op. Earlier legs are the user's own valid tokens and are left intact.
+		h.cleanupUpstreamTokens(ctx, sessionID, []string{providerID})
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to store session"))
 		return
 	}
@@ -401,20 +400,20 @@ func (h *Handler) handleUpstreamError(
 		pending, err := h.storage.LoadPendingAuthorization(ctx, internalState)
 		if err == nil {
 			_ = h.storage.DeletePendingAuthorization(ctx, internalState)
-			// Clean up upstream tokens stored by earlier legs of a multi-upstream chain
-			// (see cleanupUpstreamTokens for the per-provider scoping rationale). On a
+			// Clean up only this leg's token (see cleanupUpstreamTokens); earlier legs are
+			// the user's own valid tokens and are left intact. This leg failed at the
+			// upstream IdP before a token was stored, so the delete is normally a no-op,
+			// but it also removes a row left by a prior attempt on the same leg. On a
 			// subsequent leg the resolved user is carried in pending.ResolvedUserID; place
 			// it in ctx via WithPlatformUser so a context-keyed storage decorator resolves
 			// the canonical user for the cleanup. WithPlatformUser, not WithIdentity: there
-			// is no authenticated identity at the callback, only the storage-scoped user. A
-			// first-leg error carries no ChainUpstreams and no earlier-leg tokens, so
-			// nothing is deleted there.
+			// is no authenticated identity at the callback, only the storage-scoped user.
 			if pending.SessionID != "" {
 				cleanupCtx := ctx
 				if pending.ResolvedUserID != "" {
 					cleanupCtx = auth.WithPlatformUser(ctx, pending.ResolvedUserID)
 				}
-				h.cleanupUpstreamTokens(cleanupCtx, pending.SessionID, pending.ChainUpstreams)
+				h.cleanupUpstreamTokens(cleanupCtx, pending.SessionID, []string{pending.UpstreamProviderName})
 			}
 			ar := h.buildAuthorizeRequesterFromPending(ctx, pending)
 			if ar != nil {
@@ -432,17 +431,21 @@ func (h *Handler) handleUpstreamError(
 	http.Error(w, "upstream authentication failed", http.StatusBadGateway)
 }
 
-// cleanupUpstreamTokens best-effort removes the upstream tokens an authorization
-// chain has collected, one provider at a time. It is the failure-path counterpart
-// to a successful chain: when a leg fails, the tokens earlier legs stored under this
-// session must not be left mid-chain.
+// cleanupUpstreamTokens best-effort removes upstream tokens on a failed authorization
+// leg, one provider at a time. Callers pass the leg currently being processed, so an
+// ordinary error — a transient store/read failure, or a chain that cannot be resolved —
+// takes down only that leg's token and leaves the user's earlier legs intact. That
+// matters under a storage decorator that re-keys upstream tokens by (gateway, user),
+// where each earlier leg is the user's own live credential for another connector rather
+// than throwaway session state, so a failed connector login must not delete the others.
+// The one exception is the identity-mismatch fail-closed, which passes the whole chain
+// to tear down a session whose stored identity is no longer trustworthy.
 //
 // It deletes per provider rather than calling the session-wide DeleteUpstreamTokens
-// because that method carries no provider name. A storage decorator that re-keys
-// upstream tokens by (gateway, user) — so a session-independent caller can find a
-// user's tokens — cannot narrow a session-wide delete back to this chain, and would
-// instead delete every connector token the user holds on the gateway. Naming each
-// provider lets such a decorator scope the delete to exactly this chain's providers.
+// because that method carries no provider name: a (gateway, user)-keyed decorator cannot
+// narrow a session-wide delete back to one leg and would delete every connector token
+// the user holds on the gateway. Naming the provider lets such a decorator scope the
+// delete to exactly the named leg(s).
 //
 // Each name is checked against the configured upstream set before it is deleted, so a
 // name that is not a configured upstream — e.g. from a corrupted or tampered pending
@@ -450,22 +453,15 @@ func (h *Handler) handleUpstreamError(
 // not been through validateChain — is skipped rather than turned into a delete.
 //
 // providers is the set of provider names whose upstream-token rows should be removed;
-// empty entries, duplicates, and names outside the configured upstream set are ignored,
-// and deleting an already-absent row is a no-op (the storage contract makes a
-// missing-row delete non-fatal). Errors are logged and swallowed — cleanup is
-// best-effort and must not mask the original failure. Cost is one storage round-trip
-// per distinct provider; a chain is the corporate primary plus a handful of connectors,
-// so the sequential deletes are bounded and only run on error paths.
+// empty entries and names outside the configured upstream set are skipped, and deleting
+// an already-absent row is a no-op (the storage contract makes a missing-row delete
+// non-fatal), so a repeated name is harmless. Errors are logged and swallowed — cleanup
+// is best-effort and must not mask the original failure.
 func (h *Handler) cleanupUpstreamTokens(ctx context.Context, sessionID string, providers []string) {
-	seen := make(map[string]struct{}, len(providers))
 	for _, provider := range providers {
 		if provider == "" {
 			continue
 		}
-		if _, dup := seen[provider]; dup {
-			continue
-		}
-		seen[provider] = struct{}{}
 		// Only a configured upstream can legitimately have a stored token, so skip
 		// anything else: it keeps a tampered pending row reaching a pre-resolveChain
 		// cleanup site from naming an arbitrary delete target. The post-resolveChain
@@ -530,11 +526,11 @@ func (h *Handler) continueChainOrComplete(
 	chain, err := h.resolveChain(ctx, pending, principal)
 	if err != nil {
 		slog.Error("failed to resolve upstream chain", "error", err)
-		// The chain could not be resolved, so scope the cleanup to what is known: this
-		// leg's provider plus any chain carried forward on a subsequent leg. An earlier
-		// leg not named here (e.g. a stale pending with no ChainUpstreams) is left to
-		// expire by TTL rather than risk a user-keyed decorator over-deleting.
-		h.cleanupUpstreamTokens(ctx, sessionID, append([]string{pending.UpstreamProviderName}, pending.ChainUpstreams...))
+		// Clean up only this leg's token; earlier legs are the user's own valid tokens
+		// and are left intact. This is the issue's most-reachable trigger — a transient
+		// filter/Directory failure on leg 1 — so scoping it to the one leg is what keeps
+		// a blip from taking the user's other connectors down with it.
+		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to determine authorization chain"))
 		return
 	}
@@ -542,7 +538,8 @@ func (h *Handler) continueChainOrComplete(
 	nextProvider, err := h.nextMissingUpstream(ctx, sessionID, chain)
 	if err != nil {
 		slog.Error("failed to determine next upstream", "error", err)
-		h.cleanupUpstreamTokens(ctx, sessionID, chain)
+		// Clean up only this leg's token; earlier legs are left intact.
+		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to check authorization chain state"))
 		return
 	}
@@ -550,7 +547,10 @@ func (h *Handler) continueChainOrComplete(
 	if nextProvider == "" {
 		if err := h.verifyChainIdentity(ctx, sessionID, chain, subject); err != nil {
 			// verifyChainIdentity already logged the specific cause (with structured
-			// fields for a mismatch); here we just clean up and fail closed.
+			// fields for a mismatch). This is the one cleanup site that tears down the
+			// WHOLE chain rather than just this leg: a detected identity mismatch means
+			// the session's stored state is no longer trustworthy, so we fail closed and
+			// remove every leg's token rather than leave a possibly cross-keyed row.
 			h.cleanupUpstreamTokens(ctx, sessionID, chain)
 			h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("identity verification failed"))
 			return
@@ -559,7 +559,10 @@ func (h *Handler) continueChainOrComplete(
 		// All upstreams satisfied — issue authorization code
 		if err := h.writeAuthorizationResponse(ctx, w, pending, sessionID, subject, name, email); err != nil {
 			slog.Error("failed to create authorization response", "error", err)
-			h.cleanupUpstreamTokens(ctx, sessionID, chain)
+			// The chain was fully satisfied and identity-verified; only the response
+			// write failed (a retryable server error). Clean up just this final leg and
+			// leave the earlier legs, so a retry re-collects only this one.
+			h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
 			h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to create authorization code"))
 		}
 		return
@@ -597,7 +600,8 @@ func (h *Handler) continueChainOrComplete(
 
 	if err := h.storage.StorePendingAuthorization(ctx, secrets.State, nextPending); err != nil {
 		slog.Error("failed to store next chain leg", "error", err)
-		h.cleanupUpstreamTokens(ctx, sessionID, chain)
+		// Clean up only this leg's token; earlier legs are left intact.
+		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to continue authorization chain"))
 		return
 	}
@@ -611,7 +615,8 @@ func (h *Handler) continueChainOrComplete(
 	if !ok {
 		slog.Error("next upstream provider not found", "provider", nextProvider)
 		_ = h.storage.DeletePendingAuthorization(ctx, secrets.State)
-		h.cleanupUpstreamTokens(ctx, sessionID, chain)
+		// Clean up only this leg's token; earlier legs are left intact.
+		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("upstream provider configuration error"))
 		return
 	}
@@ -619,7 +624,8 @@ func (h *Handler) continueChainOrComplete(
 	if err != nil {
 		slog.Error("failed to build next upstream authorization URL", "error", err)
 		_ = h.storage.DeletePendingAuthorization(ctx, secrets.State)
-		h.cleanupUpstreamTokens(ctx, sessionID, chain)
+		// Clean up only this leg's token; earlier legs are left intact.
+		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to build authorization URL"))
 		return
 	}

--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -150,8 +150,8 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 
 	// Place the resolved canonical user in the request context so callback storage
 	// calls that carry no tokens argument — GetAllUpstreamTokens during chain
-	// consistency, DeleteUpstreamTokens on cleanup — can resolve the user from
-	// context. We use WithPlatformUser, not WithIdentity: no ToolHive bearer has
+	// consistency, DeleteUpstreamTokensForProvider on cleanup — can resolve the user
+	// from context. We use WithPlatformUser, not WithIdentity: no ToolHive bearer has
 	// been issued at the callback, so there is no authenticated identity to assert —
 	// only the canonical user for storage keying. (StoreUpstreamTokens does not need
 	// this; it keys off tokens.UserID below.)
@@ -182,12 +182,10 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 		slog.Error("failed to store upstream tokens",
 			"error", err,
 		)
-		// Clean up any tokens stored by earlier legs of a multi-upstream chain,
-		// scoped per provider so a user-keyed storage decorator that re-keys upstream
-		// tokens by (gateway, user) removes only this chain's providers and never the
-		// user's tokens for connectors outside it. providerID (this leg) is included
-		// even though its store just failed: any partial or carried-forward row is
-		// removed, and an absent row deletes as a no-op.
+		// Clean up tokens stored by earlier legs of a multi-upstream chain (see
+		// cleanupUpstreamTokens for the per-provider scoping rationale). providerID
+		// (this leg) is included even though its store just failed: any partial or
+		// carried-forward row is removed, and an absent row deletes as a no-op.
 		h.cleanupUpstreamTokens(ctx, sessionID, append([]string{providerID}, pending.ChainUpstreams...))
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to store session"))
 		return
@@ -403,15 +401,14 @@ func (h *Handler) handleUpstreamError(
 		pending, err := h.storage.LoadPendingAuthorization(ctx, internalState)
 		if err == nil {
 			_ = h.storage.DeletePendingAuthorization(ctx, internalState)
-			// Clean up any upstream tokens stored by earlier legs of a multi-upstream chain.
-			// On a subsequent leg the resolved user is carried in pending.ResolvedUserID;
-			// place it in ctx via WithPlatformUser so a context-keyed storage decorator can
-			// resolve the canonical user for the per-provider cleanup. WithPlatformUser, not
-			// WithIdentity: there is no authenticated identity at the callback, only the
-			// storage-scoped user. The cleanup is scoped to the chain's providers so a
-			// user-keyed decorator does not over-delete the user's other connectors; a
-			// first-leg error carries no ChainUpstreams and no earlier-leg tokens, so nothing
-			// is deleted there.
+			// Clean up upstream tokens stored by earlier legs of a multi-upstream chain
+			// (see cleanupUpstreamTokens for the per-provider scoping rationale). On a
+			// subsequent leg the resolved user is carried in pending.ResolvedUserID; place
+			// it in ctx via WithPlatformUser so a context-keyed storage decorator resolves
+			// the canonical user for the cleanup. WithPlatformUser, not WithIdentity: there
+			// is no authenticated identity at the callback, only the storage-scoped user. A
+			// first-leg error carries no ChainUpstreams and no earlier-leg tokens, so
+			// nothing is deleted there.
 			if pending.SessionID != "" {
 				cleanupCtx := ctx
 				if pending.ResolvedUserID != "" {
@@ -447,11 +444,18 @@ func (h *Handler) handleUpstreamError(
 // instead delete every connector token the user holds on the gateway. Naming each
 // provider lets such a decorator scope the delete to exactly this chain's providers.
 //
-// providers is the effective chain (or the chain carried forward in the pending on a
-// subsequent leg), optionally including the leg currently being processed. Passing a
-// provider whose leg has not been walked, or whose row is already absent, is a no-op:
-// the storage contract makes a missing-row delete non-fatal. Errors are logged and
-// swallowed — cleanup is best-effort and must not mask the original failure.
+// Each name is checked against the configured upstream set before it is deleted, so a
+// name that is not a configured upstream — e.g. from a corrupted or tampered pending
+// row reaching a pre-resolveChain cleanup site, which unlike the post-resolve sites has
+// not been through validateChain — is skipped rather than turned into a delete.
+//
+// providers is the set of provider names whose upstream-token rows should be removed;
+// empty entries, duplicates, and names outside the configured upstream set are ignored,
+// and deleting an already-absent row is a no-op (the storage contract makes a
+// missing-row delete non-fatal). Errors are logged and swallowed — cleanup is
+// best-effort and must not mask the original failure. Cost is one storage round-trip
+// per distinct provider; a chain is the corporate primary plus a handful of connectors,
+// so the sequential deletes are bounded and only run on error paths.
 func (h *Handler) cleanupUpstreamTokens(ctx context.Context, sessionID string, providers []string) {
 	seen := make(map[string]struct{}, len(providers))
 	for _, provider := range providers {
@@ -462,8 +466,15 @@ func (h *Handler) cleanupUpstreamTokens(ctx context.Context, sessionID string, p
 			continue
 		}
 		seen[provider] = struct{}{}
+		// Only a configured upstream can legitimately have a stored token, so skip
+		// anything else: it keeps a tampered pending row reaching a pre-resolveChain
+		// cleanup site from naming an arbitrary delete target. The post-resolveChain
+		// sites pass a validateChain-checked chain, so this is a no-op for them.
+		if _, ok := h.upstreamByName(provider); !ok {
+			continue
+		}
 		if err := h.storage.DeleteUpstreamTokensForProvider(ctx, sessionID, provider); err != nil {
-			slog.Warn("failed to clean up upstream token for provider",
+			slog.Warn("failed to clean up upstream token for provider", //nolint:gosec // G706 - provider name from server-side chain state
 				"provider", provider,
 				"error", err,
 			)

--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -182,10 +182,12 @@ func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 		slog.Error("failed to store upstream tokens",
 			"error", err,
 		)
-		// Clean up only this leg's token (see cleanupUpstreamTokens): its store just
-		// failed, so this removes any partial or carried-forward row and is otherwise a
-		// no-op. Earlier legs are the user's own valid tokens and are left intact.
-		h.cleanupUpstreamTokens(ctx, sessionID, []string{providerID})
+		// Do NOT clean up upstream tokens here: the store for this attempt just failed, so
+		// this attempt wrote nothing. Under a (gateway, user)-keyed storage decorator the
+		// only row at this provider is a credential from an earlier successful
+		// authorization (e.g. a re-connect whose fresh store failed), and deleting it would
+		// disconnect that already-connected account. Earlier legs are likewise the user's
+		// own valid tokens. Leave them all; the pending is single-use and errors out below.
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to store session"))
 		return
 	}
@@ -399,22 +401,14 @@ func (h *Handler) handleUpstreamError(
 	if internalState != "" {
 		pending, err := h.storage.LoadPendingAuthorization(ctx, internalState)
 		if err == nil {
+			// Delete only the single-use pending authorization. Deliberately do NOT touch
+			// upstream tokens: the upstream IdP errored before this attempt exchanged a
+			// code, so this attempt stored nothing. Under a (gateway, user)-keyed storage
+			// decorator the only row at this provider is a credential from an earlier
+			// successful authorization — e.g. canceling a re-connect (error=access_denied)
+			// would otherwise disconnect the already-connected account — and earlier legs
+			// are likewise the user's own valid tokens. Leave them all intact.
 			_ = h.storage.DeletePendingAuthorization(ctx, internalState)
-			// Clean up only this leg's token (see cleanupUpstreamTokens); earlier legs are
-			// the user's own valid tokens and are left intact. This leg failed at the
-			// upstream IdP before a token was stored, so the delete is normally a no-op,
-			// but it also removes a row left by a prior attempt on the same leg. On a
-			// subsequent leg the resolved user is carried in pending.ResolvedUserID; place
-			// it in ctx via WithPlatformUser so a context-keyed storage decorator resolves
-			// the canonical user for the cleanup. WithPlatformUser, not WithIdentity: there
-			// is no authenticated identity at the callback, only the storage-scoped user.
-			if pending.SessionID != "" {
-				cleanupCtx := ctx
-				if pending.ResolvedUserID != "" {
-					cleanupCtx = auth.WithPlatformUser(ctx, pending.ResolvedUserID)
-				}
-				h.cleanupUpstreamTokens(cleanupCtx, pending.SessionID, []string{pending.UpstreamProviderName})
-			}
 			ar := h.buildAuthorizeRequesterFromPending(ctx, pending)
 			if ar != nil {
 				// Use generic error hint to avoid exposing upstream IDP details to clients.

--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -425,30 +425,29 @@ func (h *Handler) handleUpstreamError(
 	http.Error(w, "upstream authentication failed", http.StatusBadGateway)
 }
 
-// cleanupUpstreamTokens best-effort removes upstream tokens on a failed authorization
-// leg, one provider at a time. Callers pass the leg currently being processed, so an
-// ordinary error — a transient store/read failure, or a chain that cannot be resolved —
-// takes down only that leg's token and leaves the user's earlier legs intact. That
-// matters under a storage decorator that re-keys upstream tokens by (gateway, user),
-// where each earlier leg is the user's own live credential for another connector rather
-// than throwaway session state, so a failed connector login must not delete the others.
-// The one exception is the identity-mismatch fail-closed, which passes the whole chain
-// to tear down a session whose stored identity is no longer trustworthy.
+// cleanupUpstreamTokens best-effort removes upstream tokens, one provider at a time. It
+// is called from exactly one place: the confirmed identity-mismatch fail-closed, where
+// the session's stored state is no longer trustworthy and the whole effective chain is
+// torn down. Every other callback error path deliberately preserves upstream tokens — a
+// transient storage/filter failure, a downstream response-write error, or a canceled
+// leg does not invalidate the credentials collected so far, and under a storage
+// decorator that re-keys tokens by (gateway, user) those credentials are the user's own
+// live connector logins, not throwaway session state.
 //
 // It deletes per provider rather than calling the session-wide DeleteUpstreamTokens
 // because that method carries no provider name: a (gateway, user)-keyed decorator cannot
-// narrow a session-wide delete back to one leg and would delete every connector token
-// the user holds on the gateway. Naming the provider lets such a decorator scope the
-// delete to exactly the named leg(s).
+// narrow a session-wide delete back to one chain and would delete every connector token
+// the user holds on the gateway. Naming each provider lets such a decorator scope the
+// delete to exactly the effective chain's providers, so a configured provider the filter
+// excluded from the chain is never touched.
 //
 // Each name is checked against the configured upstream set before it is deleted, so a
 // name that is not a configured upstream — e.g. from a corrupted or tampered pending
-// row reaching a pre-resolveChain cleanup site, which unlike the post-resolve sites has
-// not been through validateChain — is skipped rather than turned into a delete.
+// row — is skipped rather than turned into a delete.
 //
-// providers is the set of provider names whose upstream-token rows should be removed;
-// empty entries and names outside the configured upstream set are skipped, and deleting
-// an already-absent row is a no-op (the storage contract makes a missing-row delete
+// providers is the effective chain whose upstream-token rows should be removed; empty
+// entries and names outside the configured upstream set are skipped, and deleting an
+// already-absent row is a no-op (the storage contract makes a missing-row delete
 // non-fatal), so a repeated name is harmless. Errors are logged and swallowed — cleanup
 // is best-effort and must not mask the original failure.
 func (h *Handler) cleanupUpstreamTokens(ctx context.Context, sessionID string, providers []string) {
@@ -457,9 +456,9 @@ func (h *Handler) cleanupUpstreamTokens(ctx context.Context, sessionID string, p
 			continue
 		}
 		// Only a configured upstream can legitimately have a stored token, so skip
-		// anything else: it keeps a tampered pending row reaching a pre-resolveChain
-		// cleanup site from naming an arbitrary delete target. The post-resolveChain
-		// sites pass a validateChain-checked chain, so this is a no-op for them.
+		// anything else: it keeps a tampered chain entry from naming an arbitrary delete
+		// target. The chain passed here is validateChain-checked, so this is a no-op in
+		// normal operation — it is defense in depth for a corrupted pending row.
 		if _, ok := h.upstreamByName(provider); !ok {
 			continue
 		}
@@ -520,11 +519,9 @@ func (h *Handler) continueChainOrComplete(
 	chain, err := h.resolveChain(ctx, pending, principal)
 	if err != nil {
 		slog.Error("failed to resolve upstream chain", "error", err)
-		// Clean up only this leg's token; earlier legs are the user's own valid tokens
-		// and are left intact. This is the issue's most-reachable trigger — a transient
-		// filter/Directory failure on leg 1 — so scoping it to the one leg is what keeps
-		// a blip from taking the user's other connectors down with it.
-		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
+		// Preserve upstream tokens: a chain-resolution failure (a transient filter/Directory
+		// blip, or a stale pending) does not invalidate the credentials collected so far, and
+		// this is the issue's most-reachable trigger. Fail authorization without deleting.
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to determine authorization chain"))
 		return
 	}
@@ -532,20 +529,24 @@ func (h *Handler) continueChainOrComplete(
 	nextProvider, err := h.nextMissingUpstream(ctx, sessionID, chain)
 	if err != nil {
 		slog.Error("failed to determine next upstream", "error", err)
-		// Clean up only this leg's token; earlier legs are left intact.
-		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
+		// Preserve upstream tokens: a transient chain-state read failure does not
+		// invalidate the credentials collected so far. Fail authorization without deleting.
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to check authorization chain state"))
 		return
 	}
 
 	if nextProvider == "" {
 		if err := h.verifyChainIdentity(ctx, sessionID, chain, subject); err != nil {
-			// verifyChainIdentity already logged the specific cause (with structured
-			// fields for a mismatch). This is the one cleanup site that tears down the
-			// WHOLE chain rather than just this leg: a detected identity mismatch means
-			// the session's stored state is no longer trustworthy, so we fail closed and
-			// remove every leg's token rather than leave a possibly cross-keyed row.
-			h.cleanupUpstreamTokens(ctx, sessionID, chain)
+			// verifyChainIdentity already logged the specific cause. It fails for two very
+			// different reasons, and only one warrants deleting tokens:
+			//   - a CONFIRMED identity mismatch: the session's stored state is no longer
+			//     trustworthy, so fail closed and tear down the whole chain. This is the
+			//     ONLY path in the callback that deletes upstream tokens.
+			//   - a transient GetAllUpstreamTokens read failure: nothing is proven wrong,
+			//     so preserve every credential and just fail this authorization.
+			if errors.Is(err, errChainIdentityMismatch) {
+				h.cleanupUpstreamTokens(ctx, sessionID, chain)
+			}
 			h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("identity verification failed"))
 			return
 		}
@@ -553,10 +554,10 @@ func (h *Handler) continueChainOrComplete(
 		// All upstreams satisfied — issue authorization code
 		if err := h.writeAuthorizationResponse(ctx, w, pending, sessionID, subject, name, email); err != nil {
 			slog.Error("failed to create authorization response", "error", err)
-			// The chain was fully satisfied and identity-verified; only the response
-			// write failed (a retryable server error). Clean up just this final leg and
-			// leave the earlier legs, so a retry re-collects only this one.
-			h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
+			// Preserve upstream tokens: the chain is complete and identity-verified, so the
+			// credentials are valid. Only the downstream response write failed (client
+			// lookup / redirect parse / code generation), which does not invalidate them —
+			// matching the SingleLeg branch, which preserves tokens for this same class.
 			h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to create authorization code"))
 		}
 		return
@@ -594,8 +595,8 @@ func (h *Handler) continueChainOrComplete(
 
 	if err := h.storage.StorePendingAuthorization(ctx, secrets.State, nextPending); err != nil {
 		slog.Error("failed to store next chain leg", "error", err)
-		// Clean up only this leg's token; earlier legs are left intact.
-		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
+		// Preserve upstream tokens: failing to persist the next leg's pending does not
+		// invalidate the credentials collected so far. Fail authorization without deleting.
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to continue authorization chain"))
 		return
 	}
@@ -609,8 +610,8 @@ func (h *Handler) continueChainOrComplete(
 	if !ok {
 		slog.Error("next upstream provider not found", "provider", nextProvider)
 		_ = h.storage.DeletePendingAuthorization(ctx, secrets.State)
-		// Clean up only this leg's token; earlier legs are left intact.
-		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
+		// Preserve upstream tokens: a next-provider configuration error does not invalidate
+		// the credentials collected so far. Fail authorization without deleting.
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("upstream provider configuration error"))
 		return
 	}
@@ -618,14 +619,21 @@ func (h *Handler) continueChainOrComplete(
 	if err != nil {
 		slog.Error("failed to build next upstream authorization URL", "error", err)
 		_ = h.storage.DeletePendingAuthorization(ctx, secrets.State)
-		// Clean up only this leg's token; earlier legs are left intact.
-		h.cleanupUpstreamTokens(ctx, sessionID, []string{pending.UpstreamProviderName})
+		// Preserve upstream tokens: failing to build the next leg's authorization URL does
+		// not invalidate the credentials collected so far. Fail authorization without deleting.
 		h.provider.WriteAuthorizeError(ctx, w, ar, fosite.ErrServerError.WithHint("failed to build authorization URL"))
 		return
 	}
 
 	http.Redirect(w, req, nextURL, http.StatusFound)
 }
+
+// errChainIdentityMismatch marks the defense-in-depth failure where a chain's first
+// leg's stored token belongs to a different user than the one carried through the flow.
+// verifyChainIdentity wraps it so the callback can distinguish a confirmed mismatch —
+// the only condition that warrants deleting upstream tokens — from a transient storage
+// read failure, which must preserve them.
+var errChainIdentityMismatch = errors.New("chain identity mismatch")
 
 // verifyChainIdentity is a defense-in-depth check run once every leg of the
 // effective chain is satisfied. Despite the "chain" framing, it reconciles only
@@ -667,7 +675,9 @@ func (h *Handler) verifyChainIdentity(ctx context.Context, sessionID string, cha
 			"got", firstTokens.UserID,
 			"provider", firstProvider,
 		)
-		return fmt.Errorf("identity mismatch on provider %q", firstProvider)
+		// Wrap the sentinel so the caller can tell a confirmed mismatch (tear down the
+		// chain) apart from the storage-read failure above (preserve the tokens).
+		return fmt.Errorf("%w on provider %q", errChainIdentityMismatch, firstProvider)
 	}
 	return nil
 }

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -1307,12 +1307,43 @@ func TestCallbackHandler_Cleanup_LeavesOutOfChainProviderTokens(t *testing.T) {
 	assert.Equal(t, "keep-me", storState.upstreamTokens[outOfChainKey].AccessToken)
 }
 
-// TestCallbackHandler_StoreUpstreamTokensError_CleansUpChain covers the
-// StoreUpstreamTokens-failure cleanup site on a subsequent leg. It is the one site
-// where cleanupUpstreamTokens' dedup is load-bearing: the provider list is
-// append([]string{providerID}, pending.ChainUpstreams...), and ChainUpstreams already
-// contains providerID on a non-first leg, so the same provider is named twice.
-func TestCallbackHandler_StoreUpstreamTokensError_CleansUpChain(t *testing.T) {
+// TestCleanupUpstreamTokens_SkipsUnconfiguredAndEmpty exercises cleanupUpstreamTokens
+// directly: it skips empty names and any provider that is not a configured upstream — the
+// guard that stops a corrupted or tampered pending row reaching a pre-resolveChain
+// cleanup site from naming an arbitrary delete target — while removing the configured
+// ones.
+func TestCleanupUpstreamTokens_SkipsUnconfiguredAndEmpty(t *testing.T) {
+	t.Parallel()
+	handler, storState, _, _ := multiUpstreamTestSetup(t)
+
+	sessionID := "direct-cleanup-session"
+	for _, p := range []string{"provider-1", "provider-2", "not-configured"} {
+		storState.upstreamTokens[sessionID+":"+p] = &storage.UpstreamTokens{
+			ProviderID:  p,
+			AccessToken: "at",
+			ExpiresAt:   time.Now().Add(time.Hour),
+			ClientID:    testAuthClientID,
+			UserID:      "user-1",
+		}
+	}
+
+	handler.cleanupUpstreamTokens(t.Context(), sessionID,
+		[]string{"provider-1", "", "not-configured", "provider-2"})
+
+	// Configured providers are removed...
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1")
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2")
+	// ...while the unconfigured name is skipped (its row survives) and the empty name is
+	// a no-op rather than a panic.
+	assert.Contains(t, storState.upstreamTokens, sessionID+":not-configured",
+		"a name that is not a configured upstream must not be deleted")
+}
+
+// TestCallbackHandler_StoreUpstreamTokensError_LeavesEarlierLegs covers the
+// StoreUpstreamTokens-failure cleanup site on a subsequent leg: the cleanup is scoped to
+// the leg being processed (provider-2, whose store just failed), so the user's earlier
+// leg (provider-1) is left intact rather than wiped by the failure.
+func TestCallbackHandler_StoreUpstreamTokensError_LeavesEarlierLegs(t *testing.T) {
 	t.Parallel()
 	handler, storState, _, _ := multiUpstreamTestSetupWithStorage(t,
 		withStoreUpstreamTokensError(errors.New("storage unavailable")))
@@ -1329,8 +1360,6 @@ func TestCallbackHandler_StoreUpstreamTokensError_CleansUpChain(t *testing.T) {
 		UserID:      leg1User,
 	}
 
-	// Subsequent-leg pending whose ChainUpstreams already contains provider-2 (this
-	// leg), so the cleanup list names provider-2 twice — exercising the dedup.
 	secondLegState := "store-err-second-leg-state"
 	storState.pendingAuths[secondLegState] = &storage.PendingAuthorization{
 		ClientID:             testAuthClientID,
@@ -1358,9 +1387,10 @@ func TestCallbackHandler_StoreUpstreamTokensError_CleansUpChain(t *testing.T) {
 	assert.Equal(t, http.StatusSeeOther, rec.Code, "a store failure should produce a fosite error redirect")
 	assert.Contains(t, rec.Header().Get("Location"), "error=server_error")
 
-	// The earlier leg's token is cleaned up; provider-2's store never landed.
-	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
-		"the earlier chain leg's token should be cleaned up on a store failure")
+	// The earlier leg's token survives — cleanup is scoped to the failed leg only.
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"an earlier leg's token must survive a later leg's store failure")
+	// provider-2's store failed, so it never had a row.
 	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
 		"provider-2's store failed, so no row should exist")
 }
@@ -1451,11 +1481,12 @@ func TestCallbackHandler_WriteAuthorizationResponseError_OnSatisfiedChain_Cleans
 
 	assert.Equal(t, http.StatusSeeOther, rec.Code, "a response-write failure should produce a fosite error redirect")
 
-	// Both legs of the satisfied chain are cleaned up when the final response write fails.
-	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
-		"the first leg's token should be cleaned up")
+	// Only the final leg is cleaned up; the response-write failure is retryable and the
+	// earlier leg is left intact so a retry re-collects only the last one.
 	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
 		"the final leg's token should be cleaned up")
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"the earlier leg's token must survive a retryable response-write failure")
 }
 
 // TestCallbackHandler_Cleanup_ContinuesWhenAProviderDeleteFails covers
@@ -1878,16 +1909,18 @@ func TestCallbackHandler_PlacesPlatformUserInContext_OnChainRead(t *testing.T) {
 }
 
 // TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup verifies that
-// when a subsequent-leg callback returns an upstream error, the earlier-leg cleanup
-// (per-provider DeleteUpstreamTokensForProvider in handleUpstreamError) runs with the
-// resolved canonical user already in the request context.
+// when a subsequent-leg callback returns an upstream error, the per-provider cleanup
+// (DeleteUpstreamTokensForProvider in handleUpstreamError) runs with the resolved
+// canonical user already in the request context, and that it leaves the earlier leg.
 //
 // This is the error-path sibling of the chain-read test above. handleUpstreamError
 // runs from an early return at the top of CallbackHandler, before the happy-path
 // user injection, so it must place the user itself. DeleteUpstreamTokensForProvider
 // carries no tokens argument — so a context-keyed storage decorator can resolve the
 // canonical user only from ctx. The resolved user is carried forward from leg 1 via
-// pending.ResolvedUserID, and pending.ChainUpstreams names the earlier leg to clean.
+// pending.ResolvedUserID. The cleanup is scoped to the leg being processed (provider-2,
+// which errored at the upstream so it has no row), so the earlier leg (provider-1)
+// survives.
 func TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup(t *testing.T) {
 	t.Parallel()
 	handler, storState, _, _ := multiUpstreamTestSetup(t)
@@ -1936,11 +1969,11 @@ func TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup(t *t
 	require.True(t, ok, "handleUpstreamError must place platform user in ctx before the cleanup delete")
 	require.Equal(t, leg1User, uid)
 
-	// The earlier leg's row must actually be gone — not merely have had its ctx
-	// captured. A regression passing an empty or wrong provider list would still
-	// populate deleteUpstreamCtx (the mock runs regardless) but leave the row.
-	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
-		"the earlier-leg token should be deleted by the cleanup, not just context-propagated")
+	// The earlier leg's token survives: cleanup is scoped to the leg being processed
+	// (provider-2), not the whole chain, so a failed connector login never wipes the
+	// user's other connectors.
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"an earlier leg's token must survive a later leg's upstream error")
 
 	// The error path must NOT place a stub Identity under the identity key.
 	_, hasIdentity := auth.IdentityFromContext(storState.deleteUpstreamCtx)

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -767,10 +767,10 @@ func TestCallbackHandler_FilterError_FailsAuthorization(t *testing.T) {
 	assert.Contains(t, location, "state=client-state-error", "should preserve client state")
 	assert.Equal(t, 1, filter.calls)
 
-	// provider-1's already-stored tokens are cleaned up.
-	for key := range storState.upstreamTokens {
-		assert.Failf(t, "upstream tokens should be cleaned up", "found leftover token %q", key)
-	}
+	// A filter error does not invalidate provider-1's already-stored credential, so it is
+	// preserved; only the authorization fails.
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"a filter error must not delete the already-stored credential")
 }
 
 func TestCallbackHandler_SecondLeg_ReusesChain_DoesNotReRunFilter(t *testing.T) {
@@ -931,15 +931,12 @@ func TestCallbackHandler_SubsequentLeg_MissingChain_FailsClosed(t *testing.T) {
 	assert.Contains(t, location, "error=server_error")
 	assert.Contains(t, location, "state=client-original-state")
 
-	// Fail-closed cleanup is scoped per provider so a user-keyed storage decorator does
-	// not over-delete the user's other connectors. This stale pending carries no
-	// ChainUpstreams, so only the leg just processed (provider-2) can be named and
-	// removed; the earlier leg (provider-1) is not nameable here and is left to expire
-	// by its own TTL rather than risk a session-wide delete widening to the whole user.
-	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
-		"the leg just processed should be cleaned up")
+	// A stale pending fails the authorization closed but does not invalidate any
+	// credential, so both the earlier leg and the leg just processed are preserved.
 	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
-		"an earlier leg with no ChainUpstreams to name it is left to TTL, not session-wide deleted")
+		"the earlier leg's token must survive a fail-closed stale pending")
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-2",
+		"the just-processed leg's token must survive a fail-closed stale pending")
 }
 
 func TestCallbackHandler_SingleLeg_IssuesCodeWithoutChaining(t *testing.T) {
@@ -1185,7 +1182,7 @@ func TestCallbackHandler_TwoUpstreams_FreshSecretsPerLeg(t *testing.T) {
 	assert.Equal(t, "S256", nextPending.PKCEMethod)
 }
 
-func TestCallbackHandler_TwoUpstreams_AuthorizationURLError_CleansUp(t *testing.T) {
+func TestCallbackHandler_TwoUpstreams_AuthorizationURLError_PreservesTokens(t *testing.T) {
 	t.Parallel()
 	handler, storState, _, mockProvider2 := multiUpstreamTestSetup(t)
 
@@ -1225,86 +1222,163 @@ func TestCallbackHandler_TwoUpstreams_AuthorizationURLError_CleansUp(t *testing.
 	assert.Contains(t, location, "error=server_error", "should contain server_error")
 	assert.Contains(t, location, "state=client-state-authurl", "should preserve client state")
 
-	// Upstream tokens from the completed first leg should be cleaned up
-	for key := range storState.upstreamTokens {
-		assert.Failf(t, "upstream tokens should be cleaned up",
-			"found leftover token with key %q", key)
-	}
+	// The completed first leg's credential is preserved — a failure building the NEXT
+	// leg's authorization URL does not invalidate it.
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"the first leg's token must survive a next-leg authorization-URL failure")
 
-	// The pending authorization created for the second leg should also be cleaned up.
-	// Only the first-leg pending remains (but it was deleted by CallbackHandler on load).
+	// The ephemeral pending authorizations are still cleaned up: the first-leg pending was
+	// deleted on load, and the second-leg pending is deleted on this error path.
 	for state, p := range storState.pendingAuths {
 		assert.Failf(t, "no pending authorizations should remain",
 			"found pending for provider %q with state %q", p.UpstreamProviderName, state)
 	}
 }
 
-// TestCallbackHandler_Cleanup_LeavesOutOfChainProviderTokens is the regression guard for
-// the failure that motivated per-provider cleanup. The callback's chain-cleanup must
-// delete only the providers in THIS authorization's chain, never a token the storage
-// holds for the same session under some other provider.
+// TestCallbackHandler_MismatchCleanup_LeavesFilteredOutProvider is the regression guard
+// for the one path that deletes upstream tokens — the confirmed identity-mismatch
+// fail-closed. That cleanup must be scoped to the EFFECTIVE chain, not to every
+// configured provider: a provider the upstream filter excluded from the chain is still
+// the user's live credential and must survive.
 //
-// It matters because a storage decorator can re-key upstream tokens from toolhive's
-// native (session, provider) scheme to a per-(gateway, user) scheme so a
-// session-independent caller can find a user's tokens. Under that decorator every one of
-// a user's connector tokens shares the session slot, so the old session-wide
-// DeleteUpstreamTokens on any failing login leg deleted the user's entire connector set.
-// Naming each chain provider lets such a decorator scope the delete to exactly this
-// chain, so a provider outside the chain survives — asserted here with a raw
-// (session, provider)-keyed backend that makes the scoping directly observable.
-func TestCallbackHandler_Cleanup_LeavesOutOfChainProviderTokens(t *testing.T) {
+// This is stronger than skip-unconfigured coverage: the survivor here (provider-3) IS a
+// configured upstream, so the only thing keeping it alive is that cleanup deletes the
+// effective chain rather than the full configured set. Three providers are configured;
+// the effective chain carried into this (final) leg is [provider-1, provider-2], as a
+// first-leg filter would have narrowed it, excluding provider-3.
+func TestCallbackHandler_MismatchCleanup_LeavesFilteredOutProvider(t *testing.T) {
 	t.Parallel()
-	handler, storState, _, mockProvider2 := multiUpstreamTestSetup(t)
 
-	// provider-2 fails to build its authorization URL, driving the chain-cleanup path
-	// with the effective chain [provider-1, provider-2].
-	mockProvider2.authURLErr = errors.New("authorization URL error")
+	provider, oauth2Config, stor, storState := baseTestSetup(t)
+	p2 := &mockIDPProvider{
+		providerType: upstream.ProviderTypeOAuth2,
+		exchangeResult: &upstream.Identity{
+			Tokens:  &upstream.Tokens{AccessToken: "p2-at", ExpiresAt: time.Now().Add(time.Hour)},
+			Subject: "user-from-provider2",
+		},
+	}
+	upstreams := []NamedUpstream{
+		{Name: "provider-1", Provider: &mockIDPProvider{providerType: upstream.ProviderTypeOAuth2}},
+		{Name: "provider-2", Provider: p2},
+		{Name: "provider-3", Provider: &mockIDPProvider{providerType: upstream.ProviderTypeOAuth2}},
+	}
+	handler, err := NewHandler(provider, oauth2Config, stor, upstreams)
+	require.NoError(t, err)
 
-	sessionID := "chain-session-out-of-chain"
+	sessionID := "mismatch-scoping-session"
 
-	// A token for a provider that is NOT part of this login's chain, stored under the
-	// same session slot — this is what a (gateway, user)-keyed decorator looks like from
-	// the backend's side: every connector the user holds shares one session key.
-	outOfChainKey := sessionID + ":provider-out-of-chain"
-	storState.upstreamTokens[outOfChainKey] = &storage.UpstreamTokens{
-		ProviderID:  "provider-out-of-chain",
+	// provider-1's stored token disagrees with the carried subject → verifyChainIdentity
+	// will report a confirmed mismatch and tear down the effective chain.
+	storState.upstreamTokens[sessionID+":provider-1"] = &storage.UpstreamTokens{
+		ProviderID:  "provider-1",
+		AccessToken: "p1-at",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		ClientID:    testAuthClientID,
+		UserID:      "tampered-user-id",
+	}
+	// provider-3 is a configured upstream the filter excluded from this chain; it is the
+	// user's live credential and must survive the whole-chain cleanup.
+	filteredOutKey := sessionID + ":provider-3"
+	storState.upstreamTokens[filteredOutKey] = &storage.UpstreamTokens{
+		ProviderID:  "provider-3",
 		AccessToken: "keep-me",
 		ExpiresAt:   time.Now().Add(time.Hour),
 		ClientID:    testAuthClientID,
-		UserID:      "user-1",
+		UserID:      "correct-user-id",
 	}
 
-	firstLegState := "out-of-chain-first-leg-state"
-	storState.pendingAuths[firstLegState] = &storage.PendingAuthorization{
+	// Final leg (provider-2) of an effective chain that excludes provider-3.
+	secondLegState := "mismatch-scoping-state"
+	storState.pendingAuths[secondLegState] = &storage.PendingAuthorization{
 		ClientID:             testAuthClientID,
 		RedirectURI:          testAuthRedirectURI,
-		State:                "client-state-out-of-chain",
-		PKCEChallenge:        "challenge-out-of-chain",
+		State:                "client-original-state",
+		PKCEChallenge:        "client-challenge",
 		PKCEMethod:           "S256",
 		Scopes:               []string{"openid"},
-		InternalState:        firstLegState,
-		UpstreamPKCEVerifier: "out-of-chain-verifier-1234567890123456789012",
-		UpstreamNonce:        "out-of-chain-nonce",
-		UpstreamProviderName: "provider-1",
+		InternalState:        secondLegState,
+		UpstreamPKCEVerifier: "mismatch-scoping-verifier-123456789012345678",
+		UpstreamNonce:        "mismatch-scoping-nonce",
+		UpstreamProviderName: "provider-2",
 		SessionID:            sessionID,
+		ChainUpstreams:       []string{"provider-1", "provider-2"},
+		ResolvedUserID:       "correct-user-id",
 		CreatedAt:            time.Now(),
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=p1-code&state="+firstLegState, nil)
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=provider2-code&state="+secondLegState, nil)
 	rec := httptest.NewRecorder()
 	handler.CallbackHandler(rec, req)
 
-	assert.Equal(t, http.StatusSeeOther, rec.Code, "should return fosite error redirect")
+	assert.Equal(t, http.StatusSeeOther, rec.Code, "a confirmed mismatch should fail closed")
 
-	// The failing chain's own provider-1 token is cleaned up...
+	// The effective chain [provider-1, provider-2] is torn down...
 	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
-		"the failing chain's own provider token should be cleaned up")
-	// ...but the out-of-chain provider's token is left untouched. This is the property a
-	// user-keyed decorator relies on so a failing login never wipes the user's other
-	// connectors.
-	require.Contains(t, storState.upstreamTokens, outOfChainKey,
-		"a token for a provider outside this chain must survive the cleanup")
-	assert.Equal(t, "keep-me", storState.upstreamTokens[outOfChainKey].AccessToken)
+		"an in-chain provider should be cleaned up on a confirmed mismatch")
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
+		"an in-chain provider should be cleaned up on a confirmed mismatch")
+	// ...but the configured provider the filter excluded from the chain survives. If
+	// cleanup widened from the effective chain to every configured provider, this fails.
+	require.Contains(t, storState.upstreamTokens, filteredOutKey,
+		"a configured provider outside the effective chain must survive the cleanup")
+	assert.Equal(t, "keep-me", storState.upstreamTokens[filteredOutKey].AccessToken)
+}
+
+// TestCallbackHandler_VerifyChainIdentity_StorageFailure_PreservesTokens covers the
+// distinction the callback draws between verifyChainIdentity's two failure modes. A
+// transient GetAllUpstreamTokens failure on the identity check — the second bulk read,
+// after nextMissingUpstream's first read succeeds — is NOT a confirmed mismatch, so the
+// authorization fails closed but every upstream token is preserved. Only a confirmed
+// mismatch tears the chain down.
+func TestCallbackHandler_VerifyChainIdentity_StorageFailure_PreservesTokens(t *testing.T) {
+	t.Parallel()
+	// Fail the SECOND GetAllUpstreamTokens call: nextMissingUpstream's read (call 1)
+	// succeeds, verifyChainIdentity's read (call 2) fails.
+	handler, storState, _, _ := multiUpstreamTestSetupWithStorage(t,
+		withGetAllUpstreamTokensErrorAfterCalls(1, errors.New("storage unavailable")))
+
+	sessionID := "verify-storage-fail-session"
+	const leg1User = "resolved-user-id-from-leg1"
+
+	// First leg keyed to leg1User, so identities agree — the ONLY failure is the
+	// transient read, not a mismatch.
+	storState.upstreamTokens[sessionID+":provider-1"] = &storage.UpstreamTokens{
+		ProviderID:  "provider-1",
+		AccessToken: "p1-at",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		ClientID:    testAuthClientID,
+		UserID:      leg1User,
+	}
+
+	secondLegState := "verify-storage-fail-state"
+	storState.pendingAuths[secondLegState] = &storage.PendingAuthorization{
+		ClientID:             testAuthClientID,
+		RedirectURI:          testAuthRedirectURI,
+		State:                "client-original-state",
+		PKCEChallenge:        "client-challenge",
+		PKCEMethod:           "S256",
+		Scopes:               []string{"openid"},
+		InternalState:        secondLegState,
+		UpstreamPKCEVerifier: "verify-storage-fail-verifier-1234567890123456",
+		UpstreamNonce:        "verify-storage-fail-nonce",
+		UpstreamProviderName: "provider-2",
+		SessionID:            sessionID,
+		ChainUpstreams:       []string{"provider-1", "provider-2"},
+		ResolvedUserID:       leg1User,
+		CreatedAt:            time.Now(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=provider2-code&state="+secondLegState, nil)
+	rec := httptest.NewRecorder()
+	handler.CallbackHandler(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code, "a transient identity-check read failure should fail authorization")
+
+	// Neither leg is deleted: a storage failure is not a confirmed mismatch.
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"a transient identity-check read failure must not delete tokens")
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-2",
+		"a transient identity-check read failure must not delete tokens")
 }
 
 // TestCleanupUpstreamTokens_SkipsUnconfiguredAndEmpty exercises cleanupUpstreamTokens
@@ -1408,10 +1482,11 @@ func TestCallbackHandler_StoreUpstreamTokensError_LeavesExistingTokens(t *testin
 	assert.Equal(t, "existing-p2-at", storState.upstreamTokens[existingP2].AccessToken)
 }
 
-// TestCallbackHandler_NextMissingUpstreamError_CleansUpChain covers the
-// nextMissingUpstream-failure cleanup site: a chain-state read (GetAllUpstreamTokens)
-// error after the first leg has stored its token.
-func TestCallbackHandler_NextMissingUpstreamError_CleansUpChain(t *testing.T) {
+// TestCallbackHandler_NextMissingUpstreamError_PreservesTokens covers the
+// nextMissingUpstream-failure path: a transient chain-state read (GetAllUpstreamTokens)
+// error after the first leg has stored its token fails the authorization but preserves
+// the token — a storage blip does not invalidate a collected credential.
+func TestCallbackHandler_NextMissingUpstreamError_PreservesTokens(t *testing.T) {
 	t.Parallel()
 	handler, storState, _, _ := multiUpstreamTestSetupWithStorage(t,
 		withGetAllUpstreamTokensError(errors.New("storage unavailable")))
@@ -1440,18 +1515,20 @@ func TestCallbackHandler_NextMissingUpstreamError_CleansUpChain(t *testing.T) {
 	assert.Equal(t, http.StatusSeeOther, rec.Code, "a chain-state read failure should produce a fosite error redirect")
 	assert.Contains(t, rec.Header().Get("Location"), "error=server_error")
 
-	// The first leg's just-stored token is cleaned up when the chain-state read fails.
-	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
-		"the stored first-leg token should be cleaned up on a nextMissingUpstream failure")
+	// The first leg's token survives a transient chain-state read failure.
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"a transient nextMissingUpstream failure must not delete the stored token")
 }
 
-// TestCallbackHandler_WriteAuthorizationResponseError_OnSatisfiedChain_CleansUp covers
-// the cleanup site reached when writeAuthorizationResponse fails after a multi-upstream
-// chain is fully satisfied and the identity check has passed. GetClient is wired to fail
-// only on its second call: the first (which builds the error-redirect requester)
+// TestCallbackHandler_WriteAuthorizationResponseError_OnSatisfiedChain_PreservesTokens
+// covers the path reached when writeAuthorizationResponse fails after a multi-upstream
+// chain is fully satisfied and identity-verified. That downstream failure (client lookup
+// / redirect / code generation) does not invalidate the collected credentials, so all
+// upstream tokens are preserved — matching the SingleLeg branch. GetClient is wired to
+// fail only on its second call: the first (which builds the error-redirect requester)
 // succeeds so the failure still produces a redirect, the second (inside
-// writeAuthorizationResponse) fails to drive the cleanup.
-func TestCallbackHandler_WriteAuthorizationResponseError_OnSatisfiedChain_CleansUp(t *testing.T) {
+// writeAuthorizationResponse) drives the failure.
+func TestCallbackHandler_WriteAuthorizationResponseError_OnSatisfiedChain_PreservesTokens(t *testing.T) {
 	t.Parallel()
 	handler, storState, _, _ := multiUpstreamTestSetupWithStorage(t,
 		withGetClientErrorAfterCalls(1, errors.New("get client unavailable")))
@@ -1494,12 +1571,12 @@ func TestCallbackHandler_WriteAuthorizationResponseError_OnSatisfiedChain_Cleans
 
 	assert.Equal(t, http.StatusSeeOther, rec.Code, "a response-write failure should produce a fosite error redirect")
 
-	// Only the final leg is cleaned up; the response-write failure is retryable and the
-	// earlier leg is left intact so a retry re-collects only the last one.
-	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
-		"the final leg's token should be cleaned up")
+	// Both legs are preserved: the chain is complete and identity-verified, and only the
+	// downstream response write failed, which does not invalidate the credentials.
 	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
-		"the earlier leg's token must survive a retryable response-write failure")
+		"the first leg's token must survive a downstream response-write failure")
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-2",
+		"the final leg's token must survive a downstream response-write failure")
 }
 
 // TestCallbackHandler_Cleanup_ContinuesWhenAProviderDeleteFails covers
@@ -1557,7 +1634,7 @@ func TestCallbackHandler_Cleanup_ContinuesWhenAProviderDeleteFails(t *testing.T)
 		"cleanup must continue past a per-provider delete failure and remove sibling providers")
 }
 
-func TestCallbackHandler_TwoUpstreams_StorePendingError_CleansUp(t *testing.T) {
+func TestCallbackHandler_TwoUpstreams_StorePendingError_PreservesTokens(t *testing.T) {
 	t.Parallel()
 
 	provider, oauth2Config, stor, storState := baseTestSetup(t, withStorePendingError(errors.New("storage unavailable")))
@@ -1618,11 +1695,10 @@ func TestCallbackHandler_TwoUpstreams_StorePendingError_CleansUp(t *testing.T) {
 	assert.Contains(t, location, "error=server_error", "should contain server_error")
 	assert.Contains(t, location, "state=client-state-store-err", "should preserve client state")
 
-	// Upstream tokens should be cleaned up
-	for key := range storState.upstreamTokens {
-		assert.Failf(t, "upstream tokens should be cleaned up",
-			"found leftover token with key %q", key)
-	}
+	// The first leg's credential is preserved — failing to persist the next leg's pending
+	// does not invalidate it.
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"the first leg's token must survive a next-leg pending store failure")
 }
 
 // TestCallbackHandler_RefreshTokenCarryForward verifies the OAuth callback's

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -1307,6 +1307,212 @@ func TestCallbackHandler_Cleanup_LeavesOutOfChainProviderTokens(t *testing.T) {
 	assert.Equal(t, "keep-me", storState.upstreamTokens[outOfChainKey].AccessToken)
 }
 
+// TestCallbackHandler_StoreUpstreamTokensError_CleansUpChain covers the
+// StoreUpstreamTokens-failure cleanup site on a subsequent leg. It is the one site
+// where cleanupUpstreamTokens' dedup is load-bearing: the provider list is
+// append([]string{providerID}, pending.ChainUpstreams...), and ChainUpstreams already
+// contains providerID on a non-first leg, so the same provider is named twice.
+func TestCallbackHandler_StoreUpstreamTokensError_CleansUpChain(t *testing.T) {
+	t.Parallel()
+	handler, storState, _, _ := multiUpstreamTestSetupWithStorage(t,
+		withStoreUpstreamTokensError(errors.New("storage unavailable")))
+
+	sessionID := "store-err-session"
+	const leg1User = "resolved-user-id-from-leg1"
+
+	// First leg already completed: provider-1's token exists.
+	storState.upstreamTokens[sessionID+":provider-1"] = &storage.UpstreamTokens{
+		ProviderID:  "provider-1",
+		AccessToken: "p1-at",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		ClientID:    testAuthClientID,
+		UserID:      leg1User,
+	}
+
+	// Subsequent-leg pending whose ChainUpstreams already contains provider-2 (this
+	// leg), so the cleanup list names provider-2 twice — exercising the dedup.
+	secondLegState := "store-err-second-leg-state"
+	storState.pendingAuths[secondLegState] = &storage.PendingAuthorization{
+		ClientID:             testAuthClientID,
+		RedirectURI:          testAuthRedirectURI,
+		State:                "client-original-state",
+		PKCEChallenge:        "client-challenge",
+		PKCEMethod:           "S256",
+		Scopes:               []string{"openid"},
+		InternalState:        secondLegState,
+		UpstreamPKCEVerifier: "store-err-verifier-123456789012345678901234",
+		UpstreamNonce:        "store-err-nonce",
+		UpstreamProviderName: "provider-2",
+		SessionID:            sessionID,
+		ChainUpstreams:       []string{"provider-1", "provider-2"},
+		ResolvedUserID:       leg1User,
+		ResolvedUserName:     "First Leg User",
+		ResolvedUserEmail:    "firstleg@example.com",
+		CreatedAt:            time.Now(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=provider2-code&state="+secondLegState, nil)
+	rec := httptest.NewRecorder()
+	handler.CallbackHandler(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code, "a store failure should produce a fosite error redirect")
+	assert.Contains(t, rec.Header().Get("Location"), "error=server_error")
+
+	// The earlier leg's token is cleaned up; provider-2's store never landed.
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"the earlier chain leg's token should be cleaned up on a store failure")
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
+		"provider-2's store failed, so no row should exist")
+}
+
+// TestCallbackHandler_NextMissingUpstreamError_CleansUpChain covers the
+// nextMissingUpstream-failure cleanup site: a chain-state read (GetAllUpstreamTokens)
+// error after the first leg has stored its token.
+func TestCallbackHandler_NextMissingUpstreamError_CleansUpChain(t *testing.T) {
+	t.Parallel()
+	handler, storState, _, _ := multiUpstreamTestSetupWithStorage(t,
+		withGetAllUpstreamTokensError(errors.New("storage unavailable")))
+
+	sessionID := "next-missing-err-session"
+	firstLegState := "next-missing-err-first-leg-state"
+	storState.pendingAuths[firstLegState] = &storage.PendingAuthorization{
+		ClientID:             testAuthClientID,
+		RedirectURI:          testAuthRedirectURI,
+		State:                "client-state-next-missing",
+		PKCEChallenge:        "challenge-next-missing",
+		PKCEMethod:           "S256",
+		Scopes:               []string{"openid"},
+		InternalState:        firstLegState,
+		UpstreamPKCEVerifier: "next-missing-verifier-12345678901234567890",
+		UpstreamNonce:        "next-missing-nonce",
+		UpstreamProviderName: "provider-1",
+		SessionID:            sessionID,
+		CreatedAt:            time.Now(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=p1-code&state="+firstLegState, nil)
+	rec := httptest.NewRecorder()
+	handler.CallbackHandler(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code, "a chain-state read failure should produce a fosite error redirect")
+	assert.Contains(t, rec.Header().Get("Location"), "error=server_error")
+
+	// The first leg's just-stored token is cleaned up when the chain-state read fails.
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"the stored first-leg token should be cleaned up on a nextMissingUpstream failure")
+}
+
+// TestCallbackHandler_WriteAuthorizationResponseError_OnSatisfiedChain_CleansUp covers
+// the cleanup site reached when writeAuthorizationResponse fails after a multi-upstream
+// chain is fully satisfied and the identity check has passed. GetClient is wired to fail
+// only on its second call: the first (which builds the error-redirect requester)
+// succeeds so the failure still produces a redirect, the second (inside
+// writeAuthorizationResponse) fails to drive the cleanup.
+func TestCallbackHandler_WriteAuthorizationResponseError_OnSatisfiedChain_CleansUp(t *testing.T) {
+	t.Parallel()
+	handler, storState, _, _ := multiUpstreamTestSetupWithStorage(t,
+		withGetClientErrorAfterCalls(1, errors.New("get client unavailable")))
+
+	sessionID := "satisfied-writeresp-err-session"
+	const leg1User = "resolved-user-id-from-leg1"
+
+	// First leg already completed, keyed to leg1User so verifyChainIdentity passes.
+	storState.upstreamTokens[sessionID+":provider-1"] = &storage.UpstreamTokens{
+		ProviderID:  "provider-1",
+		AccessToken: "p1-at",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		ClientID:    testAuthClientID,
+		UserID:      leg1User,
+	}
+
+	secondLegState := "satisfied-writeresp-err-state"
+	storState.pendingAuths[secondLegState] = &storage.PendingAuthorization{
+		ClientID:             testAuthClientID,
+		RedirectURI:          testAuthRedirectURI,
+		State:                "client-original-state",
+		PKCEChallenge:        "client-challenge",
+		PKCEMethod:           "S256",
+		Scopes:               []string{"openid"},
+		InternalState:        secondLegState,
+		UpstreamPKCEVerifier: "satisfied-verifier-123456789012345678901234",
+		UpstreamNonce:        "satisfied-nonce",
+		UpstreamProviderName: "provider-2",
+		SessionID:            sessionID,
+		ChainUpstreams:       []string{"provider-1", "provider-2"},
+		ResolvedUserID:       leg1User,
+		ResolvedUserName:     "First Leg User",
+		ResolvedUserEmail:    "firstleg@example.com",
+		CreatedAt:            time.Now(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=provider2-code&state="+secondLegState, nil)
+	rec := httptest.NewRecorder()
+	handler.CallbackHandler(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code, "a response-write failure should produce a fosite error redirect")
+
+	// Both legs of the satisfied chain are cleaned up when the final response write fails.
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"the first leg's token should be cleaned up")
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
+		"the final leg's token should be cleaned up")
+}
+
+// TestCallbackHandler_Cleanup_ContinuesWhenAProviderDeleteFails covers
+// cleanupUpstreamTokens' warn-and-continue path: one provider's delete errors, and the
+// cleanup must still remove the sibling providers rather than aborting on the first
+// failure.
+func TestCallbackHandler_Cleanup_ContinuesWhenAProviderDeleteFails(t *testing.T) {
+	t.Parallel()
+	handler, storState, _, _ := multiUpstreamTestSetupWithStorage(t,
+		withDeleteUpstreamTokensForProviderError("provider-1", errors.New("delete failed")))
+
+	sessionID := "cleanup-partial-fail-session"
+
+	// provider-1 has a tampered UserID so verifyChainIdentity fails and the chain is
+	// cleaned up; provider-1's delete is wired to fail.
+	storState.upstreamTokens[sessionID+":provider-1"] = &storage.UpstreamTokens{
+		ProviderID:  "provider-1",
+		AccessToken: "p1-at",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		ClientID:    testAuthClientID,
+		UserID:      "tampered-user-id",
+	}
+
+	secondLegState := "cleanup-partial-fail-state"
+	storState.pendingAuths[secondLegState] = &storage.PendingAuthorization{
+		ClientID:             testAuthClientID,
+		RedirectURI:          testAuthRedirectURI,
+		State:                "client-original-state",
+		PKCEChallenge:        "client-challenge",
+		PKCEMethod:           "S256",
+		Scopes:               []string{"openid"},
+		InternalState:        secondLegState,
+		UpstreamPKCEVerifier: "partial-fail-verifier-12345678901234567890",
+		UpstreamNonce:        "partial-fail-nonce",
+		UpstreamProviderName: "provider-2",
+		SessionID:            sessionID,
+		ChainUpstreams:       []string{"provider-1", "provider-2"},
+		ResolvedUserID:       "correct-user-id",
+		ResolvedUserName:     "Correct User",
+		ResolvedUserEmail:    "correct@example.com",
+		CreatedAt:            time.Now(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=provider2-code&state="+secondLegState, nil)
+	rec := httptest.NewRecorder()
+	handler.CallbackHandler(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code)
+
+	// provider-1's delete failed, so its row is still present...
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"the provider whose delete failed should still be present")
+	// ...but the cleanup continued and removed provider-2 anyway.
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
+		"cleanup must continue past a per-provider delete failure and remove sibling providers")
+}
+
 func TestCallbackHandler_TwoUpstreams_StorePendingError_CleansUp(t *testing.T) {
 	t.Parallel()
 
@@ -1729,6 +1935,12 @@ func TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup(t *t
 	uid, ok := auth.PlatformUserFromContext(storState.deleteUpstreamCtx)
 	require.True(t, ok, "handleUpstreamError must place platform user in ctx before the cleanup delete")
 	require.Equal(t, leg1User, uid)
+
+	// The earlier leg's row must actually be gone — not merely have had its ctx
+	// captured. A regression passing an empty or wrong provider list would still
+	// populate deleteUpstreamCtx (the mock runs regardless) but leave the row.
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"the earlier-leg token should be deleted by the cleanup, not just context-propagated")
 
 	// The error path must NOT place a stub Identity under the identity key.
 	_, hasIdentity := auth.IdentityFromContext(storState.deleteUpstreamCtx)

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -1339,11 +1339,12 @@ func TestCleanupUpstreamTokens_SkipsUnconfiguredAndEmpty(t *testing.T) {
 		"a name that is not a configured upstream must not be deleted")
 }
 
-// TestCallbackHandler_StoreUpstreamTokensError_LeavesEarlierLegs covers the
-// StoreUpstreamTokens-failure cleanup site on a subsequent leg: the cleanup is scoped to
-// the leg being processed (provider-2, whose store just failed), so the user's earlier
-// leg (provider-1) is left intact rather than wiped by the failure.
-func TestCallbackHandler_StoreUpstreamTokensError_LeavesEarlierLegs(t *testing.T) {
+// TestCallbackHandler_StoreUpstreamTokensError_LeavesExistingTokens covers the
+// StoreUpstreamTokens-failure path: a failed store wrote nothing, so it must delete
+// nothing. The user's earlier leg (provider-1) and any existing credential for the leg
+// being processed (a re-connect of provider-2 whose fresh store failed) are both left
+// intact rather than wiped by the failure.
+func TestCallbackHandler_StoreUpstreamTokensError_LeavesExistingTokens(t *testing.T) {
 	t.Parallel()
 	handler, storState, _, _ := multiUpstreamTestSetupWithStorage(t,
 		withStoreUpstreamTokensError(errors.New("storage unavailable")))
@@ -1355,6 +1356,17 @@ func TestCallbackHandler_StoreUpstreamTokensError_LeavesEarlierLegs(t *testing.T
 	storState.upstreamTokens[sessionID+":provider-1"] = &storage.UpstreamTokens{
 		ProviderID:  "provider-1",
 		AccessToken: "p1-at",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		ClientID:    testAuthClientID,
+		UserID:      leg1User,
+	}
+
+	// provider-2 is already connected too — this is a re-connect whose fresh store will
+	// fail. Its existing credential must survive the failure.
+	existingP2 := sessionID + ":provider-2"
+	storState.upstreamTokens[existingP2] = &storage.UpstreamTokens{
+		ProviderID:  "provider-2",
+		AccessToken: "existing-p2-at",
 		ExpiresAt:   time.Now().Add(time.Hour),
 		ClientID:    testAuthClientID,
 		UserID:      leg1User,
@@ -1387,12 +1399,13 @@ func TestCallbackHandler_StoreUpstreamTokensError_LeavesEarlierLegs(t *testing.T
 	assert.Equal(t, http.StatusSeeOther, rec.Code, "a store failure should produce a fosite error redirect")
 	assert.Contains(t, rec.Header().Get("Location"), "error=server_error")
 
-	// The earlier leg's token survives — cleanup is scoped to the failed leg only.
+	// A failed store deletes nothing: the earlier leg and the existing provider-2
+	// credential both survive.
 	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
 		"an earlier leg's token must survive a later leg's store failure")
-	// provider-2's store failed, so it never had a row.
-	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
-		"provider-2's store failed, so no row should exist")
+	require.Contains(t, storState.upstreamTokens, existingP2,
+		"an existing credential must survive a re-connect whose fresh store failed")
+	assert.Equal(t, "existing-p2-at", storState.upstreamTokens[existingP2].AccessToken)
 }
 
 // TestCallbackHandler_NextMissingUpstreamError_CleansUpChain covers the
@@ -1908,74 +1921,63 @@ func TestCallbackHandler_PlacesPlatformUserInContext_OnChainRead(t *testing.T) {
 	require.False(t, hasIdentity, "callback must not place an Identity (only a platform user) in ctx")
 }
 
-// TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup verifies that
-// when a subsequent-leg callback returns an upstream error, the per-provider cleanup
-// (DeleteUpstreamTokensForProvider in handleUpstreamError) runs with the resolved
-// canonical user already in the request context, and that it leaves the earlier leg.
-//
-// This is the error-path sibling of the chain-read test above. handleUpstreamError
-// runs from an early return at the top of CallbackHandler, before the happy-path
-// user injection, so it must place the user itself. DeleteUpstreamTokensForProvider
-// carries no tokens argument — so a context-keyed storage decorator can resolve the
-// canonical user only from ctx. The resolved user is carried forward from leg 1 via
-// pending.ResolvedUserID. The cleanup is scoped to the leg being processed (provider-2,
-// which errored at the upstream so it has no row), so the earlier leg (provider-1)
-// survives.
-func TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup(t *testing.T) {
+// TestCallbackHandler_UpstreamError_LeavesExistingProviderToken is the regression guard
+// for the re-connect data-loss bug: when the upstream IdP returns an error (e.g. the user
+// cancels a re-connect), handleUpstreamError must delete only the single-use pending and
+// leave the provider's existing token — a credential from an earlier successful
+// authorization — intact. The upstream errored before this attempt exchanged a code, so
+// this attempt stored nothing; deleting the provider's row would disconnect an
+// already-connected account.
+func TestCallbackHandler_UpstreamError_LeavesExistingProviderToken(t *testing.T) {
 	t.Parallel()
 	handler, storState, _, _ := multiUpstreamTestSetup(t)
 
-	sessionID := "error-cleanup-session"
-	const leg1User = "resolved-user-id-from-leg1"
+	sessionID := "reconnect-cancel-session"
+	const userID = "user-1"
 
-	// First leg already completed: provider-1's tokens exist, keyed to leg1User.
-	storState.upstreamTokens[sessionID+":provider-1"] = &storage.UpstreamTokens{
+	// provider-1 is already connected from a prior successful authorization.
+	existingKey := sessionID + ":provider-1"
+	storState.upstreamTokens[existingKey] = &storage.UpstreamTokens{
 		ProviderID:   "provider-1",
-		AccessToken:  "p1-at",
-		RefreshToken: "p1-rt",
+		AccessToken:  "existing-at",
+		RefreshToken: "existing-rt",
 		ExpiresAt:    time.Now().Add(time.Hour),
 		ClientID:     testAuthClientID,
-		UserID:       leg1User,
+		UserID:       userID,
 	}
 
-	// Second-leg pending carries the resolved identity forward from leg 1.
-	secondLegState := "error-cleanup-second-leg-state"
-	storState.pendingAuths[secondLegState] = &storage.PendingAuthorization{
+	// A single-leg re-connect of that same provider is in flight.
+	reconnectState := "reconnect-cancel-state"
+	storState.pendingAuths[reconnectState] = &storage.PendingAuthorization{
 		ClientID:             testAuthClientID,
 		RedirectURI:          testAuthRedirectURI,
 		State:                "client-original-state",
 		PKCEChallenge:        "client-challenge",
 		PKCEMethod:           "S256",
-		Scopes:               []string{"openid", "profile"},
-		InternalState:        secondLegState,
-		UpstreamProviderName: "provider-2",
+		Scopes:               []string{"openid"},
+		InternalState:        reconnectState,
+		UpstreamPKCEVerifier: "reconnect-verifier-1234567890123456789012345",
+		UpstreamNonce:        "reconnect-nonce",
+		UpstreamProviderName: "provider-1",
 		SessionID:            sessionID,
-		ChainUpstreams:       []string{"provider-1", "provider-2"},
-		ResolvedUserID:       leg1User,
-		ResolvedUserName:     "First Leg User",
-		ResolvedUserEmail:    "firstleg@example.com",
+		SingleLeg:            true,
+		ResolvedUserID:       userID,
 		CreatedAt:            time.Now(),
 	}
 
-	// Upstream returns an error on the second leg, driving the handleUpstreamError path.
-	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?error=access_denied&state="+secondLegState, nil)
+	// The user cancels at the upstream: error=access_denied comes back.
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?error=access_denied&state="+reconnectState, nil)
 	rec := httptest.NewRecorder()
 	handler.CallbackHandler(rec, req)
 
-	// handleUpstreamError cleans up earlier-leg tokens via DeleteUpstreamTokensForProvider;
-	// the harness captured the ctx it ran with. Assert the callback placed the resolved
-	// canonical user into that ctx so a context-keyed decorator can delete the row.
-	uid, ok := auth.PlatformUserFromContext(storState.deleteUpstreamCtx)
-	require.True(t, ok, "handleUpstreamError must place platform user in ctx before the cleanup delete")
-	require.Equal(t, leg1User, uid)
+	assert.Equal(t, http.StatusSeeOther, rec.Code, "a canceled re-connect should redirect the error to the client")
+	assert.Contains(t, rec.Header().Get("Location"), "error=access_denied")
 
-	// The earlier leg's token survives: cleanup is scoped to the leg being processed
-	// (provider-2), not the whole chain, so a failed connector login never wipes the
-	// user's other connectors.
-	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
-		"an earlier leg's token must survive a later leg's upstream error")
-
-	// The error path must NOT place a stub Identity under the identity key.
-	_, hasIdentity := auth.IdentityFromContext(storState.deleteUpstreamCtx)
-	require.False(t, hasIdentity, "handleUpstreamError must not place an Identity (only a platform user) in ctx")
+	// The existing token survives the canceled re-connect...
+	require.Contains(t, storState.upstreamTokens, existingKey,
+		"canceling a re-connect must not disconnect the already-connected account")
+	assert.Equal(t, "existing-at", storState.upstreamTokens[existingKey].AccessToken)
+	// ...and the single-use pending authorization is consumed.
+	assert.NotContains(t, storState.pendingAuths, reconnectState,
+		"the single-use pending authorization should be deleted")
 }

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -931,10 +931,15 @@ func TestCallbackHandler_SubsequentLeg_MissingChain_FailsClosed(t *testing.T) {
 	assert.Contains(t, location, "error=server_error")
 	assert.Contains(t, location, "state=client-original-state")
 
-	// Upstream tokens for the session are cleaned up.
-	for key := range storState.upstreamTokens {
-		assert.Failf(t, "upstream tokens should be cleaned up", "found leftover token %q", key)
-	}
+	// Fail-closed cleanup is scoped per provider so a user-keyed storage decorator does
+	// not over-delete the user's other connectors. This stale pending carries no
+	// ChainUpstreams, so only the leg just processed (provider-2) can be named and
+	// removed; the earlier leg (provider-1) is not nameable here and is left to expire
+	// by its own TTL rather than risk a session-wide delete widening to the whole user.
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-2",
+		"the leg just processed should be cleaned up")
+	assert.Contains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"an earlier leg with no ChainUpstreams to name it is left to TTL, not session-wide deleted")
 }
 
 func TestCallbackHandler_SingleLeg_IssuesCodeWithoutChaining(t *testing.T) {
@@ -1232,6 +1237,74 @@ func TestCallbackHandler_TwoUpstreams_AuthorizationURLError_CleansUp(t *testing.
 		assert.Failf(t, "no pending authorizations should remain",
 			"found pending for provider %q with state %q", p.UpstreamProviderName, state)
 	}
+}
+
+// TestCallbackHandler_Cleanup_LeavesOutOfChainProviderTokens is the regression guard for
+// the failure that motivated per-provider cleanup. The callback's chain-cleanup must
+// delete only the providers in THIS authorization's chain, never a token the storage
+// holds for the same session under some other provider.
+//
+// It matters because a storage decorator can re-key upstream tokens from toolhive's
+// native (session, provider) scheme to a per-(gateway, user) scheme so a
+// session-independent caller can find a user's tokens. Under that decorator every one of
+// a user's connector tokens shares the session slot, so the old session-wide
+// DeleteUpstreamTokens on any failing login leg deleted the user's entire connector set.
+// Naming each chain provider lets such a decorator scope the delete to exactly this
+// chain, so a provider outside the chain survives — asserted here with a raw
+// (session, provider)-keyed backend that makes the scoping directly observable.
+func TestCallbackHandler_Cleanup_LeavesOutOfChainProviderTokens(t *testing.T) {
+	t.Parallel()
+	handler, storState, _, mockProvider2 := multiUpstreamTestSetup(t)
+
+	// provider-2 fails to build its authorization URL, driving the chain-cleanup path
+	// with the effective chain [provider-1, provider-2].
+	mockProvider2.authURLErr = errors.New("authorization URL error")
+
+	sessionID := "chain-session-out-of-chain"
+
+	// A token for a provider that is NOT part of this login's chain, stored under the
+	// same session slot — this is what a (gateway, user)-keyed decorator looks like from
+	// the backend's side: every connector the user holds shares one session key.
+	outOfChainKey := sessionID + ":provider-out-of-chain"
+	storState.upstreamTokens[outOfChainKey] = &storage.UpstreamTokens{
+		ProviderID:  "provider-out-of-chain",
+		AccessToken: "keep-me",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		ClientID:    testAuthClientID,
+		UserID:      "user-1",
+	}
+
+	firstLegState := "out-of-chain-first-leg-state"
+	storState.pendingAuths[firstLegState] = &storage.PendingAuthorization{
+		ClientID:             testAuthClientID,
+		RedirectURI:          testAuthRedirectURI,
+		State:                "client-state-out-of-chain",
+		PKCEChallenge:        "challenge-out-of-chain",
+		PKCEMethod:           "S256",
+		Scopes:               []string{"openid"},
+		InternalState:        firstLegState,
+		UpstreamPKCEVerifier: "out-of-chain-verifier-1234567890123456789012",
+		UpstreamNonce:        "out-of-chain-nonce",
+		UpstreamProviderName: "provider-1",
+		SessionID:            sessionID,
+		CreatedAt:            time.Now(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=p1-code&state="+firstLegState, nil)
+	rec := httptest.NewRecorder()
+	handler.CallbackHandler(rec, req)
+
+	assert.Equal(t, http.StatusSeeOther, rec.Code, "should return fosite error redirect")
+
+	// The failing chain's own provider-1 token is cleaned up...
+	assert.NotContains(t, storState.upstreamTokens, sessionID+":provider-1",
+		"the failing chain's own provider token should be cleaned up")
+	// ...but the out-of-chain provider's token is left untouched. This is the property a
+	// user-keyed decorator relies on so a failing login never wipes the user's other
+	// connectors.
+	require.Contains(t, storState.upstreamTokens, outOfChainKey,
+		"a token for a provider outside this chain must survive the cleanup")
+	assert.Equal(t, "keep-me", storState.upstreamTokens[outOfChainKey].AccessToken)
 }
 
 func TestCallbackHandler_TwoUpstreams_StorePendingError_CleansUp(t *testing.T) {
@@ -1600,15 +1673,15 @@ func TestCallbackHandler_PlacesPlatformUserInContext_OnChainRead(t *testing.T) {
 
 // TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup verifies that
 // when a subsequent-leg callback returns an upstream error, the earlier-leg cleanup
-// (DeleteUpstreamTokens in handleUpstreamError) runs with the resolved canonical user
-// already in the request context.
+// (per-provider DeleteUpstreamTokensForProvider in handleUpstreamError) runs with the
+// resolved canonical user already in the request context.
 //
 // This is the error-path sibling of the chain-read test above. handleUpstreamError
 // runs from an early return at the top of CallbackHandler, before the happy-path
-// user injection, so it must place the user itself. DeleteUpstreamTokens takes only
-// (ctx, sessionID) — no tokens argument — so a context-keyed storage decorator can
-// resolve the canonical user only from ctx. The resolved user is carried forward from
-// leg 1 via pending.ResolvedUserID.
+// user injection, so it must place the user itself. DeleteUpstreamTokensForProvider
+// carries no tokens argument — so a context-keyed storage decorator can resolve the
+// canonical user only from ctx. The resolved user is carried forward from leg 1 via
+// pending.ResolvedUserID, and pending.ChainUpstreams names the earlier leg to clean.
 func TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup(t *testing.T) {
 	t.Parallel()
 	handler, storState, _, _ := multiUpstreamTestSetup(t)
@@ -1638,6 +1711,7 @@ func TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup(t *t
 		InternalState:        secondLegState,
 		UpstreamProviderName: "provider-2",
 		SessionID:            sessionID,
+		ChainUpstreams:       []string{"provider-1", "provider-2"},
 		ResolvedUserID:       leg1User,
 		ResolvedUserName:     "First Leg User",
 		ResolvedUserEmail:    "firstleg@example.com",
@@ -1649,11 +1723,11 @@ func TestCallbackHandler_PlacesPlatformUserInContext_OnUpstreamErrorCleanup(t *t
 	rec := httptest.NewRecorder()
 	handler.CallbackHandler(rec, req)
 
-	// handleUpstreamError cleans up earlier-leg tokens via DeleteUpstreamTokens; the
-	// harness captured the ctx it ran with. Assert the callback placed the resolved
+	// handleUpstreamError cleans up earlier-leg tokens via DeleteUpstreamTokensForProvider;
+	// the harness captured the ctx it ran with. Assert the callback placed the resolved
 	// canonical user into that ctx so a context-keyed decorator can delete the row.
 	uid, ok := auth.PlatformUserFromContext(storState.deleteUpstreamCtx)
-	require.True(t, ok, "handleUpstreamError must place platform user in ctx before the cleanup DeleteUpstreamTokens")
+	require.True(t, ok, "handleUpstreamError must place platform user in ctx before the cleanup delete")
 	require.Equal(t, leg1User, uid)
 
 	// The error path must NOT place a stub Identity under the identity key.

--- a/pkg/authserver/server/handlers/helpers_test.go
+++ b/pkg/authserver/server/handlers/helpers_test.go
@@ -109,7 +109,8 @@ type baseTestSetupConfig struct {
 	getLatestUpstreamTokensErr error            // if non-nil, GetLatestUpstreamTokensForUser always returns this error
 	createUserErr              error            // if non-nil, CreateUser always returns this error
 	storeUpstreamTokensErr     error            // if non-nil, StoreUpstreamTokens always returns this error
-	getAllUpstreamTokensErr    error            // if non-nil, GetAllUpstreamTokens always returns this error
+	getAllUpstreamTokensErr    error            // if non-nil, GetAllUpstreamTokens returns this after getAllUpstreamErrAfter calls
+	getAllUpstreamErrAfter     int              // number of GetAllUpstreamTokens calls that succeed before the error kicks in
 	deleteForProviderErrs      map[string]error // per-provider error for DeleteUpstreamTokensForProvider
 	getClientErr               error            // if non-nil, GetClient returns this after getClientErrAfter successful calls
 	getClientErrAfter          int              // number of GetClient calls that succeed before getClientErr kicks in
@@ -130,6 +131,16 @@ func withStoreUpstreamTokensError(err error) baseTestSetupOption {
 func withGetAllUpstreamTokensError(err error) baseTestSetupOption {
 	return func(c *baseTestSetupConfig) {
 		c.getAllUpstreamTokensErr = err
+	}
+}
+
+// withGetAllUpstreamTokensErrorAfterCalls makes GetAllUpstreamTokens return err starting
+// with the (after+1)-th call, so a test can let the nextMissingUpstream read succeed and
+// fail only the later verifyChainIdentity read.
+func withGetAllUpstreamTokensErrorAfterCalls(after int, err error) baseTestSetupOption {
+	return func(c *baseTestSetupConfig) {
+		c.getAllUpstreamTokensErr = err
+		c.getAllUpstreamErrAfter = after
 	}
 }
 
@@ -444,6 +455,7 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 			return nil
 		}).AnyTimes()
 
+	getAllUpstreamCalls := 0
 	stor.EXPECT().GetAllUpstreamTokens(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, sessionID string) (map[string]*storage.UpstreamTokens, error) {
 			// GetAllUpstreamTokens takes only (ctx, sessionID) — no tokens argument to
@@ -451,7 +463,8 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 			// only from ctx. Capture the ctx here so a test can assert the callback
 			// placed the identity into it before this read runs.
 			storState.getAllUpstreamCtx = ctx
-			if setupCfg.getAllUpstreamTokensErr != nil {
+			getAllUpstreamCalls++
+			if setupCfg.getAllUpstreamTokensErr != nil && getAllUpstreamCalls > setupCfg.getAllUpstreamErrAfter {
 				return nil, setupCfg.getAllUpstreamTokensErr
 			}
 			result := make(map[string]*storage.UpstreamTokens)

--- a/pkg/authserver/server/handlers/helpers_test.go
+++ b/pkg/authserver/server/handlers/helpers_test.go
@@ -375,6 +375,18 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 			return nil
 		}).AnyTimes()
 
+	stor.EXPECT().DeleteUpstreamTokensForProvider(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, sessionID, providerName string) error {
+			// DeleteUpstreamTokensForProvider takes (ctx, sessionID, providerName) but
+			// still carries no tokens argument, so a context-keyed storage decorator
+			// resolves the user from ctx exactly as DeleteUpstreamTokens does. Capture
+			// the ctx here too so the callback's per-provider cleanup path is covered by
+			// the same context-placement assertions. Deleting an absent row is a no-op.
+			storState.deleteUpstreamCtx = ctx
+			delete(storState.upstreamTokens, sessionID+":"+providerName)
+			return nil
+		}).AnyTimes()
+
 	stor.EXPECT().GetAllUpstreamTokens(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, sessionID string) (map[string]*storage.UpstreamTokens, error) {
 			// GetAllUpstreamTokens takes only (ctx, sessionID) — no tokens argument to

--- a/pkg/authserver/server/handlers/helpers_test.go
+++ b/pkg/authserver/server/handlers/helpers_test.go
@@ -105,14 +105,53 @@ type testStorageState struct {
 type baseTestSetupOption func(*baseTestSetupConfig)
 
 type baseTestSetupConfig struct {
-	storePendingErr            error // if non-nil, StorePendingAuthorization always returns this error
-	getLatestUpstreamTokensErr error // if non-nil, GetLatestUpstreamTokensForUser always returns this error
-	createUserErr              error // if non-nil, CreateUser always returns this error
+	storePendingErr            error            // if non-nil, StorePendingAuthorization always returns this error
+	getLatestUpstreamTokensErr error            // if non-nil, GetLatestUpstreamTokensForUser always returns this error
+	createUserErr              error            // if non-nil, CreateUser always returns this error
+	storeUpstreamTokensErr     error            // if non-nil, StoreUpstreamTokens always returns this error
+	getAllUpstreamTokensErr    error            // if non-nil, GetAllUpstreamTokens always returns this error
+	deleteForProviderErrs      map[string]error // per-provider error for DeleteUpstreamTokensForProvider
+	getClientErr               error            // if non-nil, GetClient returns this after getClientErrAfter successful calls
+	getClientErrAfter          int              // number of GetClient calls that succeed before getClientErr kicks in
 }
 
 func withStorePendingError(err error) baseTestSetupOption {
 	return func(c *baseTestSetupConfig) {
 		c.storePendingErr = err
+	}
+}
+
+func withStoreUpstreamTokensError(err error) baseTestSetupOption {
+	return func(c *baseTestSetupConfig) {
+		c.storeUpstreamTokensErr = err
+	}
+}
+
+func withGetAllUpstreamTokensError(err error) baseTestSetupOption {
+	return func(c *baseTestSetupConfig) {
+		c.getAllUpstreamTokensErr = err
+	}
+}
+
+// withDeleteUpstreamTokensForProviderError makes DeleteUpstreamTokensForProvider return
+// err for the named provider only, so a test can exercise cleanupUpstreamTokens'
+// warn-and-continue path while sibling providers still delete.
+func withDeleteUpstreamTokensForProviderError(provider string, err error) baseTestSetupOption {
+	return func(c *baseTestSetupConfig) {
+		if c.deleteForProviderErrs == nil {
+			c.deleteForProviderErrs = make(map[string]error)
+		}
+		c.deleteForProviderErrs[provider] = err
+	}
+}
+
+// withGetClientErrorAfterCalls makes GetClient return err starting with the
+// (after+1)-th call, so a test can fail the GetClient inside writeAuthorizationResponse
+// while the earlier GetClient that builds the error-redirect requester still succeeds.
+func withGetClientErrorAfterCalls(after int, err error) baseTestSetupOption {
+	return func(c *baseTestSetupConfig) {
+		c.getClientErr = err
+		c.getClientErrAfter = after
 	}
 }
 
@@ -194,7 +233,12 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 	// Setup mock expectations for GetClient. Looks up storState.clients so tests
 	// can register additional clients (e.g. a loopback client under its own ID)
 	// after baseTestSetup returns.
+	getClientCalls := 0
 	stor.EXPECT().GetClient(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, id string) (fosite.Client, error) {
+		getClientCalls++
+		if setupCfg.getClientErr != nil && getClientCalls > setupCfg.getClientErrAfter {
+			return nil, setupCfg.getClientErr
+		}
 		if c, ok := storState.clients[id]; ok {
 			return c, nil
 		}
@@ -354,6 +398,9 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 	// Keyed by "sessionID:providerName" to support multiple providers per session.
 	stor.EXPECT().StoreUpstreamTokens(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, sessionID, providerName string, tokens *storage.UpstreamTokens) error {
+			if setupCfg.storeUpstreamTokensErr != nil {
+				return setupCfg.storeUpstreamTokensErr
+			}
 			key := sessionID + ":" + providerName
 			storState.upstreamTokens[key] = tokens
 			storState.idpTokenCount++
@@ -381,8 +428,18 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 			// still carries no tokens argument, so a context-keyed storage decorator
 			// resolves the user from ctx exactly as DeleteUpstreamTokens does. Capture
 			// the ctx here too so the callback's per-provider cleanup path is covered by
-			// the same context-placement assertions. Deleting an absent row is a no-op.
+			// the same context-placement assertions.
 			storState.deleteUpstreamCtx = ctx
+			// Mirror the real backends, which reject an empty session or provider rather
+			// than deleting; cleanupUpstreamTokens filters empty names, so this only
+			// fires if a future caller bug lets one through.
+			if sessionID == "" || providerName == "" {
+				return fosite.ErrInvalidRequest
+			}
+			if err := setupCfg.deleteForProviderErrs[providerName]; err != nil {
+				return err
+			}
+			// Deleting an absent row is a no-op.
 			delete(storState.upstreamTokens, sessionID+":"+providerName)
 			return nil
 		}).AnyTimes()
@@ -394,6 +451,9 @@ func baseTestSetup(t *testing.T, opts ...baseTestSetupOption) (fosite.OAuth2Prov
 			// only from ctx. Capture the ctx here so a test can assert the callback
 			// placed the identity into it before this read runs.
 			storState.getAllUpstreamCtx = ctx
+			if setupCfg.getAllUpstreamTokensErr != nil {
+				return nil, setupCfg.getAllUpstreamTokensErr
+			}
 			result := make(map[string]*storage.UpstreamTokens)
 			prefix := sessionID + ":"
 			for key, tokens := range storState.upstreamTokens {
@@ -475,13 +535,9 @@ func handlerTestSetup(t *testing.T, opts ...baseTestSetupOption) (*Handler, *tes
 	return handler, storState, mockUpstream
 }
 
-// multiUpstreamTestSetup creates a test setup with two upstream providers ("provider-1" and "provider-2")
-// for testing multi-upstream authorization chain logic. Any Option values are forwarded to NewHandler.
-func multiUpstreamTestSetup(t *testing.T, opts ...Option) (*Handler, *testStorageState, *mockIDPProvider, *mockIDPProvider) {
-	t.Helper()
-
-	provider, oauth2Config, stor, storState := baseTestSetup(t)
-
+// multiUpstreamProviders builds the two mock IdP providers ("provider-1" and
+// "provider-2") and the NamedUpstream slice shared by the multi-upstream setups.
+func multiUpstreamProviders() (*mockIDPProvider, *mockIDPProvider, []NamedUpstream) {
 	mockProvider1 := &mockIDPProvider{
 		providerType:     upstream.ProviderTypeOAuth2,
 		authorizationURL: "https://idp1.example.com/authorize",
@@ -518,7 +574,32 @@ func multiUpstreamTestSetup(t *testing.T, opts ...Option) (*Handler, *testStorag
 		{Name: "provider-1", Provider: mockProvider1},
 		{Name: "provider-2", Provider: mockProvider2},
 	}
+	return mockProvider1, mockProvider2, upstreams
+}
+
+// multiUpstreamTestSetup creates a test setup with two upstream providers ("provider-1" and "provider-2")
+// for testing multi-upstream authorization chain logic. Any Option values are forwarded to NewHandler.
+func multiUpstreamTestSetup(t *testing.T, opts ...Option) (*Handler, *testStorageState, *mockIDPProvider, *mockIDPProvider) {
+	t.Helper()
+
+	provider, oauth2Config, stor, storState := baseTestSetup(t)
+	mockProvider1, mockProvider2, upstreams := multiUpstreamProviders()
 	handler, err := NewHandler(provider, oauth2Config, stor, upstreams, opts...)
+	require.NoError(t, err)
+
+	return handler, storState, mockProvider1, mockProvider2
+}
+
+// multiUpstreamTestSetupWithStorage is multiUpstreamTestSetup with storage-behavior
+// overrides (error injection) threaded into baseTestSetup, so a test can drive the
+// callback's cleanup paths (store failure, chain-read failure, per-provider delete
+// failure) on a real two-upstream chain.
+func multiUpstreamTestSetupWithStorage(t *testing.T, storageOpts ...baseTestSetupOption) (*Handler, *testStorageState, *mockIDPProvider, *mockIDPProvider) {
+	t.Helper()
+
+	provider, oauth2Config, stor, storState := baseTestSetup(t, storageOpts...)
+	mockProvider1, mockProvider2, upstreams := multiUpstreamProviders()
+	handler, err := NewHandler(provider, oauth2Config, stor, upstreams)
 	require.NoError(t, err)
 
 	return handler, storState, mockProvider1, mockProvider2


### PR DESCRIPTION
## Summary

The `/oauth/callback` error paths clean up "the tokens this authorization collected" by calling the session-wide `DeleteUpstreamTokens(ctx, sessionID)`, which removes **every** provider row under that session. That is correct for the native `(session, provider)` storage scheme, where each authorization mints its own session.

It is wrong under a storage decorator that re-keys upstream tokens by `(gateway, user)` so a session-independent caller (e.g. a user-facing UI) can find a user's tokens. Under that scheme every one of a user's connector tokens shares the session slot, so a session-wide delete on **any** failing login leg deletes the user's **entire** connector set. A transient identity-provider/storage blip on the most-traversed leg (chain resolution) wipes a user's whole historical token set, and correlated failures widen that to every user logging in during the window. It fails safe (never grants access) and is largely self-healing, but the availability hit is real.

The callback is the only production caller of the session-wide delete. This PR:

- Routes all nine callback cleanup sites through a new `cleanupUpstreamTokens` helper that deletes **per provider** via `DeleteUpstreamTokensForProvider` (already on the `storage.Storage` interface, implemented by both memory and redis), sourcing the provider list from the **chain config** — never a storage read, which a broadening decorator cannot scope. Sites that hold the resolved `chain` pass it; pre-resolve sites pass `pending.ChainUpstreams` plus the leg currently being processed.
- Lets a user-keyed decorator scope each delete to exactly this chain's providers, so a connector **outside** the chain is never touched.

**Behavior note:** a stale subsequent-leg pending with no `ChainUpstreams` can only name the leg just processed; an earlier leg it cannot name is left to expire by TTL rather than risk a session-wide delete widening to the whole user. This matches the existing abandoned-flow orphan behavior already noted in the chain-continuation TODO.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`) — full `pkg/authserver/...` suite passes
- [x] Linting (`task lint-fix`) — `golangci-lint` clean on the changed package

Adds `TestCallbackHandler_Cleanup_LeavesOutOfChainProviderTokens`, which stores a token for a provider outside the login's chain under the same session slot and asserts it **survives** a chain cleanup (while the failing chain's own provider token is removed). Extends the handler storage mock with a `DeleteUpstreamTokensForProvider` capture, and updates the two existing tests whose assertions depend on the cleanup scope.

## API Compatibility

- [x] This PR does not break the `v1beta1` API. No operator API surface is touched; `DeleteUpstreamTokensForProvider` already exists on the storage interface.

## Does this introduce a user-facing change?

No behavior change for the native single-session storage scheme. For deployments layering a `(gateway, user)`-keyed token store, a failed login leg no longer deletes the user's other connectors' upstream tokens.

## Special notes for reviewers

- The one intentional semantic change is at the stale-pending fail-closed path (`TestCallbackHandler_SubsequentLeg_MissingChain_FailsClosed`): it now cleans only the just-stored leg and leaves an unnameable earlier leg to TTL, rather than wiping the whole session. This is the inherent trade of provider-scoped cleanup vs. stamping each row with an authorization id; happy to switch to the stamping approach if reviewers prefer the earlier leg also be cleaned.
