### PR TITLE
Detect GUI editors without a PATH binary

### DIFF
--- a/cmd/thv/app/llm.go
+++ b/cmd/thv/app/llm.go
@@ -481,6 +481,10 @@ func (a *clientManagerAdapter) IsManaged(clientType string) bool {
 	return a.cm.IsManaged(client.ClientApp(clientType))
 }
 
+func (a *clientManagerAdapter) LLMClientDetectionHint(clientType string) string {
+	return a.cm.LLMClientDetectionHint(client.ClientApp(clientType))
+}
+
 func (a *clientManagerAdapter) ConfigureEnvFile(clientType string, cfg llmgateway.ApplyConfig) (string, error) {
 	return a.cm.ConfigureEnvFile(client.ClientApp(clientType), cfg)
 }

--- a/cmd/thv/app/llm_test.go
+++ b/cmd/thv/app/llm_test.go
@@ -563,6 +563,35 @@ func TestRunLLMSetup_ClientFlag_NotInstalled(t *testing.T) {
 	assert.Contains(t, err.Error(), `"cursor" is not installed or not detected`)
 }
 
+func TestRunLLMSetup_ClientFlag_LeftoverCLIDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	cfgs := client.LLMTestIntegrations([]client.LLMTestEntry{
+		{
+			ClientType:   client.ClaudeCode,
+			Mode:         "direct",
+			SettingsDir:  []string{".claude"},
+			SettingsFile: "settings.json",
+			JSONPointers: []string{"/apiKeyHelper"},
+			ValueFields:  []string{"TokenHelperCommand"},
+		},
+	})
+	cfgs[0].LLMBinaryName = "thv-test-missing-llm-bin-6292"
+	cm := client.NewTestClientManager(dir, nil, cfgs, nil)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".claude"), 0o700))
+	provider := llmProvider(t, llm.Config{
+		GatewayURL: "https://gw.example.com",
+		OIDC:       llm.OIDCConfig{Issuer: "https://auth.example.com", ClientID: "id"},
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runLLMSetup(context.Background(), &stdout, &stderr, cm, provider, noopLogin, llm.SetOptions{}, "", false, "claude-code", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"claude-code" is not installed or not detected`)
+	assert.Contains(t, err.Error(), `was not found on PATH`)
+}
+
 // ── --client flag (teardown) ──────────────────────────────────────────────────
 
 func TestRunLLMTeardown_ClientFlag_RevertsNamedTool(t *testing.T) {

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -427,7 +427,6 @@ var supportedClientIntegrations = []clientAppConfig{
 		SkillsProjectPath: []string{".github", skillsDirName},
 		// LLM gateway: patches settings.json (same dir as mcp.json, different file)
 		LLMGatewayMode:     llmgateway.ModeProxy,
-		LLMBinaryName:      "code-insiders",
 		LLMSettingsFile:    "settings.json",
 		LLMSettingsRelPath: []string{"Code - Insiders", "User"},
 		LLMSettingsPlatformPrefix: map[Platform][]string{
@@ -470,7 +469,6 @@ var supportedClientIntegrations = []clientAppConfig{
 		SkillsProjectPath: []string{".github", skillsDirName},
 		// LLM gateway: patches settings.json (same dir as mcp.json, different file)
 		LLMGatewayMode:     llmgateway.ModeProxy,
-		LLMBinaryName:      "code",
 		LLMSettingsFile:    "settings.json",
 		LLMSettingsRelPath: []string{"Code", "User"},
 		LLMSettingsPlatformPrefix: map[Platform][]string{
@@ -508,7 +506,6 @@ var supportedClientIntegrations = []clientAppConfig{
 		SkillsProjectPath: []string{".cursor", skillsDirName},
 		// LLM gateway: patches the editor settings.json (different from the MCP mcp.json)
 		LLMGatewayMode:     llmgateway.ModeProxy,
-		LLMBinaryName:      "cursor",
 		LLMSettingsFile:    "settings.json",
 		LLMSettingsRelPath: []string{"Cursor", "User"},
 		LLMSettingsPlatformPrefix: map[Platform][]string{

--- a/pkg/client/llm_gateway.go
+++ b/pkg/client/llm_gateway.go
@@ -281,6 +281,8 @@ func (cm *ClientManager) LLMGatewayModeFor(clientType ClientApp) string {
 //
 // Requiring both CLI signals prevents false positives from leftover config
 // directories (e.g. ~/.claude or ~/.gemini) after a tool is uninstalled.
+// GUI editors leave LLMBinaryName empty so detection matches the settings-dir
+// check used by IsClientInstalled; those apps are often absent from $PATH.
 func (cm *ClientManager) DetectedLLMGatewayClients() []ClientApp {
 	var result []ClientApp
 	for i := range cm.clientIntegrations {
@@ -317,6 +319,13 @@ func (cm *ClientManager) isClientInstalled(cfg *clientAppConfig) bool {
 	return installed
 }
 
+func (cm *ClientManager) llmDetectDir(cfg *clientAppConfig) string {
+	if cfg.LLMDetectRelPath != nil {
+		return buildConfigFilePath("", cfg.LLMDetectRelPath, cfg.LLMDetectPlatformPrefix, []string{cm.homeDir})
+	}
+	return filepath.Dir(cm.buildLLMSettingsPath(cfg))
+}
+
 // sharedCLIDetection implements the generic CLI detection shared by all
 // LLM-gateway-capable clients: the detection directory (or settings directory)
 // must exist, and when LLMBinaryName is set the binary must be found on $PATH.
@@ -325,13 +334,7 @@ func (cm *ClientManager) sharedCLIDetection(cfg *clientAppConfig) bool {
 	// exist until first configured (e.g. Claude Desktop's configLibrary),
 	// LLMDetectRelPath points at a directory that exists once the app is
 	// installed. Otherwise fall back to the settings directory.
-	detectDir := func() string {
-		if cfg.LLMDetectRelPath != nil {
-			return buildConfigFilePath("", cfg.LLMDetectRelPath, cfg.LLMDetectPlatformPrefix, []string{cm.homeDir})
-		}
-		return filepath.Dir(cm.buildLLMSettingsPath(cfg))
-	}()
-	if _, err := os.Stat(detectDir); err != nil {
+	if _, err := os.Stat(cm.llmDetectDir(cfg)); err != nil {
 		return false
 	}
 	if cfg.LLMBinaryName != "" {
@@ -343,6 +346,23 @@ func (cm *ClientManager) sharedCLIDetection(cfg *clientAppConfig) bool {
 		}
 	}
 	return true
+}
+
+// LLMClientDetectionHint explains why clientType was not detected. Empty when
+// there is nothing extra to say (unknown client, already installed, or the
+// settings directory itself is missing).
+func (cm *ClientManager) LLMClientDetectionHint(clientType ClientApp) string {
+	cfg := cm.lookupClientAppConfig(clientType)
+	if cfg == nil || cfg.LLMGatewayMode == "" || cfg.LLMBinaryName == "" {
+		return ""
+	}
+	if cm.isClientInstalled(cfg) {
+		return ""
+	}
+	if _, err := os.Stat(cm.llmDetectDir(cfg)); err != nil {
+		return ""
+	}
+	return fmt.Sprintf("settings directory exists but %q was not found on PATH", cfg.LLMBinaryName)
 }
 
 // buildLLMSettingsPath resolves the absolute path to the LLM settings file

--- a/pkg/client/llm_gateway_test.go
+++ b/pkg/client/llm_gateway_test.go
@@ -665,33 +665,83 @@ func TestDetectedLLMGatewayClients_NeitherDirNorBinary(t *testing.T) {
 	assert.Empty(t, cm.DetectedLLMGatewayClients())
 }
 
+func TestDetectedLLMGatewayClients_GUIEditorsIgnoreMissingBinary(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	cm := NewTestClientManager(home, nil, supportedClientIntegrations, nil)
+	cm.lookPath = func(_ string) (string, error) { return "", os.ErrNotExist }
+
+	for _, clientType := range []ClientApp{VSCode, VSCodeInsider, Cursor} {
+		cfg := cm.lookupClientAppConfig(clientType)
+		require.NotNil(t, cfg)
+		require.Empty(t, cfg.LLMBinaryName)
+		require.NoError(t, os.MkdirAll(filepath.Dir(cm.buildLLMSettingsPath(cfg)), 0o700))
+	}
+
+	detected := cm.DetectedLLMGatewayClients()
+	assert.Contains(t, detected, VSCode)
+	assert.Contains(t, detected, VSCodeInsider)
+	assert.Contains(t, detected, Cursor)
+}
+
+func TestDetectedLLMGatewayClients_CLILeftoverDirStillRequiresBinary(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	cm := NewTestClientManager(home, nil, supportedClientIntegrations, nil)
+	cm.lookPath = func(_ string) (string, error) { return "", os.ErrNotExist }
+
+	cfg := cm.lookupClientAppConfig(ClaudeCode)
+	require.NotNil(t, cfg)
+	require.NoError(t, os.MkdirAll(filepath.Dir(cm.buildLLMSettingsPath(cfg)), 0o700))
+
+	assert.NotContains(t, cm.DetectedLLMGatewayClients(), ClaudeCode)
+	assert.Contains(t, cm.LLMClientDetectionHint(ClaudeCode), `was not found on PATH`)
+}
+
+func TestLLMClientDetectionHint_MissingDirIsSilent(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	cm := NewTestClientManager(home, nil, supportedClientIntegrations, nil)
+	cm.lookPath = func(_ string) (string, error) { return "", os.ErrNotExist }
+
+	assert.Empty(t, cm.LLMClientDetectionHint(ClaudeCode))
+	assert.Empty(t, cm.LLMClientDetectionHint(Cursor))
+}
+
 // TestRealClientConfigs_LLMBinaryNames asserts the expected binary name for
-// every LLM-gateway-capable entry in supportedClientIntegrations. This is a
-// regression guard: a silent typo (e.g. "code" instead of "code-insiders")
-// causes detection to fail on machines that only have the Insiders build.
+// every LLM-gateway-capable entry in supportedClientIntegrations. GUI editors
+// must stay empty: a PATH binary check is a false negative when the app is
+// installed as a desktop editor. CLI tools keep the binary check so leftover
+// config directories do not count as installed.
 func TestRealClientConfigs_LLMBinaryNames(t *testing.T) {
 	t.Parallel()
 
-	want := map[ClientApp]string{
-		VSCodeInsider: "code-insiders",
-		VSCode:        "code",
-		Cursor:        "cursor",
-		ClaudeCode:    "claude",
-		GeminiCli:     "gemini",
-		Codex:         "codex",
-		// Tools without a binary check (dir-only detection) are omitted.
+	wantBinary := map[ClientApp]string{
+		ClaudeCode: "claude",
+		GeminiCli:  "gemini",
+		Codex:      "codex",
 	}
+	wantEmpty := []ClientApp{VSCode, VSCodeInsider, Cursor, ClientApp(Xcode)}
 
 	home := t.TempDir()
 	cm := NewTestClientManager(home, nil, supportedClientIntegrations, nil)
 
-	for clientType, wantBinary := range want {
+	for clientType, want := range wantBinary {
 		t.Run(string(clientType), func(t *testing.T) {
 			t.Parallel()
 			cfg := cm.lookupClientAppConfig(clientType)
 			require.NotNil(t, cfg, "missing entry in supportedClientIntegrations for %s", clientType)
-			assert.Equal(t, wantBinary, cfg.LLMBinaryName,
+			assert.Equal(t, want, cfg.LLMBinaryName,
 				"wrong LLMBinaryName for %s: detection will fail on machines that only have the expected binary", clientType)
+		})
+	}
+	for _, clientType := range wantEmpty {
+		t.Run(string(clientType)+"/dir-only", func(t *testing.T) {
+			t.Parallel()
+			cfg := cm.lookupClientAppConfig(clientType)
+			require.NotNil(t, cfg, "missing entry in supportedClientIntegrations for %s", clientType)
+			assert.Empty(t, cfg.LLMBinaryName,
+				"%s is a GUI editor and must not require a PATH binary", clientType)
 		})
 	}
 }

--- a/pkg/llm/setup.go
+++ b/pkg/llm/setup.go
@@ -36,6 +36,9 @@ type GatewayManager interface {
 	// IsManaged reports whether a managed-preferences profile overrides the
 	// client's local config (so the config setup writes would be ignored).
 	IsManaged(clientType string) bool
+	// LLMClientDetectionHint explains why clientType was not detected, or "".
+	// Used when --client names a CLI tool whose settings dir is leftover after uninstall.
+	LLMClientDetectionHint(clientType string) string
 	// ConfigureEnvFile writes .env file entries for the client and returns the
 	// env file path. Returns ("", nil) when the client has no env-file entries.
 	ConfigureEnvFile(clientType string, cfg llmgateway.ApplyConfig) (string, error)
@@ -98,7 +101,7 @@ func Setup(
 	// there is nothing to configure. In non-lazy mode login still runs before any
 	// files are patched, preserving the guarantee that a failed login leaves no
 	// state.
-	detected, err := filterDetectedClients(gm.DetectedLLMGatewayClients(), targetClient)
+	detected, err := filterDetectedClients(gm, targetClient)
 	if err != nil {
 		return err
 	}
@@ -398,7 +401,8 @@ func warnTLSSkipVerify(errOut io.Writer, skip bool, configured []ToolConfig) {
 // filterDetectedClients narrows the detected client list to a single entry when
 // targetClient is non-empty. It returns an error if the named client is not in
 // the detected list. When targetClient is empty the list is returned unchanged.
-func filterDetectedClients(detected []string, targetClient string) ([]string, error) {
+func filterDetectedClients(gm GatewayManager, targetClient string) ([]string, error) {
+	detected := gm.DetectedLLMGatewayClients()
 	if targetClient == "" {
 		return detected, nil
 	}
@@ -406,6 +410,9 @@ func filterDetectedClients(detected []string, targetClient string) ([]string, er
 		if c == targetClient {
 			return []string{targetClient}, nil
 		}
+	}
+	if hint := gm.LLMClientDetectionHint(targetClient); hint != "" {
+		return nil, fmt.Errorf("client %q is not installed or not detected: %s", targetClient, hint)
 	}
 	return nil, fmt.Errorf("client %q is not installed or not detected", targetClient)
 }

--- a/pkg/llm/setup_test.go
+++ b/pkg/llm/setup_test.go
@@ -305,8 +305,9 @@ func (*stubGatewayManager) DetectedLLMGatewayClients() []string { return nil }
 func (*stubGatewayManager) ConfigureLLMGateway(_ string, _ llmgateway.ApplyConfig) (string, error) {
 	return "", nil
 }
-func (*stubGatewayManager) LLMGatewayModeFor(_ string) string { return "" }
-func (*stubGatewayManager) IsManaged(_ string) bool           { return false }
+func (*stubGatewayManager) LLMGatewayModeFor(_ string) string      { return "" }
+func (*stubGatewayManager) IsManaged(_ string) bool                { return false }
+func (*stubGatewayManager) LLMClientDetectionHint(_ string) string { return "" }
 func (*stubGatewayManager) ConfigureEnvFile(_ string, _ llmgateway.ApplyConfig) (string, error) {
 	return "", nil
 }
@@ -501,6 +502,7 @@ func TestTeardown_NoPurge_LeavesTokenRefsIntact(t *testing.T) {
 type setupGatewayManager struct {
 	detected []string
 	mode     string
+	hint     string
 }
 
 func (g *setupGatewayManager) DetectedLLMGatewayClients() []string { return g.detected }
@@ -509,6 +511,9 @@ func (*setupGatewayManager) ConfigureLLMGateway(_ string, _ llmgateway.ApplyConf
 }
 func (g *setupGatewayManager) LLMGatewayModeFor(_ string) string { return g.mode }
 func (*setupGatewayManager) IsManaged(_ string) bool             { return false }
+func (g *setupGatewayManager) LLMClientDetectionHint(_ string) string {
+	return g.hint
+}
 func (*setupGatewayManager) ConfigureEnvFile(_ string, _ llmgateway.ApplyConfig) (string, error) {
 	return "", nil
 }
@@ -554,6 +559,24 @@ func TestSetup_Lazy_SkipsLoginAndPersistsTools(t *testing.T) {
 	// User must be told that login is deferred to the first request.
 	assert.Contains(t, stdout.String(), "Lazy mode")
 	assert.Contains(t, stdout.String(), "first")
+}
+
+func TestFilterDetectedClients_LeftoverDirHint(t *testing.T) {
+	t.Parallel()
+	gm := &setupGatewayManager{
+		hint: `settings directory exists but "claude" was not found on PATH`,
+	}
+	_, err := filterDetectedClients(gm, "claude-code")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"claude-code" is not installed or not detected`)
+	assert.Contains(t, err.Error(), `was not found on PATH`)
+}
+
+func TestFilterDetectedClients_GenericMiss(t *testing.T) {
+	t.Parallel()
+	_, err := filterDetectedClients(&setupGatewayManager{}, "cursor")
+	require.Error(t, err)
+	assert.Equal(t, `client "cursor" is not installed or not detected`, err.Error())
 }
 
 func TestSetup_NonLazy_InvokesLogin(t *testing.T) {
@@ -678,8 +701,11 @@ func (g *capturingGatewayManager) ConfigureLLMGateway(_ string, cfg llmgateway.A
 }
 func (g *capturingGatewayManager) LLMGatewayModeFor(_ string) string { return g.mode }
 func (*capturingGatewayManager) IsManaged(_ string) bool             { return false }
-func (*capturingGatewayManager) LLMSetupNoteFor(_ string) string     { return "" }
-func (*capturingGatewayManager) RevertLLMGateway(_, _ string) error  { return nil }
+func (*capturingGatewayManager) LLMClientDetectionHint(_ string) string {
+	return ""
+}
+func (*capturingGatewayManager) LLMSetupNoteFor(_ string) string    { return "" }
+func (*capturingGatewayManager) RevertLLMGateway(_, _ string) error { return nil }
 func (*capturingGatewayManager) ConfigureEnvFile(_ string, _ llmgateway.ApplyConfig) (string, error) {
 	return "", nil
 }
@@ -821,6 +847,9 @@ func (*managedGatewayManager) LLMGatewayModeFor(_ string) string {
 	return llmgateway.ModeCredentialHelper
 }
 func (g *managedGatewayManager) IsManaged(c string) bool { return g.managed[c] }
+func (*managedGatewayManager) LLMClientDetectionHint(_ string) string {
+	return ""
+}
 func (*managedGatewayManager) ConfigureEnvFile(_ string, _ llmgateway.ApplyConfig) (string, error) {
 	return "", nil
 }

--- a/test/e2e/cli_llm_all_clients_test.go
+++ b/test/e2e/cli_llm_all_clients_test.go
@@ -121,7 +121,7 @@ func allClientTestCases() []llmClientTestCase {
 			detectionDir: func(tempDir string) string {
 				return llmSettingsDirFor("cursor", tempDir)
 			},
-			binaryName: "cursor",
+			binaryName: "",
 			settingsPath: func(tempDir string) string {
 				return filepath.Join(llmSettingsDirFor("cursor", tempDir), "settings.json")
 			},
@@ -140,7 +140,7 @@ func allClientTestCases() []llmClientTestCase {
 			detectionDir: func(tempDir string) string {
 				return llmSettingsDirFor("vscode", tempDir)
 			},
-			binaryName: "code",
+			binaryName: "",
 			settingsPath: func(tempDir string) string {
 				return filepath.Join(llmSettingsDirFor("vscode", tempDir), "settings.json")
 			},
@@ -159,7 +159,7 @@ func allClientTestCases() []llmClientTestCase {
 			detectionDir: func(tempDir string) string {
 				return llmSettingsDirFor("vscode-insider", tempDir)
 			},
-			binaryName: "code-insiders",
+			binaryName: "",
 			settingsPath: func(tempDir string) string {
 				return filepath.Join(llmSettingsDirFor("vscode-insider", tempDir), "settings.json")
 			},


### PR DESCRIPTION
## Summary

`thv llm setup` missed VS Code, VS Code Insiders, and Cursor when the editor was installed but `code` / `code-insiders` / `cursor` was not on PATH. MCP install checks already treat those three as "settings dir exists". LLM detection required a PATH binary on top, so the same machine could look installed for MCP and missing for the gateway.

This clears `LLMBinaryName` for those three GUI editors. CLI tools (`claude`, `gemini`, `codex`) still need both the settings dir and the binary, so a leftover `~/.claude` after uninstall does not count. If you pass `--client` for a CLI tool in that leftover state, the error now says the directory exists and the binary was not found, instead of only "not installed or not detected".

Fixes #6292

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`go test ./pkg/client -count=1 -run "TestDetectedLLMGatewayClients_|TestRealClientConfigs_LLMBinaryNames|TestLLMClientDetectionHint_"`)
- [x] `go test ./pkg/llm -count=1 -run "TestFilterDetectedClients_|TestSetup_"`
- [x] `go test ./cmd/thv/app -count=1 -run "TestRunLLMSetup_ClientFlag_"`
- [ ] E2E tests (`task test-e2e`) (POSIX-only in this suite; skipped on this Win11 box)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

On this Win11 box Cursor is installed (`%APPDATA%\Cursor` and `~/.cursor` both exist) and `cursor` is also on PATH, so the live false-negative does not fire here. The miss is pinned by `TestDetectedLLMGatewayClients_GUIEditorsIgnoreMissingBinary` (settings dir present, LookPath always missing, GUI editors detected) and `TestDetectedLLMGatewayClients_CLILeftoverDirStillRequiresBinary` (same LookPath stub, `claude-code` still omitted, leftover hint set). `--client` leftover path is `TestRunLLMSetup_ClientFlag_LeftoverCLIDir`.

Full `go test ./pkg/client` on Windows still hits pre-existing failures (claude-desktop "not supported on Windows yet", 0600 vs 0666 file mode). Same class as before this diff. CI Linux is the real gate.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes. `thv llm setup` can detect VS Code / Insiders / Cursor from the editor settings directory without a shell PATH binary. `thv llm setup --client <cli-tool>` names leftover config dirs when the binary is gone.

## Special notes for reviewers

Assigned on #6292. The three GUI editors match MCP's dir check; CLI leftover dirs keep the binary check.

Assisted by Cursor.

## Evidence

```
go test ./pkg/client -count=1 -timeout 60s -run "TestDetectedLLMGatewayClients_|TestRealClientConfigs_LLMBinaryNames|TestLLMClientDetectionHint_"
ok  	github.com/stacklok/toolhive/pkg/client	1.435s

go test ./pkg/llm -count=1 -timeout 60s -run "TestFilterDetectedClients_|TestSetup_"
ok  	github.com/stacklok/toolhive/pkg/llm	1.620s

go test ./cmd/thv/app -count=1 -timeout 90s -run "TestRunLLMSetup_ClientFlag_"
ok  	github.com/stacklok/toolhive/cmd/thv/app	1.894s
```
