### PR TITLE
Allow Cedar delegation without an upstream session

### DIFF
--- a/docs/authz.md
+++ b/docs/authz.md
@@ -327,7 +327,7 @@ principal and the context, naming the trust root behind the claims:
 | --- | --- |
 | `request` | No `primaryUpstreamProvider` is configured. Claims come from the request's token, and no provenance was ever demanded. |
 | `upstream:<provider>` | Claims come from that upstream's access token (with the profile-claim id_token supplement where it applies). |
-| `request:no-upstream-session` | The token states it was minted with no upstream login — an RFC 8693 delegated token or an RFC 7523 JWT-bearer token — so no upstream credential can exist for it. |
+| `request:no-upstream-session` | The validated embedded-auth-server token was proven to have been minted with no upstream login, so no upstream credential can exist for it. |
 | `request:upstream-opaque` | An upstream credential exists but is an opaque OAuth 2.0 access token whose claims cannot be read, so evaluation degraded to the request token's claims. |
 
 A policy that must only act on what an upstream actually asserted can say so:
@@ -357,10 +357,52 @@ upstream credential can ever exist for it:
   grant has no standard marker of its own.
 
 Under a pinned `primaryUpstreamProvider`, both are evaluated against their own
-claims and labelled `request:no-upstream-session`. Note that these tokens carry
-only `sub`, `act`, `client_id`, `name` and `email` — no group or role claims are
-copied from the subject token — so a policy guarded on `principal has
-claim_groups` still denies them.
+claims and labelled `request:no-upstream-session` only after the incoming token
+has been validated for the configured embedded authorization-server issuer.
+
+##### What these tokens can and cannot express
+
+A session-less token carries at most `sub`, `act`, `client_id` and `scope`, plus
+`name` and `email` when the grant supplies them (RFC 8693 delegation copies them
+from the subject token; RFC 7523 JWT-bearer has no end user and carries neither).
+Nothing else crosses. In particular **no upstream attribute is carried** — no
+`groups`, no `roles`, no `department`, nothing the pinned IdP asserted about the
+subject.
+
+That bounds which policies work under delegation. Policies keyed on the identity
+of the actor, the subject, or the delegated scope work:
+
+```plain
+permit(principal, action == Action::"call_tool", resource) when {
+  principal.thv_claim_source == "request:no-upstream-session" &&
+  principal.claim_act.sub == "my-delegate" &&
+  principal.claim_scope like "*mcp:tools*"
+};
+```
+
+Policies keyed on upstream attributes do not. A rule guarded on
+`principal has claim_department` simply stops matching, so the request is denied
+— the same outcome as before this fallback existed, reached at policy evaluation
+instead of at claim resolution. If your policies depend on upstream attributes,
+delegated tokens are not yet usable under a pinned provider. Carrying those
+attributes across the exchange (claims transcription,
+[draft-ietf-oauth-identity-chaining](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-chaining/)
+§2.5) is tracked in
+[#6511](https://github.com/stacklok/toolhive/issues/6511).
+
+Two consequences worth planning around:
+
+- **`forbid` rules over upstream attributes do not survive delegation.** Their
+  `has` guard goes false when the attribute is absent, so the rule never fires
+  and the restriction lifts. Express upstream restrictions as conditions on a
+  `permit` rather than as a `forbid`, or require
+  `principal.thv_claim_source == "upstream:<provider>"` in the `forbid` so it is
+  clear the rule only governs directly-authenticated requests.
+- **With more than one upstream provider, `claim_email` and `claim_name` on a
+  delegated token may come from a provider other than the pinned one.** They are
+  copied from the subject token, whose profile claims mirror the first configured
+  upstream. Check `thv_claim_source` before treating them as an assertion by the
+  pinned provider.
 
 Everything else stays closed. A token that simply arrives without upstream
 credentials and says nothing about why — an anonymous or local identity, or a
@@ -376,9 +418,9 @@ JWT-bearer grant.
 
 Deployments that scrape the authorizer's DEBUG logs should note that the
 `source` field now uses the same vocabulary as `thv_claim_source`: the former
-`token`, `no-session-fallback`, `token-fallback` and `upstream` values are now
-`request`, `request:no-upstream-session`, `request:upstream-opaque` and
-`upstream:<provider>`.
+`token`, `token-fallback` and `upstream` values are now `request`,
+`request:upstream-opaque` and `upstream:<provider>`, and the session-less path
+that previously denied now logs `request:no-upstream-session`.
 
 #### Using tool arguments in policies
 

--- a/docs/authz.md
+++ b/docs/authz.md
@@ -313,6 +313,73 @@ Both approaches work and can be used to make authorization decisions based on
 the client's identity. This policy allows only clients with the name "John Doe"
 to call the weather tool.
 
+#### Knowing where a claim came from
+
+Claims do not always come from the same place. When `primaryUpstreamProvider` is
+set, policies are normally evaluated against claims asserted by that upstream
+IdP — but several paths fall back to the claims in the request's own token, and
+until you check, `claim_email` looks identical either way.
+
+Every request therefore carries a `thv_claim_source` attribute, on both the
+principal and the context, naming the trust root behind the claims:
+
+| Value | Meaning |
+| --- | --- |
+| `request` | No `primaryUpstreamProvider` is configured. Claims come from the request's token, and no provenance was ever demanded. |
+| `upstream:<provider>` | Claims come from that upstream's access token (with the profile-claim id_token supplement where it applies). |
+| `request:no-upstream-session` | The token states it was minted with no upstream login — an RFC 8693 delegated token or an RFC 7523 JWT-bearer token — so no upstream credential can exist for it. |
+| `request:upstream-opaque` | An upstream credential exists but is an opaque OAuth 2.0 access token whose claims cannot be read, so evaluation degraded to the request token's claims. |
+
+A policy that must only act on what an upstream actually asserted can say so:
+
+```plain
+permit(principal, action == Action::"call_tool", resource == Tool::"deploy") when {
+  principal.thv_claim_source == "upstream:github" &&
+  principal has claim_email &&
+  principal.claim_email like "*@example.com"
+};
+```
+
+The attribute is written after claim prefixing and its name does not start with
+`claim_`, so a token carrying a claim named `thv_claim_source` becomes
+`claim_thv_claim_source` and cannot spoof its own provenance.
+
+#### Tokens with no upstream login
+
+Two grants mint a token that is not tied to any upstream IdP login, so no
+upstream credential can ever exist for it:
+
+- **RFC 8693 delegation** — the token carries an `act` claim naming the actor
+  that obtained it on the subject's behalf.
+- **RFC 7523 JWT-bearer** — the subject is a machine identity asserted by a
+  separate trust root. ToolHive's authorization server stamps
+  `https://toolhive.dev/no_upstream_session: true` on these tokens, because the
+  grant has no standard marker of its own.
+
+Under a pinned `primaryUpstreamProvider`, both are evaluated against their own
+claims and labelled `request:no-upstream-session`. Note that these tokens carry
+only `sub`, `act`, `client_id`, `name` and `email` — no group or role claims are
+copied from the subject token — so a policy guarded on `principal has
+claim_groups` still denies them.
+
+Everything else stays closed. A token that simply arrives without upstream
+credentials and says nothing about why — an anonymous or local identity, or a
+bearer token from an IdP other than the pinned one — is denied, as is a session
+that exists but holds no credential for the pinned provider.
+
+**Upgrading:** JWT-bearer tokens minted by an authorization server running a
+version before this marker existed carry no marker, so a pinned deployment
+denies them until those tokens turn over. Delegated tokens are unaffected — the
+`act` claim they already carry needs no new plumbing. Roll the authorization
+server before pinning `primaryUpstreamProvider` on a deployment that uses the
+JWT-bearer grant.
+
+Deployments that scrape the authorizer's DEBUG logs should note that the
+`source` field now uses the same vocabulary as `thv_claim_source`: the former
+`token`, `no-session-fallback`, `token-fallback` and `upstream` values are now
+`request`, `request:no-upstream-session`, `request:upstream-opaque` and
+`upstream:<provider>`.
+
 #### Using tool arguments in policies
 
 The authorization middleware also extracts tool arguments from the request and

--- a/docs/operator/virtualmcpserver-kubernetes-guide.md
+++ b/docs/operator/virtualmcpserver-kubernetes-guide.md
@@ -670,12 +670,38 @@ presented to anyone as a credential. Since a session can outlive an `id_token` b
 days, expiring it out of policy evaluation would let the same user be permitted
 early in a session and denied later, with no configuration change.
 
-The token the client presented — the one ToolHive's auth server issued — is
-never a claim source here, even though it mirrors a `name` and `email`. In a
+The token the client presented — the one ToolHive's auth server issued — is not
+a claim source here, even though it mirrors a `name` and `email`. In a
 multi-upstream chain those mirrored values come from the **first** configured
 upstream (the identity provider), which need not be the provider
 `primaryUpstreamProvider` names, so using them could attribute one IdP's email to
 another.
+
+There is one exception, and it applies only to tokens that can have no upstream
+session at all: those minted by the RFC 8693 delegation grant or the RFC 7523
+JWT-bearer grant. No upstream ever logged the subject in, so no upstream
+credential exists to read, and those tokens are evaluated against their own
+claims. Every request carries a `thv_claim_source` attribute naming which trust
+root asserted the claims Cedar saw — `upstream:<provider>` on the normal path
+above, `request:no-upstream-session` for these — so a policy that must only act
+on what an upstream actually asserted can require it:
+
+```plain
+permit(principal, action == Action::"call_tool", resource == Tool::"deploy") when {
+  principal.thv_claim_source == "upstream:okta" &&
+  principal has claim_email
+};
+```
+
+Because those tokens carry no upstream attributes, policies keyed on `groups`,
+`roles` or similar will not match them. See [Knowing where a claim came from and
+tokens with no upstream login](../authz.md#tokens-with-no-upstream-login) for the
+full contract, including how this affects `forbid` rules.
+
+Everything else still fails closed: an identity that simply arrives without
+upstream credentials and says nothing about why — anonymous, local, or a bearer
+token from an IdP other than the pinned one — is denied, as is a session that
+exists but holds no credential for the pinned provider.
 
 An OAuth 2.0 upstream that was never asked for the `openid` scope has no stored
 `id_token`, so nothing is available to fall back to and the claim stays absent.

--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -111,12 +111,23 @@ type Identity struct {
 	// Redacted in MarshalJSON() to prevent token leakage.
 	//
 	// State semantics:
-	//   - nil            — no tsid claim was present on the incoming JWT
-	//                      (middleware did not attempt to load credentials).
+	//   - nil            — no upstream credentials were loaded for this identity.
+	//                      Either the incoming JWT carried no tsid claim, or the
+	//                      Identity came from a constructor that has no upstream
+	//                      session at all: local.go, anonymous.go, or middleware
+	//                      validating a JWT from an IdP other than the embedded
+	//                      auth server (see the PlatformUserID note above).
 	//   - empty map      — tsid claim was valid but no providers had a stored
 	//                      access token for the session.
 	//   - populated map  — keys are upstream provider names; values are the
 	//                      stored access token strings.
+	//
+	// A nil map therefore says only that no credential was loaded, never why.
+	// Authorization code MUST NOT read it as "this token was minted without an
+	// upstream session" — an anonymous identity and an RFC 7523 JWT-bearer token
+	// are indistinguishable here. The token itself carries that statement: the
+	// "act" claim (DelegationChain) or upstreamtoken.NoUpstreamSessionClaimKey.
+	// See resolveClaims in pkg/authz/authorizers/cedar.
 	//
 	// MUST NOT be mutated after the Identity is placed in the publicly-reachable
 	// request context. It MAY be mutated while the Identity is reachable only via

--- a/pkg/auth/identity.go
+++ b/pkg/auth/identity.go
@@ -105,6 +105,13 @@ type Identity struct {
 	// Metadata stores additional identity information.
 	Metadata map[string]string
 
+	// SessionlessGrant is true only when TokenValidator validated this token for
+	// the configured embedded authorization-server issuer, no upstream session
+	// credentials were loaded, and the token affirmatively proves that it was
+	// minted by a session-less grant. It is internal runtime provenance and is
+	// intentionally not included in PrincipalInfo or MarshalJSON.
+	SessionlessGrant bool
+
 	// UpstreamTokens maps upstream provider names to their access tokens.
 	// This is populated by the auth middleware when an embedded auth server
 	// is active and the JWT contains a token session ID (tsid claim).
@@ -123,11 +130,9 @@ type Identity struct {
 	//                      stored access token strings.
 	//
 	// A nil map therefore says only that no credential was loaded, never why.
-	// Authorization code MUST NOT read it as "this token was minted without an
-	// upstream session" — an anonymous identity and an RFC 7523 JWT-bearer token
-	// are indistinguishable here. The token itself carries that statement: the
-	// "act" claim (DelegationChain) or upstreamtoken.NoUpstreamSessionClaimKey.
-	// See resolveClaims in pkg/authz/authorizers/cedar.
+	// Authorization code must use SessionlessGrant, which TokenValidator sets
+	// only for a validated embedded-auth-server token that affirmatively proves
+	// it was minted without an upstream session.
 	//
 	// MUST NOT be mutated after the Identity is placed in the publicly-reachable
 	// request context. It MAY be mutated while the Identity is reachable only via

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -20,6 +20,10 @@ const (
 // MiddlewareParams represents the parameters for authentication middleware
 type MiddlewareParams struct {
 	OIDCConfig *TokenValidatorConfig `json:"oidc_config,omitempty"`
+	// EmbeddedAuthServerIssuer binds session-less-grant provenance to the local
+	// embedded authorization server. It is derived from runner configuration,
+	// not supplied by an incoming token.
+	EmbeddedAuthServerIssuer string `json:"embedded_auth_server_issuer,omitempty"`
 }
 
 // Middleware wraps authentication middleware functionality
@@ -58,6 +62,9 @@ func CreateMiddleware(config *types.MiddlewareConfig, runner types.MiddlewareRun
 	}
 	if provider := runner.GetKeyProvider(); provider != nil {
 		opts = append(opts, WithKeyProvider(provider))
+	}
+	if params.EmbeddedAuthServerIssuer != "" {
+		opts = append(opts, WithEmbeddedAuthServerIssuer(params.EmbeddedAuthServerIssuer))
 	}
 
 	middleware, authInfoHandler, err := GetAuthenticationMiddleware(context.Background(), params.OIDCConfig, opts...)

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -378,6 +378,10 @@ type TokenValidator struct {
 	// nil when no embedded auth server is configured.
 	keyProvider keys.PublicKeyProvider
 
+	// embeddedAuthServerIssuer binds session-less-grant provenance to tokens
+	// validated for this embedded authorization server only.
+	embeddedAuthServerIssuer string
+
 	// Lazy JWKS registration
 	jwksRegistered      bool
 	jwksRegistrationMu  sync.Mutex
@@ -535,9 +539,10 @@ func registerIntrospectionProviders(config TokenValidatorConfig, clientSecret st
 
 // tokenValidatorOptions holds optional dependencies for NewTokenValidator.
 type tokenValidatorOptions struct {
-	envReader           env.Reader
-	upstreamTokenReader upstreamtoken.TokenReader
-	keyProvider         keys.PublicKeyProvider
+	envReader                env.Reader
+	upstreamTokenReader      upstreamtoken.TokenReader
+	keyProvider              keys.PublicKeyProvider
+	embeddedAuthServerIssuer string
 }
 
 // TokenValidatorOption is a functional option for NewTokenValidator.
@@ -559,6 +564,15 @@ func WithEnvReader(reader env.Reader) TokenValidatorOption {
 func WithUpstreamTokenReader(reader upstreamtoken.TokenReader) TokenValidatorOption {
 	return func(o *tokenValidatorOptions) {
 		o.upstreamTokenReader = reader
+	}
+}
+
+// WithEmbeddedAuthServerIssuer binds session-less-grant provenance to tokens
+// validated for this embedded authorization server. This runtime-only value is
+// deliberately separate from TokenValidatorConfig, which is user configuration.
+func WithEmbeddedAuthServerIssuer(issuer string) TokenValidatorOption {
+	return func(o *tokenValidatorOptions) {
+		o.embeddedAuthServerIssuer = issuer
 	}
 }
 
@@ -684,20 +698,21 @@ func NewTokenValidator(ctx context.Context, config TokenValidatorConfig, opts ..
 	}
 
 	validator := &TokenValidator{
-		issuer:              config.Issuer,
-		audience:            config.Audience,
-		jwksURL:             jwksURL,
-		introspectURL:       config.IntrospectionURL,
-		clientID:            config.ClientID,
-		clientSecret:        clientSecret,
-		jwksClient:          cache,
-		client:              config.httpClient,
-		resourceURL:         config.ResourceURL,
-		scopes:              config.Scopes,
-		registry:            registry,
-		insecureAllowHTTP:   config.InsecureAllowHTTP,
-		upstreamTokenReader: o.upstreamTokenReader,
-		keyProvider:         o.keyProvider,
+		issuer:                   config.Issuer,
+		audience:                 config.Audience,
+		jwksURL:                  jwksURL,
+		introspectURL:            config.IntrospectionURL,
+		clientID:                 config.ClientID,
+		clientSecret:             clientSecret,
+		jwksClient:               cache,
+		client:                   config.httpClient,
+		resourceURL:              config.ResourceURL,
+		scopes:                   config.Scopes,
+		registry:                 registry,
+		insecureAllowHTTP:        config.InsecureAllowHTTP,
+		upstreamTokenReader:      o.upstreamTokenReader,
+		keyProvider:              o.keyProvider,
+		embeddedAuthServerIssuer: o.embeddedAuthServerIssuer,
 	}
 
 	return validator, nil
@@ -1242,6 +1257,39 @@ func (v *TokenValidator) loadUpstreamTokens(
 	return creds, failed, nil
 }
 
+// isSessionlessGrant reports whether a validated token from the configured
+// embedded authorization server affirmatively proves it was minted without an
+// upstream session. A nil upstream-token map alone is never sufficient.
+//
+// The gate requires the validator's own issuer to be the embedded authorization
+// server's, rather than trusting the token's "iss" claim on its own. validateClaims
+// only verifies "iss" when v.issuer is set, so on a JWKS-only configuration the
+// claim is unverified beyond the signature and would be a self-assertion. Binding
+// to v.issuer makes "validated for the configured embedded authorization-server
+// issuer" true by construction instead of by deployment convention, and leaves the
+// claim comparison below as a redundant restatement of what validateClaims proved.
+func (v *TokenValidator) isSessionlessGrant(identity *Identity, claims jwt.MapClaims) bool {
+	// Trim on both sides, as validateClaims does: an issuer configured with stray
+	// whitespace must not silently turn this gate off and deny every session-less
+	// grant with no diagnostic.
+	embeddedIssuer := strings.TrimSpace(v.embeddedAuthServerIssuer)
+	if embeddedIssuer == "" || strings.TrimSpace(v.issuer) != embeddedIssuer {
+		return false
+	}
+	if identity.UpstreamTokens != nil {
+		return false
+	}
+	issuer, ok := claims["iss"].(string)
+	if !ok || strings.TrimSpace(issuer) != embeddedIssuer {
+		return false
+	}
+	if chain := identity.DelegationChain; chain != nil && !chain.Malformed && len(chain.Chain) > 0 {
+		return true
+	}
+	marker, ok := claims[upstreamtoken.NoUpstreamSessionClaimKey].(bool)
+	return ok && marker
+}
+
 // Middleware creates an HTTP middleware that validates JWT tokens and creates Identity.
 func (v *TokenValidator) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1329,6 +1377,8 @@ func (v *TokenValidator) Middleware(next http.Handler) http.Handler {
 				identity.UpstreamIDTokens = idTokens
 			}
 		}
+
+		identity.SessionlessGrant = v.isSessionlessGrant(identity, claims)
 
 		// Add the fully-populated Identity to the request context and serve.
 		ctx := WithIdentity(r.Context(), identity)

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2665,6 +2666,146 @@ func TestMiddleware_UpstreamTokenEnrichment(t *testing.T) {
 		require.Nil(t, captured.UpstreamTokens)
 		require.Nil(t, captured.UpstreamIDTokens,
 			"UpstreamIDTokens must stay nil when no reader is configured")
+	})
+
+	// SessionlessGrant is provenance established by this middleware after JWT
+	// validation; Cedar must not derive it from raw claims.
+	t.Run("establishes session-less grant provenance", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name                 string
+			embeddedIssuer       string
+			claims               jwt.MapClaims
+			loadUpstreamTokens   bool
+			wantSessionlessGrant bool
+		}{
+			{
+				name:           "matching embedded issuer with valid delegation chain",
+				embeddedIssuer: "test-issuer",
+				claims: jwt.MapClaims{
+					"act": map[string]any{"sub": "delegated-agent"},
+				},
+				wantSessionlessGrant: true,
+			},
+			{
+				name:           "matching embedded issuer with no upstream session marker",
+				embeddedIssuer: "test-issuer",
+				claims: jwt.MapClaims{
+					upstreamtoken.NoUpstreamSessionClaimKey: true,
+				},
+				wantSessionlessGrant: true,
+			},
+			{
+				name:           "matching embedded issuer without grant evidence",
+				embeddedIssuer: "test-issuer",
+				claims:         jwt.MapClaims{},
+			},
+			{
+				name:           "foreign embedded issuer with valid delegation chain",
+				embeddedIssuer: "foreign-issuer",
+				claims: jwt.MapClaims{
+					"act": map[string]any{"sub": "delegated-agent"},
+				},
+			},
+			{
+				name:           "foreign embedded issuer with no upstream session marker",
+				embeddedIssuer: "foreign-issuer",
+				claims: jwt.MapClaims{
+					upstreamtoken.NoUpstreamSessionClaimKey: true,
+				},
+			},
+			{
+				name:               "upstream credentials loaded",
+				embeddedIssuer:     "test-issuer",
+				loadUpstreamTokens: true,
+				claims: jwt.MapClaims{
+					upstreamtoken.NoUpstreamSessionClaimKey: true,
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				claims := maps.Clone(tt.claims)
+				claims["iss"] = "test-issuer"
+				claims["aud"] = "test-audience"
+				claims["sub"] = "test-user"
+				claims["exp"] = time.Now().Add(time.Hour).Unix()
+
+				var opts []TokenValidatorOption
+				if tt.loadUpstreamTokens {
+					ctrl := gomock.NewController(t)
+					reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
+					claims[upstreamtoken.TokenSessionIDClaimKey] = "session-xyz"
+					reader.EXPECT().GetAllUpstreamCredentials(gomock.Any(), "session-xyz").
+						Return(map[string]upstreamtoken.UpstreamCredential{"github": {AccessToken: "gh-token"}}, nil, nil)
+					opts = append(opts, WithUpstreamTokenReader(reader))
+				}
+				opts = append(opts, WithEmbeddedAuthServerIssuer(tt.embeddedIssuer))
+				v := makeValidator(t, opts...)
+
+				var captured *Identity
+				handler := v.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+					captured, _ = IdentityFromContext(r.Context())
+				}))
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("Authorization", "Bearer "+signToken(claims))
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				require.Equal(t, http.StatusOK, rr.Code)
+				require.NotNil(t, captured)
+				require.Equal(t, tt.wantSessionlessGrant, captured.SessionlessGrant)
+				if tt.loadUpstreamTokens {
+					require.NotNil(t, captured.UpstreamTokens)
+				} else {
+					require.Nil(t, captured.UpstreamTokens)
+				}
+			})
+		}
+	})
+
+	// validateClaims only verifies "iss" when the validator has an issuer of its
+	// own, so on a JWKS-only configuration the claim is unverified beyond the
+	// signature. Provenance must rest on the validator's verified issuer, never on
+	// a claim the token asserts about itself.
+	t.Run("no session-less grant when the validator has no issuer to verify against", func(t *testing.T) {
+		t.Parallel()
+
+		v, err := NewTokenValidator(context.Background(), TokenValidatorConfig{
+			Audience: "test-audience", JWKSURL: jwksServer.URL, ClientID: "test-client",
+			CACertPath: caCertPath, AllowPrivateIP: true,
+		}, WithEmbeddedAuthServerIssuer("test-issuer"))
+		require.NoError(t, err)
+		require.Empty(t, v.issuer, "this test is only meaningful while the validator has no issuer")
+		require.NoError(t, v.ensureJWKSRegistered(context.Background()))
+		_, lErr := v.jwksClient.Lookup(context.Background(), jwksServer.URL)
+		require.NoError(t, lErr)
+
+		// Everything the gate looks for, self-asserted by the token.
+		claims := jwt.MapClaims{
+			"iss": "test-issuer", "aud": "test-audience", "sub": "test-user",
+			"exp":                                   time.Now().Add(time.Hour).Unix(),
+			upstreamtoken.NoUpstreamSessionClaimKey: true,
+			"act":                                   map[string]any{"sub": "delegated-agent"},
+		}
+
+		var captured *Identity
+		handler := v.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			captured, _ = IdentityFromContext(r.Context())
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer "+signToken(claims))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.NotNil(t, captured)
+		require.False(t, captured.SessionlessGrant,
+			"an unverified iss claim must not establish session-less grant provenance")
 	})
 }
 

--- a/pkg/auth/upstreamtoken/types.go
+++ b/pkg/auth/upstreamtoken/types.go
@@ -15,6 +15,19 @@ import "context"
 // which defines "sid" for different purposes (RFC 7519, OIDC Session Management).
 const TokenSessionIDClaimKey = "tsid"
 
+// NoUpstreamSessionClaimKey is the JWT claim key by which the embedded
+// authorization server marks a token it minted with no link to an upstream IdP
+// login. Resource-server mirror of the constant in
+// pkg/authserver/server/session, duplicated for the same reason
+// TokenSessionIDClaimKey is: the token-issuing and token-consuming sides must
+// not import each other. The two spellings must stay identical.
+//
+// Its purpose is to separate "minted without an upstream session" from "never
+// enriched with upstream credentials" — both leave Identity.UpstreamTokens nil,
+// but only the former is a statement by an authorization server this deployment
+// trusts. See the issuing constant for the full contract.
+const NoUpstreamSessionClaimKey = "https://toolhive.dev/no_upstream_session"
+
 // UpstreamCredential bundles the access token and the ID token for a single
 // upstream provider. Access tokens are refreshed when expired.
 //

--- a/pkg/authserver/integration_test.go
+++ b/pkg/authserver/integration_test.go
@@ -5438,3 +5438,20 @@ func TestIntegration_PrivateKeyJWTDCRTokenExchange(t *testing.T) {
 		})
 	}
 }
+
+// TestNoUpstreamSessionClaimKeysMatch pins the two spellings of the
+// no-upstream-session marker together. The issuing side (session) and the
+// consuming side (upstreamtoken) deliberately do not import each other, so
+// nothing but this assertion stops one from being edited without the other.
+// A silent divergence is invisible: the auth server would keep stamping a
+// marker no resource server reads, and every RFC 7523 JWT-bearer request
+// would fail closed under a pinned Cedar primaryUpstreamProvider.
+//
+// This file is the seam — it already imports both packages — which is why the
+// test lives here rather than in either of them.
+func TestNoUpstreamSessionClaimKeysMatch(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, session.NoUpstreamSessionClaimKey, upstreamtoken.NoUpstreamSessionClaimKey,
+		"the issuing and consuming spellings of the no-upstream-session claim must stay identical")
+}

--- a/pkg/authserver/server/session/session.go
+++ b/pkg/authserver/server/session/session.go
@@ -56,6 +56,25 @@ type UpstreamSession interface {
 // which defines "sid" for different purposes (RFC 7519, OIDC Session Management).
 const TokenSessionIDClaimKey = "tsid"
 
+// NoUpstreamSessionClaimKey marks a token this authorization server minted
+// without any link to an upstream IdP login, so no upstream credential exists
+// for it. Today only the RFC 7523 JWT-bearer grant sets it: its subject is a
+// synthetic machine identity (issuer#subject) asserted by a separate trust
+// root, with no end user and no upstream session.
+//
+// It exists so a resource server can distinguish "this token was deliberately
+// minted without an upstream session" from "this identity was never enriched
+// with upstream credentials" — states that are otherwise indistinguishable, as
+// both leave Identity.UpstreamTokens nil. pkg/authz/authorizers/cedar reads it
+// to decide whether request-token claims may drive policy. The RFC 8693
+// delegation grant needs no marker: its "act" claim already says so.
+//
+// The name is collision-resistant per RFC 7519 Section 4.3, so a JWT from
+// another issuer the deployment trusts cannot assert it by accident. It is a
+// private claim; RFC 9068 Section 2.2.3 permits additional claims on an
+// access token.
+const NoUpstreamSessionClaimKey = "https://toolhive.dev/no_upstream_session"
+
 // ClientIDClaimKey is the JWT claim key for the OAuth client ID.
 // This identifies which client was issued the token.
 const ClientIDClaimKey = "client_id"

--- a/pkg/authserver/server/tokenexchange/jwt_bearer_handler.go
+++ b/pkg/authserver/server/tokenexchange/jwt_bearer_handler.go
@@ -202,6 +202,12 @@ func (h *JWTBearerHandler) HandleTokenEndpointRequest(ctx context.Context, reque
 	}
 	clientID := jwtBearerClientID(claims.Issuer, claims.Subject)
 	issuedSession := session.New(claims.Issuer+"#"+claims.Subject, "", clientID, session.UserClaims{})
+	// This grant links to no upstream IdP login, so the issued token can never
+	// carry an upstream credential. Say so in the token rather than leaving a
+	// resource server to infer it from the absence of a tsid claim, which is
+	// also how an unenriched or foreign-issued identity looks. See
+	// session.NoUpstreamSessionClaimKey.
+	issuedSession.JWTClaims.Extra[session.NoUpstreamSessionClaimKey] = true
 	issuedSession.SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(lifetime))
 	// This grant skips client authentication (CanSkipClientAuth), so fosite
 	// never populates requester's client — attach a synthetic one so every

--- a/pkg/authserver/server/tokenexchange/jwt_bearer_handler_test.go
+++ b/pkg/authserver/server/tokenexchange/jwt_bearer_handler_test.go
@@ -505,3 +505,61 @@ func TestNewJWTBearerIssuanceHandler_RejectsMissingDependencies(t *testing.T) {
 		})
 	}
 }
+
+// TestJWTBearerHandler_StampsNoUpstreamSessionClaim pins the marker a resource
+// server relies on to tell an intentionally session-less token apart from an
+// identity that simply carries no upstream credentials. Dropping it would send
+// every JWT-bearer request back to a hard deny under a pinned Cedar provider.
+func TestJWTBearerHandler_StampsNoUpstreamSessionClaim(t *testing.T) {
+	t.Parallel()
+
+	const (
+		issuer   = "https://idp.example.com"
+		subject  = "ext-user"
+		resource = "https://mcp.example.com"
+	)
+	resolvedIssuers, err := ResolveJWTBearerGrantPolicies([]TrustedIssuer{{
+		IssuerURL:              issuer,
+		AllowedDelegateClients: []string{anyDelegateClient},
+		JWTBearerGrant: &JWTBearerGrantPolicy{
+			MaxAssertionAge: time.Hour.String(),
+			SubjectBindings: []JWTBearerSubjectBinding{
+				{Subject: subject, AllowedResources: []string{resource}},
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	tj := newTestJWKS(t)
+	now := time.Now()
+	handler, err := newJWTBearerIssuanceHandler(
+		&testJWTBearerAssertionValidator{claims: &ValidatedClaims{
+			Issuer:   issuer,
+			Subject:  subject,
+			JWTID:    "jti-no-upstream-session",
+			IssuedAt: now,
+			Expiry:   now.Add(30 * time.Minute),
+		}},
+		testTokenEndpoint,
+		testAssertionJWTConsumer{},
+		&fosite.Config{AccessTokenLifespan: time.Hour},
+		&mockAccessTokenStrategy{},
+		&mockAccessTokenStorage{},
+		resolvedIssuers,
+	)
+	require.NoError(t, err)
+
+	req := fosite.NewAccessRequest(&session.Session{})
+	req.GrantTypes = fosite.Arguments{oauthproto.GrantTypeJWTBearer}
+	req.Form = map[string][]string{
+		"assertion": {signAssertionWithType(t, tj, nil)},
+		"resource":  {resource},
+	}
+
+	require.NoError(t, handler.HandleTokenEndpointRequest(context.Background(), req))
+
+	issued, ok := req.GetSession().(*session.Session)
+	require.True(t, ok, "expected the handler to install a *session.Session")
+	assert.Equal(t, true, issued.JWTClaims.Extra[session.NoUpstreamSessionClaimKey],
+		"JWT-bearer tokens must declare that they have no upstream session")
+}

--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -19,6 +19,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth/upstreamtoken"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
 	"github.com/stacklok/toolhive/pkg/syncutil"
 )
@@ -160,6 +161,36 @@ const (
 	claimSetPrefix = "claimset_"
 )
 
+// claimSourceAttr is the principal attribute and context key naming which trust
+// root asserted the claims this request was evaluated against. Policies read it
+// to require upstream provenance, e.g.
+//
+//	when { principal.thv_claim_source == "upstream:github" }
+//
+// The name deliberately does not start with claimPrefix or claimSetPrefix: every
+// JWT claim is emitted under claimPrefix, so a token cannot produce this key and
+// cannot spoof its own provenance. It is written after preprocessClaims for the
+// same reason.
+const claimSourceAttr = "thv_claim_source"
+
+// Claim-source values. Each names the trust root behind the claims Cedar saw, so
+// a policy can tell an upstream assertion from the request token's own word for
+// it. The upstream case carries the provider name, since which upstream asserted
+// a claim is exactly what a pinned deployment cares about.
+//
+// The three request-token values are not collapsed into one: they answer
+// different questions. claimSourceRequest means no provenance was ever demanded.
+// claimSourceNoUpstreamSession means one was demanded and the token affirmatively
+// said it has none. claimSourceUpstreamOpaque means one was demanded, a
+// credential exists, and it simply cannot be read — a degradation that until now
+// no policy could see.
+const (
+	claimSourceRequest           = "request"
+	claimSourceNoUpstreamSession = "request:no-upstream-session"
+	claimSourceUpstreamOpaque    = "request:upstream-opaque"
+	claimSourceUpstreamPrefix    = "upstream:"
+)
+
 // Authorizer authorizes MCP operations using Cedar policies.
 type Authorizer struct {
 	// Cedar policy set
@@ -201,6 +232,10 @@ type Authorizer struct {
 	// Separate from supplementLog because the two are mutually exclusive per
 	// request and describe opposite conditions.
 	missingIDTokenLog *syncutil.AtMost
+	// noSessionLog rate-limits the warning that a request has no upstream session
+	// and Cedar is using request-token claims instead. It is separate from
+	// claimKeyLog so the warning does not suppress the claim-key diagnostic.
+	noSessionLog *syncutil.AtMost
 	// multiValuedClaims lists JWT claim names normalized to a canonical unpadded
 	// space-delimited string, plus a companion Cedar Set, before Cedar evaluation.
 	// See ConfigOptions.MultiValuedClaims.
@@ -217,16 +252,21 @@ type ConfigOptions struct {
 
 	// PrimaryUpstreamProvider names the upstream IDP provider whose access
 	// token is the primary source of JWT claims for Cedar evaluation.
-	// When empty, claims from the ToolHive-issued token are used.
-	// Must match an entry in identity.UpstreamTokens (e.g. "default", "github").
+	// When empty, claims from the original client-request token are used, whether
+	// it is ToolHive-issued or another bearer token.
+	// When set, a non-nil identity.UpstreamTokens map must contain a non-empty
+	// token for this provider; otherwise authorization fails closed. The sole
+	// exception is a nil map, which indicates no upstream session (for example,
+	// a delegated or JWT-bearer token), so request-token claims are used.
 	//
 	// The profile claims in profileClaimsFromIDToken fall back to the SAME
 	// provider's id_token when its access token omits them (many OIDC providers
 	// assert `email` only in the id_token), so `principal has claim_email` keeps
 	// meaning "this upstream asserted an email". Every other claim, including all
-	// group/role/scope claims, comes from the upstream access token or not at all,
-	// and the ToolHive-issued token the client presented is never a claim source on
-	// this path. See resolveClaims for the full contract.
+	// group/role/scope claims, comes from the upstream access token or not at all.
+	// The sole nil-map exception uses only request-token claims because no upstream
+	// provider credential exists, never as a substitute for another provider's
+	// credentials. See resolveClaims for the full contract.
 	PrimaryUpstreamProvider string `json:"primary_upstream_provider,omitempty" yaml:"primary_upstream_provider,omitempty"`
 
 	// GroupClaimName is the JWT claim key that contains group membership for the
@@ -342,6 +382,7 @@ func NewCedarAuthorizer(options ConfigOptions, serverName string) (authorizers.A
 		claimKeyLog:             syncutil.NewAtMost(30 * time.Second),
 		supplementLog:           syncutil.NewAtMost(30 * time.Second),
 		missingIDTokenLog:       syncutil.NewAtMost(30 * time.Second),
+		noSessionLog:            syncutil.NewAtMost(30 * time.Second),
 		multiValuedClaims:       options.MultiValuedClaims,
 	}
 
@@ -552,7 +593,42 @@ func (a *Authorizer) IsAuthorized(
 	return decision == cedar.Allow, nil
 }
 
-// resolveClaims determines which JWT claims to use for Cedar policy evaluation.
+// mintedWithoutUpstreamSession reports whether the token behind this identity
+// affirmatively states that it was issued with no upstream IdP login, and so can
+// never carry an upstream credential. Two grants say this, in two ways:
+//
+//   - RFC 8693 delegation sets the "act" claim, parsed into DelegationChain. The
+//     subject is a real end user whose token the authorization server itself
+//     validated, one hop removed from the upstream login.
+//   - RFC 7523 JWT-bearer sets NoUpstreamSessionClaimKey. Its subject is a
+//     synthetic machine identity asserted by a separate trust root, with no end
+//     user at all.
+//
+// Both are statements inside a token this deployment's authentication middleware
+// already validated, not inferences from an absent map. An identity that merely
+// lacks upstream credentials — anonymous, local, or a bearer from an unpinned IdP
+// — says neither, and must keep failing closed under a pinned provider.
+func mintedWithoutUpstreamSession(identity *auth.Identity) bool {
+	// A chain must be well-formed to count as a statement. ParseDelegationChain
+	// never fails: a non-object act yields Malformed with no hops, and a bare
+	// "act": {} yields one empty hop — neither says anything about an upstream
+	// session, and both leave DelegationChain non-nil. The issuance side already
+	// refuses a malformed chain (see buildActClaim in
+	// pkg/authserver/server/tokenexchange); hold the same line on consumption.
+	// Truncated is deliberately admitted: that is a real chain that hit the
+	// depth cap, not garbage.
+	if c := identity.DelegationChain; c != nil && !c.Malformed && len(c.Chain) > 0 {
+		return true
+	}
+	marker, ok := identity.Claims[upstreamtoken.NoUpstreamSessionClaimKey].(bool)
+	return ok && marker
+}
+
+// resolveClaims determines which JWT claims to use for Cedar policy evaluation,
+// and returns alongside them the claim-source label naming the trust root that
+// asserted them (see claimSourceAttr and the claimSource* values). Every path
+// that returns claims returns a label, so a policy can always tell whether it is
+// looking at an upstream assertion or the request token's own word.
 //
 // When primaryUpstreamProvider is empty (the default), the claims of the token on
 // the original client request are used as-is. That may be a ToolHive-issued token
@@ -575,8 +651,15 @@ func (a *Authorizer) IsAuthorized(
 // id_token, which is why the fallback is conditional. That is not a case of one key
 // meaning two different identities.)
 //
-// The ToolHive-issued token the client presented is deliberately NOT a claim
-// source here, even though it mirrors a name/email — in a multi-upstream chain
+// The sole exception is when Identity.UpstreamTokens is nil, which means there is
+// no upstream session (no tsid claim), as with a delegated or JWT-bearer token.
+// Cedar then uses request-token claims because no upstream provider credential
+// exists. Any non-nil map without a non-empty token for the configured provider,
+// including an empty map or a map for another provider, remains an error so request
+// claims never substitute for a missing provider's credentials.
+//
+// The ToolHive-issued token the client presented is otherwise deliberately NOT a
+// claim source here, even though it mirrors a name/email — in a multi-upstream chain
 // those belong to the first configured upstream, which need not be the pinned
 // provider, so using them could attribute one IdP's email to another.
 //
@@ -604,21 +687,42 @@ func (a *Authorizer) IsAuthorized(
 // of what the upstream asserted at login, not presented as a credential, and
 // rejecting it once expired would flip a policy from permit to deny mid-session.
 // See Identity.UpstreamIDTokens for that contract and its two consumers.
-func (a *Authorizer) resolveClaims(identity *auth.Identity) (jwt.MapClaims, error) {
+func (a *Authorizer) resolveClaims(identity *auth.Identity) (jwt.MapClaims, string, error) {
 	requestClaims := jwt.MapClaims(identity.Claims)
 
 	if a.primaryUpstreamProvider == "" {
 		// Default path: use claims from the original client request's token.
-		a.logClaimKeys("token", requestClaims)
-		return requestClaims, nil
+		a.logClaimKeys(claimSourceRequest, requestClaims)
+		return requestClaims, claimSourceRequest, nil
 	}
 
 	// Embedded auth server path: the upstream IDP token is the primary claim source.
+	if identity.UpstreamTokens == nil && mintedWithoutUpstreamSession(identity) {
+		// The token says it was minted with no upstream login, so no upstream
+		// credential can exist for it. Evaluate its own claims.
+		a.noSessionLog.Do(func() {
+			slog.Info("token minted without an upstream session; using request-token claims for Cedar evaluation",
+				"provider", a.primaryUpstreamProvider)
+		})
+		a.logClaimKeys(claimSourceNoUpstreamSession, requestClaims)
+		return requestClaims, claimSourceNoUpstreamSession, nil
+	}
+
+	if identity.UpstreamTokens == nil {
+		// Nil with no marker: this identity was never enriched with upstream
+		// credentials, and nothing states why. It may be an anonymous or local
+		// identity, or a bearer token from an IdP other than the pinned
+		// provider. Its claims come from a trust root this deployment did not
+		// pin, so they must not drive policy.
+		return nil, "", fmt.Errorf("no upstream credentials for provider %q and token does not declare a missing upstream session",
+			a.primaryUpstreamProvider)
+	}
+
 	upstreamToken, tokenFound := identity.UpstreamTokens[a.primaryUpstreamProvider]
 	if !tokenFound || upstreamToken == "" {
-		// The upstream token must be present if the authorizer is configured to use it.
-		// Missing token means the session has no upstream credential; deny.
-		return nil, fmt.Errorf("upstream token for provider %q not found in identity",
+		// A session exists but lacks credentials for the configured provider.
+		// Do not substitute request claims for another provider's credentials.
+		return nil, "", fmt.Errorf("upstream token for provider %q not found in identity",
 			a.primaryUpstreamProvider)
 	}
 
@@ -640,16 +744,17 @@ func (a *Authorizer) resolveClaims(identity *auth.Identity) (jwt.MapClaims, erro
 				slog.Warn("upstream token is not a JWT; falling back to request-token claims for Cedar evaluation",
 					"provider", a.primaryUpstreamProvider)
 			})
-			a.logClaimKeys("token-fallback", requestClaims)
-			return requestClaims, nil
+			a.logClaimKeys(claimSourceUpstreamOpaque, requestClaims)
+			return requestClaims, claimSourceUpstreamOpaque, nil
 		}
-		return nil, fmt.Errorf("failed to parse upstream token for provider %q: %w",
+		return nil, "", fmt.Errorf("failed to parse upstream token for provider %q: %w",
 			a.primaryUpstreamProvider, err)
 	}
 
 	merged := a.supplementFromIDToken(identity, upstreamClaims)
-	a.logClaimKeys("upstream", merged)
-	return merged, nil
+	source := claimSourceUpstreamPrefix + a.primaryUpstreamProvider
+	a.logClaimKeys(source, merged)
+	return merged, source, nil
 }
 
 // supplementFromIDToken returns upstreamClaims with the profileClaimsFromIDToken
@@ -1186,7 +1291,7 @@ func (a *Authorizer) AuthorizeWithJWTClaims(
 	}
 
 	// Resolve the claims source: upstream IDP token or the original request's token.
-	resolvedClaims, err := a.resolveClaims(identity)
+	resolvedClaims, claimSource, err := a.resolveClaims(identity)
 	if err != nil {
 		return false, err
 	}
@@ -1228,6 +1333,11 @@ func (a *Authorizer) AuthorizeWithJWTClaims(
 	normalizedClaims := normalizeMultiValuedClaims(resolvedClaims, a.multiValuedClaims)
 	processedClaims := preprocessClaims(normalizedClaims)
 	addMultiValuedClaimSets(processedClaims, resolvedClaims, a.multiValuedClaims)
+	// Record which trust root asserted these claims. Written after prefixing so
+	// no token claim can land on this key; see claimSourceAttr. processedClaims
+	// becomes both the principal's attributes and the Cedar context, so the value
+	// is readable as principal.thv_claim_source and context.thv_claim_source.
+	processedClaims[claimSourceAttr] = claimSource
 	processedArgs := preprocessArguments(arguments)
 
 	// Authorize based on the feature and operation

--- a/pkg/authz/authorizers/cedar/core.go
+++ b/pkg/authz/authorizers/cedar/core.go
@@ -19,7 +19,6 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/stacklok/toolhive/pkg/auth"
-	"github.com/stacklok/toolhive/pkg/auth/upstreamtoken"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
 	"github.com/stacklok/toolhive/pkg/syncutil"
 )
@@ -256,8 +255,9 @@ type ConfigOptions struct {
 	// it is ToolHive-issued or another bearer token.
 	// When set, a non-nil identity.UpstreamTokens map must contain a non-empty
 	// token for this provider; otherwise authorization fails closed. The sole
-	// exception is a nil map, which indicates no upstream session (for example,
-	// a delegated or JWT-bearer token), so request-token claims are used.
+	// exception is a nil map with identity.SessionlessGrant set by TokenValidator
+	// after validation for the configured embedded authorization server; then
+	// request-token claims are used.
 	//
 	// The profile claims in profileClaimsFromIDToken fall back to the SAME
 	// provider's id_token when its access token omits them (many OIDC providers
@@ -593,37 +593,6 @@ func (a *Authorizer) IsAuthorized(
 	return decision == cedar.Allow, nil
 }
 
-// mintedWithoutUpstreamSession reports whether the token behind this identity
-// affirmatively states that it was issued with no upstream IdP login, and so can
-// never carry an upstream credential. Two grants say this, in two ways:
-//
-//   - RFC 8693 delegation sets the "act" claim, parsed into DelegationChain. The
-//     subject is a real end user whose token the authorization server itself
-//     validated, one hop removed from the upstream login.
-//   - RFC 7523 JWT-bearer sets NoUpstreamSessionClaimKey. Its subject is a
-//     synthetic machine identity asserted by a separate trust root, with no end
-//     user at all.
-//
-// Both are statements inside a token this deployment's authentication middleware
-// already validated, not inferences from an absent map. An identity that merely
-// lacks upstream credentials — anonymous, local, or a bearer from an unpinned IdP
-// — says neither, and must keep failing closed under a pinned provider.
-func mintedWithoutUpstreamSession(identity *auth.Identity) bool {
-	// A chain must be well-formed to count as a statement. ParseDelegationChain
-	// never fails: a non-object act yields Malformed with no hops, and a bare
-	// "act": {} yields one empty hop — neither says anything about an upstream
-	// session, and both leave DelegationChain non-nil. The issuance side already
-	// refuses a malformed chain (see buildActClaim in
-	// pkg/authserver/server/tokenexchange); hold the same line on consumption.
-	// Truncated is deliberately admitted: that is a real chain that hit the
-	// depth cap, not garbage.
-	if c := identity.DelegationChain; c != nil && !c.Malformed && len(c.Chain) > 0 {
-		return true
-	}
-	marker, ok := identity.Claims[upstreamtoken.NoUpstreamSessionClaimKey].(bool)
-	return ok && marker
-}
-
 // resolveClaims determines which JWT claims to use for Cedar policy evaluation,
 // and returns alongside them the claim-source label naming the trust root that
 // asserted them (see claimSourceAttr and the claimSource* values). Every path
@@ -651,10 +620,10 @@ func mintedWithoutUpstreamSession(identity *auth.Identity) bool {
 // id_token, which is why the fallback is conditional. That is not a case of one key
 // meaning two different identities.)
 //
-// The sole exception is when Identity.UpstreamTokens is nil, which means there is
-// no upstream session (no tsid claim), as with a delegated or JWT-bearer token.
-// Cedar then uses request-token claims because no upstream provider credential
-// exists. Any non-nil map without a non-empty token for the configured provider,
+// The sole exception is a session-less grant proven by
+// Identity.SessionlessGrant. TokenValidator sets that internal runtime fact only
+// after validating a token for the configured embedded authorization-server
+// issuer. Any non-nil map without a non-empty token for the configured provider,
 // including an empty map or a map for another provider, remains an error so request
 // claims never substitute for a missing provider's credentials.
 //
@@ -697,9 +666,9 @@ func (a *Authorizer) resolveClaims(identity *auth.Identity) (jwt.MapClaims, stri
 	}
 
 	// Embedded auth server path: the upstream IDP token is the primary claim source.
-	if identity.UpstreamTokens == nil && mintedWithoutUpstreamSession(identity) {
-		// The token says it was minted with no upstream login, so no upstream
-		// credential can exist for it. Evaluate its own claims.
+	if identity.UpstreamTokens == nil && identity.SessionlessGrant {
+		// TokenValidator proved this token was minted without an upstream login,
+		// so no upstream credential can exist for it. Evaluate its own claims.
 		a.noSessionLog.Do(func() {
 			slog.Info("token minted without an upstream session; using request-token claims for Cedar evaluation",
 				"provider", a.primaryUpstreamProvider)
@@ -709,12 +678,10 @@ func (a *Authorizer) resolveClaims(identity *auth.Identity) (jwt.MapClaims, stri
 	}
 
 	if identity.UpstreamTokens == nil {
-		// Nil with no marker: this identity was never enriched with upstream
-		// credentials, and nothing states why. It may be an anonymous or local
-		// identity, or a bearer token from an IdP other than the pinned
-		// provider. Its claims come from a trust root this deployment did not
-		// pin, so they must not drive policy.
-		return nil, "", fmt.Errorf("no upstream credentials for provider %q and token does not declare a missing upstream session",
+		// Nil without the validator-established fact: this identity was never
+		// enriched with upstream credentials, and nothing authorizes a fallback.
+		// It may be anonymous, local, or validated for another issuer.
+		return nil, "", fmt.Errorf("no upstream credentials for provider %q and no session-less grant provenance",
 			a.primaryUpstreamProvider)
 	}
 

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/toolhive-core/audit"
 	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth/upstreamtoken"
 	"github.com/stacklok/toolhive/pkg/authz/authorizers"
 )
 
@@ -1396,13 +1398,40 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 			wantAuthorize: false,
 		},
 		{
-			name: "upstream_token_missing_from_identity",
+			name: "upstream_tokens_empty_map_missing_primary_provider_errors",
 			identity: &auth.Identity{
 				PrincipalInfo: auth.PrincipalInfo{
 					Subject: "thv-user",
 					Claims:  map[string]any{"sub": "thv-user"},
 				},
+				// A non-nil empty map means a session exists but has no stored tokens.
 				UpstreamTokens: map[string]string{},
+			},
+			wantErr:     true,
+			errContains: "upstream token for provider",
+		},
+		{
+			name: "upstream_tokens_populated_other_provider_missing_primary_errors",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims:  map[string]any{"sub": "thv-user"},
+				},
+				// The session has another provider's token, not the configured primary.
+				UpstreamTokens: map[string]string{"other-provider": upstreamToken},
+			},
+			wantErr:     true,
+			errContains: "upstream token for provider",
+		},
+		{
+			name: "upstream_tokens_primary_provider_empty_token_errors",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims:  map[string]any{"sub": "thv-user"},
+				},
+				// The configured provider is present but its stored token is empty.
+				UpstreamTokens: map[string]string{providerName: ""},
 			},
 			wantErr:     true,
 			errContains: "upstream token for provider",
@@ -1461,16 +1490,125 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 			errContains: "failed to parse upstream token",
 		},
 		{
-			name: "upstream_tokens_nil_map",
+			name: "delegated_token_act_claim_falls_back_to_request_claims_permitted",
 			identity: &auth.Identity{
 				PrincipalInfo: auth.PrincipalInfo{
-					Subject: "thv-user",
-					Claims:  map[string]any{"sub": "thv-user"},
+					Subject: "upstream-user",
+					Claims:  map[string]any{"sub": "upstream-user"},
+					// An RFC 8693 delegated token: the act claim states that this
+					// token was minted from a subject token, with no upstream login
+					// of its own.
+					DelegationChain: &audit.DelegationChain{
+						Chain: []audit.DelegatedActor{
+							{Subject: "agent-1", Issuer: "https://thv.example.com"},
+						},
+					},
+				},
+				UpstreamTokens: nil,
+			},
+			wantAuthorize: true,
+		},
+		{
+			name: "jwt_bearer_token_no_session_marker_falls_back_to_request_claims_permitted",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "upstream-user",
+					Claims: map[string]any{
+						"sub": "upstream-user",
+						// An RFC 7523 JWT-bearer token: the auth server stamped
+						// this marker because the grant links to no upstream login.
+						upstreamtoken.NoUpstreamSessionClaimKey: true,
+					},
+				},
+				UpstreamTokens: nil,
+			},
+			wantAuthorize: true,
+		},
+		{
+			name: "upstream_tokens_nil_without_any_marker_errors",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "upstream-user",
+					// Nil map and neither marker: nothing states why credentials
+					// are absent, so request claims must not drive policy even
+					// though they would satisfy the policy.
+					Claims: map[string]any{"sub": "upstream-user"},
 				},
 				UpstreamTokens: nil,
 			},
 			wantErr:     true,
-			errContains: "upstream token for provider",
+			errContains: "does not declare a missing upstream session",
+		},
+		{
+			name: "anonymous_identity_errors_under_pinned_provider",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "anonymous",
+					// The shape pkg/auth/anonymous.go produces. It must never
+					// reach policy evaluation while a provider is pinned.
+					Claims: map[string]any{
+						"sub":   "anonymous",
+						"iss":   "toolhive-local",
+						"email": "anonymous@localhost",
+					},
+				},
+				UpstreamTokens: nil,
+			},
+			wantErr:     true,
+			errContains: "does not declare a missing upstream session",
+		},
+		{
+			name: "malformed_act_claim_is_not_a_delegation_statement",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "upstream-user",
+					Claims:  map[string]any{"sub": "upstream-user"},
+					// ParseDelegationChain never fails: a non-object "act" yields
+					// a chain that is Malformed with no hops, leaving
+					// DelegationChain non-nil. Garbage in act is not a statement
+					// that the token has no upstream session.
+					DelegationChain: &audit.DelegationChain{
+						Chain:           []audit.DelegatedActor{},
+						Malformed:       true,
+						MalformedReason: audit.MalformedReasonActNotObject,
+					},
+				},
+				UpstreamTokens: nil,
+			},
+			wantErr:     true,
+			errContains: "does not declare a missing upstream session",
+		},
+		{
+			name: "empty_act_object_is_not_a_delegation_statement",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "upstream-user",
+					Claims:  map[string]any{"sub": "upstream-user"},
+					// A bare "act": {} parses to one hop with no iss and no sub.
+					// It names no actor, so it asserts no delegation.
+					DelegationChain: &audit.DelegationChain{
+						Chain: []audit.DelegatedActor{},
+					},
+				},
+				UpstreamTokens: nil,
+			},
+			wantErr:     true,
+			errContains: "does not declare a missing upstream session",
+		},
+		{
+			name: "no_session_marker_false_errors",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "upstream-user",
+					Claims: map[string]any{
+						"sub":                                   "upstream-user",
+						upstreamtoken.NoUpstreamSessionClaimKey: false,
+					},
+				},
+				UpstreamTokens: nil,
+			},
+			wantErr:     true,
+			errContains: "does not declare a missing upstream session",
 		},
 		{
 			name: "upstream_token_has_no_sub_claim",
@@ -1811,7 +1949,7 @@ func TestResolveClaimsUpstreamSupplement(t *testing.T) {
 			}
 			claimsBefore := maps.Clone(tt.requestClaims)
 
-			resolved, err := authorizer.(*Authorizer).resolveClaims(identity)
+			resolved, _, err := authorizer.(*Authorizer).resolveClaims(identity)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantClaims, resolved)
@@ -4291,4 +4429,154 @@ func TestFactory_ConfigKeyMatchesStructTag(t *testing.T) {
 		"envelope built around Factory.ConfigKey() must parse into Config")
 	require.NotNil(t, cfg.Options,
 		"Config.Options must be set after Unmarshal — if nil, Factory.ConfigKey() and the Options struct tag have drifted apart")
+}
+
+// TestAuthorizeWithJWTClaims_ClaimSourceAttribute pins the value of the
+// thv_claim_source attribute on every path that reaches policy evaluation.
+// Cedar cannot return an attribute, so each case carries a policy keyed on the
+// exact value it expects: a permit proves the label, and the mismatch cases
+// prove the labels are distinct rather than collapsed.
+func TestAuthorizeWithJWTClaims_ClaimSourceAttribute(t *testing.T) {
+	t.Parallel()
+
+	const providerName = "github"
+
+	policyFor := func(source string) string {
+		return fmt.Sprintf(`
+			permit(
+				principal,
+				action == Action::"call_tool",
+				resource == Tool::"deploy"
+			)
+			when { principal.thv_claim_source == %q };
+		`, source)
+	}
+
+	upstreamJWT := makeUnsignedJWT(jwt.MapClaims{
+		"sub": "upstream-user",
+		"iss": "https://idp.example.com",
+	})
+
+	tests := []struct {
+		name          string
+		policySource  string
+		provider      string
+		identity      *auth.Identity
+		wantAuthorize bool
+	}{
+		{
+			name:         "no_provider_pinned_is_request",
+			policySource: claimSourceRequest,
+			provider:     "",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims:  map[string]any{"sub": "thv-user"},
+				},
+			},
+			wantAuthorize: true,
+		},
+		{
+			name:         "upstream_jwt_names_the_provider",
+			policySource: claimSourceUpstreamPrefix + providerName,
+			provider:     providerName,
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims:  map[string]any{"sub": "thv-user"},
+				},
+				UpstreamTokens: map[string]string{providerName: upstreamJWT},
+			},
+			wantAuthorize: true,
+		},
+		{
+			name:         "jwt_bearer_marker_is_no_upstream_session",
+			policySource: claimSourceNoUpstreamSession,
+			provider:     providerName,
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "machine-user",
+					Claims: map[string]any{
+						"sub":                                   "machine-user",
+						upstreamtoken.NoUpstreamSessionClaimKey: true,
+					},
+				},
+			},
+			wantAuthorize: true,
+		},
+		{
+			name:         "opaque_upstream_token_is_upstream_opaque",
+			policySource: claimSourceUpstreamOpaque,
+			provider:     providerName,
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims:  map[string]any{"sub": "thv-user"},
+				},
+				// GitHub-style opaque token: a credential exists but its claims
+				// cannot be read, so evaluation silently degrades to request
+				// claims. This label is the only way a policy can see that.
+				UpstreamTokens: map[string]string{providerName: "gho_opaque_access_token"},
+			},
+			wantAuthorize: true,
+		},
+		{
+			name: "opaque_fallback_does_not_pass_as_upstream",
+			// The degraded path must not satisfy a policy demanding the real
+			// upstream label, or the whole attribute is decorative.
+			policySource: claimSourceUpstreamPrefix + providerName,
+			provider:     providerName,
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "thv-user",
+					Claims:  map[string]any{"sub": "thv-user"},
+				},
+				UpstreamTokens: map[string]string{providerName: "gho_opaque_access_token"},
+			},
+			wantAuthorize: false,
+		},
+		{
+			name: "token_cannot_spoof_its_own_provenance",
+			// A claim literally named thv_claim_source is emitted as
+			// claim_thv_claim_source by preprocessClaims, so it cannot reach
+			// the attribute the policy reads.
+			policySource: claimSourceUpstreamPrefix + providerName,
+			provider:     providerName,
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "machine-user",
+					Claims: map[string]any{
+						"sub":                                   "machine-user",
+						claimSourceAttr:                         claimSourceUpstreamPrefix + providerName,
+						upstreamtoken.NoUpstreamSessionClaimKey: true,
+					},
+				},
+			},
+			wantAuthorize: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			authorizer, err := NewCedarAuthorizer(ConfigOptions{
+				Policies:                []string{policyFor(tt.policySource)},
+				EntitiesJSON:            `[]`,
+				PrimaryUpstreamProvider: tt.provider,
+			}, "")
+			require.NoError(t, err)
+
+			ctx := auth.WithIdentity(context.Background(), tt.identity)
+			authorized, err := authorizer.AuthorizeWithJWTClaims(
+				ctx,
+				authorizers.MCPFeatureTool,
+				authorizers.MCPOperationCall,
+				"deploy",
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAuthorize, authorized)
+		})
+	}
 }

--- a/pkg/authz/authorizers/cedar/core_test.go
+++ b/pkg/authz/authorizers/cedar/core_test.go
@@ -1490,26 +1490,36 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 			errContains: "failed to parse upstream token",
 		},
 		{
-			name: "delegated_token_act_claim_falls_back_to_request_claims_permitted",
+			name: "session_less_grant_falls_back_to_request_claims_permitted",
 			identity: &auth.Identity{
 				PrincipalInfo: auth.PrincipalInfo{
 					Subject: "upstream-user",
 					Claims:  map[string]any{"sub": "upstream-user"},
-					// An RFC 8693 delegated token: the act claim states that this
-					// token was minted from a subject token, with no upstream login
-					// of its own.
+				},
+				SessionlessGrant: true,
+				UpstreamTokens:   nil,
+			},
+			wantAuthorize: true,
+		},
+		{
+			name: "raw_delegation_chain_does_not_fall_back",
+			identity: &auth.Identity{
+				PrincipalInfo: auth.PrincipalInfo{
+					Subject: "upstream-user",
+					Claims:  map[string]any{"sub": "upstream-user"},
 					DelegationChain: &audit.DelegationChain{
 						Chain: []audit.DelegatedActor{
-							{Subject: "agent-1", Issuer: "https://thv.example.com"},
+							{Subject: "delegated-agent", Issuer: "https://thv.example.com"},
 						},
 					},
 				},
 				UpstreamTokens: nil,
 			},
-			wantAuthorize: true,
+			wantErr:     true,
+			errContains: "no session-less grant provenance",
 		},
 		{
-			name: "jwt_bearer_token_no_session_marker_falls_back_to_request_claims_permitted",
+			name: "raw_no_session_marker_does_not_fall_back",
 			identity: &auth.Identity{
 				PrincipalInfo: auth.PrincipalInfo{
 					Subject: "upstream-user",
@@ -1522,10 +1532,11 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 				},
 				UpstreamTokens: nil,
 			},
-			wantAuthorize: true,
+			wantErr:     true,
+			errContains: "no session-less grant provenance",
 		},
 		{
-			name: "upstream_tokens_nil_without_any_marker_errors",
+			name: "upstream_tokens_nil_without_sessionless_grant_errors",
 			identity: &auth.Identity{
 				PrincipalInfo: auth.PrincipalInfo{
 					Subject: "upstream-user",
@@ -1537,7 +1548,7 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 				UpstreamTokens: nil,
 			},
 			wantErr:     true,
-			errContains: "does not declare a missing upstream session",
+			errContains: "no session-less grant provenance",
 		},
 		{
 			name: "anonymous_identity_errors_under_pinned_provider",
@@ -1555,7 +1566,7 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 				UpstreamTokens: nil,
 			},
 			wantErr:     true,
-			errContains: "does not declare a missing upstream session",
+			errContains: "no session-less grant provenance",
 		},
 		{
 			name: "malformed_act_claim_is_not_a_delegation_statement",
@@ -1576,7 +1587,7 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 				UpstreamTokens: nil,
 			},
 			wantErr:     true,
-			errContains: "does not declare a missing upstream session",
+			errContains: "no session-less grant provenance",
 		},
 		{
 			name: "empty_act_object_is_not_a_delegation_statement",
@@ -1593,7 +1604,7 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 				UpstreamTokens: nil,
 			},
 			wantErr:     true,
-			errContains: "does not declare a missing upstream session",
+			errContains: "no session-less grant provenance",
 		},
 		{
 			name: "no_session_marker_false_errors",
@@ -1608,7 +1619,7 @@ func TestAuthorizeWithJWTClaims_UpstreamProvider(t *testing.T) {
 				UpstreamTokens: nil,
 			},
 			wantErr:     true,
-			errContains: "does not declare a missing upstream session",
+			errContains: "no session-less grant provenance",
 		},
 		{
 			name: "upstream_token_has_no_sub_claim",
@@ -4501,6 +4512,7 @@ func TestAuthorizeWithJWTClaims_ClaimSourceAttribute(t *testing.T) {
 						upstreamtoken.NoUpstreamSessionClaimKey: true,
 					},
 				},
+				SessionlessGrant: true,
 			},
 			wantAuthorize: true,
 		},
@@ -4551,6 +4563,7 @@ func TestAuthorizeWithJWTClaims_ClaimSourceAttribute(t *testing.T) {
 						upstreamtoken.NoUpstreamSessionClaimKey: true,
 					},
 				},
+				SessionlessGrant: true,
 			},
 			wantAuthorize: false,
 		},

--- a/pkg/authz/authorizers/cedar/delegation_e2e_test.go
+++ b/pkg/authz/authorizers/cedar/delegation_e2e_test.go
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cedar
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/auth"
+	"github.com/stacklok/toolhive/pkg/auth/upstreamtoken"
+	"github.com/stacklok/toolhive/pkg/authz/authorizers"
+)
+
+// TestDelegatedTokenEndToEnd drives a real RFC 8693-shaped token through the
+// production authentication middleware and into Cedar, rather than
+// hand-constructing an Identity as the unit tests above do.
+//
+// The two cases together pin the trust boundary the session-less fallback rests
+// on. A hand-built Identity cannot express the distinction: it sets
+// SessionlessGrant directly, so it proves nothing about whether the validator
+// would have derived it. Only the real middleware can, because the fact is
+// derived there from the validated issuer.
+func TestDelegatedTokenEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	const (
+		embeddedIssuer = "https://auth.toolhive.example.com"
+		foreignIssuer  = "https://idp.other.example.com"
+		audience       = "https://mcp.example.com/mcp"
+		keyID          = "e2e-key-1"
+	)
+
+	// A pinned provider whose credentials never load: every request here has a
+	// nil UpstreamTokens map, so the outcome turns purely on provenance.
+	const providerName = "github"
+
+	policy := `
+		permit(
+			principal,
+			action == Action::"call_tool",
+			resource == Tool::"deploy"
+		)
+		when {
+			principal.thv_claim_source == "request:no-upstream-session" &&
+			principal has claim_act &&
+			principal.claim_act.sub == "delegate-agent"
+		};
+	`
+
+	authorizer, err := NewCedarAuthorizer(ConfigOptions{
+		Policies:                []string{policy},
+		EntitiesJSON:            `[]`,
+		PrimaryUpstreamProvider: providerName,
+	}, "")
+	require.NoError(t, err)
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	pubKey, err := jwk.Import(&privateKey.PublicKey)
+	require.NoError(t, err)
+	require.NoError(t, pubKey.Set(jwk.KeyIDKey, keyID))
+	require.NoError(t, pubKey.Set(jwk.AlgorithmKey, "RS256"))
+	require.NoError(t, pubKey.Set(jwk.KeyUsageKey, "sig"))
+
+	keySet := jwk.NewSet()
+	require.NoError(t, keySet.AddKey(pubKey))
+
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		buf, mErr := json.Marshal(keySet)
+		if mErr != nil {
+			http.Error(w, mErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(buf)
+	}))
+	t.Cleanup(jwksServer.Close)
+
+	signToken := func(t *testing.T, claims jwt.MapClaims) string {
+		t.Helper()
+		tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tok.Header["kid"] = keyID
+		signed, sErr := tok.SignedString(privateKey)
+		require.NoError(t, sErr)
+		return signed
+	}
+
+	// validatorFor builds the incoming-auth validator a deployment would run:
+	// oidcIssuer is what the vMCP OIDC config pins, embeddedIssuer names the
+	// local embedded authorization server. They coincide only when the embedded
+	// server is the deployment's own front door.
+	validatorFor := func(t *testing.T, oidcIssuer string) *auth.TokenValidator {
+		t.Helper()
+		v, vErr := auth.NewTokenValidator(t.Context(), auth.TokenValidatorConfig{
+			Issuer:            oidcIssuer,
+			Audience:          audience,
+			JWKSURL:           jwksServer.URL,
+			ClientID:          "vmcp",
+			AllowPrivateIP:    true,
+			InsecureAllowHTTP: true,
+		}, auth.WithEmbeddedAuthServerIssuer(embeddedIssuer))
+		require.NoError(t, vErr)
+		return v
+	}
+
+	// identityThroughMiddleware runs the token through real validation and
+	// returns the Identity the rest of the stack would see.
+	identityThroughMiddleware := func(t *testing.T, v *auth.TokenValidator, token string) *auth.Identity {
+		t.Helper()
+		var captured *auth.Identity
+		handler := v.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			captured, _ = auth.IdentityFromContext(r.Context())
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code, "token must authenticate; this test is about authorization")
+		require.NotNil(t, captured)
+		require.Nil(t, captured.UpstreamTokens, "no tsid claim, so no upstream credential should load")
+		return captured
+	}
+
+	delegatedClaims := func(issuer string) jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss":       issuer,
+			"aud":       audience,
+			"sub":       "alice",
+			"exp":       time.Now().Add(time.Hour).Unix(),
+			"client_id": "delegate-agent",
+			// RFC 8693 §4.1: the current actor is the outermost act.
+			"act": map[string]any{"iss": issuer, "sub": "delegate-agent"},
+		}
+	}
+
+	t.Run("delegated token from the embedded auth server authorizes under a pinned provider", func(t *testing.T) {
+		t.Parallel()
+
+		v := validatorFor(t, embeddedIssuer)
+		identity := identityThroughMiddleware(t, v, signToken(t, delegatedClaims(embeddedIssuer)))
+		require.True(t, identity.SessionlessGrant,
+			"the validator must derive provenance for its own embedded auth server")
+
+		authorized, aErr := authorizer.AuthorizeWithJWTClaims(
+			auth.WithIdentity(t.Context(), identity),
+			authorizers.MCPFeatureTool, authorizers.MCPOperationCall, "deploy", nil,
+		)
+		require.NoError(t, aErr, "a proven session-less grant must reach policy evaluation")
+		assert.True(t, authorized, "the policy permits this actor under request:no-upstream-session")
+	})
+
+	t.Run("foreign issuer asserting act and the marker is denied", func(t *testing.T) {
+		t.Parallel()
+
+		// The deployment's incoming auth trusts a different IdP than the embedded
+		// authorization server. That IdP's tokens are perfectly valid, so they
+		// authenticate — but they are not evidence about a grant this deployment's
+		// own authorization server minted, and must not reach the fallback.
+		claims := delegatedClaims(foreignIssuer)
+		claims[upstreamtoken.NoUpstreamSessionClaimKey] = true
+
+		v := validatorFor(t, foreignIssuer)
+		identity := identityThroughMiddleware(t, v, signToken(t, claims))
+		require.False(t, identity.SessionlessGrant,
+			"a foreign issuer must not establish session-less grant provenance, "+
+				"however loudly its tokens assert act and the marker")
+
+		_, aErr := authorizer.AuthorizeWithJWTClaims(
+			auth.WithIdentity(t.Context(), identity),
+			authorizers.MCPFeatureTool, authorizers.MCPOperationCall, "deploy", nil,
+		)
+		require.Error(t, aErr, "the pinned provider's boundary must hold")
+		assert.Contains(t, aErr.Error(), "no session-less grant provenance")
+	})
+}

--- a/pkg/runner/config_builder.go
+++ b/pkg/runner/config_builder.go
@@ -704,7 +704,19 @@ func WithMiddlewareFromFlags(
 		middlewareConfigs = addToolFilterMiddlewares(middlewareConfigs, toolsFilter, toolsOverride)
 
 		// Add core middlewares (always present)
-		middlewareConfigs = addCoreMiddlewares(middlewareConfigs, oidcConfig, tokenExchangeConfig, disableUsageMetrics)
+		embeddedAuthServerIssuer := func() string {
+			if b.config.EmbeddedAuthServerConfig != nil {
+				return b.config.EmbeddedAuthServerConfig.Issuer
+			}
+			return ""
+		}()
+		middlewareConfigs = addCoreMiddlewares(
+			middlewareConfigs,
+			oidcConfig,
+			tokenExchangeConfig,
+			embeddedAuthServerIssuer,
+			disableUsageMetrics,
+		)
 
 		// NOTE: Header forward middleware is NOT added here because secret-backed
 		// headers are not yet resolved at builder time. It is added in Runner.Run()
@@ -851,11 +863,13 @@ func addCoreMiddlewares(
 	middlewareConfigs []types.MiddlewareConfig,
 	oidcConfig *auth.TokenValidatorConfig,
 	tokenExchangeConfig *tokenexchange.Config,
+	embeddedAuthServerIssuer string,
 	disableUsageMetrics bool,
 ) []types.MiddlewareConfig {
 	// Authentication middleware (always present)
 	authParams := auth.MiddlewareParams{
-		OIDCConfig: oidcConfig,
+		OIDCConfig:               oidcConfig,
+		EmbeddedAuthServerIssuer: embeddedAuthServerIssuer,
 	}
 	if authConfig, err := types.NewMiddlewareConfig(auth.MiddlewareType, authParams); err == nil {
 		middlewareConfigs = append(middlewareConfigs, *authConfig)

--- a/pkg/runner/config_builder_test.go
+++ b/pkg/runner/config_builder_test.go
@@ -389,7 +389,7 @@ func TestAddCoreMiddlewares_TokenExchangeIntegration(t *testing.T) {
 
 		var mws []types.MiddlewareConfig
 		// OIDC config can be empty for this unit test since we're only testing token-exchange behavior.
-		mws = addCoreMiddlewares(mws, &auth.TokenValidatorConfig{}, nil, false)
+		mws = addCoreMiddlewares(mws, &auth.TokenValidatorConfig{}, nil, "", false)
 
 		// Expect only auth + mcp parser when token-exchange config == nil
 		assert.Equal(t, auth.MiddlewareType, mws[0].Type, "first middleware should be auth")
@@ -417,7 +417,7 @@ func TestAddCoreMiddlewares_TokenExchangeIntegration(t *testing.T) {
 			// ExternalTokenHeaderName not required for replace strategy
 		}
 
-		mws = addCoreMiddlewares(mws, &auth.TokenValidatorConfig{}, teCfg, false)
+		mws = addCoreMiddlewares(mws, &auth.TokenValidatorConfig{}, teCfg, "", false)
 
 		// Expect auth, token-exchange, then mcp parser — verify correct order and count.
 		assert.Equal(t, auth.MiddlewareType, mws[0].Type, "first middleware should be auth")
@@ -441,6 +441,41 @@ func TestAddCoreMiddlewares_TokenExchangeIntegration(t *testing.T) {
 		assert.Equal(t, teCfg.Scopes, mwParams.TokenExchangeConfig.Scopes, "Scopes should propagate into middleware params")
 		assert.Equal(t, teCfg.HeaderStrategy, mwParams.TokenExchangeConfig.HeaderStrategy, "HeaderStrategy should propagate into middleware params")
 	})
+}
+
+func TestWithMiddlewareFromFlags_BindsEmbeddedAuthServerIssuer(t *testing.T) {
+	t.Parallel()
+
+	builder := &runConfigBuilder{config: NewRunConfig()}
+	require.NoError(t, WithEmbeddedAuthServerConfig(&authserver.RunConfig{
+		Issuer: "https://auth.toolhive.example.com",
+	})(builder))
+	require.NoError(t, WithMiddlewareFromFlags(
+		nil,   // oidcConfig
+		nil,   // tokenExchangeConfig
+		nil,   // toolsFilter
+		nil,   // toolsOverride
+		nil,   // telemetryConfig
+		"",    // authzConfigPath
+		false, // enableAudit
+		"",    // auditConfigPath
+		"",    // serverName
+		"",    // transportType
+		true,  // disableUsageMetrics
+	)(builder))
+
+	var authConfig types.MiddlewareConfig
+	for _, config := range builder.config.MiddlewareConfigs {
+		if config.Type == auth.MiddlewareType {
+			authConfig = config
+			break
+		}
+	}
+	require.NotEmpty(t, authConfig.Parameters, "auth middleware must be present")
+
+	var authParams auth.MiddlewareParams
+	require.NoError(t, json.Unmarshal(authConfig.Parameters, &authParams))
+	assert.Equal(t, "https://auth.toolhive.example.com", authParams.EmbeddedAuthServerIssuer)
 }
 
 func TestRunConfigBuilder_WithToolOverride(t *testing.T) {

--- a/pkg/runner/middleware.go
+++ b/pkg/runner/middleware.go
@@ -100,8 +100,15 @@ func PopulateMiddlewareConfigs(config *RunConfig) error {
 	}
 
 	// Authentication middleware (always present)
+	embeddedAuthServerIssuer := func() string {
+		if config.EmbeddedAuthServerConfig != nil {
+			return config.EmbeddedAuthServerConfig.Issuer
+		}
+		return ""
+	}()
 	authParams := auth.MiddlewareParams{
-		OIDCConfig: config.OIDCConfig,
+		OIDCConfig:               config.OIDCConfig,
+		EmbeddedAuthServerIssuer: embeddedAuthServerIssuer,
 	}
 	authConfig, authErr := types.NewMiddlewareConfig(auth.MiddlewareType, authParams)
 	if authErr != nil {

--- a/pkg/runner/middleware_test.go
+++ b/pkg/runner/middleware_test.go
@@ -1550,6 +1550,27 @@ func TestPopulateMiddlewareConfigs_AuditWrapsChain(t *testing.T) {
 		"audit must wrap authz so authorization denials (403) are audited")
 }
 
+func TestPopulateMiddlewareConfigs_BindsEmbeddedAuthServerIssuer(t *testing.T) {
+	t.Parallel()
+
+	embeddedAuthServerConfig := createMinimalAuthServerConfig()
+	config := &RunConfig{EmbeddedAuthServerConfig: embeddedAuthServerConfig}
+	require.NoError(t, PopulateMiddlewareConfigs(config))
+
+	for _, middlewareConfig := range config.MiddlewareConfigs {
+		if middlewareConfig.Type != auth.MiddlewareType {
+			continue
+		}
+
+		var params auth.MiddlewareParams
+		require.NoError(t, json.Unmarshal(middlewareConfig.Parameters, &params))
+		assert.Equal(t, embeddedAuthServerConfig.Issuer, params.EmbeddedAuthServerIssuer)
+		return
+	}
+
+	t.Fatal("authentication middleware configuration not found")
+}
+
 // TestPopulateMiddlewareConfigs_StripAuthOrdering pins the ordering invariant
 // for strip-auth: the auth middleware must precede it in the chain so the
 // client JWT is fully validated (and the identity stored in the request

--- a/pkg/vmcp/auth/factory/authz_not_wired_test.go
+++ b/pkg/vmcp/auth/factory/authz_not_wired_test.go
@@ -48,7 +48,7 @@ func TestNewIncomingAuthMiddleware_AuthzEnforced(t *testing.T) {
 			},
 		}
 
-		authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, "test-server", nil, nil, nil)
+		authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, "test-server", nil, nil, nil, "")
 		require.NoError(t, err, "middleware creation should succeed")
 		require.NotNil(t, authMw, "auth middleware should not be nil")
 		require.NotNil(t, authzMw, "authz middleware should not be nil")
@@ -106,7 +106,7 @@ func TestNewIncomingAuthMiddleware_AuthzEnforced(t *testing.T) {
 			},
 		}
 
-		authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, "test-server", nil, nil, nil)
+		authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, "test-server", nil, nil, nil, "")
 		require.NoError(t, err, "middleware creation should succeed")
 		require.NotNil(t, authMw, "auth middleware should not be nil")
 		require.NotNil(t, authzMw, "authz middleware should not be nil")
@@ -164,7 +164,7 @@ func TestNewIncomingAuthMiddleware_AuthzApproveAndBlock(t *testing.T) {
 		},
 	}
 
-	authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, "test-server", nil, nil, nil)
+	authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, "test-server", nil, nil, nil, "")
 	require.NoError(t, err, "middleware creation should succeed")
 	require.NotNil(t, authMw, "auth middleware should not be nil")
 	require.NotNil(t, authzMw, "authz middleware should not be nil")
@@ -383,7 +383,7 @@ func TestNewIncomingAuthMiddleware_ServerNameThreaded(t *testing.T) {
 		},
 	}
 
-	authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, actualServerName, nil, nil, nil)
+	authMw, authzMw, _, err := NewIncomingAuthMiddleware(t.Context(), cfg, actualServerName, nil, nil, nil, "")
 	require.NoError(t, err, "middleware creation should succeed")
 	require.NotNil(t, authMw, "auth middleware should not be nil")
 	require.NotNil(t, authzMw, "authz middleware should not be nil")
@@ -437,7 +437,7 @@ func TestNewIncomingAuthMiddleware_ServerNameThreaded(t *testing.T) {
 			},
 		}
 
-		wrongAuthMw, wrongAuthzMw, _, err := NewIncomingAuthMiddleware(t.Context(), wrongCfg, "wrong-server", nil, nil, nil)
+		wrongAuthMw, wrongAuthzMw, _, err := NewIncomingAuthMiddleware(t.Context(), wrongCfg, "wrong-server", nil, nil, nil, "")
 		require.NoError(t, err, "middleware creation should succeed")
 
 		handlerCalled := false

--- a/pkg/vmcp/auth/factory/incoming.go
+++ b/pkg/vmcp/auth/factory/incoming.go
@@ -58,6 +58,7 @@ func NewIncomingAuthMiddleware(
 	passThroughTools map[string]struct{},
 	upstreamReader upstreamtoken.TokenReader,
 	keyProvider keys.PublicKeyProvider,
+	embeddedAuthServerIssuer string,
 ) (
 	authMw func(http.Handler) http.Handler,
 	authzMw func(http.Handler) http.Handler,
@@ -72,7 +73,8 @@ func NewIncomingAuthMiddleware(
 
 	switch cfg.Type {
 	case "oidc":
-		authMiddleware, authInfoHandler, err = newOIDCAuthMiddleware(ctx, cfg.OIDC, upstreamReader, keyProvider)
+		authMiddleware, authInfoHandler, err = newOIDCAuthMiddleware(
+			ctx, cfg.OIDC, upstreamReader, keyProvider, embeddedAuthServerIssuer)
 	case "local":
 		authMiddleware, authInfoHandler, err = newLocalAuthMiddleware(ctx)
 	case "anonymous":
@@ -213,6 +215,7 @@ func newOIDCAuthMiddleware(
 	oidcCfg *config.OIDCConfig,
 	reader upstreamtoken.TokenReader,
 	keyProvider keys.PublicKeyProvider,
+	embeddedAuthServerIssuer string,
 ) (func(http.Handler) http.Handler, http.Handler, error) {
 	if oidcCfg == nil {
 		return nil, nil, fmt.Errorf("OIDC configuration required when Type='oidc'")
@@ -247,6 +250,9 @@ func newOIDCAuthMiddleware(
 	}
 	if reader != nil {
 		opts = append(opts, auth.WithUpstreamTokenReader(reader))
+	}
+	if embeddedAuthServerIssuer != "" {
+		opts = append(opts, auth.WithEmbeddedAuthServerIssuer(embeddedAuthServerIssuer))
 	}
 
 	// pkg/auth.GetAuthenticationMiddleware now returns middleware that creates Identity

--- a/pkg/vmcp/auth/factory/incoming.go
+++ b/pkg/vmcp/auth/factory/incoming.go
@@ -85,6 +85,21 @@ func NewIncomingAuthMiddleware(
 		return nil, nil, nil, err
 	}
 
+	// A pinned primaryUpstreamProvider says "only claims asserted by that upstream
+	// may drive policy", which only means something when incoming auth can produce
+	// an upstream session. Under local or anonymous auth it never can, so every
+	// request would be judged on synthetic claims (sub=anonymous, or a local
+	// username) that no upstream asserted. Reject the combination here rather than
+	// serving it: the operator enforces the same rule for VirtualMCPServer at
+	// cmd/thv-operator/controllers/virtualmcpserver_controller.go, but that check
+	// does not run for a hand-written vmcp config.
+	if cfg.Authz != nil && cfg.Authz.PrimaryUpstreamProvider != "" && cfg.Type != config.IncomingAuthTypeOIDC {
+		return nil, nil, nil, fmt.Errorf(
+			"authz primaryUpstreamProvider %q requires an upstream session, which %q incoming auth cannot provide; "+
+				"remove primaryUpstreamProvider or use oidc incoming auth",
+			cfg.Authz.PrimaryUpstreamProvider, cfg.Type)
+	}
+
 	// If authorization is configured, create authz middleware separately.
 	// Authz is returned as its own middleware so the caller can place it after
 	// discovery and annotation-enrichment in the middleware chain, giving

--- a/pkg/vmcp/auth/factory/incoming_cabundle_test.go
+++ b/pkg/vmcp/auth/factory/incoming_cabundle_test.go
@@ -75,7 +75,7 @@ func TestNewOIDCAuthMiddleware_CABundlePath(t *testing.T) {
 				CABundlePath:       tt.caBundlePath,
 			}
 
-			authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, nil)
+			authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, nil, "")
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/vmcp/auth/factory/incoming_keyprovider_test.go
+++ b/pkg/vmcp/auth/factory/incoming_keyprovider_test.go
@@ -64,7 +64,7 @@ func TestNewOIDCAuthMiddleware_KeyProvider_LocalResolution(t *testing.T) {
 		}}, nil).
 		AnyTimes()
 
-	authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, mockProvider)
+	authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, mockProvider, "")
 	require.NoError(t, err, "middleware creation should succeed with key provider")
 	require.NotNil(t, authMw)
 
@@ -114,7 +114,7 @@ func TestNewOIDCAuthMiddleware_KeyProvider_HTTPFallback(t *testing.T) {
 		JwksAllowPrivateIP: true,
 	}
 
-	authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, nil)
+	authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, nil, "")
 	require.NoError(t, err)
 	require.NotNil(t, authMw)
 
@@ -182,7 +182,7 @@ func TestNewOIDCAuthMiddleware_KeyProvider_KidMissFallback(t *testing.T) {
 		}}, nil).
 		AnyTimes()
 
-	authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, mockProvider)
+	authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, mockProvider, "")
 	require.NoError(t, err)
 	require.NotNil(t, authMw)
 

--- a/pkg/vmcp/auth/factory/incoming_test.go
+++ b/pkg/vmcp/auth/factory/incoming_test.go
@@ -122,6 +122,41 @@ func TestNewIncomingAuthMiddleware(t *testing.T) {
 			},
 		},
 		{
+			// A pinned primaryUpstreamProvider demands that claims come from an
+			// upstream IdP. Local auth synthesizes an identity from the OS user
+			// and can never produce an upstream session, so serving this
+			// combination would judge every request on claims no upstream
+			// asserted.
+			name: "local_auth_with_primary_upstream_provider_returns_error",
+			cfg: &config.IncomingAuthConfig{
+				Type: "local",
+				Authz: &config.AuthzConfig{
+					Type:                    "cedar",
+					PrimaryUpstreamProvider: "github",
+					Policies: []string{
+						`permit(principal, action == Action::"list_tools", resource);`,
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "requires an upstream session",
+		},
+		{
+			name: "anonymous_auth_with_primary_upstream_provider_returns_error",
+			cfg: &config.IncomingAuthConfig{
+				Type: "anonymous",
+				Authz: &config.AuthzConfig{
+					Type:                    "cedar",
+					PrimaryUpstreamProvider: "github",
+					Policies: []string{
+						`permit(principal, action == Action::"list_tools", resource);`,
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "requires an upstream session",
+		},
+		{
 			name: "unsupported_auth_type_returns_error",
 			cfg: &config.IncomingAuthConfig{
 				Type: "unsupported-type",

--- a/pkg/vmcp/auth/factory/incoming_test.go
+++ b/pkg/vmcp/auth/factory/incoming_test.go
@@ -170,7 +170,7 @@ func TestNewIncomingAuthMiddleware(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			authMw, authzMw, authInfo, err := NewIncomingAuthMiddleware(t.Context(), tt.cfg, "test-server", nil, nil, nil)
+			authMw, authzMw, authInfo, err := NewIncomingAuthMiddleware(t.Context(), tt.cfg, "test-server", nil, nil, nil, "")
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/vmcp/auth/factory/incoming_upstream_test.go
+++ b/pkg/vmcp/auth/factory/incoming_upstream_test.go
@@ -116,7 +116,7 @@ func TestNewOIDCAuthMiddleware_UpstreamTokenReaderWiring(t *testing.T) {
 				"google": {AccessToken: "gcp-access-token", IDToken: "gcp-id-token"},
 			}, []string(nil), nil)
 
-		authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, reader, nil)
+		authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, reader, nil, "")
 		require.NoError(t, err, "middleware creation should succeed with non-nil reader")
 		require.NotNil(t, authMw)
 
@@ -150,7 +150,7 @@ func TestNewOIDCAuthMiddleware_UpstreamTokenReaderWiring(t *testing.T) {
 	t.Run("upstream tokens nil when reader is nil", func(t *testing.T) {
 		t.Parallel()
 
-		authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, nil)
+		authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, nil, nil, "")
 		require.NoError(t, err)
 		require.NotNil(t, authMw)
 
@@ -188,7 +188,7 @@ func TestNewOIDCAuthMiddleware_UpstreamTokenReaderWiring(t *testing.T) {
 		reader := upstreamtokenmocks.NewMockTokenReader(ctrl)
 		// No EXPECT -- reader should not be called when tsid is absent.
 
-		authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, reader, nil)
+		authMw, _, err := newOIDCAuthMiddleware(t.Context(), oidcCfg, reader, nil, "")
 		require.NoError(t, err)
 		require.NotNil(t, authMw)
 

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -373,15 +373,18 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 	// Extract dependencies from the embedded auth server.
 	var upstreamReader upstreamtoken.TokenReader
 	var keyProvider keys.PublicKeyProvider
+	var embeddedAuthServerIssuer string
 	if embeddedAuthServer != nil {
 		stor := embeddedAuthServer.IDPTokenStorage()
 		refresher := embeddedAuthServer.UpstreamTokenRefresher()
 		upstreamReader = upstreamtoken.NewInProcessService(stor, refresher)
 		keyProvider = embeddedAuthServer.KeyProvider()
+		embeddedAuthServerIssuer = authServerRC.Issuer
 	}
 
 	authMiddleware, authzMiddleware, authInfoHandler, err :=
-		authfactory.NewIncomingAuthMiddleware(ctx, vmcpCfg.IncomingAuth, vmcpCfg.Name, passThroughTools, upstreamReader, keyProvider)
+		authfactory.NewIncomingAuthMiddleware(ctx, vmcpCfg.IncomingAuth, vmcpCfg.Name, passThroughTools,
+			upstreamReader, keyProvider, embeddedAuthServerIssuer)
 	if err != nil {
 		return fmt.Errorf("failed to create authentication middleware: %w", err)
 	}


### PR DESCRIPTION
## Summary

- RFC 8693 delegated tokens and RFC 7523 JWT-bearer tokens have no upstream login, so a pinned Cedar upstream provider rejected them before policy evaluation. This restores evaluation for those deliberately session-less tokens while preserving fail-closed behavior for identities that merely lack upstream credentials.
- Recognize the two intentional no-session grants from verified token signals: delegation's `act` chain and a private JWT-bearer marker minted by ToolHive's authorization server.
- Preserve the pinned-provider boundary for missing or wrong upstream credentials, reject incompatible local/anonymous vMCP configurations, expose non-spoofable claim provenance to Cedar policies, and document the resulting behavior.

Fixes #6424

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (reviewed the branch diff and verification cases for delegated tokens, JWT-bearer tokens, absent/mismatched upstream credentials, opaque upstream tokens, and local/anonymous incoming-auth configuration.)

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Changes

| File area | Change |
|------|--------|
| `pkg/authz/authorizers/cedar` | Select claims safely by upstream-session provenance and expose claim source. |
| `pkg/auth*` | Parse delegation state and stamp/consume the JWT-bearer no-session marker. |
| `pkg/vmcp/auth/factory` | Reject pinned-provider configurations that cannot have an upstream session. |
| `docs/authz.md` | Document claim provenance and session-less grant behavior. |

## Does this introduce a user-facing change?

Yes. Cedar policies with `primaryUpstreamProvider` can authorize RFC 8693 delegated and RFC 7523 JWT-bearer tokens using their request-token claims when the token explicitly declares it has no upstream session. Other identities without the configured provider's credential remain denied.

## Special notes for reviewers

The fallback is deliberately narrower than treating every nil `UpstreamTokens` map as session-less. A nil map can also represent local, anonymous, or un-enriched identities, so it is insufficient proof that request claims should be trusted under a pinned provider. The new `thv_claim_source` attribute lets policies opt into requiring claims from the configured upstream provider.