### PR TITLE
Encode empty mirrored parameter headers

### DIFF
--- a/pkg/mcp/revision.go
+++ b/pkg/mcp/revision.go
@@ -677,6 +677,9 @@ func decodeSentinelName(v string) (string, error) {
 // EncodeSentinelName encodes v into the draft spec's base64 sentinel format
 // (=?base64?<payload>?=) when required — the mirror of decodeSentinelName.
 // Encoding is required when EITHER:
+//   - v is empty: a plain empty HTTP header value is indistinguishable from an
+//     omitted header to receivers, so its sentinel form preserves that the
+//     parameter was present;
 //   - v is not safely representable as a plain ASCII header value: any byte
 //     falls outside printable ASCII 0x21-0x7E, which also covers leading/
 //     trailing whitespace and CR/LF (both fall below 0x21 and would
@@ -695,9 +698,9 @@ func EncodeSentinelName(v string) string {
 }
 
 // needsSentinelEncoding reports whether v requires sentinel encoding; see
-// EncodeSentinelName for the two conditions checked.
+// EncodeSentinelName for the three conditions checked.
 func needsSentinelEncoding(v string) bool {
-	if strings.HasPrefix(v, sentinelPrefix) && strings.HasSuffix(v, sentinelSuffix) {
+	if v == "" || (strings.HasPrefix(v, sentinelPrefix) && strings.HasSuffix(v, sentinelSuffix)) {
 		return true
 	}
 	for i := 0; i < len(v); i++ {

--- a/pkg/mcp/revision_test.go
+++ b/pkg/mcp/revision_test.go
@@ -688,6 +688,7 @@ func TestEncodeSentinelName(t *testing.T) {
 	}{
 		{name: "plain ASCII name unchanged", input: "my-tool", wantSame: true},
 		{name: "URI with colon and slash unchanged", input: "file:///tmp/foo.txt", wantSame: true},
+		{name: "empty value is encoded", input: "", wantSame: false},
 		{name: "accented character encoded", input: "café-résumé", wantSame: false},
 		{name: "CJK character encoded", input: "工具", wantSame: false},
 		{name: "CR in value encoded", input: "bad\rname", wantSame: false},

--- a/pkg/mcp/xmcpheader.go
+++ b/pkg/mcp/xmcpheader.go
@@ -226,7 +226,9 @@ var ErrUnmirrorableValue = errors.New("parameter value cannot be mirrored into a
 // A designated parameter that is absent from args contributes no header. That is
 // deliberate rather than an error: an optional parameter the caller did not
 // supply has no value to mirror, and SEP-2243's -32020 covers the server's view
-// of a genuinely missing designated value.
+// of a genuinely missing designated value. A provided empty string is instead
+// sent as the base64 sentinel so it remains distinguishable from an absent
+// header.
 //
 // Annotations reached through an array element ("[]" in the path) are skipped: an
 // array holds many elements and a header holds one value, so there is no
@@ -317,6 +319,8 @@ func isCombinatorSegment(seg string) bool {
 
 // renderHeaderValue converts a designated parameter's value to its header
 // spelling, enforcing the schema's declared type and SEP-2243's integer range.
+// A present empty string is sentinel-encoded so it remains distinguishable from
+// an absent mirrored parameter; absent values are omitted by MirrorParamHeaders.
 func renderHeaderValue(h ParamHeader, value any) (string, error) {
 	where := strings.Join(h.Path, ".")
 	switch h.Type {
@@ -328,6 +332,9 @@ func renderHeaderValue(h ParamHeader, value any) (string, error) {
 		if bad, invalid := firstControlChar(s); invalid {
 			return "", fmt.Errorf(
 				"%w: parameter %q contains a control character (%q)", ErrUnmirrorableValue, where, bad)
+		}
+		if s == "" {
+			return EncodeSentinelName(s), nil
 		}
 		return s, nil
 	case "boolean":

--- a/pkg/mcp/xmcpheader_mirror_test.go
+++ b/pkg/mcp/xmcpheader_mirror_test.go
@@ -37,6 +37,14 @@ func TestParamHeadersForSchema(t *testing.T) {
 			want: map[string]string{"Mcp-Param-Region": "eu-west1"},
 		},
 		{
+			name: "designated empty string is sentinel-encoded",
+			schema: objSchema(map[string]any{
+				"region": annotated("string", "Region"),
+			}),
+			args: map[string]any{"region": ""},
+			want: map[string]string{"Mcp-Param-Region": "=?base64??="},
+		},
+		{
 			name:   "boolean is mirrored as true/false",
 			schema: objSchema(map[string]any{"dry_run": annotated("boolean", "Dry-Run")}),
 			args:   map[string]any{"dry_run": true},


### PR DESCRIPTION
## Summary

An HTTP header with an empty value is indistinguishable from an absent header
to most receivers. For SEP-2243 designated (`x-mcp-header`) parameters, that
collapses "the caller passed an empty string" and "the caller didn't pass this
argument at all" into the same wire representation, even though the two cases
must stay distinguishable for the mirrored header to be meaningful.

- `needsSentinelEncoding` now also treats the empty string as requiring
  sentinel encoding, alongside the existing non-ASCII/control-character and
  sentinel-collision cases.
- `renderHeaderValue`'s string branch sentinel-encodes a present-but-empty
  value (`=?base64??=`) instead of emitting a bare empty header, reusing the
  existing `EncodeSentinelName`/`decodeSentinelName` machinery.
- Adds regression coverage for the empty-string encoder case and for the
  mirrored-header integration path.

Fixes #6484

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)

## API Compatibility

Not applicable — no operator API surface touched.

## Special notes for reviewers

Only the outgoing mirroring path is touched (`MirrorParamHeaders` /
`renderHeaderValue`); there is no `Mcp-Param-*` decode counterpart in this
package yet to keep in sync.

Generated with [Claude Code](https://claude.com/claude-code)
