### PR TITLE
Bound and close HTTP client connection pools

### DIFF
--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -919,8 +919,14 @@ type Config struct {
 	//   - Per-upstream failure isolation. Upstream construction inside New is
 	//     otherwise all-or-nothing: one unreachable or mistyped issuer_url fails
 	//     the whole call. A factory owning construction can apply a per-upstream
-	//     deadline and skip or substitute a single failing provider while the
-	//     rest serve.
+	//     deadline and substitute a provider for a single failing upstream while
+	//     the rest serve.
+	//
+	// The factory cannot drop an upstream: every entry in Upstreams must yield a
+	// provider, and returning a nil provider with a nil error is rejected by New
+	// rather than producing an upstream that panics on the first authorization
+	// request. To serve without an upstream, omit it from Upstreams; to keep its
+	// slot in the chain, return a substitute provider.
 	//
 	// SECURITY: the returned provider validates the upstream's ID tokens and
 	// resolves user identity. A factory that returns a permissive provider

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -904,6 +904,26 @@ type Config struct {
 	// Multiple upstreams form a sequential authorization chain.
 	Upstreams []UpstreamConfig
 
+	// UpstreamFactory, when set, is used instead of DefaultUpstreamFactory to
+	// construct each configured upstream's OAuth2Provider. Two reasons to set it:
+	//
+	//   - Connection reuse. DefaultUpstreamFactory builds a private HTTP client
+	//     per upstream, so a process that reconstructs the server to change its
+	//     upstream set creates a fresh connection pool each time. A factory that
+	//     passes a client shared per issuer host via upstream.WithHTTPClient /
+	//     upstream.WithOAuth2HTTPClient creates none.
+	//   - Per-upstream failure isolation. Upstream construction inside New is
+	//     otherwise all-or-nothing: one unreachable or mistyped issuer_url fails
+	//     the whole call. A factory owning construction can apply a per-upstream
+	//     deadline and skip or substitute a single failing provider while the
+	//     rest serve.
+	//
+	// SECURITY: the returned provider validates the upstream's ID tokens and
+	// resolves user identity. A factory that returns a permissive provider
+	// bypasses upstream authentication for that leg of the chain. Delegate to
+	// DefaultUpstreamFactory for upstreams you do not need to customize.
+	UpstreamFactory UpstreamProviderFactory
+
 	// UpstreamFilter, when set, narrows the upstream authorization chain after the
 	// first leg resolves (see handlers.WithUpstreamFilter). When nil, all
 	// configured upstreams are walked — the current behavior. Pass nil itself,

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -910,12 +910,13 @@ type Config struct {
 	//   - Connection reuse. DefaultUpstreamFactory builds a private HTTP client
 	//     per upstream, so a process that reconstructs the server to change its
 	//     upstream set creates a fresh connection pool each time. A factory that
-	//     passes a client shared per issuer host via upstream.WithHTTPClient /
-	//     upstream.WithOAuth2HTTPClient creates none: both constructors apply
-	//     options before building their default client, and an injected client
-	//     stays owned by the caller, so Server.CloseIdleConnections leaves its
-	//     warm connections intact when a superseded server is retired. The
-	//     caller is then responsible for that client's pool.
+	//     passes a shared client via upstream.WithHTTPClient /
+	//     upstream.WithOAuth2HTTPClient creates none. Key the sharing by
+	//     distinct trust posture rather than by host: two upstreams can share a
+	//     host while differing in CAFilePath, AllowPrivateIPs or
+	//     InsecureAllowHTTP. An injected client stays owned by the caller — see
+	//     upstream.IdleConnectionCloser — who is then responsible for its pool,
+	//     its TLS trust and its dial-time SSRF guard.
 	//   - Per-upstream failure isolation. Upstream construction inside New is
 	//     otherwise all-or-nothing: one unreachable or mistyped issuer_url fails
 	//     the whole call. A factory owning construction can apply a per-upstream

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -911,7 +911,11 @@ type Config struct {
 	//     per upstream, so a process that reconstructs the server to change its
 	//     upstream set creates a fresh connection pool each time. A factory that
 	//     passes a client shared per issuer host via upstream.WithHTTPClient /
-	//     upstream.WithOAuth2HTTPClient creates none.
+	//     upstream.WithOAuth2HTTPClient creates none: both constructors apply
+	//     options before building their default client, and an injected client
+	//     stays owned by the caller, so Server.CloseIdleConnections leaves its
+	//     warm connections intact when a superseded server is retired. The
+	//     caller is then responsible for that client's pool.
 	//   - Per-upstream failure isolation. Upstream construction inside New is
 	//     otherwise all-or-nothing: one unreachable or mistyped issuer_url fails
 	//     the whole call. A factory owning construction can apply a per-upstream

--- a/pkg/authserver/integration_test.go
+++ b/pkg/authserver/integration_test.go
@@ -335,12 +335,18 @@ func setupTestServer(t *testing.T, opts ...testServerOption) *testServer {
 	}
 
 	// 7. Create server using newServer with test options
-	srv, err := newServer(ctx, cfg, stor,
-		withUpstreamFactory(func(_ context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
-			// Return the provided upstream or nil (which is valid for tests without upstream)
+	cfg.UpstreamFactory = func(_ context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
+		if options.upstream != nil {
 			return options.upstream, nil
-		}),
-	)
+		}
+		// A test that configures an upstream slot but no provider still needs a
+		// non-nil one: newServer rejects nil (it would panic on the first
+		// /oauth/authorize instead of failing at boot). This placeholder panics
+		// if a test actually exercises the upstream, which is what a nil
+		// provider did anyway.
+		return &plainProvider{}, nil
+	}
+	srv, err := newServer(ctx, cfg, stor)
 	require.NoError(t, err)
 
 	// 8. Create HTTP test server
@@ -3311,15 +3317,14 @@ func setupTestServerWithTwoUpstreams(t *testing.T, m1, m2 *mockoidc.MockOIDC, op
 	}
 
 	// 8. Create server using newServer with a factory that returns the correct provider per name
-	srv, err := newServer(ctx, serverCfg, stor,
-		withUpstreamFactory(func(_ context.Context, cfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
-			p, ok := providers[cfg.Name]
-			if !ok {
-				return nil, fmt.Errorf("unknown upstream: %s", cfg.Name)
-			}
-			return p, nil
-		}),
-	)
+	serverCfg.UpstreamFactory = func(_ context.Context, cfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
+		p, ok := providers[cfg.Name]
+		if !ok {
+			return nil, fmt.Errorf("unknown upstream: %s", cfg.Name)
+		}
+		return p, nil
+	}
+	srv, err := newServer(ctx, serverCfg, stor)
 	require.NoError(t, err)
 
 	// 9. Create HTTP test server

--- a/pkg/authserver/integration_test.go
+++ b/pkg/authserver/integration_test.go
@@ -2381,14 +2381,14 @@ func TestIntegration_FullPKCEFlow_DefaultAudience(t *testing.T) {
 }
 
 // ============================================================================
-// OIDC Provider Integration Tests (OIDCProviderImpl via defaultUpstreamFactory)
+// OIDC Provider Integration Tests (OIDCProviderImpl via DefaultUpstreamFactory)
 // ============================================================================
 
 // setupTestServerWithOIDCProvider creates a test server with a real OIDCProviderImpl
-// created through the defaultUpstreamFactory. Unlike setupTestServerWithMockOIDC which
+// created through the DefaultUpstreamFactory. Unlike setupTestServerWithMockOIDC which
 // manually creates a BaseOAuth2Provider, this test path exercises:
 //   - UpstreamConfig{Type: OIDC, OIDCConfig: ...}
-//   - defaultUpstreamFactory dispatching to NewOIDCProvider
+//   - DefaultUpstreamFactory dispatching to NewOIDCProvider
 //   - OIDCProviderImpl with OIDC discovery, ID token validation, and nonce support
 //
 // Variadic opts allow swapping the storage backend (e.g. withRedisBackedStorage)
@@ -2438,7 +2438,7 @@ func setupTestServerWithOIDCProvider(t *testing.T, m *mockoidc.MockOIDC, opts ..
 	require.NoError(t, err)
 
 	// 5. Build OIDC upstream config - this is the key difference from setupTestServerWithMockOIDC.
-	// We use UpstreamProviderTypeOIDC with OIDCConfig so that defaultUpstreamFactory
+	// We use UpstreamProviderTypeOIDC with OIDCConfig so that DefaultUpstreamFactory
 	// creates an OIDCProviderImpl (not BaseOAuth2Provider).
 	serverCfg := Config{
 		Issuer:               testIssuer,
@@ -2465,7 +2465,7 @@ func setupTestServerWithOIDCProvider(t *testing.T, m *mockoidc.MockOIDC, opts ..
 	}
 
 	// 6. Create server using newServer WITHOUT overriding the upstream factory.
-	// This exercises the real defaultUpstreamFactory -> NewOIDCProvider path.
+	// This exercises the real DefaultUpstreamFactory -> NewOIDCProvider path.
 	srv, err := newServer(ctx, serverCfg, stor)
 	require.NoError(t, err)
 
@@ -2489,7 +2489,7 @@ func setupTestServerWithOIDCProvider(t *testing.T, m *mockoidc.MockOIDC, opts ..
 }
 
 // TestIntegration_OIDCProvider_FullFlow tests the complete OAuth flow using the real
-// OIDCProviderImpl created through defaultUpstreamFactory. This verifies that:
+// OIDCProviderImpl created through DefaultUpstreamFactory. This verifies that:
 // - OIDC discovery is performed against the mock OIDC server
 // - The authorization flow redirects through the OIDC provider correctly
 // - Token exchange produces a valid JWT access token

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -315,6 +315,13 @@ func (e *EmbeddedAuthServer) Close() error {
 	return e.closeErr
 }
 
+// CloseIdleConnections releases the idle keep-alive connections pooled by the
+// underlying server's upstream IDP providers, without touching storage. See
+// authserver.Server.CloseIdleConnections for when to use this rather than Close.
+func (e *EmbeddedAuthServer) CloseIdleConnections() {
+	e.server.CloseIdleConnections()
+}
+
 // IDPTokenStorage returns storage for upstream IDP tokens.
 // Returns nil if no upstream IDP is configured.
 // This is used by the upstream swap middleware to exchange ToolHive JWTs

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -317,9 +317,9 @@ func (e *EmbeddedAuthServer) Close() error {
 
 // CloseIdleConnections releases the idle keep-alive connections pooled by the
 // underlying server's upstream IDP providers, without touching storage. See
-// authserver.Server.CloseIdleConnections for when to use this rather than Close.
+// authserver.CloseIdleConnections for when to use this rather than Close.
 func (e *EmbeddedAuthServer) CloseIdleConnections() {
-	e.server.CloseIdleConnections()
+	authserver.CloseIdleConnections(e.server)
 }
 
 // IDPTokenStorage returns storage for upstream IDP tokens.

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -1498,6 +1498,7 @@ func (s *stubServer) Handler() http.Handler                                { ret
 func (*stubServer) IDPTokenStorage() storage.UpstreamTokenStorage          { return nil }
 func (*stubServer) UpstreamTokenRefresher() storage.UpstreamTokenRefresher { return nil }
 func (*stubServer) DCRStore() storage.DCRCredentialStore                   { return nil }
+func (*stubServer) CloseIdleConnections()                                  {}
 func (*stubServer) Close() error                                           { return nil }
 
 func TestRoutes(t *testing.T) {

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -1491,14 +1491,15 @@ func TestConvertRedisRunConfig_WithEnvVars(t *testing.T) {
 // It returns a fixed http.Handler that writes a 200 response with a marker body,
 // and no-ops on all other interface methods.
 type stubServer struct {
-	handler http.Handler
+	handler    http.Handler
+	idleCloses atomic.Int32
 }
 
 func (s *stubServer) Handler() http.Handler                                { return s.handler }
 func (*stubServer) IDPTokenStorage() storage.UpstreamTokenStorage          { return nil }
 func (*stubServer) UpstreamTokenRefresher() storage.UpstreamTokenRefresher { return nil }
 func (*stubServer) DCRStore() storage.DCRCredentialStore                   { return nil }
-func (*stubServer) CloseIdleConnections()                                  {}
+func (s *stubServer) CloseIdleConnections()                                { s.idleCloses.Add(1) }
 func (*stubServer) Close() error                                           { return nil }
 
 func TestRoutes(t *testing.T) {
@@ -2428,4 +2429,25 @@ func TestResolveDelegateClients_ClonesPermissions(t *testing.T) {
 
 	assert.Equal(t, "openid", resolved[0].Scopes[0])
 	assert.Equal(t, "audience", resolved[0].Audiences[0])
+}
+
+// TestCloseIdleConnectionsDelegates pins that the wrapper forwards to the
+// underlying server rather than no-opping or calling Close. This is the method
+// runner-path embedders reach for when retiring a superseded server, and an
+// empty body here would pass every other test in the package.
+func TestCloseIdleConnectionsDelegates(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubServer{}
+	eas := &EmbeddedAuthServer{server: stub}
+
+	eas.CloseIdleConnections()
+	assert.Equal(t, int32(1), stub.idleCloses.Load())
+
+	// Safe after Close: Close is sync.Once-guarded and draining an already
+	// closed client's pool is a no-op, so a retire-then-shutdown sequence
+	// cannot double-close anything.
+	require.NoError(t, eas.Close())
+	eas.CloseIdleConnections()
+	assert.Equal(t, int32(2), stub.idleCloses.Load())
 }

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -1487,9 +1487,15 @@ func TestConvertRedisRunConfig_WithEnvVars(t *testing.T) {
 	})
 }
 
-// stubServer is a minimal authserver.Server implementation for testing RegisterHandlers.
-// It returns a fixed http.Handler that writes a 200 response with a marker body,
-// and no-ops on all other interface methods.
+// stubServer is a minimal authserver.Server implementation for testing
+// RegisterHandlers. It returns a fixed http.Handler that writes a 200 response
+// with a marker body, and no-ops on all other interface methods.
+//
+// CloseIdleConnections is not part of authserver.Server — it is the optional
+// capability authserver.CloseIdleConnections detects — so this stub implements
+// it only to assert that the wrapper forwards. capabilityFreeStubServer covers a
+// server that does not. Note it must not be embedded to build that one: the
+// method would be promoted and the capability satisfied after all.
 type stubServer struct {
 	handler    http.Handler
 	idleCloses atomic.Int32
@@ -1501,6 +1507,26 @@ func (*stubServer) UpstreamTokenRefresher() storage.UpstreamTokenRefresher { ret
 func (*stubServer) DCRStore() storage.DCRCredentialStore                   { return nil }
 func (s *stubServer) CloseIdleConnections()                                { s.idleCloses.Add(1) }
 func (*stubServer) Close() error                                           { return nil }
+
+// capabilityFreeStubServer omits CloseIdleConnections, as an out-of-tree
+// authserver.Server implementation written before the capability existed would.
+// It counts Close so a test can prove the wrapper does not fall back to it.
+type capabilityFreeStubServer struct {
+	closed atomic.Int32
+}
+
+func (*capabilityFreeStubServer) Handler() http.Handler                         { return nil }
+func (*capabilityFreeStubServer) IDPTokenStorage() storage.UpstreamTokenStorage { return nil }
+func (*capabilityFreeStubServer) DCRStore() storage.DCRCredentialStore          { return nil }
+
+func (*capabilityFreeStubServer) UpstreamTokenRefresher() storage.UpstreamTokenRefresher {
+	return nil
+}
+
+func (s *capabilityFreeStubServer) Close() error {
+	s.closed.Add(1)
+	return nil
+}
 
 func TestRoutes(t *testing.T) {
 	t.Parallel()
@@ -2450,4 +2476,18 @@ func TestCloseIdleConnectionsDelegates(t *testing.T) {
 	require.NoError(t, eas.Close())
 	eas.CloseIdleConnections()
 	assert.Equal(t, int32(2), stub.idleCloses.Load())
+}
+
+// TestCloseIdleConnectionsWithoutCapability pins that the wrapper degrades
+// quietly when the underlying Server does not implement the optional capability,
+// and in particular that it does not fall back to Close — the two are separate
+// precisely because Close also tears down storage.
+func TestCloseIdleConnectionsWithoutCapability(t *testing.T) {
+	t.Parallel()
+
+	stub := &capabilityFreeStubServer{}
+	eas := &EmbeddedAuthServer{server: stub}
+
+	assert.NotPanics(t, eas.CloseIdleConnections)
+	assert.Zero(t, stub.closed.Load(), "must not fall back to Close")
 }

--- a/pkg/authserver/server.go
+++ b/pkg/authserver/server.go
@@ -75,6 +75,12 @@ type Server interface {
 	// providers built around a caller-supplied HTTP client — the caller owns
 	// that client's pool (see Config.UpstreamFactory).
 	//
+	// Scope: this releases the upstream providers' HTTP connection pools and
+	// nothing else. A server configured with TrustedIssuers also holds one JWKS
+	// refresh worker pool per issuer, started against context.Background() and
+	// released by neither this method nor Close, so an embedder that
+	// reconstructs repeatedly still grows goroutines through that path.
+	//
 	// Unlike upstream.IdleConnectionCloser, which is an optional capability an
 	// OAuth2Provider may implement, this is a required part of the Server
 	// interface: Server has a single in-repo implementation, so requiring it

--- a/pkg/authserver/server.go
+++ b/pkg/authserver/server.go
@@ -71,7 +71,16 @@ type Server interface {
 	//
 	// Safe to call on a server that is still serving: only idle connections are
 	// closed, in-flight requests are unaffected, and later upstream calls dial
-	// again. Providers that do not expose the capability are skipped.
+	// again. Providers that do not expose the capability are skipped, as are
+	// providers built around a caller-supplied HTTP client — the caller owns
+	// that client's pool (see Config.UpstreamFactory).
+	//
+	// Unlike upstream.IdleConnectionCloser, which is an optional capability an
+	// OAuth2Provider may implement, this is a required part of the Server
+	// interface: Server has a single in-repo implementation, so requiring it
+	// keeps the call compile-time safe rather than a silent no-op, whereas
+	// OAuth2Provider is documented as open to external implementations that
+	// widening would break.
 	CloseIdleConnections()
 
 	// Close releases resources held by the server. It drains upstream idle

--- a/pkg/authserver/server.go
+++ b/pkg/authserver/server.go
@@ -9,7 +9,13 @@ import (
 	"net/http"
 
 	"github.com/stacklok/toolhive/pkg/authserver/storage"
+	"github.com/stacklok/toolhive/pkg/authserver/upstream"
 )
+
+// UpstreamProviderFactory constructs the OAuth2Provider for one configured
+// upstream IDP. Set it on Config.UpstreamFactory to own upstream construction;
+// DefaultUpstreamFactory is the built-in implementation and can be delegated to.
+type UpstreamProviderFactory func(ctx context.Context, cfg *UpstreamConfig) (upstream.OAuth2Provider, error)
 
 // Server is the OAuth authorization server.
 // It provides HTTP handlers that serve all OAuth/OIDC endpoints.
@@ -53,7 +59,24 @@ type Server interface {
 	// its closed connection pool).
 	DCRStore() storage.DCRCredentialStore
 
-	// Close releases resources held by the server.
+	// CloseIdleConnections releases the idle keep-alive connections pooled by
+	// the server's upstream IDP providers, without touching storage.
+	//
+	// Each upstream provider owns a private HTTP client whose connection pool
+	// outlives the provider unless it is drained. An embedder that reconstructs
+	// the server to change its upstream set — passing the same storage.Storage
+	// and keys.KeyProvider so token and JWKS continuity is preserved — must
+	// retire the superseded server with this method rather than Close, because
+	// Close would also close the storage the new server is now serving through.
+	//
+	// Safe to call on a server that is still serving: only idle connections are
+	// closed, in-flight requests are unaffected, and later upstream calls dial
+	// again. Providers that do not expose the capability are skipped.
+	CloseIdleConnections()
+
+	// Close releases resources held by the server. It drains upstream idle
+	// connections (see CloseIdleConnections) and then closes storage. Do not
+	// call it on a server whose storage is shared with another live server.
 	Close() error
 }
 

--- a/pkg/authserver/server.go
+++ b/pkg/authserver/server.go
@@ -60,33 +60,23 @@ type Server interface {
 	DCRStore() storage.DCRCredentialStore
 
 	// CloseIdleConnections releases the idle keep-alive connections pooled by
-	// the server's upstream IDP providers, without touching storage.
+	// the server's upstream IDP providers, without touching storage. It is
+	// required rather than optional so the call cannot silently degrade to a
+	// no-op; see upstream.IdleConnectionCloser for the per-provider capability
+	// it delegates to, and for the caller-owned-client exemption.
 	//
-	// Each upstream provider owns a private HTTP client whose connection pool
-	// outlives the provider unless it is drained. An embedder that reconstructs
-	// the server to change its upstream set — passing the same storage.Storage
-	// and keys.KeyProvider so token and JWKS continuity is preserved — must
-	// retire the superseded server with this method rather than Close, because
-	// Close would also close the storage the new server is now serving through.
+	// An embedder that reconstructs the server to change its upstream set —
+	// passing the same storage.Storage and keys.KeyProvider so token and JWKS
+	// continuity is preserved — must retire the superseded server with this
+	// method rather than Close, because Close would also close the storage the
+	// new server is now serving through.
 	//
 	// Safe to call on a server that is still serving: only idle connections are
-	// closed, in-flight requests are unaffected, and later upstream calls dial
-	// again. Providers that do not expose the capability are skipped, as are
-	// providers built around a caller-supplied HTTP client — the caller owns
-	// that client's pool (see Config.UpstreamFactory).
+	// closed and in-flight requests are unaffected.
 	//
-	// Scope: this releases the upstream providers' HTTP connection pools and
-	// nothing else. A server configured with TrustedIssuers also holds one JWKS
-	// refresh worker pool per issuer, started against context.Background() and
-	// released by neither this method nor Close, so an embedder that
-	// reconstructs repeatedly still grows goroutines through that path.
-	//
-	// Unlike upstream.IdleConnectionCloser, which is an optional capability an
-	// OAuth2Provider may implement, this is a required part of the Server
-	// interface: Server has a single in-repo implementation, so requiring it
-	// keeps the call compile-time safe rather than a silent no-op, whereas
-	// OAuth2Provider is documented as open to external implementations that
-	// widening would break.
+	// Scope: upstream HTTP pools only. A server configured with TrustedIssuers
+	// also holds one JWKS refresh worker pool per issuer that neither this
+	// method nor Close releases.
 	CloseIdleConnections()
 
 	// Close releases resources held by the server. It drains upstream idle

--- a/pkg/authserver/server.go
+++ b/pkg/authserver/server.go
@@ -59,30 +59,50 @@ type Server interface {
 	// its closed connection pool).
 	DCRStore() storage.DCRCredentialStore
 
-	// CloseIdleConnections releases the idle keep-alive connections pooled by
-	// the server's upstream IDP providers, without touching storage. It is
-	// required rather than optional so the call cannot silently degrade to a
-	// no-op; see upstream.IdleConnectionCloser for the per-provider capability
-	// it delegates to, and for the caller-owned-client exemption.
-	//
-	// An embedder that reconstructs the server to change its upstream set —
-	// passing the same storage.Storage and keys.KeyProvider so token and JWKS
-	// continuity is preserved — must retire the superseded server with this
-	// method rather than Close, because Close would also close the storage the
-	// new server is now serving through.
-	//
-	// Safe to call on a server that is still serving: only idle connections are
-	// closed and in-flight requests are unaffected.
-	//
-	// Scope: upstream HTTP pools only. A server configured with TrustedIssuers
-	// also holds one JWKS refresh worker pool per issuer that neither this
-	// method nor Close releases.
-	CloseIdleConnections()
-
-	// Close releases resources held by the server. It drains upstream idle
-	// connections (see CloseIdleConnections) and then closes storage. Do not
-	// call it on a server whose storage is shared with another live server.
+	// Close releases resources held by the server. It drains the upstream idle
+	// connections (see the CloseIdleConnections function) and then closes
+	// storage. Do not call it on a server whose storage is shared with another
+	// live server; retire that one with CloseIdleConnections instead.
 	Close() error
+}
+
+// idleConnectionCloser is the capability CloseIdleConnections detects. It is
+// deliberately not a method on Server: adding one would be a source-incompatible
+// change for out-of-tree implementations and test doubles, and the only in-tree
+// consumer needs a single call. Kept unexported so callers go through the
+// CloseIdleConnections function rather than asserting themselves — the
+// `var _ idleConnectionCloser = (*server)(nil)` check in server_impl.go is what
+// keeps the real implementation compile-time guaranteed to satisfy it.
+type idleConnectionCloser interface {
+	CloseIdleConnections()
+}
+
+// CloseIdleConnections releases the idle keep-alive connections pooled by s's
+// upstream IDP providers, without touching storage, and reports whether s
+// supported the operation. Only an implementation of Server that does not come
+// from New can report false; the production type is checked at compile time.
+//
+// An embedder that reconstructs the server to change its upstream set — passing
+// the same storage.Storage and keys.KeyProvider so token and JWKS continuity is
+// preserved — must retire the superseded server with this function rather than
+// Close, because Close would also close the storage the new server is now
+// serving through. That split is the whole point: without it there is no correct
+// call to make.
+//
+// Safe to call on a server that is still serving: only idle connections are
+// closed and in-flight requests are unaffected. See upstream.IdleConnectionCloser
+// for the per-provider capability this delegates to, and for the
+// caller-owned-client exemption.
+//
+// Scope: upstream HTTP pools only. A server configured with TrustedIssuers also
+// holds one JWKS refresh worker pool per issuer that neither this function nor
+// Close releases.
+func CloseIdleConnections(s Server) bool {
+	closer, ok := s.(idleConnectionCloser)
+	if ok {
+		closer.CloseIdleConnections()
+	}
+	return ok
 }
 
 // New creates a new OAuth authorization server.

--- a/pkg/authserver/server/tokenexchange/multi_issuer_validator.go
+++ b/pkg/authserver/server/tokenexchange/multi_issuer_validator.go
@@ -334,6 +334,18 @@ type limitedBodyTransport struct {
 // doesn't intend to parse — draining it is only ever io.Discard-ed, not
 // unbounded, so this errs on the safe side rather than special-casing status
 // codes.
+// CloseIdleConnections forwards to the wrapped transport. http.Client discovers
+// this capability by asserting the outermost transport, so a wrapper that omits
+// it makes the client's CloseIdleConnections a silent no-op — see the same
+// method on networking.ValidatingTransport. Currently there is no pool to drain
+// (this client is built WithDisableKeepAlives(true)), but the forwarder keeps
+// that an optimization decision rather than a correctness dependency.
+func (t *limitedBodyTransport) CloseIdleConnections() {
+	if closer, ok := t.base.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
 func (t *limitedBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.base.RoundTrip(req)
 	if err != nil {

--- a/pkg/authserver/server/tokenexchange/multi_issuer_validator.go
+++ b/pkg/authserver/server/tokenexchange/multi_issuer_validator.go
@@ -343,14 +343,12 @@ func (t *limitedBodyTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return resp, nil
 }
 
-// CloseIdleConnections forwards to the wrapped transport. http.Client discovers
-// this capability by asserting the outermost transport, so a wrapper that omits
-// it makes the client's CloseIdleConnections a silent no-op — see the same
-// method on networking.ValidatingTransport. Currently there is no pool to drain
-// (this client is built WithDisableKeepAlives(true)), but the forwarder keeps
-// that an optimization decision rather than a correctness dependency.
+// CloseIdleConnections forwards to the wrapped transport, as every wrapping
+// RoundTripper must — see networking.IdleConnectionCloser. There is no pool to
+// drain today (this client is built WithDisableKeepAlives(true)); the forwarder
+// keeps that an optimization decision rather than a correctness dependency.
 func (t *limitedBodyTransport) CloseIdleConnections() {
-	if closer, ok := t.base.(interface{ CloseIdleConnections() }); ok {
+	if closer, ok := t.base.(networking.IdleConnectionCloser); ok {
 		closer.CloseIdleConnections()
 	}
 }

--- a/pkg/authserver/server/tokenexchange/multi_issuer_validator.go
+++ b/pkg/authserver/server/tokenexchange/multi_issuer_validator.go
@@ -334,6 +334,15 @@ type limitedBodyTransport struct {
 // doesn't intend to parse — draining it is only ever io.Discard-ed, not
 // unbounded, so this errs on the safe side rather than special-casing status
 // codes.
+func (t *limitedBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = http.MaxBytesReader(nil, resp.Body, t.max)
+	return resp, nil
+}
+
 // CloseIdleConnections forwards to the wrapped transport. http.Client discovers
 // this capability by asserting the outermost transport, so a wrapper that omits
 // it makes the client's CloseIdleConnections a silent no-op — see the same
@@ -344,15 +353,6 @@ func (t *limitedBodyTransport) CloseIdleConnections() {
 	if closer, ok := t.base.(interface{ CloseIdleConnections() }); ok {
 		closer.CloseIdleConnections()
 	}
-}
-
-func (t *limitedBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	resp, err := t.base.RoundTrip(req)
-	if err != nil {
-		return nil, err
-	}
-	resp.Body = http.MaxBytesReader(nil, resp.Body, t.max)
-	return resp, nil
 }
 
 // newActorMatcherEngine creates a CEL engine for admin-authored actor matcher

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -423,7 +423,13 @@ func newUpstreamTokenRefresher(
 	}
 }
 
-// CloseIdleConnections implements Server; see that interface for the contract.
+// Compile-time check that the concrete server satisfies the capability the
+// CloseIdleConnections function detects, so that call can never degrade to a
+// no-op for a server built by New.
+var _ idleConnectionCloser = (*server)(nil)
+
+// CloseIdleConnections drains the upstream providers' pooled connections; see
+// the package-level CloseIdleConnections function for the contract.
 func (s *server) CloseIdleConnections() {
 	closeUpstreamIdleConnections(s.upstreams)
 }

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -100,6 +100,13 @@ func buildUpstreams(
 			closeUpstreamIdleConnections(upstreams)
 			return nil, fmt.Errorf("failed to create upstream provider %q: %w", upCfg.Name, err)
 		}
+		// A nil provider would be wired into the authorization chain and panic on
+		// the first /oauth/authorize request instead of failing at boot, so a
+		// custom Config.UpstreamFactory cannot use it to drop an upstream.
+		if provider == nil {
+			closeUpstreamIdleConnections(upstreams)
+			return nil, fmt.Errorf("upstream factory returned a nil provider for upstream %q", upCfg.Name)
+		}
 		upstreams = append(upstreams, handlers.NamedUpstream{Name: upCfg.Name, Provider: provider})
 		slog.Debug("upstream IDP provider configured", "type", upCfg.Type, "name", upCfg.Name)
 	}

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"reflect"
 	"time"
 
 	josev3 "github.com/go-jose/go-jose/v3"
@@ -44,14 +45,6 @@ type server struct {
 	upstreams         []handlers.NamedUpstream
 }
 
-// serverOption configures the server during construction.
-type serverOption func(*serverOptions)
-
-// serverOptions holds optional configuration for server creation.
-type serverOptions struct {
-	upstreamFactory UpstreamProviderFactory
-}
-
 // DefaultUpstreamFactory creates the production upstream provider based on type.
 // For OIDC providers, it creates an OIDCProviderImpl with discovery and ID token
 // validation. For OAuth2 providers, it creates a BaseOAuth2Provider.
@@ -69,28 +62,16 @@ func DefaultUpstreamFactory(ctx context.Context, cfg *UpstreamConfig) (upstream.
 	}
 }
 
-// resolveUpstreamFactory picks the upstream provider factory to build with. The
-// in-package test seam wins over the caller-supplied Config.UpstreamFactory,
-// which in turn wins over DefaultUpstreamFactory.
-func resolveUpstreamFactory(seam, configured UpstreamProviderFactory) UpstreamProviderFactory {
-	switch {
-	case seam != nil:
-		return seam
-	case configured != nil:
-		return configured
-	default:
-		return DefaultUpstreamFactory
+// buildUpstreams constructs the ordered upstream provider list using
+// cfg.UpstreamFactory, or DefaultUpstreamFactory when the caller supplied none.
+// A provider that fails to construct aborts the whole list — but the providers
+// already built have live connection pools, so they are drained before the
+// error is returned.
+func buildUpstreams(ctx context.Context, cfg Config) ([]handlers.NamedUpstream, error) {
+	factory := cfg.UpstreamFactory
+	if factory == nil {
+		factory = DefaultUpstreamFactory
 	}
-}
-
-// buildUpstreams constructs the ordered upstream provider list. A provider that
-// fails to construct aborts the whole list — but the providers already built
-// have live connection pools, so they are drained before the error is returned.
-func buildUpstreams(
-	ctx context.Context,
-	cfg Config,
-	factory UpstreamProviderFactory,
-) ([]handlers.NamedUpstream, error) {
 	upstreams := make([]handlers.NamedUpstream, 0, len(cfg.Upstreams))
 	for i := range cfg.Upstreams {
 		upCfg := &cfg.Upstreams[i]
@@ -102,8 +83,11 @@ func buildUpstreams(
 		}
 		// A nil provider would be wired into the authorization chain and panic on
 		// the first /oauth/authorize request instead of failing at boot, so a
-		// custom Config.UpstreamFactory cannot use it to drop an upstream.
-		if provider == nil {
+		// custom Config.UpstreamFactory cannot use it to drop an upstream. The
+		// reflect check also catches a typed nil (`var p *OIDCProviderImpl;
+		// return p, nil`), which is non-nil as an interface and would instead
+		// panic during the drain, on the embedded *BaseOAuth2Provider.
+		if isNilProvider(provider) {
 			closeUpstreamIdleConnections(upstreams)
 			return nil, fmt.Errorf("upstream factory returned a nil provider for upstream %q", upCfg.Name)
 		}
@@ -111,6 +95,16 @@ func buildUpstreams(
 		slog.Debug("upstream IDP provider configured", "type", upCfg.Type, "name", upCfg.Name)
 	}
 	return upstreams, nil
+}
+
+// isNilProvider reports whether an OAuth2Provider is unusable — either a nil
+// interface value or an interface holding a nil pointer.
+func isNilProvider(provider upstream.OAuth2Provider) bool {
+	if provider == nil {
+		return true
+	}
+	v := reflect.ValueOf(provider)
+	return v.Kind() == reflect.Pointer && v.IsNil()
 }
 
 // closeUpstreamIdleConnections drains the pooled idle connections of every
@@ -128,30 +122,10 @@ func closeUpstreamIdleConnections(upstreams []handlers.NamedUpstream) {
 	}
 }
 
-// withUpstreamFactory sets a custom upstream provider factory, taking
-// precedence over Config.UpstreamFactory. This is the in-package test seam;
-// external callers use Config.UpstreamFactory.
-func withUpstreamFactory(factory UpstreamProviderFactory) serverOption {
-	return func(o *serverOptions) {
-		o.upstreamFactory = factory
-	}
-}
-
 // newServer creates a new OAuth authorization server.
 // The opts parameter allows injecting dependencies for testing.
-func newServer(
-	ctx context.Context,
-	cfg Config,
-	stor storage.Storage,
-	opts ...serverOption,
-) (_ *server, retErr error) {
+func newServer(ctx context.Context, cfg Config, stor storage.Storage) (_ *server, retErr error) {
 	slog.Debug("initializing OAuth authorization server")
-
-	// Apply server options
-	options := &serverOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
 
 	// Apply defaults to config
 	if err := cfg.applyDefaults(); err != nil {
@@ -229,14 +203,20 @@ func newServer(
 	)
 
 	// Build ordered upstream provider list from all configured upstreams.
-	upstreams, err := buildUpstreams(ctx, cfg, resolveUpstreamFactory(options.upstreamFactory, cfg.UpstreamFactory))
+	upstreams, err := buildUpstreams(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
-	// Every failure below abandons providers that have already run discovery and
-	// hold a live connection pool. Without this the pathological case from #6479
-	// — a caller retrying a reconstruction against an unreachable issuer —
-	// accumulates a transport per upstream per attempt.
+	// Defense in depth for the failure returns below, which would otherwise
+	// abandon providers that have already run discovery and hold a live
+	// connection pool. No such failure is reachable today with a Config that
+	// passes Validate — runLegacyMigration is a no-op off Redis, the CIMD cache
+	// bounds and the trusted issuers are validated up front, and every
+	// handlers.NewHandler precondition (non-nil config, non-empty and unique
+	// upstream names, non-nil providers) is already guaranteed by Validate and
+	// buildUpstreams. So this drains nothing at present; it is here so that a
+	// future step which fails after touching the network cannot strand a pool,
+	// and so a `return nil, err` added above it is covered by default.
 	defer func() {
 		if retErr != nil {
 			closeUpstreamIdleConnections(upstreams)

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -83,6 +83,44 @@ func resolveUpstreamFactory(seam, configured UpstreamProviderFactory) UpstreamPr
 	}
 }
 
+// buildUpstreams constructs the ordered upstream provider list. A provider that
+// fails to construct aborts the whole list — but the providers already built
+// have live connection pools, so they are drained before the error is returned.
+func buildUpstreams(
+	ctx context.Context,
+	cfg Config,
+	factory UpstreamProviderFactory,
+) ([]handlers.NamedUpstream, error) {
+	upstreams := make([]handlers.NamedUpstream, 0, len(cfg.Upstreams))
+	for i := range cfg.Upstreams {
+		upCfg := &cfg.Upstreams[i]
+		slog.Debug("creating upstream IDP provider", "type", upCfg.Type, "name", upCfg.Name)
+		provider, err := factory(ctx, upCfg)
+		if err != nil {
+			closeUpstreamIdleConnections(upstreams)
+			return nil, fmt.Errorf("failed to create upstream provider %q: %w", upCfg.Name, err)
+		}
+		upstreams = append(upstreams, handlers.NamedUpstream{Name: upCfg.Name, Provider: provider})
+		slog.Debug("upstream IDP provider configured", "type", upCfg.Type, "name", upCfg.Name)
+	}
+	return upstreams, nil
+}
+
+// closeUpstreamIdleConnections drains the pooled idle connections of every
+// upstream that exposes the capability. Providers that do not implement it, and
+// providers holding a caller-supplied client, are no-ops.
+func closeUpstreamIdleConnections(upstreams []handlers.NamedUpstream) {
+	for _, u := range upstreams {
+		// Optional capability: the OAuth2Provider interface is open to external
+		// implementations, so a provider that holds no pool of its own simply
+		// does not implement it.
+		if closer, ok := u.Provider.(upstream.IdleConnectionCloser); ok {
+			slog.Debug("closing upstream idle connections", "name", u.Name)
+			closer.CloseIdleConnections()
+		}
+	}
+}
+
 // withUpstreamFactory sets a custom upstream provider factory, taking
 // precedence over Config.UpstreamFactory. This is the in-package test seam;
 // external callers use Config.UpstreamFactory.
@@ -94,7 +132,12 @@ func withUpstreamFactory(factory UpstreamProviderFactory) serverOption {
 
 // newServer creates a new OAuth authorization server.
 // The opts parameter allows injecting dependencies for testing.
-func newServer(ctx context.Context, cfg Config, stor storage.Storage, opts ...serverOption) (*server, error) {
+func newServer(
+	ctx context.Context,
+	cfg Config,
+	stor storage.Storage,
+	opts ...serverOption,
+) (_ *server, retErr error) {
 	slog.Debug("initializing OAuth authorization server")
 
 	// Apply server options
@@ -179,21 +222,19 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage, opts ...se
 	)
 
 	// Build ordered upstream provider list from all configured upstreams.
-	upstreamFactory := resolveUpstreamFactory(options.upstreamFactory, cfg.UpstreamFactory)
-	upstreams := make([]handlers.NamedUpstream, 0, len(cfg.Upstreams))
-	for i := range cfg.Upstreams {
-		upCfg := &cfg.Upstreams[i]
-		slog.Debug("creating upstream IDP provider", "type", upCfg.Type, "name", upCfg.Name)
-		upstreamProvider, upErr := upstreamFactory(ctx, upCfg)
-		if upErr != nil {
-			return nil, fmt.Errorf("failed to create upstream provider %q: %w", upCfg.Name, upErr)
-		}
-		upstreams = append(upstreams, handlers.NamedUpstream{
-			Name:     upCfg.Name,
-			Provider: upstreamProvider,
-		})
-		slog.Debug("upstream IDP provider configured", "type", upCfg.Type, "name", upCfg.Name)
+	upstreams, err := buildUpstreams(ctx, cfg, resolveUpstreamFactory(options.upstreamFactory, cfg.UpstreamFactory))
+	if err != nil {
+		return nil, err
 	}
+	// Every failure below abandons providers that have already run discovery and
+	// hold a live connection pool. Without this the pathological case from #6479
+	// — a caller retrying a reconstruction against an unreachable issuer —
+	// accumulates a transport per upstream per attempt.
+	defer func() {
+		if retErr != nil {
+			closeUpstreamIdleConnections(upstreams)
+		}
+	}()
 
 	// Run one-shot bulk migration of legacy data before handler construction.
 	// TODO(migration): Remove once all deployments have upgraded past this version.
@@ -410,15 +451,7 @@ func newUpstreamTokenRefresher(
 // server's upstream IDP providers. See the Server interface for why this is kept
 // separate from Close.
 func (s *server) CloseIdleConnections() {
-	for _, u := range s.upstreams {
-		// Optional capability: the OAuth2Provider interface is open to external
-		// implementations, so a provider that holds no pool of its own simply
-		// does not implement it.
-		if closer, ok := u.Provider.(upstream.IdleConnectionCloser); ok {
-			slog.Debug("closing upstream idle connections", "name", u.Name)
-			closer.CloseIdleConnections()
-		}
-	}
+	closeUpstreamIdleConnections(s.upstreams)
 }
 
 // Close releases resources held by the server.

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -81,12 +81,9 @@ func buildUpstreams(ctx context.Context, cfg Config) ([]handlers.NamedUpstream, 
 			closeUpstreamIdleConnections(upstreams)
 			return nil, fmt.Errorf("failed to create upstream provider %q: %w", upCfg.Name, err)
 		}
-		// A nil provider would be wired into the authorization chain and panic on
-		// the first /oauth/authorize request instead of failing at boot, so a
-		// custom Config.UpstreamFactory cannot use it to drop an upstream. The
-		// reflect check also catches a typed nil (`var p *OIDCProviderImpl;
-		// return p, nil`), which is non-nil as an interface and would instead
-		// panic during the drain, on the embedded *BaseOAuth2Provider.
+		// A nil provider would reach the authorization chain and panic on the
+		// first /oauth/authorize rather than failing at boot, so a custom
+		// factory cannot use one to drop an upstream.
 		if isNilProvider(provider) {
 			closeUpstreamIdleConnections(upstreams)
 			return nil, fmt.Errorf("upstream factory returned a nil provider for upstream %q", upCfg.Name)
@@ -108,13 +105,10 @@ func isNilProvider(provider upstream.OAuth2Provider) bool {
 }
 
 // closeUpstreamIdleConnections drains the pooled idle connections of every
-// upstream that exposes the capability. Providers that do not implement it, and
-// providers holding a caller-supplied client, are no-ops.
+// upstream that implements the optional upstream.IdleConnectionCloser
+// capability; see that interface for why it is optional and what it exempts.
 func closeUpstreamIdleConnections(upstreams []handlers.NamedUpstream) {
 	for _, u := range upstreams {
-		// Optional capability: the OAuth2Provider interface is open to external
-		// implementations, so a provider that holds no pool of its own simply
-		// does not implement it.
 		if closer, ok := u.Provider.(upstream.IdleConnectionCloser); ok {
 			slog.Debug("closing upstream idle connections", "name", u.Name)
 			closer.CloseIdleConnections()
@@ -207,16 +201,11 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage) (_ *server
 	if err != nil {
 		return nil, err
 	}
-	// Defense in depth for the failure returns below, which would otherwise
-	// abandon providers that have already run discovery and hold a live
-	// connection pool. No such failure is reachable today with a Config that
-	// passes Validate — runLegacyMigration is a no-op off Redis, the CIMD cache
-	// bounds and the trusted issuers are validated up front, and every
-	// handlers.NewHandler precondition (non-nil config, non-empty and unique
-	// upstream names, non-nil providers) is already guaranteed by Validate and
-	// buildUpstreams. So this drains nothing at present; it is here so that a
-	// future step which fails after touching the network cannot strand a pool,
-	// and so a `return nil, err` added above it is covered by default.
+	// Defense in depth: the failure returns below would otherwise abandon
+	// providers holding a live pool. None is reachable today (Validate covers
+	// every precondition they check), so this drains nothing at present — it is
+	// here so a future step that fails after touching the network, or a new
+	// error return added above it, is covered by default.
 	defer func() {
 		if retErr != nil {
 			closeUpstreamIdleConnections(upstreams)
@@ -434,9 +423,7 @@ func newUpstreamTokenRefresher(
 	}
 }
 
-// CloseIdleConnections releases the idle keep-alive connections pooled by the
-// server's upstream IDP providers. See the Server interface for why this is kept
-// separate from Close.
+// CloseIdleConnections implements Server; see that interface for the contract.
 func (s *server) CloseIdleConnections() {
 	closeUpstreamIdleConnections(s.upstreams)
 }

--- a/pkg/authserver/server_impl.go
+++ b/pkg/authserver/server_impl.go
@@ -44,22 +44,21 @@ type server struct {
 	upstreams         []handlers.NamedUpstream
 }
 
-// upstreamProviderFactory creates an upstream OAuth2Provider from configuration.
-// This type enables dependency injection for testing.
-type upstreamProviderFactory func(ctx context.Context, cfg *UpstreamConfig) (upstream.OAuth2Provider, error)
-
 // serverOption configures the server during construction.
 type serverOption func(*serverOptions)
 
 // serverOptions holds optional configuration for server creation.
 type serverOptions struct {
-	upstreamFactory upstreamProviderFactory
+	upstreamFactory UpstreamProviderFactory
 }
 
-// defaultUpstreamFactory creates the production upstream provider based on type.
-// For OIDC providers, it creates an OIDCProviderImpl with discovery and ID token validation.
-// For OAuth2 providers, it creates a BaseOAuth2Provider.
-func defaultUpstreamFactory(ctx context.Context, cfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
+// DefaultUpstreamFactory creates the production upstream provider based on type.
+// For OIDC providers, it creates an OIDCProviderImpl with discovery and ID token
+// validation. For OAuth2 providers, it creates a BaseOAuth2Provider.
+//
+// It is exported so a Config.UpstreamFactory implementation can delegate to the
+// built-in behavior for the upstreams it does not want to handle itself.
+func DefaultUpstreamFactory(ctx context.Context, cfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
 	switch cfg.Type {
 	case UpstreamProviderTypeOIDC:
 		return upstream.NewOIDCProvider(ctx, cfg.OIDCConfig)
@@ -70,9 +69,24 @@ func defaultUpstreamFactory(ctx context.Context, cfg *UpstreamConfig) (upstream.
 	}
 }
 
-// withUpstreamFactory sets a custom upstream provider factory.
-// This is intended for testing and is not part of the public API.
-func withUpstreamFactory(factory upstreamProviderFactory) serverOption {
+// resolveUpstreamFactory picks the upstream provider factory to build with. The
+// in-package test seam wins over the caller-supplied Config.UpstreamFactory,
+// which in turn wins over DefaultUpstreamFactory.
+func resolveUpstreamFactory(seam, configured UpstreamProviderFactory) UpstreamProviderFactory {
+	switch {
+	case seam != nil:
+		return seam
+	case configured != nil:
+		return configured
+	default:
+		return DefaultUpstreamFactory
+	}
+}
+
+// withUpstreamFactory sets a custom upstream provider factory, taking
+// precedence over Config.UpstreamFactory. This is the in-package test seam;
+// external callers use Config.UpstreamFactory.
+func withUpstreamFactory(factory UpstreamProviderFactory) serverOption {
 	return func(o *serverOptions) {
 		o.upstreamFactory = factory
 	}
@@ -84,9 +98,7 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage, opts ...se
 	slog.Debug("initializing OAuth authorization server")
 
 	// Apply server options
-	options := &serverOptions{
-		upstreamFactory: defaultUpstreamFactory,
-	}
+	options := &serverOptions{}
 	for _, opt := range opts {
 		opt(options)
 	}
@@ -167,11 +179,12 @@ func newServer(ctx context.Context, cfg Config, stor storage.Storage, opts ...se
 	)
 
 	// Build ordered upstream provider list from all configured upstreams.
+	upstreamFactory := resolveUpstreamFactory(options.upstreamFactory, cfg.UpstreamFactory)
 	upstreams := make([]handlers.NamedUpstream, 0, len(cfg.Upstreams))
 	for i := range cfg.Upstreams {
 		upCfg := &cfg.Upstreams[i]
 		slog.Debug("creating upstream IDP provider", "type", upCfg.Type, "name", upCfg.Name)
-		upstreamProvider, upErr := options.upstreamFactory(ctx, upCfg)
+		upstreamProvider, upErr := upstreamFactory(ctx, upCfg)
 		if upErr != nil {
 			return nil, fmt.Errorf("failed to create upstream provider %q: %w", upCfg.Name, upErr)
 		}
@@ -393,9 +406,25 @@ func newUpstreamTokenRefresher(
 	}
 }
 
+// CloseIdleConnections releases the idle keep-alive connections pooled by the
+// server's upstream IDP providers. See the Server interface for why this is kept
+// separate from Close.
+func (s *server) CloseIdleConnections() {
+	for _, u := range s.upstreams {
+		// Optional capability: the OAuth2Provider interface is open to external
+		// implementations, so a provider that holds no pool of its own simply
+		// does not implement it.
+		if closer, ok := u.Provider.(upstream.IdleConnectionCloser); ok {
+			slog.Debug("closing upstream idle connections", "name", u.Name)
+			closer.CloseIdleConnections()
+		}
+	}
+}
+
 // Close releases resources held by the server.
 func (s *server) Close() error {
 	slog.Debug("closing OAuth authorization server")
+	s.CloseIdleConnections()
 	return s.storage.Close()
 }
 

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -788,6 +788,13 @@ func TestServer_Close_DrainsRealOIDCUpstream(t *testing.T) {
 	t.Cleanup(issuer.Close)
 
 	stor := storage.NewMemoryStorage()
+	var closeOnce sync.Once
+	closeStorage := func() { closeOnce.Do(func() { _ = stor.Close() }) }
+	// Registered so an aborted require below does not leave storage running;
+	// idempotent because srv.Close() closes the same store, and
+	// MemoryStorage.Close panics if called twice.
+	t.Cleanup(closeStorage)
+
 	srv, err := newServer(t.Context(), Config{
 		Issuer:      "https://example.com",
 		KeyProvider: keys.NewGeneratingProvider(keys.DefaultAlgorithm),
@@ -811,11 +818,14 @@ func TestServer_Close_DrainsRealOIDCUpstream(t *testing.T) {
 	require.NoError(t, err)
 	require.IsType(t, &upstream.OIDCProviderImpl{}, srv.upstreams[0].Provider)
 
-	// Discovery leaves one idle keep-alive connection behind; before this change
-	// it was retained for the lifetime of the process.
-	require.Equal(t, int32(1), openConns.Load(), "discovery must leave a pooled connection")
+	// Discovery leaves at least one idle keep-alive connection behind; before
+	// this change it was retained for the lifetime of the process. Not an exact
+	// count — go-oidc is free to add a fetch or a retry, and ConnState fires on
+	// the httptest server's own goroutines.
+	require.GreaterOrEqual(t, openConns.Load(), int32(1), "discovery must leave a pooled connection")
 
 	require.NoError(t, srv.Close())
+	closeOnce.Do(func() {}) // srv.Close closed the store; disarm the cleanup
 
 	// The issuer observes the close asynchronously.
 	assert.Eventually(t, func() bool { return openConns.Load() == 0 }, 5*time.Second, 10*time.Millisecond,

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -713,6 +713,34 @@ func TestBuildUpstreams_DrainsAlreadyBuiltProvidersOnFailure(t *testing.T) {
 		"the provider built before the failure must be drained")
 }
 
+// TestBuildUpstreams_RejectsNilProvider pins that a custom
+// Config.UpstreamFactory cannot drop an upstream by returning (nil, nil). Such a
+// NamedUpstream would be wired into the authorization chain and panic on the
+// first /oauth/authorize request, after any startup health check had passed.
+func TestBuildUpstreams_RejectsNilProvider(t *testing.T) {
+	t.Parallel()
+
+	built := &closeCountingProvider{}
+	cfg := Config{Upstreams: []UpstreamConfig{
+		{Name: "first", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
+		{Name: "second", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
+	}}
+
+	factory := func(_ context.Context, upCfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
+		if upCfg.Name == "second" {
+			return nil, nil //nolint:nilnil // the point of the test: a nil provider with no error
+		}
+		return built, nil
+	}
+
+	upstreams, err := buildUpstreams(t.Context(), cfg, factory)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `nil provider for upstream "second"`)
+	assert.Nil(t, upstreams)
+	assert.Equal(t, int32(1), built.closes.Load(),
+		"the provider built before the rejection must be drained")
+}
+
 // TestServer_Close_DrainsRealOIDCUpstream exercises the production wiring that
 // the other tests stub out: a server built through DefaultUpstreamFactory holds
 // an *upstream.OIDCProviderImpl, which satisfies upstream.IdleConnectionCloser

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -6,8 +6,12 @@ package authserver
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -679,4 +683,112 @@ func TestNewServer_UpstreamFactoryPrecedence(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildUpstreams_DrainsAlreadyBuiltProvidersOnFailure pins the pathological
+// case from #6479: a caller retrying a reconstruction against an unreachable
+// issuer must not accumulate a live connection pool per attempt for the
+// upstreams that did construct before the failure.
+func TestBuildUpstreams_DrainsAlreadyBuiltProvidersOnFailure(t *testing.T) {
+	t.Parallel()
+
+	built := &closeCountingProvider{}
+	cfg := Config{Upstreams: []UpstreamConfig{
+		{Name: "first", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
+		{Name: "second", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
+	}}
+
+	factory := func(_ context.Context, upCfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
+		if upCfg.Name == "second" {
+			return nil, assert.AnError
+		}
+		return built, nil
+	}
+
+	upstreams, err := buildUpstreams(t.Context(), cfg, factory)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), `"second"`, "the error must name the failing upstream")
+	assert.Nil(t, upstreams)
+	assert.Equal(t, int32(1), built.closes.Load(),
+		"the provider built before the failure must be drained")
+}
+
+// TestServer_Close_DrainsRealOIDCUpstream exercises the production wiring that
+// the other tests stub out: a server built through DefaultUpstreamFactory holds
+// an *upstream.OIDCProviderImpl, which satisfies upstream.IdleConnectionCloser
+// only by promotion from its embedded *BaseOAuth2Provider. The pool is observed
+// from the issuer's side, so this fails if the type assertion in
+// closeUpstreamIdleConnections ever silently stops matching.
+func TestServer_Close_DrainsRealOIDCUpstream(t *testing.T) {
+	t.Parallel()
+
+	var openConns atomic.Int32
+	issuer := httptest.NewUnstartedServer(nil)
+	issuer.Config.Handler = oidcDiscoveryHandler(func() string { return issuer.URL })
+	issuer.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		switch state {
+		case http.StateNew:
+			openConns.Add(1)
+		case http.StateClosed, http.StateHijacked:
+			openConns.Add(-1)
+		case http.StateActive, http.StateIdle:
+		}
+	}
+	issuer.Start()
+	t.Cleanup(issuer.Close)
+
+	stor := storage.NewMemoryStorage()
+	srv, err := newServer(t.Context(), Config{
+		Issuer:      "https://example.com",
+		KeyProvider: keys.NewGeneratingProvider(keys.DefaultAlgorithm),
+		HMACSecrets: &servercrypto.HMACSecrets{Current: validHMACSecret()},
+		Upstreams: []UpstreamConfig{{
+			Name: "oidc",
+			Type: UpstreamProviderTypeOIDC,
+			OIDCConfig: &upstream.OIDCConfig{
+				CommonOAuthConfig: upstream.CommonOAuthConfig{
+					ClientID:    "test-client",
+					RedirectURI: "https://example.com/callback",
+					Scopes:      []string{"openid"},
+				},
+				Issuer:            issuer.URL,
+				InsecureAllowHTTP: true,
+				AllowPrivateIPs:   true,
+			},
+		}},
+		AllowedAudiences: []string{"https://mcp.example.com"},
+	}, stor)
+	require.NoError(t, err)
+	require.IsType(t, &upstream.OIDCProviderImpl{}, srv.upstreams[0].Provider)
+
+	// Discovery leaves one idle keep-alive connection behind; before this change
+	// it was retained for the lifetime of the process.
+	require.Equal(t, int32(1), openConns.Load(), "discovery must leave a pooled connection")
+
+	require.NoError(t, srv.Close())
+
+	// The issuer observes the close asynchronously.
+	assert.Eventually(t, func() bool { return openConns.Load() == 0 }, 5*time.Second, 10*time.Millisecond,
+		"Close must drain the OIDC upstream's pooled connection")
+}
+
+// oidcDiscoveryHandler serves the minimum OIDC discovery document
+// upstream.NewOIDCProvider accepts. issuerURL is a func because httptest only
+// knows the bound URL after Start.
+func oidcDiscoveryHandler(issuerURL func() string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		base := issuerURL()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                base,
+			"authorization_endpoint":                base + "/auth",
+			"token_endpoint":                        base + "/token",
+			"jwks_uri":                              base + "/jwks",
+			"response_types_supported":              []string{"code"},
+			"subject_types_supported":               []string{"public"},
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	})
+	return mux
 }

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -529,6 +529,18 @@ type plainProvider struct {
 	upstream.OAuth2Provider
 }
 
+// capabilityFreeServer is a Server implementation that does NOT implement the
+// idleConnectionCloser capability, standing in for an out-of-tree implementation
+// or test double — the reason CloseIdleConnections is a function rather than a
+// Server method.
+type capabilityFreeServer struct{}
+
+func (capabilityFreeServer) Handler() http.Handler                                  { return nil }
+func (capabilityFreeServer) IDPTokenStorage() storage.UpstreamTokenStorage          { return nil }
+func (capabilityFreeServer) UpstreamTokenRefresher() storage.UpstreamTokenRefresher { return nil }
+func (capabilityFreeServer) DCRStore() storage.DCRCredentialStore                   { return nil }
+func (capabilityFreeServer) Close() error                                           { return nil }
+
 // eventRecordingStorage records when the server closes storage, so the ordering
 // between upstream draining and storage teardown can be asserted. Close does not
 // delegate: MemoryStorage.Close panics when called twice and the test cleanup
@@ -851,4 +863,44 @@ func oidcDiscoveryHandler(issuerURL func() string) http.Handler {
 		})
 	})
 	return mux
+}
+
+// TestCloseIdleConnectionsFunction pins the capability-detection contract that
+// keeps CloseIdleConnections off the Server interface: it drains a server built
+// by New and reports true, and it reports false — without panicking — for an
+// implementation that predates the capability, which is what an out-of-tree
+// Server or test double looks like.
+func TestCloseIdleConnectionsFunction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("drains a server from New and reports true", func(t *testing.T) {
+		t.Parallel()
+
+		stor := storage.NewMemoryStorage()
+		t.Cleanup(func() { _ = stor.Close() })
+
+		provider := &closeCountingProvider{}
+		srv, err := newServer(t.Context(), Config{
+			Issuer:           "https://example.com",
+			KeyProvider:      keys.NewGeneratingProvider(keys.DefaultAlgorithm),
+			HMACSecrets:      &servercrypto.HMACSecrets{Current: validHMACSecret()},
+			Upstreams:        []UpstreamConfig{{Name: "only", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()}},
+			AllowedAudiences: []string{"https://mcp.example.com"},
+			UpstreamFactory: func(_ context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
+				return provider, nil
+			},
+		}, stor)
+		require.NoError(t, err)
+
+		// Called through the Server interface, exactly as an embedder would.
+		var asInterface Server = srv
+		assert.True(t, CloseIdleConnections(asInterface))
+		assert.Equal(t, int32(1), provider.closes.Load())
+	})
+
+	t.Run("reports false for an implementation without the capability", func(t *testing.T) {
+		t.Parallel()
+
+		assert.False(t, CloseIdleConnections(capabilityFreeServer{}))
+	})
 }

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -6,9 +6,11 @@ package authserver
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -493,4 +495,188 @@ func TestNewServer_RegistersDelegateClientsBeforeUpstreamConstruction(t *testing
 	client, err := stor.GetClient(ctx, "delegate")
 	require.NoError(t, err)
 	assert.False(t, registration.DCRIssued(client))
+}
+
+// closeCountingProvider is an OAuth2Provider that implements the optional
+// upstream.IdleConnectionCloser capability and records invocations.
+type closeCountingProvider struct {
+	upstream.OAuth2Provider
+	closes  atomic.Int32
+	onClose func()
+}
+
+func (p *closeCountingProvider) CloseIdleConnections() {
+	p.closes.Add(1)
+	if p.onClose != nil {
+		p.onClose()
+	}
+}
+
+// plainProvider is an OAuth2Provider that does NOT implement
+// upstream.IdleConnectionCloser, standing in for an external implementation of
+// the open interface.
+type plainProvider struct {
+	upstream.OAuth2Provider
+}
+
+// eventRecordingStorage records when the server closes storage, so the ordering
+// between upstream draining and storage teardown can be asserted. Close does not
+// delegate: MemoryStorage.Close panics when called twice and the test cleanup
+// closes the underlying store.
+type eventRecordingStorage struct {
+	*storage.MemoryStorage
+	record func(string)
+}
+
+func (s *eventRecordingStorage) Unwrap() storage.Storage { return s.MemoryStorage }
+
+func (s *eventRecordingStorage) Close() error {
+	s.record("storage")
+	return nil
+}
+
+// TestServer_CloseIdleConnections pins the Close/CloseIdleConnections split that
+// lets an embedder retire a superseded server without closing the storage a
+// replacement server is still serving through (see #6479). It also pins that
+// providers lacking the optional capability are skipped rather than panicking.
+func TestServer_CloseIdleConnections(t *testing.T) {
+	t.Parallel()
+
+	newTestServer := func(t *testing.T, record func(string), providers ...upstream.OAuth2Provider) *server {
+		t.Helper()
+
+		base := storage.NewMemoryStorage()
+		t.Cleanup(func() { _ = base.Close() })
+		stor := &eventRecordingStorage{MemoryStorage: base, record: record}
+
+		upstreams := make([]UpstreamConfig, 0, len(providers))
+		for i := range providers {
+			upstreams = append(upstreams, UpstreamConfig{
+				Name:         fmt.Sprintf("upstream-%d", i),
+				Type:         UpstreamProviderTypeOAuth2,
+				OAuth2Config: validUpstreamConfig(),
+			})
+		}
+
+		next := 0
+		factory := func(_ context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
+			p := providers[next]
+			next++
+			return p, nil
+		}
+
+		srv, err := newServer(t.Context(), Config{
+			Issuer:           "https://example.com",
+			KeyProvider:      keys.NewGeneratingProvider(keys.DefaultAlgorithm),
+			HMACSecrets:      &servercrypto.HMACSecrets{Current: validHMACSecret()},
+			Upstreams:        upstreams,
+			AllowedAudiences: []string{"https://mcp.example.com"},
+		}, stor, withUpstreamFactory(factory))
+		require.NoError(t, err)
+		return srv
+	}
+
+	t.Run("drains every capable upstream without closing storage", func(t *testing.T) {
+		t.Parallel()
+
+		var events []string
+		first, second := &closeCountingProvider{}, &closeCountingProvider{}
+		srv := newTestServer(t, func(e string) { events = append(events, e) }, first, second)
+
+		srv.CloseIdleConnections()
+
+		assert.Equal(t, int32(1), first.closes.Load())
+		assert.Equal(t, int32(1), second.closes.Load())
+		// Leaving storage open is the whole point of the split: an embedder
+		// retiring a superseded server must not tear down the storage the
+		// replacement server is serving through.
+		assert.Empty(t, events, "CloseIdleConnections must not touch storage")
+	})
+
+	t.Run("Close drains upstreams then closes storage", func(t *testing.T) {
+		t.Parallel()
+
+		var events []string
+		record := func(e string) { events = append(events, e) }
+		provider := &closeCountingProvider{}
+		provider.onClose = func() { record("upstream") }
+		srv := newTestServer(t, record, provider)
+
+		require.NoError(t, srv.Close())
+
+		assert.Equal(t, int32(1), provider.closes.Load())
+		assert.Equal(t, []string{"upstream", "storage"}, events)
+	})
+
+	t.Run("skips upstreams without the capability", func(t *testing.T) {
+		t.Parallel()
+
+		capable := &closeCountingProvider{}
+		srv := newTestServer(t, func(string) {}, &plainProvider{}, capable)
+
+		assert.NotPanics(t, srv.CloseIdleConnections)
+		assert.Equal(t, int32(1), capable.closes.Load())
+	})
+}
+
+// TestNewServer_UpstreamFactoryPrecedence pins that a caller can own upstream
+// construction through Config.UpstreamFactory, that the in-package test seam
+// still overrides it, and that DefaultUpstreamFactory is used when neither is
+// set.
+func TestNewServer_UpstreamFactoryPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		setConfig  bool
+		setOption  bool
+		wantSource string
+	}{
+		{name: "config factory is used", setConfig: true, wantSource: "config"},
+		{name: "option overrides config factory", setConfig: true, setOption: true, wantSource: "option"},
+		{name: "option alone is used", setOption: true, wantSource: "option"},
+		// Neither set: DefaultUpstreamFactory runs and builds a real
+		// BaseOAuth2Provider from validUpstreamConfig.
+		{name: "default factory is used when neither is set", wantSource: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stor := storage.NewMemoryStorage()
+			t.Cleanup(func() { _ = stor.Close() })
+
+			var source string
+			factoryNamed := func(name string) UpstreamProviderFactory {
+				return func(_ context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
+					source = name
+					return &plainProvider{}, nil
+				}
+			}
+
+			cfg := Config{
+				Issuer:           "https://example.com",
+				KeyProvider:      keys.NewGeneratingProvider(keys.DefaultAlgorithm),
+				HMACSecrets:      &servercrypto.HMACSecrets{Current: validHMACSecret()},
+				Upstreams:        []UpstreamConfig{{Name: "default", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()}},
+				AllowedAudiences: []string{"https://mcp.example.com"},
+			}
+			if tt.setConfig {
+				cfg.UpstreamFactory = factoryNamed("config")
+			}
+			var opts []serverOption
+			if tt.setOption {
+				opts = append(opts, withUpstreamFactory(factoryNamed("option")))
+			}
+
+			srv, err := newServer(t.Context(), cfg, stor, opts...)
+			require.NoError(t, err)
+			require.Len(t, srv.upstreams, 1)
+			assert.Equal(t, tt.wantSource, source)
+			if tt.wantSource == "" {
+				assert.IsType(t, &upstream.BaseOAuth2Provider{}, srv.upstreams[0].Provider)
+			}
+		})
+	}
 }

--- a/pkg/authserver/server_test.go
+++ b/pkg/authserver/server_test.go
@@ -184,8 +184,9 @@ func TestNewServer_Success(t *testing.T) {
 	}
 
 	// Call newServer with the mock factory
+	cfg.UpstreamFactory = mockFactory
 	ctx := context.Background()
-	srv, err := newServer(ctx, cfg, stor, withUpstreamFactory(mockFactory))
+	srv, err := newServer(ctx, cfg, stor)
 
 	if err != nil {
 		t.Fatalf("newServer() unexpected error: %v", err)
@@ -323,7 +324,9 @@ func TestNewServer_AllowConfidentialClientRegistration_Logs(t *testing.T) {
 			stor := storage.NewMemoryStorage()
 			t.Cleanup(func() { _ = stor.Close() })
 
-			srv, err := newServer(context.Background(), newCfg(tt.allowConfidential), stor, withUpstreamFactory(mockFactory))
+			cfg := newCfg(tt.allowConfidential)
+			cfg.UpstreamFactory = mockFactory
+			srv, err := newServer(context.Background(), cfg, stor)
 			require.NoError(t, err, "startup must succeed for every flag combination")
 			require.NotNil(t, srv)
 
@@ -388,7 +391,8 @@ func TestNewServer_CIMDEnabled_WrapsStorage(t *testing.T) {
 		return mockUpstream, nil
 	}
 
-	srv, err := newServer(context.Background(), cfg, stor, withUpstreamFactory(mockFactory))
+	cfg.UpstreamFactory = mockFactory
+	srv, err := newServer(context.Background(), cfg, stor)
 	if err != nil {
 		t.Fatalf("newServer() unexpected error: %v", err)
 	}
@@ -426,7 +430,8 @@ func TestNewServer_UpstreamRefresherSharedInstance(t *testing.T) {
 		return mockUpstream, nil
 	}
 
-	srv, err := newServer(context.Background(), cfg, stor, withUpstreamFactory(mockFactory))
+	cfg.UpstreamFactory = mockFactory
+	srv, err := newServer(context.Background(), cfg, stor)
 	require.NoError(t, err)
 
 	first := srv.UpstreamTokenRefresher()
@@ -486,7 +491,8 @@ func TestNewServer_RegistersDelegateClientsBeforeUpstreamConstruction(t *testing
 		return nil, assert.AnError
 	}
 
-	_, err := newServer(ctx, cfg, stor, withUpstreamFactory(factory))
+	cfg.UpstreamFactory = factory
+	_, err := newServer(ctx, cfg, stor)
 	require.ErrorIs(t, err, assert.AnError)
 
 	// Startup registration is an upsert. Replacing a same-ID DCR client makes
@@ -494,7 +500,7 @@ func TestNewServer_RegistersDelegateClientsBeforeUpstreamConstruction(t *testing
 	dcrClient, err := registration.NewConfidentialPlain(registration.Config{ID: "delegate", Secret: "old-secret"})
 	require.NoError(t, err)
 	require.NoError(t, stor.RegisterClient(ctx, dcrClient))
-	_, err = newServer(ctx, cfg, stor, withUpstreamFactory(factory))
+	_, err = newServer(ctx, cfg, stor)
 	require.ErrorIs(t, err, assert.AnError)
 	client, err := stor.GetClient(ctx, "delegate")
 	require.NoError(t, err)
@@ -575,7 +581,8 @@ func TestServer_CloseIdleConnections(t *testing.T) {
 			HMACSecrets:      &servercrypto.HMACSecrets{Current: validHMACSecret()},
 			Upstreams:        upstreams,
 			AllowedAudiences: []string{"https://mcp.example.com"},
-		}, stor, withUpstreamFactory(factory))
+			UpstreamFactory:  factory,
+		}, stor)
 		require.NoError(t, err)
 		return srv
 	}
@@ -623,25 +630,22 @@ func TestServer_CloseIdleConnections(t *testing.T) {
 	})
 }
 
-// TestNewServer_UpstreamFactoryPrecedence pins that a caller can own upstream
-// construction through Config.UpstreamFactory, that the in-package test seam
-// still overrides it, and that DefaultUpstreamFactory is used when neither is
-// set.
-func TestNewServer_UpstreamFactoryPrecedence(t *testing.T) {
+// TestNewServer_UpstreamFactory pins that a caller can own upstream
+// construction through Config.UpstreamFactory, and that DefaultUpstreamFactory
+// is used when the field is nil.
+func TestNewServer_UpstreamFactory(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name       string
-		setConfig  bool
-		setOption  bool
-		wantSource string
+		setFactory bool
+		// wantCustom is true when the caller's factory should have run; false
+		// means DefaultUpstreamFactory built a real BaseOAuth2Provider from
+		// validUpstreamConfig.
+		wantCustom bool
 	}{
-		{name: "config factory is used", setConfig: true, wantSource: "config"},
-		{name: "option overrides config factory", setConfig: true, setOption: true, wantSource: "option"},
-		{name: "option alone is used", setOption: true, wantSource: "option"},
-		// Neither set: DefaultUpstreamFactory runs and builds a real
-		// BaseOAuth2Provider from validUpstreamConfig.
-		{name: "default factory is used when neither is set", wantSource: ""},
+		{name: "config factory is used", setFactory: true, wantCustom: true},
+		{name: "default factory is used when the field is nil"},
 	}
 
 	for _, tt := range tests {
@@ -651,14 +655,7 @@ func TestNewServer_UpstreamFactoryPrecedence(t *testing.T) {
 			stor := storage.NewMemoryStorage()
 			t.Cleanup(func() { _ = stor.Close() })
 
-			var source string
-			factoryNamed := func(name string) UpstreamProviderFactory {
-				return func(_ context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
-					source = name
-					return &plainProvider{}, nil
-				}
-			}
-
+			var called bool
 			cfg := Config{
 				Issuer:           "https://example.com",
 				KeyProvider:      keys.NewGeneratingProvider(keys.DefaultAlgorithm),
@@ -666,19 +663,22 @@ func TestNewServer_UpstreamFactoryPrecedence(t *testing.T) {
 				Upstreams:        []UpstreamConfig{{Name: "default", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()}},
 				AllowedAudiences: []string{"https://mcp.example.com"},
 			}
-			if tt.setConfig {
-				cfg.UpstreamFactory = factoryNamed("config")
-			}
-			var opts []serverOption
-			if tt.setOption {
-				opts = append(opts, withUpstreamFactory(factoryNamed("option")))
+			if tt.setFactory {
+				cfg.UpstreamFactory = func(_ context.Context, _ *UpstreamConfig) (upstream.OAuth2Provider, error) {
+					called = true
+					return &plainProvider{}, nil
+				}
 			}
 
-			srv, err := newServer(t.Context(), cfg, stor, opts...)
+			srv, err := newServer(t.Context(), cfg, stor)
 			require.NoError(t, err)
+			// The default factory builds a provider with a live pool; drain it
+			// so the suite does not leak the resource this change fixes.
+			t.Cleanup(srv.CloseIdleConnections)
+
 			require.Len(t, srv.upstreams, 1)
-			assert.Equal(t, tt.wantSource, source)
-			if tt.wantSource == "" {
+			assert.Equal(t, tt.wantCustom, called)
+			if !tt.wantCustom {
 				assert.IsType(t, &upstream.BaseOAuth2Provider{}, srv.upstreams[0].Provider)
 			}
 		})
@@ -693,19 +693,20 @@ func TestBuildUpstreams_DrainsAlreadyBuiltProvidersOnFailure(t *testing.T) {
 	t.Parallel()
 
 	built := &closeCountingProvider{}
-	cfg := Config{Upstreams: []UpstreamConfig{
-		{Name: "first", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
-		{Name: "second", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
-	}}
-
-	factory := func(_ context.Context, upCfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
-		if upCfg.Name == "second" {
-			return nil, assert.AnError
-		}
-		return built, nil
+	cfg := Config{
+		Upstreams: []UpstreamConfig{
+			{Name: "first", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
+			{Name: "second", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
+		},
+		UpstreamFactory: func(_ context.Context, upCfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
+			if upCfg.Name == "second" {
+				return nil, assert.AnError
+			}
+			return built, nil
+		},
 	}
 
-	upstreams, err := buildUpstreams(t.Context(), cfg, factory)
+	upstreams, err := buildUpstreams(t.Context(), cfg)
 	require.ErrorIs(t, err, assert.AnError)
 	assert.Contains(t, err.Error(), `"second"`, "the error must name the failing upstream")
 	assert.Nil(t, upstreams)
@@ -720,25 +721,46 @@ func TestBuildUpstreams_DrainsAlreadyBuiltProvidersOnFailure(t *testing.T) {
 func TestBuildUpstreams_RejectsNilProvider(t *testing.T) {
 	t.Parallel()
 
-	built := &closeCountingProvider{}
-	cfg := Config{Upstreams: []UpstreamConfig{
-		{Name: "first", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
-		{Name: "second", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
-	}}
-
-	factory := func(_ context.Context, upCfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
-		if upCfg.Name == "second" {
-			return nil, nil //nolint:nilnil // the point of the test: a nil provider with no error
-		}
-		return built, nil
+	tests := []struct {
+		name     string
+		provider upstream.OAuth2Provider
+	}{
+		// A nil interface value.
+		{name: "nil interface"},
+		// An interface holding a nil pointer — non-nil as an interface, so it
+		// passes a bare `== nil` check, satisfies the IdleConnectionCloser
+		// assertion, and then nil-derefs on the embedded *BaseOAuth2Provider
+		// during the drain. An easy mistake in the "substitute a provider"
+		// pattern Config.UpstreamFactory documents.
+		{name: "typed nil pointer", provider: (*upstream.OIDCProviderImpl)(nil)},
 	}
 
-	upstreams, err := buildUpstreams(t.Context(), cfg, factory)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `nil provider for upstream "second"`)
-	assert.Nil(t, upstreams)
-	assert.Equal(t, int32(1), built.closes.Load(),
-		"the provider built before the rejection must be drained")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			built := &closeCountingProvider{}
+			cfg := Config{
+				Upstreams: []UpstreamConfig{
+					{Name: "first", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
+					{Name: "second", Type: UpstreamProviderTypeOAuth2, OAuth2Config: validUpstreamConfig()},
+				},
+				UpstreamFactory: func(_ context.Context, upCfg *UpstreamConfig) (upstream.OAuth2Provider, error) {
+					if upCfg.Name == "second" {
+						return tt.provider, nil
+					}
+					return built, nil
+				},
+			}
+
+			upstreams, err := buildUpstreams(t.Context(), cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), `nil provider for upstream "second"`)
+			assert.Nil(t, upstreams)
+			assert.Equal(t, int32(1), built.closes.Load(),
+				"the provider built before the rejection must be drained")
+		})
+	}
 }
 
 // TestServer_Close_DrainsRealOIDCUpstream exercises the production wiring that

--- a/pkg/authserver/upstream/doc.go
+++ b/pkg/authserver/upstream/doc.go
@@ -72,10 +72,8 @@
 // To add a new IDP type (e.g., SAML), implement the OAuth2Provider interface.
 //
 // A provider that owns an HTTP client should also implement the optional
-// IdleConnectionCloser capability so consumers can release its pooled
-// connections when the provider is retired. It is deliberately not part of
-// OAuth2Provider: adding it there would break existing implementations, and a
-// provider that holds no pool has nothing to release.
+// IdleConnectionCloser capability, so consumers can release its pooled
+// connections when the provider is retired.
 //
 // # UserInfo Extensibility
 //

--- a/pkg/authserver/upstream/doc.go
+++ b/pkg/authserver/upstream/doc.go
@@ -71,6 +71,12 @@
 //
 // To add a new IDP type (e.g., SAML), implement the OAuth2Provider interface.
 //
+// A provider that owns an HTTP client should also implement the optional
+// IdleConnectionCloser capability so consumers can release its pooled
+// connections when the provider is retired. It is deliberately not part of
+// OAuth2Provider: adding it there would break existing implementations, and a
+// provider that holds no pool has nothing to release.
+//
 // # UserInfo Extensibility
 //
 // The package supports flexible userinfo fetching through UserInfoConfig.

--- a/pkg/authserver/upstream/mocks/mock_provider.go
+++ b/pkg/authserver/upstream/mocks/mock_provider.go
@@ -104,3 +104,39 @@ func (mr *MockOAuth2ProviderMockRecorder) Type() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockOAuth2Provider)(nil).Type))
 }
+
+// MockIdleConnectionCloser is a mock of IdleConnectionCloser interface.
+type MockIdleConnectionCloser struct {
+	ctrl     *gomock.Controller
+	recorder *MockIdleConnectionCloserMockRecorder
+	isgomock struct{}
+}
+
+// MockIdleConnectionCloserMockRecorder is the mock recorder for MockIdleConnectionCloser.
+type MockIdleConnectionCloserMockRecorder struct {
+	mock *MockIdleConnectionCloser
+}
+
+// NewMockIdleConnectionCloser creates a new mock instance.
+func NewMockIdleConnectionCloser(ctrl *gomock.Controller) *MockIdleConnectionCloser {
+	mock := &MockIdleConnectionCloser{ctrl: ctrl}
+	mock.recorder = &MockIdleConnectionCloserMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIdleConnectionCloser) EXPECT() *MockIdleConnectionCloserMockRecorder {
+	return m.recorder
+}
+
+// CloseIdleConnections mocks base method.
+func (m *MockIdleConnectionCloser) CloseIdleConnections() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CloseIdleConnections")
+}
+
+// CloseIdleConnections indicates an expected call of CloseIdleConnections.
+func (mr *MockIdleConnectionCloserMockRecorder) CloseIdleConnections() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseIdleConnections", reflect.TypeOf((*MockIdleConnectionCloser)(nil).CloseIdleConnections))
+}

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -296,6 +296,22 @@ type BaseOAuth2Provider struct {
 	httpClient   *http.Client
 }
 
+// IdleConnectionCloser is an optional capability an OAuth2Provider may
+// implement to release the idle keep-alive connections held by its private HTTP
+// client. It is deliberately kept out of the OAuth2Provider interface: doc.go
+// invites external implementations of that interface, so widening it would be a
+// breaking change. Consumers should type-assert against this interface and treat
+// a provider that does not implement it as having nothing to release.
+//
+// The connections are only idle ones; in-flight requests are unaffected and the
+// provider remains usable afterwards (a subsequent call simply dials again).
+type IdleConnectionCloser interface {
+	CloseIdleConnections()
+}
+
+// Compile-time capability check.
+var _ IdleConnectionCloser = (*BaseOAuth2Provider)(nil)
+
 // OAuth2ProviderOption configures a BaseOAuth2Provider.
 type OAuth2ProviderOption func(*BaseOAuth2Provider)
 
@@ -346,6 +362,20 @@ func newBaseOAuth2Provider(config *OAuth2Config, hostForClient string) (*BaseOAu
 		oauth2Config: oauth2Cfg,
 		httpClient:   httpClient,
 	}, nil
+}
+
+// CloseIdleConnections releases the idle keep-alive connections pooled by the
+// provider's HTTP client. The provider stays usable: only idle connections are
+// closed, and later requests dial fresh ones.
+//
+// Call this when retiring a provider. Without it the pool's sockets and their
+// servicing goroutines are held until the idle timeout elapses, and a process
+// that constructs providers repeatedly accumulates them in the meantime.
+func (p *BaseOAuth2Provider) CloseIdleConnections() {
+	if p.httpClient == nil {
+		return
+	}
+	p.httpClient.CloseIdleConnections()
 }
 
 // authStyleFromMethod maps an RFC 7591 token_endpoint_auth_method to the

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -323,6 +323,12 @@ type OAuth2ProviderOption func(*BaseOAuth2Provider)
 // WithOAuth2HTTPClient sets a custom HTTP client. The caller retains ownership
 // of its connection pool: CloseIdleConnections leaves an injected client alone,
 // so one client can be shared safely across providers and reconstructions.
+//
+// The injected client fully supersedes the one the provider would have built,
+// so the caller also owns its TLS trust and SSRF posture: the config's
+// CAFilePath, AllowPrivateIPs and InsecureAllowHTTP shape only the default
+// client and are not applied here. A set CAFilePath is logged as a warning
+// because it is otherwise inert.
 func WithOAuth2HTTPClient(client *http.Client) OAuth2ProviderOption {
 	return func(p *BaseOAuth2Provider) {
 		p.httpClient = client
@@ -361,6 +367,8 @@ func newBaseOAuth2Provider(
 		}
 		p.httpClient = httpClient
 		p.ownsHTTPClient = true
+	} else {
+		warnInjectedClientSupersedesCABundle(config.CAFilePath)
 	}
 
 	// AuthStyle is derived from the negotiated token_endpoint_auth_method
@@ -403,6 +411,19 @@ func (p *BaseOAuth2Provider) CloseIdleConnections() {
 		return
 	}
 	p.httpClient.CloseIdleConnections()
+}
+
+// warnInjectedClientSupersedesCABundle warns when an operator configured a CA
+// bundle that a caller-injected HTTP client makes inert. The bundle used to be
+// read (and validated) unconditionally, so dropping it silently would turn an
+// explicit trust decision into a no-op with no signal.
+func warnInjectedClientSupersedesCABundle(caFilePath string) {
+	if caFilePath == "" {
+		return
+	}
+	slog.Warn("ignoring upstream caFilePath: the injected HTTP client supersedes it; "+
+		"configure the CA bundle on that client instead",
+		"ca_file_path", caFilePath)
 }
 
 // authStyleFromMethod maps an RFC 7591 token_endpoint_auth_method to the

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -308,15 +308,18 @@ type BaseOAuth2Provider struct {
 // trust-anchor misconfiguration a boot-time error rather than a silent no-op.
 var ErrCABundleWithInjectedClient = errors.New("caFilePath cannot be combined with an injected HTTP client")
 
-// IdleConnectionCloser is an optional capability an OAuth2Provider may
-// implement to release the idle keep-alive connections held by its private HTTP
-// client. It is deliberately kept out of the OAuth2Provider interface: doc.go
-// invites external implementations of that interface, so widening it would be a
-// breaking change. Consumers should type-assert against this interface and treat
-// a provider that does not implement it as having nothing to release.
+// IdleConnectionCloser is an optional capability an OAuth2Provider may implement
+// to release the idle keep-alive connections held by its HTTP client. It is the
+// provider-level analogue of networking.IdleConnectionCloser, and is optional
+// rather than part of OAuth2Provider because doc.go invites external
+// implementations of that interface, which widening would break. Consumers
+// type-assert against it and treat a provider that does not implement it as
+// having nothing to release.
 //
-// The connections are only idle ones; in-flight requests are unaffected and the
-// provider remains usable afterwards (a subsequent call simply dials again).
+// Only idle connections are closed: in-flight requests are unaffected and the
+// provider stays usable, dialing again on its next call. An implementation must
+// leave a caller-supplied client alone — the caller may be sharing it — which is
+// the ownership rule BaseOAuth2Provider.CloseIdleConnections implements.
 type IdleConnectionCloser interface {
 	CloseIdleConnections()
 }

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -349,7 +349,7 @@ func newBaseOAuth2Provider(
 	config *OAuth2Config,
 	hostForClient string,
 	opts ...OAuth2ProviderOption,
-) (*BaseOAuth2Provider, error) {
+) (_ *BaseOAuth2Provider, retErr error) {
 	if err := config.ValidateWithInsecure(config.InsecureAllowHTTP); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
@@ -367,6 +367,14 @@ func newBaseOAuth2Provider(
 		}
 		p.httpClient = httpClient
 		p.ownsHTTPClient = true
+		// A later failure (an unsupported token_endpoint_auth_method) otherwise
+		// abandons the client with no caller able to reach it. Symmetric with
+		// NewOIDCProvider; the ownership check leaves an injected client alone.
+		defer func() {
+			if retErr != nil {
+				p.CloseIdleConnections()
+			}
+		}()
 	} else {
 		warnInjectedClientSupersedesCABundle(config.CAFilePath)
 	}
@@ -417,6 +425,12 @@ func (p *BaseOAuth2Provider) CloseIdleConnections() {
 // bundle that a caller-injected HTTP client makes inert. The bundle used to be
 // read (and validated) unconditionally, so dropping it silently would turn an
 // explicit trust decision into a no-op with no signal.
+//
+// CAFilePath is the only superseded field warned about, deliberately:
+// AllowPrivateIPs was already inert with an injected client before options moved
+// ahead of the client build (the option simply overwrote the built client), and
+// InsecureAllowHTTP still drives ValidateWithInsecure. CAFilePath is the one
+// field whose validation this ordering removed.
 func warnInjectedClientSupersedesCABundle(caFilePath string) {
 	if caFilePath == "" {
 		return

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -301,6 +301,13 @@ type BaseOAuth2Provider struct {
 	ownsHTTPClient bool
 }
 
+// ErrCABundleWithInjectedClient is returned when a provider config sets
+// CAFilePath while the caller also injects an HTTP client via
+// WithOAuth2HTTPClient / WithHTTPClient. The injected client carries its own TLS
+// trust, so the bundle could never take effect; failing loudly keeps a
+// trust-anchor misconfiguration a boot-time error rather than a silent no-op.
+var ErrCABundleWithInjectedClient = errors.New("caFilePath cannot be combined with an injected HTTP client")
+
 // IdleConnectionCloser is an optional capability an OAuth2Provider may
 // implement to release the idle keep-alive connections held by its private HTTP
 // client. It is deliberately kept out of the OAuth2Provider interface: doc.go
@@ -320,15 +327,16 @@ var _ IdleConnectionCloser = (*BaseOAuth2Provider)(nil)
 // OAuth2ProviderOption configures a BaseOAuth2Provider.
 type OAuth2ProviderOption func(*BaseOAuth2Provider)
 
-// WithOAuth2HTTPClient sets a custom HTTP client. The caller retains ownership
-// of its connection pool: CloseIdleConnections leaves an injected client alone,
-// so one client can be shared safely across providers and reconstructions.
+// WithOAuth2HTTPClient sets a custom HTTP client. See IdleConnectionCloser for
+// the ownership rule this implies.
 //
-// The injected client fully supersedes the one the provider would have built,
-// so the caller also owns its TLS trust and SSRF posture: the config's
-// CAFilePath, AllowPrivateIPs and InsecureAllowHTTP shape only the default
-// client and are not applied here. A set CAFilePath is logged as a warning
-// because it is otherwise inert.
+// The injected client fully supersedes the one the provider would have built, so
+// the caller owns its request-time scheme enforcement (the HTTPS check
+// networking.ValidatingTransport applies) and its dial-time private-IP blocking.
+// Config-level validation is unaffected: InsecureAllowHTTP still governs whether
+// a plain-http endpoint is accepted at all, via ValidateWithInsecure. Setting
+// CAFilePath alongside an injected client is a contradiction and is rejected —
+// see ErrCABundleWithInjectedClient.
 func WithOAuth2HTTPClient(client *http.Client) OAuth2ProviderOption {
 	return func(p *BaseOAuth2Provider) {
 		p.httpClient = client
@@ -367,16 +375,17 @@ func newBaseOAuth2Provider(
 		}
 		p.httpClient = httpClient
 		p.ownsHTTPClient = true
-		// A later failure (an unsupported token_endpoint_auth_method) otherwise
-		// abandons the client with no caller able to reach it. Symmetric with
-		// NewOIDCProvider; the ownership check leaves an injected client alone.
+		// Symmetric with NewOIDCProvider's drain. Nothing below issues a request
+		// today — the only later failure is authStyleFromMethod — so the pool is
+		// empty and this is currently a no-op; it is here so a future step that
+		// performs I/O before returning an error cannot strand a connection.
 		defer func() {
 			if retErr != nil {
 				p.CloseIdleConnections()
 			}
 		}()
-	} else {
-		warnInjectedClientSupersedesCABundle(config.CAFilePath)
+	} else if err := checkInjectedClientCABundle(config.CAFilePath); err != nil {
+		return nil, err
 	}
 
 	// AuthStyle is derived from the negotiated token_endpoint_auth_method
@@ -421,23 +430,22 @@ func (p *BaseOAuth2Provider) CloseIdleConnections() {
 	p.httpClient.CloseIdleConnections()
 }
 
-// warnInjectedClientSupersedesCABundle warns when an operator configured a CA
-// bundle that a caller-injected HTTP client makes inert. The bundle used to be
-// read (and validated) unconditionally, so dropping it silently would turn an
-// explicit trust decision into a no-op with no signal.
+// checkInjectedClientCABundle rejects a CA bundle configured alongside a
+// caller-injected HTTP client. The two are contradictory: the injected client
+// carries its own TLS trust, so the bundle can never take effect. Failing here
+// keeps a trust-anchor misconfiguration a boot-time error, as it was when the
+// bundle was read unconditionally.
 //
-// CAFilePath is the only superseded field warned about, deliberately:
-// AllowPrivateIPs was already inert with an injected client before options moved
-// ahead of the client build (the option simply overwrote the built client), and
-// InsecureAllowHTTP still drives ValidateWithInsecure. CAFilePath is the one
-// field whose validation this ordering removed.
-func warnInjectedClientSupersedesCABundle(caFilePath string) {
+// CAFilePath is the only field checked. AllowPrivateIPs was already inert with
+// an injected client, and InsecureAllowHTTP still gates config-level scheme
+// validation via ValidateWithInsecure, so neither is silently dropped.
+func checkInjectedClientCABundle(caFilePath string) error {
 	if caFilePath == "" {
-		return
+		return nil
 	}
-	slog.Warn("ignoring upstream caFilePath: the injected HTTP client supersedes it; "+
-		"configure the CA bundle on that client instead",
-		"ca_file_path", caFilePath)
+	return fmt.Errorf("%w: caFilePath %q cannot take effect because the injected client carries "+
+		"its own TLS trust; configure the CA bundle on that client and clear caFilePath",
+		ErrCABundleWithInjectedClient, caFilePath)
 }
 
 // authStyleFromMethod maps an RFC 7591 token_endpoint_auth_method to the

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -294,6 +294,11 @@ type BaseOAuth2Provider struct {
 	config       *OAuth2Config
 	oauth2Config *oauth2.Config
 	httpClient   *http.Client
+	// ownsHTTPClient is true only when the provider built httpClient itself. A
+	// client injected via WithOAuth2HTTPClient / WithHTTPClient belongs to the
+	// caller, who may be sharing it across providers, so CloseIdleConnections
+	// must not drain it.
+	ownsHTTPClient bool
 }
 
 // IdleConnectionCloser is an optional capability an OAuth2Provider may
@@ -315,10 +320,13 @@ var _ IdleConnectionCloser = (*BaseOAuth2Provider)(nil)
 // OAuth2ProviderOption configures a BaseOAuth2Provider.
 type OAuth2ProviderOption func(*BaseOAuth2Provider)
 
-// WithOAuth2HTTPClient sets a custom HTTP client.
+// WithOAuth2HTTPClient sets a custom HTTP client. The caller retains ownership
+// of its connection pool: CloseIdleConnections leaves an injected client alone,
+// so one client can be shared safely across providers and reconstructions.
 func WithOAuth2HTTPClient(client *http.Client) OAuth2ProviderOption {
 	return func(p *BaseOAuth2Provider) {
 		p.httpClient = client
+		p.ownsHTTPClient = false
 	}
 }
 
@@ -326,15 +334,33 @@ func WithOAuth2HTTPClient(client *http.Client) OAuth2ProviderOption {
 // The hostForClient parameter determines which URL to use for HTTP client configuration
 // (e.g., TokenEndpoint for OAuth2, Issuer for OIDC).
 //
+// Options are applied before the default HTTP client is built, so a caller that
+// injects one does not pay for a discarded transport (nor for reading the CA
+// bundle) on every construction.
+//
 // IMPORTANT: Callers must ensure config is non-nil before calling this function.
-func newBaseOAuth2Provider(config *OAuth2Config, hostForClient string) (*BaseOAuth2Provider, error) {
+func newBaseOAuth2Provider(
+	config *OAuth2Config,
+	hostForClient string,
+	opts ...OAuth2ProviderOption,
+) (*BaseOAuth2Provider, error) {
 	if err := config.ValidateWithInsecure(config.InsecureAllowHTTP); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	httpClient, err := newHTTPClientForHost(hostForClient, config.AllowPrivateIPs, config.InsecureAllowHTTP, config.CAFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	p := &BaseOAuth2Provider{config: config}
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	if p.httpClient == nil {
+		httpClient, err := newHTTPClientForHost(
+			hostForClient, config.AllowPrivateIPs, config.InsecureAllowHTTP, config.CAFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+		}
+		p.httpClient = httpClient
+		p.ownsHTTPClient = true
 	}
 
 	// AuthStyle is derived from the negotiated token_endpoint_auth_method
@@ -345,7 +371,7 @@ func newBaseOAuth2Provider(config *OAuth2Config, hostForClient string) (*BaseOAu
 	}
 
 	// Create the oauth2.Config for use with golang.org/x/oauth2 library.
-	oauth2Cfg := &oauth2.Config{
+	p.oauth2Config = &oauth2.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
 		RedirectURL:  config.RedirectURI,
@@ -357,11 +383,7 @@ func newBaseOAuth2Provider(config *OAuth2Config, hostForClient string) (*BaseOAu
 		},
 	}
 
-	return &BaseOAuth2Provider{
-		config:       config,
-		oauth2Config: oauth2Cfg,
-		httpClient:   httpClient,
-	}, nil
+	return p, nil
 }
 
 // CloseIdleConnections releases the idle keep-alive connections pooled by the
@@ -371,8 +393,13 @@ func newBaseOAuth2Provider(config *OAuth2Config, hostForClient string) (*BaseOAu
 // Call this when retiring a provider. Without it the pool's sockets and their
 // servicing goroutines are held until the idle timeout elapses, and a process
 // that constructs providers repeatedly accumulates them in the meantime.
+//
+// It is a no-op when the client was supplied by the caller
+// (WithOAuth2HTTPClient / WithHTTPClient): that client's pool belongs to the
+// caller, who may be sharing it across providers, and draining it here would
+// cold-start connections another live provider is using.
 func (p *BaseOAuth2Provider) CloseIdleConnections() {
-	if p.httpClient == nil {
+	if p.httpClient == nil || !p.ownsHTTPClient {
 		return
 	}
 	p.httpClient.CloseIdleConnections()
@@ -436,13 +463,9 @@ func NewOAuth2Provider(config *OAuth2Config, opts ...OAuth2ProviderOption) (*Bas
 	if err != nil {
 		return nil, fmt.Errorf("invalid token endpoint URL: %w", err)
 	}
-	p, err := newBaseOAuth2Provider(config, tokenURL.Host)
+	p, err := newBaseOAuth2Provider(config, tokenURL.Host, opts...)
 	if err != nil {
 		return nil, err
-	}
-
-	for _, opt := range opts {
-		opt(p)
 	}
 
 	slog.Info("oauth2 provider created successfully",

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -294,10 +294,8 @@ type BaseOAuth2Provider struct {
 	config       *OAuth2Config
 	oauth2Config *oauth2.Config
 	httpClient   *http.Client
-	// ownsHTTPClient is true only when the provider built httpClient itself. A
-	// client injected via WithOAuth2HTTPClient / WithHTTPClient belongs to the
-	// caller, who may be sharing it across providers, so CloseIdleConnections
-	// must not drain it.
+	// ownsHTTPClient is true only when the provider built httpClient itself;
+	// see CloseIdleConnections.
 	ownsHTTPClient bool
 }
 
@@ -330,8 +328,8 @@ var _ IdleConnectionCloser = (*BaseOAuth2Provider)(nil)
 // OAuth2ProviderOption configures a BaseOAuth2Provider.
 type OAuth2ProviderOption func(*BaseOAuth2Provider)
 
-// WithOAuth2HTTPClient sets a custom HTTP client. See IdleConnectionCloser for
-// the ownership rule this implies.
+// WithOAuth2HTTPClient sets a custom HTTP client. See
+// BaseOAuth2Provider.CloseIdleConnections for the ownership rule this implies.
 //
 // The injected client fully supersedes the one the provider would have built, so
 // the caller owns its request-time scheme enforcement (the HTTPS check
@@ -415,17 +413,15 @@ func newBaseOAuth2Provider(
 }
 
 // CloseIdleConnections releases the idle keep-alive connections pooled by the
-// provider's HTTP client. The provider stays usable: only idle connections are
-// closed, and later requests dial fresh ones.
+// provider's HTTP client. Call it when retiring a provider: otherwise the pool's
+// sockets and their servicing goroutines are held until the idle timeout
+// elapses, and a process that constructs providers repeatedly accumulates them.
 //
-// Call this when retiring a provider. Without it the pool's sockets and their
-// servicing goroutines are held until the idle timeout elapses, and a process
-// that constructs providers repeatedly accumulates them in the meantime.
-//
-// It is a no-op when the client was supplied by the caller
-// (WithOAuth2HTTPClient / WithHTTPClient): that client's pool belongs to the
-// caller, who may be sharing it across providers, and draining it here would
-// cold-start connections another live provider is using.
+// This is the ownership rule the package enforces: a client supplied by the
+// caller (WithOAuth2HTTPClient / WithHTTPClient) is left alone, because the
+// caller may be sharing it and draining it here would cold-start connections
+// another live provider is using. Only a client the provider built itself is
+// drained.
 func (p *BaseOAuth2Provider) CloseIdleConnections() {
 	if p.httpClient == nil || !p.ownsHTTPClient {
 		return
@@ -434,14 +430,11 @@ func (p *BaseOAuth2Provider) CloseIdleConnections() {
 }
 
 // checkInjectedClientCABundle rejects a CA bundle configured alongside a
-// caller-injected HTTP client. The two are contradictory: the injected client
-// carries its own TLS trust, so the bundle can never take effect. Failing here
-// keeps a trust-anchor misconfiguration a boot-time error, as it was when the
-// bundle was read unconditionally.
-//
-// CAFilePath is the only field checked. AllowPrivateIPs was already inert with
-// an injected client, and InsecureAllowHTTP still gates config-level scheme
-// validation via ValidateWithInsecure, so neither is silently dropped.
+// caller-injected HTTP client: the injected client carries its own TLS trust, so
+// the bundle can never take effect, and a trust-anchor decision must fail at
+// boot rather than be dropped. AllowPrivateIPs and InsecureAllowHTTP need no
+// equivalent check — the former was already inert with an injected client, the
+// latter still gates config-level scheme validation.
 func checkInjectedClientCABundle(caFilePath string) error {
 	if caFilePath == "" {
 		return nil

--- a/pkg/authserver/upstream/oauth2_test.go
+++ b/pkg/authserver/upstream/oauth2_test.go
@@ -21,8 +21,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"net/url"
 	"strings"
 	"sync/atomic"
@@ -2869,4 +2871,56 @@ func TestOAuth2Config_AllowPrivateIPs(t *testing.T) {
 		require.NotNil(t, provider)
 		assert.False(t, provider.config.AllowPrivateIPs)
 	})
+}
+
+// TestBaseOAuth2Provider_CloseIdleConnections pins that retiring a provider
+// releases the connection pool its private HTTP client holds. Without it, a
+// process that constructs providers repeatedly accumulates one socket and
+// goroutine pair per provider (see #6479).
+func TestBaseOAuth2Provider_CloseIdleConnections(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	host, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	client, err := newHTTPClientForHost(host.Host, true, true, "")
+	require.NoError(t, err)
+
+	p := &BaseOAuth2Provider{httpClient: client}
+
+	require.False(t, providerRequestReusedConn(t, p, srv.URL), "first request cannot reuse a connection")
+	require.True(t, providerRequestReusedConn(t, p, srv.URL), "second request must reuse the pooled connection")
+
+	p.CloseIdleConnections()
+
+	assert.False(t, providerRequestReusedConn(t, p, srv.URL),
+		"CloseIdleConnections must drain the provider's pool")
+
+	// A provider constructed without a client (an OIDC provider that failed
+	// before its client was set) must not panic.
+	assert.NotPanics(t, (&BaseOAuth2Provider{}).CloseIdleConnections)
+}
+
+// providerRequestReusedConn issues a GET through the provider's HTTP client and
+// reports whether it was served from that client's idle connection pool.
+func providerRequestReusedConn(t *testing.T, p *BaseOAuth2Provider, target string) bool {
+	t.Helper()
+
+	var reused bool
+	ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) { reused = info.Reused },
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	resp, err := p.httpClient.Do(req)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, resp.Body.Close())
+
+	return reused
 }

--- a/pkg/authserver/upstream/oauth2_test.go
+++ b/pkg/authserver/upstream/oauth2_test.go
@@ -2885,12 +2885,18 @@ func TestBaseOAuth2Provider_CloseIdleConnections(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	host, err := url.Parse(srv.URL)
+	// Built without an injected client, so the provider owns its pool.
+	p, err := NewOAuth2Provider(&OAuth2Config{
+		CommonOAuthConfig: CommonOAuthConfig{
+			ClientID:    "test-client",
+			RedirectURI: srv.URL + "/callback",
+		},
+		AuthorizationEndpoint: srv.URL + "/auth",
+		TokenEndpoint:         srv.URL + "/token",
+		InsecureAllowHTTP:     true,
+		AllowPrivateIPs:       true,
+	})
 	require.NoError(t, err)
-	client, err := newHTTPClientForHost(host.Host, true, true, "")
-	require.NoError(t, err)
-
-	p := &BaseOAuth2Provider{httpClient: client}
 
 	require.False(t, providerRequestReusedConn(t, p, srv.URL), "first request cannot reuse a connection")
 	require.True(t, providerRequestReusedConn(t, p, srv.URL), "second request must reuse the pooled connection")
@@ -2903,6 +2909,47 @@ func TestBaseOAuth2Provider_CloseIdleConnections(t *testing.T) {
 	// A provider constructed without a client (an OIDC provider that failed
 	// before its client was set) must not panic.
 	assert.NotPanics(t, (&BaseOAuth2Provider{}).CloseIdleConnections)
+}
+
+// TestBaseOAuth2Provider_CloseIdleConnections_InjectedClientNotDrained pins that
+// a caller-supplied client is left alone. Config.UpstreamFactory documents
+// sharing one client per issuer host across reconstructions; draining it when a
+// superseded provider is retired would cold-start the pool a live provider is
+// still using.
+func TestBaseOAuth2Provider_CloseIdleConnections_InjectedClientNotDrained(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	host, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	shared, err := newHTTPClientForHost(host.Host, true, true, "")
+	require.NoError(t, err)
+
+	config := &OAuth2Config{
+		CommonOAuthConfig: CommonOAuthConfig{
+			ClientID:    "test-client",
+			RedirectURI: srv.URL + "/callback",
+		},
+		AuthorizationEndpoint: srv.URL + "/auth",
+		TokenEndpoint:         srv.URL + "/token",
+		InsecureAllowHTTP:     true,
+		AllowPrivateIPs:       true,
+	}
+	p, err := NewOAuth2Provider(config, WithOAuth2HTTPClient(shared))
+	require.NoError(t, err)
+	assert.Same(t, shared, p.httpClient, "the injected client must not be rebuilt")
+
+	require.False(t, providerRequestReusedConn(t, p, srv.URL), "first request cannot reuse a connection")
+	require.True(t, providerRequestReusedConn(t, p, srv.URL), "second request must reuse the pooled connection")
+
+	p.CloseIdleConnections()
+
+	assert.True(t, providerRequestReusedConn(t, p, srv.URL),
+		"a caller-owned client's pool must survive the provider being retired")
 }
 
 // providerRequestReusedConn issues a GET through the provider's HTTP client and

--- a/pkg/authserver/upstream/oauth2_test.go
+++ b/pkg/authserver/upstream/oauth2_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httptest"
 	"net/http/httptrace"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -2970,4 +2971,63 @@ func providerRequestReusedConn(t *testing.T, p *BaseOAuth2Provider, target strin
 	require.NoError(t, resp.Body.Close())
 
 	return reused
+}
+
+// TestInjectedClientRejectsCABundle pins that a CA bundle configured alongside
+// an injected HTTP client fails construction rather than being silently
+// dropped. Before options moved ahead of the default client build, the bundle
+// was read and parsed unconditionally, so a malformed one failed at boot; a
+// trust-anchor decision must not degrade to a log line.
+func TestInjectedClientRejectsCABundle(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	host, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	injected, err := newHTTPClientForHost(host.Host, true, true, "")
+	require.NoError(t, err)
+
+	newConfig := func(caFilePath string) *OAuth2Config {
+		return &OAuth2Config{
+			CommonOAuthConfig: CommonOAuthConfig{
+				ClientID:    "test-client",
+				RedirectURI: srv.URL + "/callback",
+			},
+			AuthorizationEndpoint: srv.URL + "/auth",
+			TokenEndpoint:         srv.URL + "/token",
+			InsecureAllowHTTP:     true,
+			AllowPrivateIPs:       true,
+			CAFilePath:            caFilePath,
+		}
+	}
+
+	t.Run("rejected when both are set", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewOAuth2Provider(newConfig("/etc/ssl/certs/some-bundle.pem"),
+			WithOAuth2HTTPClient(injected))
+		require.ErrorIs(t, err, ErrCABundleWithInjectedClient)
+	})
+
+	t.Run("accepted when only the client is injected", func(t *testing.T) {
+		t.Parallel()
+
+		p, err := NewOAuth2Provider(newConfig(""), WithOAuth2HTTPClient(injected))
+		require.NoError(t, err)
+		assert.Same(t, injected, p.httpClient)
+	})
+
+	t.Run("a CA bundle alone still reaches the default client build", func(t *testing.T) {
+		t.Parallel()
+
+		// No client injected, so the bundle is read — and an unreadable one is
+		// still a construction error, the behavior this guard preserves.
+		_, err := NewOAuth2Provider(newConfig(filepath.Join(t.TempDir(), "missing.pem")))
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrCABundleWithInjectedClient)
+	})
 }

--- a/pkg/authserver/upstream/oidc.go
+++ b/pkg/authserver/upstream/oidc.go
@@ -124,10 +124,12 @@ type OIDCProviderImpl struct {
 	verifier            *oidc.IDTokenVerifier             // ID token verifier from go-oidc
 }
 
-// Compile-time capability check: OIDCProviderImpl satisfies
-// IdleConnectionCloser only by promotion from the embedded *BaseOAuth2Provider,
-// and (*server).CloseIdleConnections reaches it through a type assertion that
-// would degrade to a silent no-op if the promotion were ever lost. This pins it.
+// Compile-time capability check that the embedded *BaseOAuth2Provider keeps
+// promoting CloseIdleConnections, since (*server).CloseIdleConnections reaches
+// OIDCProviderImpl through a type assertion that would degrade to a silent
+// no-op if the promotion were dropped. It does not pin the behavior — a method
+// declared on OIDCProviderImpl would shadow the promoted one and still satisfy
+// this — so TestServer_Close_DrainsRealOIDCUpstream is the actual guard.
 var _ IdleConnectionCloser = (*OIDCProviderImpl)(nil)
 
 // OIDCProviderOption configures an OIDCProvider.
@@ -137,6 +139,12 @@ type OIDCProviderOption func(*OIDCProviderImpl)
 // ownership of its connection pool: CloseIdleConnections leaves an injected
 // client alone, so one client can be shared safely across providers and
 // reconstructions.
+//
+// The injected client fully supersedes the one the provider would have built,
+// so the caller also owns its TLS trust and SSRF posture: the config's
+// CAFilePath, AllowPrivateIPs and InsecureAllowHTTP shape only the default
+// client and are not applied here. A set CAFilePath is logged as a warning
+// because it is otherwise inert.
 func WithHTTPClient(client *http.Client) OIDCProviderOption {
 	return func(p *OIDCProviderImpl) {
 		p.httpClient = client
@@ -212,6 +220,8 @@ func NewOIDCProvider(
 		}
 		p.httpClient = httpClient
 		p.ownsHTTPClient = true
+	} else {
+		warnInjectedClientSupersedesCABundle(config.CAFilePath)
 	}
 
 	// Use go-oidc for discovery - inject custom HTTP client via context

--- a/pkg/authserver/upstream/oidc.go
+++ b/pkg/authserver/upstream/oidc.go
@@ -124,22 +124,19 @@ type OIDCProviderImpl struct {
 	verifier            *oidc.IDTokenVerifier             // ID token verifier from go-oidc
 }
 
-// Compile-time capability check that the embedded *BaseOAuth2Provider keeps
-// promoting CloseIdleConnections, since (*server).CloseIdleConnections reaches
-// OIDCProviderImpl through a type assertion that would degrade to a silent
-// no-op if the promotion were dropped. It does not pin the behavior — a method
-// declared on OIDCProviderImpl would shadow the promoted one and still satisfy
-// this — so TestServer_Close_DrainsRealOIDCUpstream is the actual guard.
+// Compile-time check that the embedded *BaseOAuth2Provider keeps promoting
+// CloseIdleConnections, which (*server).CloseIdleConnections reaches by type
+// assertion. It does not pin the behavior — a method declared here would shadow
+// the promoted one and still satisfy this — so
+// TestServer_Close_DrainsRealOIDCUpstream is the actual guard.
 var _ IdleConnectionCloser = (*OIDCProviderImpl)(nil)
 
 // OIDCProviderOption configures an OIDCProvider.
 type OIDCProviderOption func(*OIDCProviderImpl)
 
 // WithHTTPClient sets a custom HTTP client for the provider. See
-// IdleConnectionCloser for the ownership rule this implies, and
-// WithOAuth2HTTPClient for what the injected client takes over from the config.
-// Setting CAFilePath alongside it is rejected — see
-// ErrCABundleWithInjectedClient.
+// WithOAuth2HTTPClient, which carries the same ownership and config-supersession
+// rules.
 func WithHTTPClient(client *http.Client) OIDCProviderOption {
 	return func(p *OIDCProviderImpl) {
 		p.httpClient = client

--- a/pkg/authserver/upstream/oidc.go
+++ b/pkg/authserver/upstream/oidc.go
@@ -182,7 +182,7 @@ func NewOIDCProvider(
 	ctx context.Context,
 	config *OIDCConfig,
 	opts ...OIDCProviderOption,
-) (*OIDCProviderImpl, error) {
+) (_ *OIDCProviderImpl, retErr error) {
 	if config == nil {
 		return nil, errors.New("config is required")
 	}
@@ -220,6 +220,15 @@ func NewOIDCProvider(
 		}
 		p.httpClient = httpClient
 		p.ownsHTTPClient = true
+		// Discovery below runs before any later failure (bad claims, an invalid
+		// discovery document, a missing openid scope), so a failed construction
+		// otherwise abandons a client with a pooled connection that no caller
+		// can reach — nothing is returned to call CloseIdleConnections on.
+		defer func() {
+			if retErr != nil {
+				p.CloseIdleConnections()
+			}
+		}()
 	} else {
 		warnInjectedClientSupersedesCABundle(config.CAFilePath)
 	}

--- a/pkg/authserver/upstream/oidc.go
+++ b/pkg/authserver/upstream/oidc.go
@@ -135,16 +135,11 @@ var _ IdleConnectionCloser = (*OIDCProviderImpl)(nil)
 // OIDCProviderOption configures an OIDCProvider.
 type OIDCProviderOption func(*OIDCProviderImpl)
 
-// WithHTTPClient sets a custom HTTP client for the provider. The caller retains
-// ownership of its connection pool: CloseIdleConnections leaves an injected
-// client alone, so one client can be shared safely across providers and
-// reconstructions.
-//
-// The injected client fully supersedes the one the provider would have built,
-// so the caller also owns its TLS trust and SSRF posture: the config's
-// CAFilePath, AllowPrivateIPs and InsecureAllowHTTP shape only the default
-// client and are not applied here. A set CAFilePath is logged as a warning
-// because it is otherwise inert.
+// WithHTTPClient sets a custom HTTP client for the provider. See
+// IdleConnectionCloser for the ownership rule this implies, and
+// WithOAuth2HTTPClient for what the injected client takes over from the config.
+// Setting CAFilePath alongside it is rejected — see
+// ErrCABundleWithInjectedClient.
 func WithHTTPClient(client *http.Client) OIDCProviderOption {
 	return func(p *OIDCProviderImpl) {
 		p.httpClient = client
@@ -229,8 +224,8 @@ func NewOIDCProvider(
 				p.CloseIdleConnections()
 			}
 		}()
-	} else {
-		warnInjectedClientSupersedesCABundle(config.CAFilePath)
+	} else if err := checkInjectedClientCABundle(config.CAFilePath); err != nil {
+		return nil, err
 	}
 
 	// Use go-oidc for discovery - inject custom HTTP client via context

--- a/pkg/authserver/upstream/oidc.go
+++ b/pkg/authserver/upstream/oidc.go
@@ -124,13 +124,23 @@ type OIDCProviderImpl struct {
 	verifier            *oidc.IDTokenVerifier             // ID token verifier from go-oidc
 }
 
+// Compile-time capability check: OIDCProviderImpl satisfies
+// IdleConnectionCloser only by promotion from the embedded *BaseOAuth2Provider,
+// and (*server).CloseIdleConnections reaches it through a type assertion that
+// would degrade to a silent no-op if the promotion were ever lost. This pins it.
+var _ IdleConnectionCloser = (*OIDCProviderImpl)(nil)
+
 // OIDCProviderOption configures an OIDCProvider.
 type OIDCProviderOption func(*OIDCProviderImpl)
 
-// WithHTTPClient sets a custom HTTP client for the provider.
+// WithHTTPClient sets a custom HTTP client for the provider. The caller retains
+// ownership of its connection pool: CloseIdleConnections leaves an injected
+// client alone, so one client can be shared safely across providers and
+// reconstructions.
 func WithHTTPClient(client *http.Client) OIDCProviderOption {
 	return func(p *OIDCProviderImpl) {
 		p.httpClient = client
+		p.ownsHTTPClient = false
 	}
 }
 
@@ -179,24 +189,29 @@ func NewOIDCProvider(
 		"client_id", config.ClientID,
 	)
 
-	// Create HTTP client for the issuer host
-	issuerURL, _ := url.Parse(config.Issuer) // Error already checked in ValidateWithInsecure()
-	httpClient, err := newHTTPClientForHost(issuerURL.Host, config.AllowPrivateIPs, config.InsecureAllowHTTP, config.CAFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
-	}
-
 	p := &OIDCProviderImpl{
 		oidcConfig: config,
-		BaseOAuth2Provider: &BaseOAuth2Provider{
-			httpClient: httpClient,
-			// config will be set after discovery
-		},
+		// config will be set after discovery
+		BaseOAuth2Provider: &BaseOAuth2Provider{},
 	}
 
-	// Apply OIDC-specific options
+	// Apply OIDC-specific options before building the default HTTP client, so a
+	// caller that injects one does not pay for a discarded transport (nor for
+	// reading the CA bundle) on every construction.
 	for _, opt := range opts {
 		opt(p)
+	}
+
+	if p.httpClient == nil {
+		// Create HTTP client for the issuer host
+		issuerURL, _ := url.Parse(config.Issuer) // Error already checked in ValidateWithInsecure()
+		httpClient, err := newHTTPClientForHost(
+			issuerURL.Host, config.AllowPrivateIPs, config.InsecureAllowHTTP, config.CAFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+		}
+		p.httpClient = httpClient
+		p.ownsHTTPClient = true
 	}
 
 	// Use go-oidc for discovery - inject custom HTTP client via context

--- a/pkg/authserver/upstream/oidc_test.go
+++ b/pkg/authserver/upstream/oidc_test.go
@@ -355,12 +355,31 @@ func TestNewOIDCProvider(t *testing.T) {
 			Issuer: mock.issuer,
 		}
 
-		customClient := &http.Client{Timeout: 5 * time.Second}
+		// Built via the builder rather than a bare &http.Client so the pool is
+		// real and the ownership assertions below are meaningful.
+		issuerURL, err := url.Parse(mock.issuer)
+		require.NoError(t, err)
+		customClient, err := newHTTPClientForHost(issuerURL.Host, true, true, "")
+		require.NoError(t, err)
 
 		ctx := context.Background()
 		provider, err := NewOIDCProvider(ctx, config, WithHTTPClient(customClient))
 		require.NoError(t, err)
 		require.NotNil(t, provider)
+
+		// The injected client must be used as-is, not rebuilt — otherwise every
+		// reconstruction still allocates (and discards) a transport.
+		assert.Same(t, customClient, provider.httpClient)
+
+		// OIDCProviderImpl is the type #6479 identifies as leaking and the one
+		// DefaultUpstreamFactory builds, and WithHTTPClient clears the ownership
+		// flag on its own line — so pin that retiring this provider leaves the
+		// caller's shared pool warm. Discovery already populated it.
+		require.True(t, providerRequestReusedConn(t, provider.BaseOAuth2Provider, mock.issuer),
+			"discovery must have left a pooled connection")
+		provider.CloseIdleConnections()
+		assert.True(t, providerRequestReusedConn(t, provider.BaseOAuth2Provider, mock.issuer),
+			"a caller-owned client's pool must survive the provider being retired")
 	})
 
 	t.Run("with force consent screen", func(t *testing.T) {

--- a/pkg/authserver/upstream/oidc_test.go
+++ b/pkg/authserver/upstream/oidc_test.go
@@ -10,9 +10,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1525,4 +1527,58 @@ func TestOIDCProvider_RefreshTokens(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "refreshed-access-token", tokens.AccessToken)
 	})
+}
+
+// TestNewOIDCProvider_DrainsOwnClientOnFailure pins that a construction that
+// fails *after* discovery does not abandon the client it built. Nothing is
+// returned, so no caller can drain it — this is the retry case #6479 calls
+// pathological ("re-runs discovery on every attempt"), and neither
+// buildUpstreams' drain nor newServer's deferred drain can reach it.
+func TestNewOIDCProvider_DrainsOwnClientOnFailure(t *testing.T) {
+	t.Parallel()
+
+	var openConns atomic.Int32
+	// Discovery succeeds (so a connection is pooled) but the document omits
+	// token_endpoint, so validation fails afterwards.
+	issuer := httptest.NewUnstartedServer(nil)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                issuer.URL,
+			"authorization_endpoint":                issuer.URL + "/authorize",
+			"jwks_uri":                              issuer.URL + "/jwks",
+			"response_types_supported":              []string{"code"},
+			"subject_types_supported":               []string{"public"},
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	})
+	issuer.Config.Handler = mux
+	issuer.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		switch state {
+		case http.StateNew:
+			openConns.Add(1)
+		case http.StateClosed, http.StateHijacked:
+			openConns.Add(-1)
+		case http.StateActive, http.StateIdle:
+		}
+	}
+	issuer.Start()
+	t.Cleanup(issuer.Close)
+
+	_, err := NewOIDCProvider(context.Background(), &OIDCConfig{
+		CommonOAuthConfig: CommonOAuthConfig{
+			ClientID:    testClientID,
+			RedirectURI: testRedirectURI,
+			Scopes:      []string{"openid"},
+		},
+		Issuer:            issuer.URL,
+		InsecureAllowHTTP: true,
+		AllowPrivateIPs:   true,
+	})
+	require.Error(t, err, "a discovery document without token_endpoint must be rejected")
+
+	// The issuer observes the close asynchronously.
+	assert.Eventually(t, func() bool { return openConns.Load() == 0 }, 5*time.Second, 10*time.Millisecond,
+		"a failed construction must drain the client it built")
 }

--- a/pkg/networking/http_client.go
+++ b/pkg/networking/http_client.go
@@ -52,12 +52,11 @@ const (
 	// maxIdleConns caps pooled idle connections across all hosts. The zero
 	// value is unlimited. 100 matches http.DefaultTransport.
 	maxIdleConns = 100
-	// maxIdleConnsPerHost caps them per host. Unlike the two above, the zero
-	// value here is already bounded — http.DefaultMaxIdleConnsPerHost, which is
-	// 2 — so this is a deliberate increase, not a newly imposed bound: most
-	// clients this builder produces are host-scoped and drive a single
-	// upstream, so a slightly larger per-host pool serves concurrent requests
-	// without dialing, now that the idle timeout is finite.
+	// maxIdleConnsPerHost caps them per host. The zero value here is already
+	// bounded (http.DefaultMaxIdleConnsPerHost is 2), so this is a deliberate
+	// increase rather than a new bound: these clients are host-scoped, and a
+	// slightly larger pool serves concurrent requests without dialing now that
+	// the idle timeout is finite.
 	maxIdleConnsPerHost = 4
 )
 

--- a/pkg/networking/http_client.go
+++ b/pkg/networking/http_client.go
@@ -126,6 +126,18 @@ func NewPrivateIPBlockingDialContext() func(ctx context.Context, network, addr s
 	return (&net.Dialer{Control: protectedDialerControl}).DialContext
 }
 
+// IdleConnectionCloser is the capability http.Client discovers on its outermost
+// transport to drain pooled connections (it asserts an identical unexported
+// interface). Any RoundTripper in this repo that wraps another must implement it
+// and forward the call, or every CloseIdleConnections on the resulting client is
+// a silent no-op. Assert against this named type rather than re-declaring an
+// anonymous `interface{ CloseIdleConnections() }`.
+//
+// upstream.IdleConnectionCloser is the provider-level analogue one layer up.
+type IdleConnectionCloser interface {
+	CloseIdleConnections()
+}
+
 // ValidatingTransport is for validating URLs prior to request
 type ValidatingTransport struct {
 	Transport         http.RoundTripper
@@ -156,14 +168,12 @@ func (t *ValidatingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 // CloseIdleConnections forwards to the wrapped transport so that
 // http.Client.CloseIdleConnections reaches the real connection pool.
 //
-// http.Client discovers this capability by asserting the *outermost* transport
-// against an unexported `interface{ CloseIdleConnections() }`. Because Build
-// always wraps the pool in a ValidatingTransport, omitting this method makes
-// every client's CloseIdleConnections a silent no-op. The assertion on
-// t.Transport is required because the field is an http.RoundTripper; it holds
-// an *http.Transport for every client Build produces.
+// Because Build always wraps the pool in a ValidatingTransport, omitting this
+// method would make every client's CloseIdleConnections a silent no-op — see
+// IdleConnectionCloser. The assertion is required because the field is an
+// http.RoundTripper; it holds an *http.Transport for every client Build produces.
 func (t *ValidatingTransport) CloseIdleConnections() {
-	if closer, ok := t.Transport.(interface{ CloseIdleConnections() }); ok {
+	if closer, ok := t.Transport.(IdleConnectionCloser); ok {
 		closer.CloseIdleConnections()
 	}
 }

--- a/pkg/networking/http_client.go
+++ b/pkg/networking/http_client.go
@@ -129,7 +129,7 @@ func NewPrivateIPBlockingDialContext() func(ctx context.Context, network, addr s
 // transport to drain pooled connections (it asserts an identical unexported
 // interface). Any RoundTripper in this repo that wraps another must implement it
 // and forward the call, or every CloseIdleConnections on the resulting client is
-// a silent no-op. Assert against this named type rather than re-declaring an
+// a silent no-op. Assert against this named type rather than redeclaring an
 // anonymous `interface{ CloseIdleConnections() }`.
 //
 // upstream.IdleConnectionCloser is the provider-level analogue one layer up.

--- a/pkg/networking/http_client.go
+++ b/pkg/networking/http_client.go
@@ -41,20 +41,23 @@ const HttpScheme = "http"
 // before giving up. Matches the cap used by the transparent proxy data path.
 const MaxRedirects = 10
 
-// Connection-pool bounds applied by Build. http.Transport's zero values mean
-// "never expire" and "unlimited", so a client that performs one request and is
-// then dropped pins a socket and its readLoop/writeLoop goroutine pair for the
-// lifetime of the process.
+// Connection-pool bounds applied by Build.
 const (
 	// idleConnTimeout bounds how long a pooled keep-alive connection is
-	// retained after its last use. Matches http.DefaultTransport.
+	// retained after its last use. This is the leak: http.Transport's zero
+	// value means "never expire", so a client that performs one request and is
+	// then dropped pins a socket and its readLoop/writeLoop goroutine pair for
+	// the lifetime of the process. 90s matches http.DefaultTransport.
 	idleConnTimeout = 90 * time.Second
-	// maxIdleConns caps pooled idle connections across all hosts. Matches
-	// http.DefaultTransport.
+	// maxIdleConns caps pooled idle connections across all hosts. The zero
+	// value is unlimited. 100 matches http.DefaultTransport.
 	maxIdleConns = 100
-	// maxIdleConnsPerHost caps them per host. Most clients this builder
-	// produces are host-scoped and drive a single upstream, so a small cap
-	// bounds the pool while still serving concurrent requests from it.
+	// maxIdleConnsPerHost caps them per host. Unlike the two above, the zero
+	// value here is already bounded — http.DefaultMaxIdleConnsPerHost, which is
+	// 2 — so this is a deliberate increase, not a newly imposed bound: most
+	// clients this builder produces are host-scoped and drive a single
+	// upstream, so a slightly larger per-host pool serves concurrent requests
+	// without dialing, now that the idle timeout is finite.
 	maxIdleConnsPerHost = 4
 )
 

--- a/pkg/networking/http_client.go
+++ b/pkg/networking/http_client.go
@@ -41,6 +41,23 @@ const HttpScheme = "http"
 // before giving up. Matches the cap used by the transparent proxy data path.
 const MaxRedirects = 10
 
+// Connection-pool bounds applied by Build. http.Transport's zero values mean
+// "never expire" and "unlimited", so a client that performs one request and is
+// then dropped pins a socket and its readLoop/writeLoop goroutine pair for the
+// lifetime of the process.
+const (
+	// idleConnTimeout bounds how long a pooled keep-alive connection is
+	// retained after its last use. Matches http.DefaultTransport.
+	idleConnTimeout = 90 * time.Second
+	// maxIdleConns caps pooled idle connections across all hosts. Matches
+	// http.DefaultTransport.
+	maxIdleConns = 100
+	// maxIdleConnsPerHost caps them per host. Most clients this builder
+	// produces are host-scoped and drive a single upstream, so a small cap
+	// bounds the pool while still serving concurrent requests from it.
+	maxIdleConnsPerHost = 4
+)
+
 // ErrRedirectRefused is wrapped by SameHostRedirectPolicy when it declines to
 // follow a redirect, so callers can match it with errors.Is.
 var ErrRedirectRefused = errors.New("redirect refused")
@@ -131,6 +148,34 @@ func (t *ValidatingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	}
 
 	return t.Transport.RoundTrip(req)
+}
+
+// CloseIdleConnections forwards to the wrapped transport so that
+// http.Client.CloseIdleConnections reaches the real connection pool.
+//
+// http.Client discovers this capability by asserting the *outermost* transport
+// against an unexported `interface{ CloseIdleConnections() }`. Because Build
+// always wraps the pool in a ValidatingTransport, omitting this method makes
+// every client's CloseIdleConnections a silent no-op. The assertion on
+// t.Transport is required because the field is an http.RoundTripper; it holds
+// an *http.Transport for every client Build produces.
+func (t *ValidatingTransport) CloseIdleConnections() {
+	if closer, ok := t.Transport.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
+// closeIdlerTransport wraps a RoundTripper that does not implement
+// CloseIdleConnections (oauth2.Transport) and forwards the call to the
+// *http.Transport owning the connection pool underneath it.
+type closeIdlerTransport struct {
+	http.RoundTripper
+	pool *http.Transport
+}
+
+// CloseIdleConnections closes the idle connections held by the underlying pool.
+func (t *closeIdlerTransport) CloseIdleConnections() {
+	t.pool.CloseIdleConnections()
 }
 
 // createTokenSourceFromFile creates an oauth2.TokenSource from a token file
@@ -278,6 +323,9 @@ func (b *HttpClientBuilder) Build() (*http.Client, error) {
 	transport := &http.Transport{
 		TLSHandshakeTimeout:   b.tlsHandshakeTimeout,
 		ResponseHeaderTimeout: b.responseHeaderTimeout,
+		IdleConnTimeout:       idleConnTimeout,
+		MaxIdleConns:          maxIdleConns,
+		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
 	}
 	transport.DisableKeepAlives = b.disableKeepAlives
 
@@ -329,10 +377,15 @@ func (b *HttpClientBuilder) Build() (*http.Client, error) {
 			return nil, fmt.Errorf("failed to create token source: %w", err)
 		}
 
-		// oauth2.Transport wraps our existing transport and adds Bearer token authentication
-		clientTransport = &oauth2.Transport{
-			Source: tokenSource,
-			Base:   clientTransport, // Preserves our ValidatingTransport
+		// oauth2.Transport wraps our existing transport and adds Bearer token
+		// authentication. It exposes only RoundTrip/CancelRequest, so wrap it
+		// again to keep http.Client.CloseIdleConnections reaching the pool.
+		clientTransport = &closeIdlerTransport{
+			RoundTripper: &oauth2.Transport{
+				Source: tokenSource,
+				Base:   clientTransport, // Preserves our ValidatingTransport
+			},
+			pool: transport,
 		}
 	}
 

--- a/pkg/networking/http_client_test.go
+++ b/pkg/networking/http_client_test.go
@@ -4,6 +4,7 @@
 package networking
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -14,6 +15,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -384,7 +386,11 @@ lT/G27CBRUlDiDhthwY1dccTCFhICg6ENUGqh2I=
 			expectError: false,
 			validateClient: func(t *testing.T, client *http.Client) {
 				t.Helper()
-				assert.IsType(t, &oauth2.Transport{}, client.Transport)
+				// The oauth2 transport is wrapped so that
+				// http.Client.CloseIdleConnections still reaches the pool.
+				wrapper, ok := client.Transport.(*closeIdlerTransport)
+				require.True(t, ok)
+				assert.IsType(t, &oauth2.Transport{}, wrapper.RoundTripper)
 			},
 		},
 		{
@@ -427,7 +433,10 @@ lT/G27CBRUlDiDhthwY1dccTCFhICg6ENUGqh2I=
 			validateClient: func(t *testing.T, client *http.Client) {
 				t.Helper()
 				// Should have oauth2 transport wrapping validating transport
-				authTransport := client.Transport.(*oauth2.Transport)
+				wrapper, ok := client.Transport.(*closeIdlerTransport)
+				require.True(t, ok)
+				authTransport, ok := wrapper.RoundTripper.(*oauth2.Transport)
+				require.True(t, ok)
 				assert.IsType(t, &ValidatingTransport{}, authTransport.Base)
 			},
 		},
@@ -921,4 +930,89 @@ func TestSameHostRedirectPolicy_Integration(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "OK", string(body))
 	})
+}
+
+// TestBuild_BoundsIdleConnectionPool guards the transport fields against being
+// dropped again. Zero values mean "retain idle connections forever" and
+// "unlimited", which turns every dropped client into a permanently held socket
+// and goroutine pair (see #6479).
+func TestBuild_BoundsIdleConnectionPool(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewHttpClientBuilder().Build()
+	require.NoError(t, err)
+
+	validating, ok := client.Transport.(*ValidatingTransport)
+	require.True(t, ok, "Build must wrap the pool in a ValidatingTransport")
+	transport, ok := validating.Transport.(*http.Transport)
+	require.True(t, ok, "ValidatingTransport must wrap an *http.Transport")
+
+	assert.Equal(t, idleConnTimeout, transport.IdleConnTimeout)
+	assert.Equal(t, maxIdleConns, transport.MaxIdleConns)
+	assert.Equal(t, maxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+}
+
+// TestBuild_CloseIdleConnectionsReachesPool pins that
+// http.Client.CloseIdleConnections is not a silent no-op on a built client. The
+// client discovers the capability by asserting the outermost transport, so every
+// wrapper Build installs must forward the call.
+func TestBuild_CloseIdleConnectionsReachesPool(t *testing.T) {
+	t.Parallel()
+
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("test-token"), 0o600))
+
+	tests := []struct {
+		name      string
+		tokenFile string
+	}{
+		{name: "validating transport"},
+		{name: "oauth2 token file transport", tokenFile: tokenFile},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+
+			builder := NewHttpClientBuilder().WithPrivateIPs(true).WithInsecureAllowHTTP(true)
+			if tt.tokenFile != "" {
+				builder = builder.WithTokenFromFile(tt.tokenFile)
+			}
+			client, err := builder.Build()
+			require.NoError(t, err)
+
+			require.False(t, getReusedConn(t, client, srv.URL), "first request cannot reuse a connection")
+			require.True(t, getReusedConn(t, client, srv.URL), "second request must reuse the pooled connection")
+
+			client.CloseIdleConnections()
+
+			assert.False(t, getReusedConn(t, client, srv.URL),
+				"CloseIdleConnections must drain the pool, so the next request dials again")
+		})
+	}
+}
+
+// getReusedConn issues a GET and reports whether it was served from the
+// client's idle connection pool.
+func getReusedConn(t *testing.T, client *http.Client, target string) bool {
+	t.Helper()
+
+	var reused bool
+	ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) { reused = info.Reused },
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, resp.Body.Close())
+
+	return reused
 }

--- a/pkg/networking/http_client_test.go
+++ b/pkg/networking/http_client_test.go
@@ -947,9 +947,11 @@ func TestBuild_BoundsIdleConnectionPool(t *testing.T) {
 	transport, ok := validating.Transport.(*http.Transport)
 	require.True(t, ok, "ValidatingTransport must wrap an *http.Transport")
 
-	assert.Equal(t, idleConnTimeout, transport.IdleConnTimeout)
-	assert.Equal(t, maxIdleConns, transport.MaxIdleConns)
-	assert.Equal(t, maxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
+	// Literals, not the constants: comparing a constant to itself still passes
+	// if the constant is set back to zero, which is the regression this guards.
+	assert.Equal(t, 90*time.Second, transport.IdleConnTimeout)
+	assert.Equal(t, 100, transport.MaxIdleConns)
+	assert.Equal(t, 4, transport.MaxIdleConnsPerHost)
 }
 
 // TestBuild_CloseIdleConnectionsReachesPool pins that


### PR DESCRIPTION
## Summary

Every `*http.Client` produced by `networking.HttpClientBuilder.Build()` had a connection pool that could never be drained. `IdleConnTimeout` was left at its zero value, which in `http.Transport` means *never expire*, so a client that performed a single request and was then dropped pinned a socket and its `readLoop`/`writeLoop` goroutine pair for the lifetime of the process. The obvious remediation was already unavailable and silently so: `Build` always wraps the pool in a `ValidatingTransport` (and, on the `authTokenFile` path, an `oauth2.Transport`), neither of which implements `CloseIdleConnections`, and `http.Client.CloseIdleConnections` is a type assertion on the *outermost* transport — so the call returned having done nothing, with no error and no log.

On the auth-server upstream path this compounded into a real leak. `authserver.New` builds a private HTTP client per configured upstream with keep-alives deliberately on, `server.Close()` closed storage only, and nothing walked `s.upstreams`. An embedder that reconstructs the server to change its upstream set — a pattern the API otherwise supports, since `New` accepts an existing `storage.Storage` and `KeyProvider` — leaked one transport per OIDC upstream per reconstruction, unbounded, with no correct call available to reclaim them: `Close()` would also close the storage the new server was now serving through.

This lands all three changes proposed in the issue:

- **Bound the pool** in `networking.Build` — finite `IdleConnTimeout`, plus `MaxIdleConns` and `MaxIdleConnsPerHost`. This alone converts every leak of this shape in the repo from unbounded to self-draining and makes an abandoned transport garbage-collectable.
- **Make the pool reachable** — `CloseIdleConnections` forwarders on the transport wrappers, on `BaseOAuth2Provider` (promoted to `OIDCProviderImpl`), and a new package-level `authserver.CloseIdleConnections(Server) bool` kept deliberately distinct from `Close()`. The split is the load-bearing part for embedders: it is what lets a superseded server release its own upstream connections without touching shared storage. It is a function rather than a `Server` method so that `Server` stays source-compatible — see the user-facing-change section.
- **Export the upstream provider factory** as `Config.UpstreamFactory`, with `DefaultUpstreamFactory` exported so a custom factory can delegate. This makes reconstruction structurally free (share a client per issuer host via the already-public `WithHTTPClient` / `WithOAuth2HTTPClient`) and makes per-upstream failure isolation possible.

**What this closes, and what it does not.** #6479 is scoped to HTTP client pools — "HTTP client pools are unbounded and uncloseable" — and all three of its proposed changes land here. Closing it is therefore accurate for its stated scope.

One adjacent resource is deliberately left open and tracked separately: a `TrustedIssuers` server starts one JWKS refresh worker pool per issuer rooted at `context.Background()`, released by neither `Close` nor `CloseIdleConnections`, so a process that reconstructs the auth server repeatedly still grows goroutines through that path. That is a different resource than the connection pools this issue is about, it is pre-existing, and it is now tracked in **#6482** and documented in the `Scope:` paragraph on `Server.CloseIdleConnections` so the remaining gap is not silent. **#6483** tracks the hand-rolled transports outside `networking.Build` that share the original defect.

**Scope decision.** The issue says of its item 3: *"This one is a genuine API surface commitment ... so it deserves its own discussion and shouldn't block 1 and 2."* This PR lands it anyway, as an explicit choice rather than an oversight: it is the piece that makes reconstruction structurally free rather than merely bounded, which is the scenario the issue is about, so splitting it would leave the headline case only half-addressed across two PRs. It is separable — items 1+2 are a self-contained ~200-line fix — so if a reviewer would rather decide the API question on its own, say so and I will split it out. Note that `Config.UpstreamFactory` currently has no in-repo caller.

Closes #6479

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`) — full unit suite passes
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`) — 0 issues; `task license-check` also passes
- [ ] Manual testing (describe below)

New tests: `TestBuild_BoundsIdleConnectionPool` and `TestBuild_CloseIdleConnectionsReachesPool` (regression guards against the two builder defects, the latter asserting the call reaches the real pool through the wrappers); `TestServer_CloseIdleConnections`, `TestServer_Close_DrainsRealOIDCUpstream` (end-to-end against an `httptest` OIDC issuer — the actual guard on the promoted method), `TestNewServer_UpstreamFactoryPrecedence`, `TestBuildUpstreams_DrainsAlreadyBuiltProvidersOnFailure`, `TestBuildUpstreams_RejectsNilProvider`; `TestBaseOAuth2Provider_CloseIdleConnections`, `TestBaseOAuth2Provider_CloseIdleConnections_InjectedClientNotDrained` (ownership), `TestNewOIDCProvider_DrainsOwnClientOnFailure`.

## Changes

| File | Change |
|------|--------|
| `pkg/networking/http_client.go` | Set `IdleConnTimeout` (90s), `MaxIdleConns` (100), `MaxIdleConnsPerHost` (4) in `Build`. Add `(*ValidatingTransport).CloseIdleConnections`; add `closeIdlerTransport` to carry the capability past `oauth2.Transport` on the `authTokenFile` path. |
| `pkg/authserver/server.go` | Add the package-level `CloseIdleConnections(Server) bool` and the unexported capability it detects, documenting the `Close`/`CloseIdleConnections` split and its scope. `Server` itself is unchanged. Add the exported `UpstreamProviderFactory` type. |
| `pkg/authserver/config.go` | Add `Config.UpstreamFactory` with the connection-reuse and failure-isolation rationale and a SECURITY note (the provider validates upstream ID tokens). |
| `pkg/authserver/server_impl.go` | Export `DefaultUpstreamFactory`; extract `buildUpstreams` / `closeUpstreamIdleConnections` / `resolveUpstreamFactory`; drain already-built providers when construction aborts and when any later `newServer` step fails; `Close` now drains before closing storage. Reject a nil provider from a custom factory, and name the offending upstream in the error. |
| `pkg/authserver/upstream/oauth2.go` | Add the optional `IdleConnectionCloser` interface and `(*BaseOAuth2Provider).CloseIdleConnections`. Track `ownsHTTPClient` so an injected client is never drained. Apply options *before* building the default client, and warn when a configured `CAFilePath` is superseded by an injected client. |
| `pkg/authserver/upstream/oidc.go` | Same option-ordering and ownership handling; drain the provider's own client if construction fails after discovery. Compile-time capability assertion on `*OIDCProviderImpl`. |
| `pkg/authserver/server/tokenexchange/multi_issuer_validator.go` | `CloseIdleConnections` forwarder on `limitedBodyTransport` so the wrapper does not silently swallow the call (no pool today — the client disables keep-alives — but keeps that an optimization, not a correctness dependency). |
| `pkg/authserver/runner/embeddedauthserver.go` | Forward `CloseIdleConnections` to the embedded server via `authserver.CloseIdleConnections`. |
| `pkg/authserver/upstream/mocks/mock_provider.go` | Regenerated: adds `MockIdleConnectionCloser`. |
| `pkg/authserver/upstream/doc.go` | Document `IdleConnectionCloser` as an optional capability for external `OAuth2Provider` implementations. |

## Does this introduce a user-facing change?

Yes, two — both additive. **No interface is widened and nothing that compiles today stops compiling**, other than case 2 below.

An earlier revision of this PR added `CloseIdleConnections()` as a *required* method on the exported `authserver.Server` interface, which would have been a source-incompatible change for any out-of-tree implementation or test double. That is gone. The drain is now a package-level `authserver.CloseIdleConnections(Server) bool`, which detects an unexported capability interface — the same shape `upstream.IdleConnectionCloser` already uses one layer down, so both layers now use capability detection for the same reason and the asymmetry that previously needed explaining is gone.

The compile-time safety that motivated requiring the method is preserved by `var _ idleConnectionCloser = (*server)(nil)`: a server built by `New` can never silently no-op. The `bool` return covers the remaining case, so a caller holding an implementation that predates the capability learns it did nothing instead of assuming success. Both new tests assign a capability-free `Server` implementation to the interface, which is a compile-time proof of the source compatibility claim.

**1. Behavioral change in retained connections.** `MaxIdleConnsPerHost` goes from Go's default of 2 to 4 for *every* client produced by `networking.HttpClientBuilder.Build`. Unlike `IdleConnTimeout` and `MaxIdleConns` (whose zero values are "unlimited", so setting them only imposes bounds), the per-host zero value was already bounded at `http.DefaultMaxIdleConnsPerHost` — so this is an increase, not a newly imposed cap. A client may now retain up to 4 idle connections per host instead of 2. The trade is against the now-finite 90s `IdleConnTimeout`: most clients this builder produces are host-scoped and drive a single upstream, so a slightly larger per-host pool serves concurrent requests without dialing, and retention is now time-bounded where before it was forever.

**2. A CA bundle configured alongside an injected HTTP client is now an error.** Options are applied before the default client is built, so `newHTTPClientForHost` — and with it the read and parse of `config.CAFilePath` — is skipped when a caller injects a client via `upstream.WithHTTPClient` / `WithOAuth2HTTPClient`. Rather than let a trust-anchor decision be silently dropped, both provider constructors now return `upstream.ErrCABundleWithInjectedClient` for that combination. An external embedder that today sets both will start failing at construction; the combination was already meaningless (the injected client carries its own TLS trust, and the CA-configured client was built and then discarded), so this converts a silent no-op into a boot-time error. No in-repo caller injects a client.

## Special notes for reviewers

Two follow-ups are deliberately out of scope for this PR:

1. **#6483 — hand-rolled transports outside `networking.Build`.** Roughly five `&http.Transport{}` literals elsewhere in the tree — in `pkg/auth/discovery`, `pkg/oauthproto`, and `pkg/auth/oauth/oidc.go` — share the same zero-`IdleConnTimeout` defect, and four more wrappers (`bearerTokenTransport`, `oauthproto.UserAgentTransport`, `auth.WrapTransport`, `pkg/authz/authorizers/http`) still swallow `CloseIdleConnections` on a builder-built client. The right long-term answer is routing them through the builder, which is a larger refactor than this PR should carry.

2. **#6482 — per-issuer JWKS refresh workers.** A server configured with `TrustedIssuers` starts one JWKS refresh worker pool per issuer in `MultiIssuerTokenValidator`, against `context.Background()`. These are released by neither `Close` nor `CloseIdleConnections`, so an embedder that reconstructs repeatedly still grows goroutines through that path. Documented in the Scope paragraph on `Server.CloseIdleConnections` so the remaining gap is not silent.

Two points worth extra scrutiny:

- **Option-ordering change in both provider constructors.** Options are now applied *before* the default HTTP client is built, so an injected client no longer costs a discarded transport and a CA-bundle read per construction. The side effect is that a configured `CAFilePath` would no longer be read or validated in that case, so the combination is rejected outright (see user-facing change 2). `CAFilePath` is the only field needing this treatment: `AllowPrivateIPs` was already inert with an injected client, and `InsecureAllowHTTP` still gates config-level scheme validation via `ValidateWithInsecure`. What the injected client does take over is request-time scheme enforcement and dial-time private-IP blocking, which the option docs now say explicitly.
- **Ownership semantics.** `CloseIdleConnections` is a no-op on a caller-injected client, since the caller may be sharing it across providers and draining it would cold-start connections a live provider is using. This is what makes the `Config.UpstreamFactory` connection-sharing pattern safe, and it is covered by a dedicated test.

Generated with [Claude Code](https://claude.com/claude-code)



