### PR TITLE
Restore go.mod patch-version lint with floor-friendly regex

### DIFF
--- a/.claude/rules/go-style.md
+++ b/.claude/rules/go-style.md
@@ -1,11 +1,20 @@
 ---
 paths:
   - "**/*.go"
+  - "**/go.mod"
 ---
 
 # Go Style Rules
 
 Applies to all Go files in the project.
+
+## Go Module (`go.mod`) Conventions
+
+- The `go` directive must not pin a non-zero patch version (`go 1.26.4` is
+  rejected by CI). `go 1.26` and `go 1.26.0` are both fine — a dependency's
+  own `go.mod` floor is always `X.Y.0`, never a later patch, so `X.Y.0` is
+  allowed to unblock a forced bump (e.g. picking up a CVE fix) without
+  reintroducing the patch-version churn this rule exists to prevent.
 
 ## File Organization
 - Public methods in the top half of files, private methods in the bottom half

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,9 @@ jobs:
             ${{ runner.os }}-go-build-lint-
             ${{ runner.os }}-go-build-
 
+      - name: Check go.mod version format
+        run: "! grep -qE '^go [0-9]+\\.[0-9]+\\.[1-9][0-9]*$' go.mod || { echo 'ERROR: go.mod must not pin a non-zero Go patch version (go 1.26 or go 1.26.0 are fine; a dependency floor is always X.Y.0, never a later patch)'; exit 1; }"
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:


### PR DESCRIPTION
## Summary

- Bumping x/crypto to v0.56.0 (#6494) required setting go.mod's `go` directive to `go 1.26.0`, which collided with the old lint check ("go.mod must pin Go to minor version"), so that check was dropped entirely instead of fixed.
- We've had churn before from contributors accidentally bumping the go directive to an arbitrary patch version, so losing the guard entirely isn't the right trade — we still want to catch that class of mistake.
- Restores the check in `lint.yml` with a tighter regex that allows both `go 1.26` and `go 1.26.0` (a dependency's own go.mod floor is always `X.Y.0`, never a later patch) while still rejecting a stray patch bump like `go 1.26.4`.
- Documents the convention in `.claude/rules/go-style.md` so it isn't only enforced in CI.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Manually verified the new regex against the four relevant cases:
- `go 1.26` → allowed
- `go 1.26.0` → allowed
- `go 1.26.4` → rejected
- `go 1.26.10` → rejected

Confirmed the repo's current `go 1.26.0` directive still passes the restored check.

## API Compatibility

N/A — CI/docs only change, no operator API surface touched.

## Does this introduce a user-facing change?

No.

Generated with [Claude Code](https://claude.com/claude-code)