### PR TITLE
Bump x/crypto to v0.56.0 and adopt go 1.26.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,9 +44,6 @@ jobs:
             ${{ runner.os }}-go-build-lint-
             ${{ runner.os }}-go-build-
 
-      - name: Check go.mod version format
-        run: "! grep -qE '^go [0-9]+\\.[0-9]+\\.[0-9]+' go.mod || { echo 'ERROR: go.mod must pin Go to minor version (e.g. go 1.26), not patch (e.g. go 1.26.1)'; exit 1; }"
-
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stacklok/toolhive
 
-go 1.26
+go 1.26.0
 
 require (
 	dario.cat/mergo v1.0.2
@@ -356,7 +356,7 @@ require (
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/sys v0.47.0
 	k8s.io/client-go v0.35.3

--- a/go.sum
+++ b/go.sum
@@ -992,8 +992,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/exp/event v0.0.0-20260611194520-c48552f49976 h1:aMc3mP8qjwSEdljznT5CYeyvpoFP7e3VCNqZZwUf3F0=


### PR DESCRIPTION
## Summary

**Why:** two advisories were published against `golang.org/x/crypto/ssh` — **GO-2026-6354** and **GO-2026-6355**, both channel-deadlock DoS bugs a malicious SSH peer can trigger. They fail the `govulncheck` security gate on every open PR and will fail `main`'s next scheduled scan.

**What:**
- Bump `golang.org/x/crypto` **v0.55.0 → v0.56.0** (the release that fixes both advisories).
- Move the `go` directive **`go 1.26` → `go 1.26.0`**.
- Remove the "go.mod must pin Go to minor version" check in `.github/workflows/lint.yml`.

## Reachability (severity context)

These are **production-reachable, not test-only.** `govulncheck` traces the vulnerable `ssh.NewClientConn` from our own code:

```
pkg/git.Clone
  → go-git CloneContext → … → transport/ssh.dial
    → golang.org/x/crypto/ssh.NewClientConn   (vulnerable)
```

`pkg/git.Clone` calls `git.CloneContext`, and go-git registers its SSH transport by default, so the vulnerable path is linked in and reachable whenever a repository is cloned over SSH (`pkg/git` exposes `WithAuth(transport.AuthMethod)`, which accepts SSH auth). The dependency therefore **cannot be removed** without dropping go-git's SSH transport support — bumping to the patched release is the correct fix.

## Why the go directive has to change (and the lint rule has to go)

`x/crypto v0.56.0` declares `go 1.26.0` in its own `go.mod`. Go's module rules require a consumer to declare a `go` version **>= the maximum of its dependencies'** `go` directives, so pulling v0.56.0 forces this module's `go.mod` to `go 1.26.0` (patch-level).

That directly collides with `lint.yml`'s guard:

```
! grep -qE '^go [0-9]+\.[0-9]+\.[0-9]+' go.mod || { echo 'ERROR: go.mod must pin Go to minor version ...'; exit 1; }
```

The two constraints cannot both hold: any `go` step (build, `go mod tidy`, codegen verify) rewrites the directive to `1.26.0`, and the lint check then rejects it. Adopting `go 1.26.0` and dropping the minor-version guard is the only way to consume the patched dependency. `go mod tidy` was re-run so `go.sum` is consistent under the new floor.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `govulncheck ./...` locally: GO-2026-6354 and GO-2026-6355 no longer appear after the bump.
- [x] `go build ./...` passes; `go mod tidy` leaves the tree clean under `go 1.26.0`.
- [x] Only non-stdlib finding left is `GO-2026-5932`, already in `IGNORED_VULNS`.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers — please confirm the approach

This PR makes a **repo-wide policy change** (the `go` directive floor and the removal of the minor-version lint guard), which is broader than a routine dependency bump. Please confirm you're comfortable with:

1. **Raising the `go` directive to `go 1.26.0`.** This sets a patch-level minimum for the whole module. It's transitively required by `x/crypto v0.56.0` — there's no way to take the fix on `go 1.26`.
2. **Removing the minor-version lint guard.** That rule presumably existed to keep the patch toolchain floating via `GOTOOLCHAIN`; with a dependency now pinning a patch floor, the guard can no longer pass.

An ignore-list entry was considered and rejected: the vuln is reachable from production git-over-SSH (see Reachability above), so suppressing it would leave a real DoS path unaddressed. Removing the dependency was also investigated and isn't viable — it backs go-git's SSH transport.

Generated with [Claude Code](https://claude.com/claude-code)
