### PR TITLE
Route Claude workflows through the Stacklok LLM gateway

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,7 +18,7 @@ jobs:
     # This is an allow-list rather than a deny-list. Denying NONE, FIRST_TIMER
     # and FIRST_TIME_CONTRIBUTOR still admitted CONTRIBUTOR — which anyone
     # earns permanently by getting a single pull request merged — and
-    # MANNEQUIN. This job holds contents: write and ANTHROPIC_API_KEY and
+    # MANNEQUIN. This job holds contents: write and a gateway API key and
     # allows Bash(git *), so the bar needs to be write access to the
     # repository, not a history of contributing to it.
     #
@@ -74,8 +74,10 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@16b3b310c3d7b5279df73130324d5205aeea8eac # v1.0.205
+        env:
+          ANTHROPIC_BASE_URL: https://llm-gateway.stacklok.dev/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_CLAUDE_TAG }}
           # Security: Restrict tools to prevent arbitrary code execution.
           # Bash is scoped to known-safe commands (task, go, git, helm-docs).
           # No unrestricted Bash access — prevents prompt injection from

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Run Claude Code for Issue Triage
         uses: anthropics/claude-code-action@16b3b310c3d7b5279df73130324d5205aeea8eac # v1.0.205
+        env:
+          ANTHROPIC_BASE_URL: https://llm-gateway.stacklok.dev/anthropic
         with:
           prompt: |
             You are an issue triage assistant. Analyze issue #${{ github.event.issue.number }} in ${{ github.repository }} and apply appropriate labels.
@@ -42,6 +44,6 @@ jobs:
             - DO NOT post comments or otherwise communicate with the issue author.
             - If no labels are clearly applicable, do not apply any.
           claude_args: --model claude-sonnet-4-6
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_ISSUE_TRIAGE }}
           allowed_non_write_users: "*"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -112,8 +112,9 @@ jobs:
           # via GH_TOKEN. Read access is sufficient — publishing happens in a
           # later, deterministic step, not by the model.
           GH_TOKEN: ${{ github.token }}
+          ANTHROPIC_BASE_URL: https://llm-gateway.stacklok.dev/anthropic
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_RELEASE_NOTES }}
           # Hand the action a token explicitly so it does not try to mint one via
           # OIDC (the Claude GitHub App flow), which would require `id-token: write`
           # and the app installed. We only need the API key for Anthropic auth and


### PR DESCRIPTION
## Summary

- Centralizing LLM usage through Stacklok's internal gateway (instead of hitting the Anthropic API directly) requires each Claude Code Action workflow to authenticate with a gateway-issued key and point at the gateway endpoint.
- Replaced the shared `ANTHROPIC_API_KEY` secret with three per-workflow gateway keys, and set `ANTHROPIC_BASE_URL` so all Claude Code Action traffic routes through `https://llm-gateway.stacklok.dev/anthropic`:
  - `claude.yml` (Claude PR Assistant) now uses `STACKLOK_GATEWAY_KEY_CLAUDE_TAG`
  - `issue-triage.yml` now uses `STACKLOK_GATEWAY_KEY_ISSUE_TRIAGE`
  - `release-notes.yml` now uses `STACKLOK_GATEWAY_KEY_RELEASE_NOTES`

## Type of change

- [x] Other (describe): CI workflow configuration change (auth/routing only, no functional behavior change)

## Test plan

- [x] Manual testing (describe below)

Verified via `grep` that no workflow still references `secrets.ANTHROPIC_API_KEY`, and that each workflow sets exactly one `STACKLOK_GATEWAY_KEY_*` secret plus `ANTHROPIC_BASE_URL`. These are GitHub Actions YAML changes only — there is no local build/test path that exercises them; correctness will be confirmed by the next live trigger of each workflow.

## Does this introduce a user-facing change?

No — internal CI/automation configuration only.

## Special notes for reviewers

The three new secrets (`STACKLOK_GATEWAY_KEY_RELEASE_NOTES`, `STACKLOK_GATEWAY_KEY_ISSUE_TRIAGE`, `STACKLOK_GATEWAY_KEY_CLAUDE_TAG`) must exist in the repo/org secrets store before merge, or these workflows will fail on their next trigger. The old `ANTHROPIC_API_KEY` secret can be removed once this is merged and verified, if it's not used elsewhere.

Generated with [Claude Code](https://claude.com/claude-code)