### PR TITLE
Honour a pinned cosign key on sync and upgrade

### DIFF
--- a/docs/arch/12-skills-system.md
+++ b/docs/arch/12-skills-system.md
@@ -438,7 +438,13 @@ Dispatch between the two paths is decided by the **lock entry, never the artifac
 
 Verifying a key-pair signature binds it to the artifact explicitly. The signature covers cosign's simple-signing payload, and signature manifests are discovered by a tag derived from the digest being verified — so attachment proves nothing about which artifact a signature describes. The payload digest is reconstructed from the requested reference and each candidate must sign exactly those bytes, which is what stops one artifact's signature from being replayed onto another by copying its signature layer into that artifact's `.sig` manifest (`bundleSignsPayload`).
 
-Scope for v1 (issue [#6442](https://github.com/stacklok/toolhive/issues/6442)): install only. `--public-key` is not yet accepted on `upgrade` or `sync --adopt`, and the plugins surface does not accept it at all yet.
+Once an entry is pinned, the key does its job on the lock-driven operations too, because the anchor is read from the entry rather than supplied again:
+
+- **`sync`** re-verifies the stored bundle against the pinned key offline. This has to be a distinct path — the keyless verifier refuses a key-pinned entry, and sync reads a refusal as drift it can heal by reinstalling, so a key-pinned skill would report as modified on every run and `--check` would fail permanently on a project that is in fact intact.
+- **`upgrade`** applies the pinned key to the candidate. Verifying against it *is* the evidence the signer has not changed, since there is no certificate identity to compare. A candidate that moved to keyless signing or lost its signature is a signer change and blocks like one — `--allow-signer-change` genuinely resolves those, by dropping the recorded key and re-verifying keylessly. A candidate signed by a *different* key is reported as a failure instead: re-anchoring in place is not supported, so it needs an uninstall and a reinstall, and printing the `--allow-signer-change` remedy would send the caller into a refusal one step later.
+- **`sync --adopt`** refuses a key-signed install. Adoption back-fills trust from what the stored bundle reveals, and a key-pair bundle reveals no identity and does not carry the key; recording the install as unsigned instead would file a false trust decision about an artifact that is signed.
+
+Scope for v1 (issue [#6442](https://github.com/stacklok/toolhive/issues/6442)): `--public-key` is accepted on `install` only — `upgrade` and `sync` use the anchor the lock already records and take no key of their own, and in-place re-anchoring to a different key is deliberately not offered. The plugins surface does not accept a key at all yet.
 
 ### Schema
 

--- a/pkg/skills/skillsvc/sync.go
+++ b/pkg/skills/skillsvc/sync.go
@@ -267,10 +267,49 @@ func (s *service) verifyStoredSignature(entry lockfile.Entry, sk skills.Installe
 		if !strings.Contains(entry.Digest, ":") {
 			return nil // git install: no stored bundle by design
 		}
-		return fmt.Errorf("%w: lock entry records signer %q but no bundle is stored",
-			verifier.ErrSignatureInvalid, entry.Provenance.SignerIdentity)
+		return fmt.Errorf("%w: lock entry is pinned to %s but no bundle is stored",
+			verifier.ErrSignatureInvalid, describeLockAnchor(entry.Provenance))
+	}
+	if entry.Provenance.PublicKey != "" {
+		return s.verifyStoredKeySignature(entry, sk)
 	}
 	return s.artifactVerifier().VerifyBundleOffline(sk.SigstoreBundle, entry.Digest, entry.Provenance)
+}
+
+// describeLockAnchor names the trust anchor an entry pins, for errors that
+// report what could not be satisfied. A key entry records no signer identity,
+// so the keyless phrasing would have named an empty string.
+func describeLockAnchor(provenance *lockfile.Provenance) string {
+	if provenance.PublicKey != "" {
+		return "a cosign public key"
+	}
+	return fmt.Sprintf("signer %q", provenance.SignerIdentity)
+}
+
+// verifyStoredKeySignature re-verifies a key-signed stored bundle against the
+// public key its lock entry pins. Without this the keyless path rejects the
+// entry outright, and sync reads that as drift it can heal by reinstalling —
+// so a key-pinned skill reported as modified on every run and never settled,
+// while --check failed permanently on a project that was in fact intact.
+//
+// The reference is taken from the lock rather than the install record because
+// the payload it reconstructs is part of what is being verified: the lock is
+// the authority on what the project is pinned to, and the install record is
+// the thing being checked against it.
+func (s *service) verifyStoredKeySignature(entry lockfile.Entry, sk skills.InstalledSkill) error {
+	pubKeyPEM, err := verifier.DecodePublicKey(entry.Provenance.PublicKey)
+	if err != nil {
+		return fmt.Errorf("%w: lock entry's pinned %s", verifier.ErrSignatureInvalid, err.Error())
+	}
+	ref := entry.ResolvedReference
+	if ref == "" {
+		ref = sk.Reference
+	}
+	if ref == "" {
+		return fmt.Errorf("%w: entry is pinned to a cosign public key but records no reference to"+
+			" reconstruct the signed payload from", verifier.ErrSignatureInvalid)
+	}
+	return s.artifactVerifier().VerifyBundleOfflineWithKey(sk.SigstoreBundle, ref, entry.Digest, pubKeyPEM)
 }
 
 // adoptSkill writes a lock entry for an existing, unmanaged project-scope
@@ -295,6 +334,22 @@ func (s *service) adoptSkill(ctx context.Context, opts skills.SyncOptions, sk sk
 	unsigned := false
 	if len(sk.SigstoreBundle) > 0 {
 		result, verifyErr := s.artifactVerifier().ResultFromBundle(sk.SigstoreBundle, sk.Digest)
+		if errors.Is(verifyErr, verifier.ErrKeySigned) {
+			// Adoption back-fills trust from what the bundle itself reveals,
+			// and a key-signed bundle reveals nothing: the key is not in it,
+			// and sync takes no --public-key to supply one. Recording the
+			// install as unsigned instead would be a lie about a signed
+			// artifact, so the honest move is to send it through the one
+			// path that can anchor it.
+			return httperr.WithCode(
+				fmt.Errorf("%w: %q is signed with a cosign key pair, so adopting it cannot record"+
+					" a trust anchor — the key is carried neither by the artifact nor by its bundle."+
+					" Install it with --public-key instead, which verifies the signature and pins"+
+					" the key (--allow-unsigned is not a substitute: the artifact is signed)",
+					verifyErr, sk.Metadata.Name),
+				http.StatusForbidden,
+			)
+		}
 		if verifyErr != nil {
 			return fmt.Errorf("verifying stored bundle for adoption: %w", verifyErr)
 		}

--- a/pkg/skills/skillsvc/sync_verify_test.go
+++ b/pkg/skills/skillsvc/sync_verify_test.go
@@ -4,6 +4,7 @@
 package skillsvc
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/stacklok/toolhive-core/httperr"
 	"github.com/stacklok/toolhive/pkg/skills"
 	"github.com/stacklok/toolhive/pkg/skills/lockfile"
 	"github.com/stacklok/toolhive/pkg/skills/verifier"
@@ -124,4 +126,141 @@ func TestVerifyStoredSignature(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestVerifyStoredSignature_KeyPinnedEntry covers the branch that keeps a
+// key-pinned project from reporting drift forever. The keyless path refuses a
+// key-pinned entry outright, and sync reads a refusal as drift it can heal by
+// reinstalling — so before this branch existed the skill was reported modified
+// on every run and --check failed permanently on an intact project.
+func TestVerifyStoredSignature_KeyPinnedEntry(t *testing.T) {
+	t.Parallel()
+
+	keyPEM, err := verifier.DecodePublicKey(testPublicKeyB64)
+	require.NoError(t, err)
+	bundle := []byte(`{"bundle":true}`)
+
+	t.Run("verifies against the pinned key, not the keyless path", func(t *testing.T) {
+		t.Parallel()
+		entry := keyedLockEntry()
+		mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+		mv.EXPECT().VerifyBundleOfflineWithKey(bundle, entry.ResolvedReference, entry.Digest, keyPEM).
+			Return(nil)
+		// Not merely "the key path was taken": reaching the keyless path at
+		// all is the bug, and it fails closed in a way that looks like drift.
+		mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		svc := &service{sigVerifier: mv}
+		require.NoError(t, svc.verifyStoredSignature(entry, skills.InstalledSkill{SigstoreBundle: bundle}))
+	})
+
+	t.Run("a real verification failure still propagates", func(t *testing.T) {
+		t.Parallel()
+		entry := keyedLockEntry()
+		mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+		mv.EXPECT().VerifyBundleOfflineWithKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(verifier.ErrSignatureInvalid)
+
+		svc := &service{sigVerifier: mv}
+		require.ErrorIs(t,
+			svc.verifyStoredSignature(entry, skills.InstalledSkill{SigstoreBundle: bundle}),
+			verifier.ErrSignatureInvalid)
+	})
+
+	t.Run("falls back to the install record when the entry pins no reference", func(t *testing.T) {
+		t.Parallel()
+		entry := keyedLockEntry()
+		entry.ResolvedReference = ""
+		mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+		mv.EXPECT().VerifyBundleOfflineWithKey(bundle, "example.com/org/from-install", entry.Digest, keyPEM).
+			Return(nil)
+
+		svc := &service{sigVerifier: mv}
+		require.NoError(t, svc.verifyStoredSignature(entry, skills.InstalledSkill{
+			SigstoreBundle: bundle,
+			Reference:      "example.com/org/from-install",
+		}))
+	})
+
+	t.Run("no reference anywhere fails closed rather than verifying nothing", func(t *testing.T) {
+		t.Parallel()
+		entry := keyedLockEntry()
+		entry.ResolvedReference = ""
+		mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+		mv.EXPECT().VerifyBundleOfflineWithKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		svc := &service{sigVerifier: mv}
+		err := svc.verifyStoredSignature(entry, skills.InstalledSkill{SigstoreBundle: bundle})
+		require.ErrorIs(t, err, verifier.ErrSignatureInvalid)
+		assert.Contains(t, err.Error(), "no reference to reconstruct the signed payload from")
+	})
+
+	t.Run("a missing bundle names the key anchor, not an empty signer", func(t *testing.T) {
+		t.Parallel()
+		entry := keyedLockEntry()
+		svc := &service{sigVerifier: verifiermocks.NewMockVerifier(gomock.NewController(t))}
+		err := svc.verifyStoredSignature(entry, skills.InstalledSkill{})
+		require.ErrorIs(t, err, verifier.ErrSignatureInvalid)
+		assert.Contains(t, err.Error(), "a cosign public key")
+		assert.NotContains(t, err.Error(), `signer ""`,
+			"a key entry records no signer identity; the keyless phrasing named an empty string")
+	})
+}
+
+// TestAdoptSkill_RefusesKeySignedInstall covers the one place a key-signed
+// artifact has no path through: adoption back-fills trust from what the stored
+// bundle reveals, and a key-pair bundle reveals no identity and does not carry
+// the key. Recording it as unsigned instead would file a false trust decision
+// about an artifact that IS signed, so the refusal has to name the route that
+// can anchor it.
+//
+//nolint:paralleltest // uses t.Setenv via newLockTestService, incompatible with t.Parallel
+func TestAdoptSkill_RefusesKeySignedInstall(t *testing.T) {
+	gr, fx := newGitResolverMock(t)
+	fx.register("adopt-keyed", gitSkill("adopt-keyed"))
+
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	mv.EXPECT().VerifyGit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(signedResult(), nil)
+	mv.EXPECT().VerifyBundleOffline(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	// The stored bundle is a key-pair one: nothing to observe.
+	mv.EXPECT().ResultFromBundle(gomock.Any(), gomock.Any()).
+		AnyTimes().Return(nil, verifier.ErrKeySigned)
+
+	svc, projectRoot := newLockTestService(t, gr, WithVerifier(mv))
+	ref, _ := gitRef("adopt-keyed")
+	_, err := svc.Install(t.Context(), skills.InstallOptions{
+		Name: ref, Scope: skills.ScopeProject, ProjectRoot: projectRoot, Clients: []string{"claude-code"},
+	})
+	require.NoError(t, err)
+
+	// Strip it back to the unmanaged state a pre-lock-tracking install is in,
+	// but leave a stored bundle behind so adoption has something to read.
+	syncer := svc.(*service) //nolint:forcetypeassert
+	root := mustOpenRoot(t, projectRoot)
+	require.NoError(t, lockfile.Update(root, func(lf *lockfile.Lockfile) error {
+		lf.Remove("adopt-keyed")
+		return nil
+	}))
+	legacy, err := syncer.store.Get(t.Context(), "adopt-keyed", skills.ScopeProject, projectRoot)
+	require.NoError(t, err)
+	legacy.Managed = false
+	legacy.SigstoreBundle = []byte(`{"bundle":true}`)
+	require.NoError(t, syncer.store.Update(t.Context(), legacy))
+
+	adoptErr := syncer.adoptSkill(t.Context(),
+		skills.SyncOptions{ProjectRoot: projectRoot}, legacy)
+
+	require.Error(t, adoptErr)
+	assert.Equal(t, http.StatusForbidden, httperr.Code(adoptErr))
+	require.ErrorIs(t, adoptErr, verifier.ErrKeySigned)
+	assert.Contains(t, adoptErr.Error(), "--public-key",
+		"the refusal must name the path that can anchor it, not merely refuse")
+	assert.Contains(t, adoptErr.Error(), "--allow-unsigned is not a substitute",
+		"the artifact is signed; recording an unsigned exception would be a false trust decision")
+
+	// The refusal must not leave a lock entry behind.
+	lf := readLockfile(t, projectRoot)
+	_, ok := lf.Get("adopt-keyed")
+	assert.False(t, ok, "a refused adoption must write nothing")
 }

--- a/pkg/skills/skillsvc/upgrade.go
+++ b/pkg/skills/skillsvc/upgrade.go
@@ -226,6 +226,9 @@ func (s *service) guardSignerChange(
 	newRef, newDigest string,
 	outcome *skills.UpgradeOutcome,
 ) bool {
+	if entry.Provenance.PublicKey != "" {
+		return s.guardKeyedSignerChange(ctx, entry, newRef, newDigest, outcome)
+	}
 	probe, probeErr := s.probeCandidateSigner(ctx, newRef, newDigest)
 	switch {
 	case probeErr != nil && errors.Is(probeErr, verifier.ErrUnsigned):
@@ -248,6 +251,51 @@ func (s *service) guardSignerChange(
 		return true
 	}
 	return false
+}
+
+// guardKeyedSignerChange is guardSignerChange for an entry pinned to a cosign
+// public key. There is no identity to probe for and compare — a key-pair
+// bundle carries no certificate — so the pinned key is applied to the
+// candidate directly: verifying against it IS the evidence that the signer
+// has not changed, and the upgrade then proceeds on the anchor the entry
+// already records. No new key is accepted here; the lock supplies it.
+//
+// The blocked arms are split by whether --allow-signer-change would actually
+// help, because the caller is told to use it. It does for a candidate that
+// moved to keyless signing or dropped its signature: dropping the recorded
+// key and re-verifying is exactly the key-to-keyless move resolveKeyAnchor
+// supports. It does NOT for a candidate signed by a different key — that
+// needs an in-place re-anchor, which v1 does not offer — so that arm reports
+// a failure naming the route that works instead of a remedy that does not.
+func (s *service) guardKeyedSignerChange(
+	ctx context.Context,
+	entry lockfile.Entry,
+	newRef, newDigest string,
+	outcome *skills.UpgradeOutcome,
+) bool {
+	pubKeyPEM, err := verifier.DecodePublicKey(entry.Provenance.PublicKey)
+	if err != nil {
+		outcome.Status = skills.UpgradeStatusFailed
+		outcome.Reason = skills.FailureReasonUnknown
+		outcome.Error = fmt.Errorf("lock entry's pinned %w", err).Error()
+		return true
+	}
+	_, verifyErr := s.artifactVerifier().VerifyOCIWithKey(ctx, newRef, newDigest, pubKeyPEM)
+	switch {
+	case verifyErr == nil:
+		return false
+	case errors.Is(verifyErr, verifier.ErrKeylessSigned), errors.Is(verifyErr, verifier.ErrUnsigned):
+		outcome.Status = skills.UpgradeStatusSignerChangeBlocked
+		return true
+	default:
+		outcome.Status = skills.UpgradeStatusFailed
+		outcome.Reason = skills.FailureReasonSignatureInvalid
+		outcome.Error = fmt.Errorf("candidate does not verify against the cosign public key this entry"+
+			" is pinned to — either it was signed with a different key or the signature is damaged:"+
+			" %w (re-anchoring to a new key is not supported in place; uninstall and reinstall with"+
+			" --public-key)", verifyErr).Error()
+		return true
+	}
 }
 
 // runnerEnvironmentChanged reports whether the candidate's runner class

--- a/pkg/skills/skillsvc/upgrade_verify_test.go
+++ b/pkg/skills/skillsvc/upgrade_verify_test.go
@@ -4,6 +4,7 @@
 package skillsvc
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -353,4 +354,104 @@ func TestUpgrade_SignerChangePreviewParity(t *testing.T) {
 	entry, ok := lf.Get("guarded-skill")
 	require.True(t, ok)
 	assert.Equal(t, testSignerIdentity, entry.Provenance.SignerIdentity)
+}
+
+// TestGuardKeyedSignerChange covers the guard for a key-pinned entry. The
+// keyless guard probes for a certificate identity to compare, which a
+// key-pair bundle does not have — so before this branch a key-pinned entry
+// could never be upgraded at all: the probe returned "key-signed" and the
+// plan failed with a signature error that named none of the real situation.
+//
+// The blocked arms are split by whether the remedy the CLI prints actually
+// works. "signer change blocked" tells the user to pass --allow-signer-change,
+// which drops the recorded key and re-verifies keylessly — a real fix when the
+// candidate moved to keyless signing or lost its signature, and a dead end
+// when it is simply signed by a different key.
+func TestGuardKeyedSignerChange(t *testing.T) {
+	t.Parallel()
+
+	keyPEM, err := verifier.DecodePublicKey(testPublicKeyB64)
+	require.NoError(t, err)
+	entry := keyedLockEntry()
+	newRef, newDigest := "example.com/org/keyed-skill:v2", "sha256:"+strings.Repeat("c", 64)
+
+	tests := []struct {
+		name        string
+		verifyErr   error
+		wantBlocked bool
+		wantStatus  skills.UpgradeStatus
+		wantErrText string
+	}{
+		{
+			name:        "verifying against the pinned key is the evidence the signer is unchanged",
+			wantBlocked: false,
+		},
+		{
+			name:        "a candidate that moved to keyless signing is a signer change",
+			verifyErr:   verifier.ErrKeylessSigned,
+			wantBlocked: true,
+			wantStatus:  skills.UpgradeStatusSignerChangeBlocked,
+		},
+		{
+			name:        "a candidate that lost its signature is a signer change",
+			verifyErr:   verifier.ErrUnsigned,
+			wantBlocked: true,
+			wantStatus:  skills.UpgradeStatusSignerChangeBlocked,
+		},
+		{
+			name:        "a different key is a failure, since allow_signer_change cannot re-anchor",
+			verifyErr:   verifier.ErrSignatureInvalid,
+			wantBlocked: true,
+			wantStatus:  skills.UpgradeStatusFailed,
+			wantErrText: "uninstall and reinstall with --public-key",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+			mv.EXPECT().VerifyOCIWithKey(gomock.Any(), newRef, newDigest, keyPEM).
+				Return(nil, tc.verifyErr)
+			// The keyless probe must not run: it is what produced the
+			// unhelpful diagnosis this branch exists to replace.
+			mv.EXPECT().VerifyOCI(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+			svc := &service{sigVerifier: mv}
+			outcome := skills.UpgradeOutcome{Name: entry.Name}
+			blocked := svc.guardSignerChange(t.Context(), entry, newRef, newDigest, &outcome)
+
+			assert.Equal(t, tc.wantBlocked, blocked)
+			if !tc.wantBlocked {
+				return
+			}
+			assert.Equal(t, tc.wantStatus, outcome.Status)
+			if tc.wantErrText != "" {
+				assert.Contains(t, outcome.Error, tc.wantErrText)
+			}
+			if tc.wantStatus == skills.UpgradeStatusSignerChangeBlocked {
+				assert.Empty(t, outcome.NewSignerIdentity,
+					"a key-signed candidate has no identity to report, and inventing one would"+
+						" print a signer the artifact never claimed")
+			}
+		})
+	}
+}
+
+// TestGuardKeyedSignerChange_UndecodablePinnedKey fails the plan rather than
+// treating a corrupt anchor as a signer change: the lock file is hand-editable
+// and the entry cannot be evaluated at all, which is not the same claim.
+func TestGuardKeyedSignerChange_UndecodablePinnedKey(t *testing.T) {
+	t.Parallel()
+
+	entry := keyedLockEntry()
+	entry.Provenance = &lockfile.Provenance{PublicKey: "not-base64!!"}
+	mv := verifiermocks.NewMockVerifier(gomock.NewController(t))
+	mv.EXPECT().VerifyOCIWithKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	svc := &service{sigVerifier: mv}
+	outcome := skills.UpgradeOutcome{Name: entry.Name}
+	require.True(t, svc.guardSignerChange(
+		t.Context(), entry, "example.com/org/keyed-skill:v2", "sha256:"+strings.Repeat("c", 64), &outcome))
+	assert.Equal(t, skills.UpgradeStatusFailed, outcome.Status)
+	assert.NotEqual(t, skills.UpgradeStatusSignerChangeBlocked, outcome.Status)
 }

--- a/pkg/skills/skillsvc/verify_test.go
+++ b/pkg/skills/skillsvc/verify_test.go
@@ -1164,7 +1164,8 @@ func TestCatalogInstallNamesKeySignedArtifact(t *testing.T) {
 
 // keyedLockEntry is a lock entry pinned to testPublicKeyB64 — the shape a
 // previous key-verified install leaves behind.
-func keyedLockEntry(name string) lockfile.Entry {
+func keyedLockEntry() lockfile.Entry {
+	const name = "keyed-skill"
 	return lockfile.Entry{
 		Name:              name,
 		Source:            "example.com/org/" + name,
@@ -1196,11 +1197,11 @@ func TestVerifyOCIInstall_KeyPathDispatch(t *testing.T) {
 		},
 		{
 			name:  "pinned entry verifies against the locked key with no flag",
-			entry: ptrTo(keyedLockEntry("keyed-skill")),
+			entry: ptrTo(keyedLockEntry()),
 		},
 		{
 			name:  "supplied key that agrees with the pin is accepted",
-			entry: ptrTo(keyedLockEntry("keyed-skill")),
+			entry: ptrTo(keyedLockEntry()),
 			opts:  skills.InstallOptions{PublicKey: testPublicKeyB64},
 		},
 	}

--- a/pkg/skills/verifier/offline.go
+++ b/pkg/skills/verifier/offline.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 
 	"github.com/stacklok/toolhive-core/container/signer"
@@ -72,9 +73,21 @@ func (*Default) VerifyBundleOfflineWithKey(bundleBytes []byte, imageRef, digest 
 // ResultFromBundle verifies a stored bundle offline (chain of trust only)
 // and returns the observed identity, for back-filling provenance of
 // adopted skills.
+//
+// A key-signed bundle is reported as ErrKeySigned rather than attempted:
+// there is no identity to observe, so the back-fill this exists for has
+// nothing to record, and the keyless verification below would fail on the
+// missing certificate with a message about the wrong thing entirely.
 func (*Default) ResultFromBundle(bundleBytes []byte, digest string) (*Result, error) {
 	if len(bundleBytes) == 0 {
 		return nil, fmt.Errorf("%w: no stored bundle to verify", ErrSignatureInvalid)
+	}
+	keySigned, err := bundleIsKeySigned(bundleBytes)
+	if err != nil {
+		return nil, wrapInvalid(err)
+	}
+	if keySigned {
+		return nil, ErrKeySigned
 	}
 	vr, err := coreverifier.VerifyBundleOffline(bundleBytes, digest, nil)
 	if err != nil {
@@ -102,4 +115,16 @@ func checkStoredBundlePins(vr *verify.VerificationResult, expected *lockfile.Pro
 		return fmt.Errorf("%w: %s", ErrSignatureInvalid, err.Error())
 	}
 	return checkPinnedCertificateFields(observed, expected)
+}
+
+// bundleIsKeySigned reports whether a stored bundle came from the cosign
+// key-pair flow, which is visible in its shape: a keyless bundle carries the
+// Fulcio certificate its identity is read from, and a key-signed one carries
+// none, since the trust anchor lives outside the artifact entirely.
+func bundleIsKeySigned(bundleBytes []byte) (bool, error) {
+	parsed := &sgbundle.Bundle{}
+	if err := parsed.UnmarshalJSON(bundleBytes); err != nil {
+		return false, fmt.Errorf("parsing stored bundle: %w", err)
+	}
+	return !coreverifier.Bundle{Parsed: parsed}.HasCertificate(), nil
 }

--- a/pkg/skills/verifier/verifier_test.go
+++ b/pkg/skills/verifier/verifier_test.go
@@ -219,6 +219,24 @@ func TestVerifyOCIWithKeyRejectsTransplantedSignature(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestResultFromBundleRejectsKeySignedBundle pins the classification adoption
+// depends on. A key-signed bundle has no certificate, so there is no identity
+// to back-fill — and the keyless verification underneath would have failed on
+// the missing certificate, reporting a broken signature for a bundle that is
+// perfectly intact.
+func TestResultFromBundleRejectsKeySignedBundle(t *testing.T) {
+	t.Parallel()
+	host := startTestRegistry(t)
+	ref, digest := pushTestArtifact(t, host)
+	_, bundle := signArtifact(t, ref, digest)
+	require.NotEmpty(t, bundle)
+
+	_, err := NewDefault(nil).ResultFromBundle(bundle, digest)
+	require.ErrorIs(t, err, ErrKeySigned)
+	require.NotErrorIs(t, err, ErrSignatureInvalid,
+		"the bundle verifies fine against its key; calling it invalid is the misdiagnosis this ends")
+}
+
 func TestVerifyOCIUnsignedArtifact(t *testing.T) {
 	t.Parallel()
 	host := startTestRegistry(t)


### PR DESCRIPTION
## Summary

[#6447](https://github.com/stacklok/toolhive/pull/6447) taught `install` to verify a key-signed skill and pin the key in the lock file. Nothing downstream read that pin back. This PR makes the lock-driven operations honour the anchor they already record — no new flag, no new trust decision, just the recorded key doing its job.

- **`sync` re-verified everything through the keyless path**, which refuses a key-pinned entry outright. Sync reads a refusal as drift it can heal by reinstalling, so a key-pinned skill reported as modified on *every* run and never settled, and `--check` failed permanently on a project that was in fact intact. It now re-verifies against the pinned key offline.
- **`upgrade` could not advance a key-pinned entry at all.** The signer-change guard probes the candidate for a certificate identity to compare, and a key-pair bundle has none — so the probe returned "key-signed" and the plan failed with a signature error naming none of the real situation. The apply step would have worked all along: it reads the anchor from the lock. Only the guard stood in the way.
- **`sync --adopt` attempted a key-signed install and failed opaquely.** Adoption back-fills trust from what the bundle reveals; a key-pair bundle reveals no identity and does not carry the key. It is now refused with the route that can anchor it.

Part of #6442. `--public-key` remains **install-only** — `upgrade` and `sync` take no key of their own, and in-place re-anchoring is still deliberately not offered.

### Where the remedy had to be chosen carefully

`SignerChangeBlocked` makes the CLI print *"use `--allow-signer-change`"*, so the status can only be used where that advice works. For a key-pinned entry it works when the candidate moved to keyless signing or lost its signature — dropping the recorded key and re-verifying keylessly is the key-to-keyless move `resolveKeyAnchor` supports. It does **not** work when the candidate is signed by a *different* key: `--allow-signer-change` drops the key, takes the keyless path, and hits `ErrKeySigned` one step later. That arm reports a failure naming the uninstall-and-reinstall route instead.

This is the same trap as the stale install-time guidance fixed in #6447 — a status that advertises a remedy the code then refuses.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

| File | Change |
|---|---|
| `pkg/skills/verifier/offline.go` | `ResultFromBundle` reports `ErrKeySigned` for a certificate-less bundle, decided from its shape rather than from a failed identity read |
| `pkg/skills/skillsvc/sync.go` | `verifyStoredKeySignature` for key-pinned entries; `describeLockAnchor`; adoption refuses key-signed installs |
| `pkg/skills/skillsvc/upgrade.go` | `guardKeyedSignerChange`: the pinned key applied to the candidate, blocked arms split by whether the printed remedy works |
| `docs/arch/12-skills-system.md` | What the pinned key does on sync, upgrade and adopt, and what stays out of scope |

## Test plan

- [x] Unit tests added/updated
- [x] `task test` passes with no failures
- [x] `task lint-fix` clean for every file touched (the 6 remaining `staticcheck` hits are pre-existing, in untouched `cmd/thv-operator/` files)

New coverage: the sync key branch including the reference fallback and the fail-closed case when no reference is recorded anywhere; every arm of the keyed upgrade guard, including that the keyless probe is never reached and that an undecodable pinned key fails rather than reporting a signer change; the adoption refusal, including that it writes no lock entry; and `ResultFromBundle`'s classification against a genuinely key-signed bundle produced by the signer package.

## Does this introduce a user-facing change?

Yes. A skill installed with `--public-key` now syncs, upgrades and reports correctly instead of showing permanent drift and refusing to upgrade. Adopting a key-signed install is refused with an actionable message rather than an opaque verification error.

## Special notes for reviewers

**Why the lock's reference, not the install record's.** The offline key check reconstructs the signed payload from a reference, so that reference is part of what is being verified. The lock is the authority on what the project is pinned to; the install record is the thing being checked against it. It falls back to the install record only when the entry records no resolved reference, and fails closed when neither has one.

**No new trust decision anywhere.** Every path here consumes an anchor that a previous `install` already verified and recorded. The one place that would have needed a new one — adoption — refuses instead.

Production diff is 130 insertions across 3 files, inside the repo's guideline.

Generated with [Claude Code](https://claude.com/claude-code)
