### PR TITLE
Close leaked test validators and fix validator-sharing docs

### DIFF
--- a/docs/arch/17-token-exchange-delegation.md
+++ b/docs/arch/17-token-exchange-delegation.md
@@ -753,14 +753,18 @@ spec:
   computed by the same `jwtBearerGrantEnabled` helper that decides whether
   `buildProvider` registers the grant with fosite in the first place — the two
   can't drift out of sync).
-- **Validator sharing.** When both RFC 8693 token exchange and the JWT-bearer
-  grant are enabled for the same trusted issuers, `buildProvider` constructs a
-  single `MultiIssuerTokenValidator` (`tokenexchange.NewSharedTrustedIssuerValidator`)
-  and passes it to both `tokenexchange.FactoryWithSharedTrustedIssuerValidator`
-  and `tokenexchange.JWTBearerIssuanceFactory`, rather than each building its own —
-  a `MultiIssuerTokenValidator` registers a `jwk.Cache` and background refresh
-  goroutines per issuer, so building two would double that cost with no
-  benefit.
+- **Validator sharing.** Whenever any trusted issuer is configured,
+  `buildProvider` constructs a single `MultiIssuerTokenValidator`
+  (`tokenexchange.NewSharedTrustedIssuerValidator`), holds it on the server, and
+  passes it to `tokenexchange.FactoryWithSharedTrustedIssuerValidator` (and, when
+  the JWT-bearer grant is enabled, `tokenexchange.JWTBearerIssuanceFactory`),
+  which require it rather than each building its own. A `MultiIssuerTokenValidator`
+  registers a `jwk.Cache` and background refresh goroutines per issuer, so one
+  shared instance both avoids doubling that cost and gives the server a single
+  handle to shut those workers down on `Close`. (Previously the shared validator
+  was built only when the JWT-bearer grant was also enabled, and a token-exchange-only
+  server built its validator inside a factory closure where nothing could release
+  it.)
 - **No delegation consent.** The JWT-bearer grant does not apply
   `allowedActors`, `actorMatcher`, or `may_act` — those are RFC 8693 delegation
   concepts. An issuer's JWT-bearer subjects are authorized entirely by

--- a/pkg/authserver/server/tokenexchange/factory.go
+++ b/pkg/authserver/server/tokenexchange/factory.go
@@ -14,12 +14,16 @@ import (
 )
 
 // NewSharedTrustedIssuerValidator builds the single MultiIssuerTokenValidator
-// a caller should pass to both Factory and JWTBearerIssuanceFactory when
-// enabling both the RFC 8693 token-exchange and RFC 7523 JWT-bearer grants
-// for the same trusted issuers, so only one JWKS cache/goroutine set per
-// issuer is ever registered. Returns (nil, nil) when trustedIssuers is
-// empty — both factories fall back to building their own validator (or none)
-// in that case.
+// that backs a server's trusted-issuer handling. buildProvider constructs it
+// whenever any trusted issuer is configured — not only when the RFC 7523
+// JWT-bearer grant is also enabled — and passes it to
+// FactoryWithSharedTrustedIssuerValidator (and, when the JWT-bearer grant is
+// enabled, JWTBearerIssuanceFactory), both of which now require it for a
+// non-empty trusted-issuer set rather than building their own. One shared
+// instance keeps a single JWKS cache/goroutine set per issuer and, crucially,
+// gives the server one validator to Close on shutdown so those goroutines are
+// released (see MultiIssuerTokenValidator.Close). Returns (nil, nil) when
+// trustedIssuers is empty, in which case no external validator is built.
 func NewSharedTrustedIssuerValidator(
 	config *server.AuthorizationServerConfig, trustedIssuers []TrustedIssuer,
 ) (*MultiIssuerTokenValidator, error) {

--- a/pkg/authserver/server/tokenexchange/multi_issuer_validator_test.go
+++ b/pkg/authserver/server/tokenexchange/multi_issuer_validator_test.go
@@ -1579,6 +1579,7 @@ func TestNewMultiIssuerTokenValidator_EmptyAllowedActorsAccepted(t *testing.T) {
 		AllowedDelegateClients: []string{anyDelegateClient},
 	}}, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = v.Close() })
 	assert.NotNil(t, v)
 }
 
@@ -1604,6 +1605,7 @@ func TestNewMultiIssuerTokenValidator_GrantOnlyIssuerAccepted(t *testing.T) {
 		},
 	}}, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = v.Close() })
 	assert.NotNil(t, v)
 }
 
@@ -1837,6 +1839,7 @@ func TestNewMultiIssuerTokenValidator_AudienceShapeWarning(t *testing.T) {
 				AllowedDelegateClients: []string{anyDelegateClient},
 			}}, nil)
 			require.NoError(t, err)
+			t.Cleanup(func() { _ = v.Close() })
 			require.NotNil(t, v)
 
 			logged := buf.String()
@@ -2259,6 +2262,7 @@ func TestMultiIssuerTokenValidator_DiscoveryRefusesPrivateAddress(t *testing.T) 
 	require.NoError(t, err)
 	validator, err := NewMultiIssuerTokenValidator(selfValidator, testIssuer, trustedIssuers, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = validator.Close() })
 
 	claims := externalClaims()
 	claims.Issuer = server.URL
@@ -2819,6 +2823,7 @@ func TestMultiIssuerTokenValidator_SharedJWKSURL_DifferingPolicy(t *testing.T) {
 		},
 	}, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = validator.Close() })
 
 	tokenFor := func(issuer, audience, actor, jti string) string {
 		now := time.Now()


### PR DESCRIPTION
## Summary

**Why:** the review on #6493 (which fixed the auth-server JWKS worker-pool leak, issue #6482) approved with two non-blocking follow-ups. This PR addresses both.

**What:**
- **Close leaked validators in tests.** Several pre-existing tests in `multi_issuer_validator_test.go` constructed a `MultiIssuerTokenValidator` directly and never `Close()`d it, so each still leaked one JWKS refresh worker pool per issuer — the exact leak #6493 closed in production. Registered `t.Cleanup(func() { _ = v.Close() })` at each success-construction site (`EmptyAllowedActorsAccepted`, `GrantOnlyIssuerAccepted`, `AudienceShapeWarning`, the private-IP discovery test, and the shared-JWKS-URL per-issuer test). Sites that intentionally fail construction were left alone — the constructor drains any started pool on its own error path.
- **Fix doc drift.** `NewSharedTrustedIssuerValidator`'s doc comment and the "Validator sharing" note in `docs/arch/17-token-exchange-delegation.md` still described the old "only builds the shared validator when the JWT-bearer grant is also enabled" behavior. #6482 changed this — `buildProvider` now builds the shared validator whenever any trusted issuer is configured and holds it on the server for `Close`. Updated both to match.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — test-only leak + docs

## Test plan

- [x] `task lint-fix` — 0 issues.
- [x] `go test -race ./pkg/authserver/server/tokenexchange/` passes, including the touched tests.
- [x] `go build ./pkg/authserver/...` passes.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

Pure test + documentation change; no production code paths are modified. Follows up on the two items raised in https://github.com/stacklok/toolhive/pull/6493#pullrequestreview-5100334043.

Generated with [Claude Code](https://claude.com/claude-code)
