### PR TITLE
Preserve config-level outgoing auth across backend watcher reconciles

### DIFF
--- a/pkg/vmcp/aggregator/discoverer.go
+++ b/pkg/vmcp/aggregator/discoverer.go
@@ -220,49 +220,11 @@ func (d *backendDiscoverer) Discover(ctx context.Context, groupRef string) (back
 // applyAuthConfigToBackend applies authentication configuration to a backend based on the source mode.
 // It determines whether to use discovered auth from the MCPServer or auth from the vMCP config.
 //
-// Auth resolution logic:
-// - "discovered" mode: Use discovered auth if available, otherwise fall back to Default or backend-specific config
-// - "inline" mode (or ""): Always use config-based auth, ignore discovered auth
-// - unknown mode: Default to config-based auth for safety
-//
-// When useDiscoveredAuth is false, ResolveForBackend is called which handles:
-// 1. Backend-specific config (d.authConfig.Backends[backendName])
-// 2. Default config fallback (d.authConfig.Default)
-// 3. No auth if neither is configured
+// The resolution logic lives in config.OutgoingAuthConfig.ApplyToBackend so the
+// Kubernetes backend watcher's reconciler applies the exact same semantics when it
+// rebuilds a backend (see pkg/vmcp/k8s).
 func (d *backendDiscoverer) applyAuthConfigToBackend(backend *vmcp.Backend, backendName string) {
-	if d.authConfig == nil {
-		return
-	}
-
-	// Determine if we should use discovered auth or config-based auth
-	var useDiscoveredAuth bool
-	switch d.authConfig.Source {
-	case "discovered":
-		// In discovered mode, use auth discovered from MCPServer (if any exists)
-		// If no auth is discovered, fall back to config-based auth via ResolveForBackend
-		// which will use backend-specific config, then Default, then no auth
-		useDiscoveredAuth = backend.AuthConfig != nil
-	case "inline", "":
-		// For inline mode or empty source, always use config-based auth
-		// Ignore any discovered auth from backends
-		useDiscoveredAuth = false
-	default:
-		// Unknown source mode - default to config-based auth for safety
-		slog.Warn("unknown auth source mode, defaulting to config-based auth", "source", d.authConfig.Source)
-		useDiscoveredAuth = false
-	}
-
-	if useDiscoveredAuth {
-		// Keep the auth discovered from MCPServer (already populated in backend)
-		slog.Debug("backend using discovered auth strategy", "backend", backendName, "strategy", backend.AuthConfig.Type)
-	} else {
-		// Use auth from config (inline mode)
-		authConfig := d.authConfig.ResolveForBackend(backendName)
-		if authConfig != nil {
-			backend.AuthConfig = authConfig
-			slog.Debug("backend configured with auth strategy from config", "backend", backendName, "strategy", authConfig.Type)
-		}
-	}
+	d.authConfig.ApplyToBackend(backend, backendName)
 }
 
 // discoverFromStaticConfig converts pre-configured static backends into vmcp.Backend objects

--- a/pkg/vmcp/backendregistry/registry.go
+++ b/pkg/vmcp/backendregistry/registry.go
@@ -28,13 +28,15 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/k8s"
 	"github.com/stacklok/toolhive/pkg/vmcp/server"
 )
 
 // options holds the optional settings for NewKubernetesBackendRegistry.
 type options struct {
-	restConfig *rest.Config
+	restConfig   *rest.Config
+	outgoingAuth *config.OutgoingAuthConfig
 }
 
 // Option configures NewKubernetesBackendRegistry.
@@ -48,6 +50,17 @@ type Option func(*options)
 func WithRESTConfig(cfg *rest.Config) Option {
 	return func(o *options) {
 		o.restConfig = cfg
+	}
+}
+
+// WithOutgoingAuth supplies the vMCP config-level outgoing auth configuration.
+// The watcher applies it to every reconciled backend with the same precedence
+// startup discovery uses (discovered CR-side auth first, then backends[<name>],
+// then Default). The default (no option) is nil: reconciled backends keep only
+// the auth discovered from their own resource references.
+func WithOutgoingAuth(authConfig *config.OutgoingAuthConfig) Option {
+	return func(o *options) {
+		o.outgoingAuth = authConfig
 	}
 }
 
@@ -127,7 +140,7 @@ func NewKubernetesBackendRegistry(
 	// Start empty; the watcher's initial informer sync populates the registry.
 	dynamicRegistry := vmcp.NewDynamicRegistry(nil)
 
-	watcher, err := k8s.NewBackendWatcher(restConfig, namespace, group, dynamicRegistry)
+	watcher, err := k8s.NewBackendWatcher(restConfig, namespace, group, dynamicRegistry, o.outgoingAuth)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create backend watcher: %w", err)
 	}

--- a/pkg/vmcp/cli/serve.go
+++ b/pkg/vmcp/cli/serve.go
@@ -230,7 +230,7 @@ func Serve(ctx context.Context, cfg ServeConfig) error {
 			return fmt.Errorf("VMCP_NAMESPACE environment variable not set")
 		}
 
-		backendWatcher, err = k8s.NewBackendWatcher(restConfig, namespace, vmcpCfg.Group, dynamicRegistry)
+		backendWatcher, err = k8s.NewBackendWatcher(restConfig, namespace, vmcpCfg.Group, dynamicRegistry, vmcpCfg.OutgoingAuth)
 		if err != nil {
 			return fmt.Errorf("failed to create backend watcher: %w", err)
 		}

--- a/pkg/vmcp/config/config.go
+++ b/pkg/vmcp/config/config.go
@@ -11,6 +11,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/stacklok/toolhive/pkg/audit"
@@ -425,6 +426,54 @@ func (c *OutgoingAuthConfig) ResolveForBackend(backendID string) *authtypes.Back
 
 	// No authentication configured
 	return nil
+}
+
+// ApplyToBackend applies this outgoing auth configuration to a backend, choosing
+// between the backend's own discovered auth and config-based auth. It is the single
+// implementation shared by startup discovery (pkg/vmcp/aggregator) and the Kubernetes
+// backend watcher's reconciler (pkg/vmcp/k8s), so both paths resolve auth identically.
+//
+// Auth resolution logic:
+//   - "discovered" mode: keep discovered auth if the backend has any, otherwise fall
+//     back to config-based auth via ResolveForBackend (backend-specific entry, then
+//     Default, then no auth)
+//   - "inline" mode (or ""): always use config-based auth, ignore discovered auth
+//   - unknown mode: default to config-based auth for safety
+//
+// A nil receiver is a no-op: the backend keeps whatever auth it already carries.
+func (c *OutgoingAuthConfig) ApplyToBackend(backend *vmcp.Backend, backendName string) {
+	if c == nil {
+		return
+	}
+
+	// Determine if we should use discovered auth or config-based auth
+	var useDiscoveredAuth bool
+	switch c.Source {
+	case "discovered":
+		// In discovered mode, use auth discovered from MCPServer (if any exists)
+		// If no auth is discovered, fall back to config-based auth via ResolveForBackend
+		// which will use backend-specific config, then Default, then no auth
+		useDiscoveredAuth = backend.AuthConfig != nil
+	case "inline", "":
+		// For inline mode or empty source, always use config-based auth
+		// Ignore any discovered auth from backends
+		useDiscoveredAuth = false
+	default:
+		// Unknown source mode - default to config-based auth for safety
+		slog.Warn("unknown auth source mode, defaulting to config-based auth", "source", c.Source)
+		useDiscoveredAuth = false
+	}
+
+	if useDiscoveredAuth {
+		// Keep the auth discovered from MCPServer (already populated in backend)
+		slog.Debug("backend using discovered auth strategy", "backend", backendName, "strategy", backend.AuthConfig.Type)
+	} else {
+		// Use auth from config (inline mode)
+		if authConfig := c.ResolveForBackend(backendName); authConfig != nil {
+			backend.AuthConfig = authConfig
+			slog.Debug("backend configured with auth strategy from config", "backend", backendName, "strategy", authConfig.Type)
+		}
+	}
 }
 
 // AggregationConfig defines tool aggregation, filtering, and conflict resolution strategies.

--- a/pkg/vmcp/k8s/backend_reconciler.go
+++ b/pkg/vmcp/k8s/backend_reconciler.go
@@ -18,6 +18,7 @@ import (
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
 )
 
@@ -55,7 +56,8 @@ const (
 //  3. If groupRef doesn't match → Remove from registry (moved to different group)
 //  4. Convert to vmcp.Backend using discoverer
 //  5. If conversion fails or returns nil (auth failed) → Remove from registry
-//  6. Upsert backend to registry (triggers version increment + cache invalidation)
+//  6. Apply config-level outgoing auth (same semantics as startup discovery)
+//  7. Upsert backend to registry (triggers version increment + cache invalidation)
 type BackendReconciler struct {
 	client.Client
 
@@ -70,6 +72,13 @@ type BackendReconciler struct {
 
 	// Discoverer converts K8s resources to vmcp.Backend (reuses existing code)
 	Discoverer workloads.Discoverer
+
+	// OutgoingAuth is the vMCP config-level outgoing auth configuration. It is
+	// applied to every reconciled backend with the same precedence startup
+	// discovery uses (discovered CR-side auth first, then backends[<name>],
+	// then Default), so a reconcile does not strip auth that only exists in
+	// the config. May be nil: backends then keep only their discovered auth.
+	OutgoingAuth *config.OutgoingAuthConfig
 }
 
 // SetupIndexes registers field indexes required by the reconciler's watch handlers.
@@ -282,6 +291,13 @@ func (r *BackendReconciler) convertAndUpsertBackend(
 		ctxLogger.Info("Backend conversion returned nil (auth failure or no URL)", "backendID", backendID)
 		return r.removeBackendFromRegistry(ctx, backendID, "Auth failure or no URL")
 	}
+
+	// Apply config-level outgoing auth with the same precedence startup discovery
+	// uses (discovered CR-side auth first, then backends[<name>], then Default).
+	// The discoverer above only resolves auth from the resource's own references,
+	// so without this step a reconcile would strip auth that exists only in the
+	// vMCP config (outgoingAuth.default / outgoingAuth.backends).
+	r.OutgoingAuth.ApplyToBackend(backend, resourceInfo.Name)
 
 	// Upsert backend to registry (triggers version increment + cache invalidation)
 	if err := r.Registry.Upsert(*backend); err != nil {

--- a/pkg/vmcp/k8s/backend_reconciler_test.go
+++ b/pkg/vmcp/k8s/backend_reconciler_test.go
@@ -20,6 +20,8 @@ import (
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1/v1beta1test"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	authtypes "github.com/stacklok/toolhive/pkg/vmcp/auth/types"
+	"github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/k8s"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
 )
@@ -644,4 +646,141 @@ func TestMapAuthConfigToEntries(t *testing.T) {
 			assert.Equal(t, tt.wantNames, gotNames)
 		})
 	}
+}
+
+// newOutgoingAuthTestFixture creates the fake client, discoverer, and registry
+// shared by the outgoing-auth reconciliation tests below. The MCPServer carries
+// no ExternalAuthConfigRef, so any auth on the upserted backend must come from
+// the reconciler's OutgoingAuth config (or from discoveredAuth when non-nil,
+// simulating auth resolved from the resource's own references).
+func newOutgoingAuthTestFixture(
+	t *testing.T,
+	discoveredAuth *authtypes.BackendAuthStrategy,
+) (client.Client, *mockDiscoverer, *mockRegistry) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, mcpv1beta1.AddToScheme(scheme))
+
+	mcpServer := &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-server",
+			Namespace: "default",
+		},
+		Spec: mcpv1beta1.MCPServerSpec{
+			GroupRef: &mcpv1beta1.MCPGroupRef{Name: "test-group"},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(mcpServer).
+		Build()
+
+	mockBackend := &vmcp.Backend{
+		ID:         "test-server",
+		Name:       "test-server",
+		BaseURL:    "http://test-server:8080",
+		AuthConfig: discoveredAuth,
+	}
+
+	return k8sClient, &mockDiscoverer{backend: mockBackend}, &mockRegistry{}
+}
+
+// reconcileTestServer runs one reconcile of the "test-server" MCPServer and
+// returns the single upserted backend.
+func reconcileTestServer(t *testing.T, reconciler *k8s.BackendReconciler, mockReg *mockRegistry) vmcp.Backend {
+	t.Helper()
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-server",
+			Namespace: "default",
+		},
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	require.Len(t, mockReg.upsertedBackends, 1, "Backend should be upserted to registry")
+	return mockReg.upsertedBackends[0]
+}
+
+// TestReconcile_OutgoingAuthBackendsEntry verifies that a config-level
+// outgoingAuth.backends.<name> entry survives reconciliation for a backend whose
+// own resource carries no discovered auth. Regression test for the watcher path
+// silently dropping config-level outgoing auth (#6454).
+func TestReconcile_OutgoingAuthBackendsEntry(t *testing.T) {
+	t.Parallel()
+
+	k8sClient, mockDisc, mockReg := newOutgoingAuthTestFixture(t, nil)
+
+	wantStrategy := &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUpstreamInject}
+	reconciler := newTestReconciler(k8sClient, "default", "test-group", mockReg, mockDisc)
+	reconciler.OutgoingAuth = &config.OutgoingAuthConfig{
+		Source: "discovered",
+		Backends: map[string]*authtypes.BackendAuthStrategy{
+			"test-server": wantStrategy,
+		},
+	}
+
+	upserted := reconcileTestServer(t, reconciler, mockReg)
+	require.NotNil(t, upserted.AuthConfig, "backends[<name>] auth config must survive reconciliation")
+	assert.Equal(t, authtypes.StrategyTypeUpstreamInject, upserted.AuthConfig.Type)
+}
+
+// TestReconcile_OutgoingAuthDefault verifies that the config-level
+// outgoingAuth.default survives reconciliation for a backend whose own resource
+// carries no discovered auth. Regression test for #6454.
+func TestReconcile_OutgoingAuthDefault(t *testing.T) {
+	t.Parallel()
+
+	k8sClient, mockDisc, mockReg := newOutgoingAuthTestFixture(t, nil)
+
+	reconciler := newTestReconciler(k8sClient, "default", "test-group", mockReg, mockDisc)
+	reconciler.OutgoingAuth = &config.OutgoingAuthConfig{
+		Source:  "discovered",
+		Default: &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeHeaderInjection},
+	}
+
+	upserted := reconcileTestServer(t, reconciler, mockReg)
+	require.NotNil(t, upserted.AuthConfig, "default auth config must survive reconciliation")
+	assert.Equal(t, authtypes.StrategyTypeHeaderInjection, upserted.AuthConfig.Type)
+}
+
+// TestReconcile_OutgoingAuthDiscoveredWins verifies that in discovered mode the
+// auth resolved from the backend's own resource references takes precedence over
+// a conflicting config-level backends entry — the same precedence startup
+// discovery applies.
+func TestReconcile_OutgoingAuthDiscoveredWins(t *testing.T) {
+	t.Parallel()
+
+	discovered := &authtypes.BackendAuthStrategy{Type: authtypes.StrategyTypeUpstreamInject}
+	k8sClient, mockDisc, mockReg := newOutgoingAuthTestFixture(t, discovered)
+
+	reconciler := newTestReconciler(k8sClient, "default", "test-group", mockReg, mockDisc)
+	reconciler.OutgoingAuth = &config.OutgoingAuthConfig{
+		Source: "discovered",
+		Backends: map[string]*authtypes.BackendAuthStrategy{
+			"test-server": {Type: authtypes.StrategyTypeHeaderInjection},
+		},
+	}
+
+	upserted := reconcileTestServer(t, reconciler, mockReg)
+	require.NotNil(t, upserted.AuthConfig)
+	assert.Equal(t, authtypes.StrategyTypeUpstreamInject, upserted.AuthConfig.Type,
+		"discovered auth must win over the config-level entry in discovered mode")
+}
+
+// TestReconcile_OutgoingAuthNilConfig verifies that a nil OutgoingAuth leaves
+// the reconciled backend untouched (the pre-existing behavior).
+func TestReconcile_OutgoingAuthNilConfig(t *testing.T) {
+	t.Parallel()
+
+	k8sClient, mockDisc, mockReg := newOutgoingAuthTestFixture(t, nil)
+
+	reconciler := newTestReconciler(k8sClient, "default", "test-group", mockReg, mockDisc)
+
+	upserted := reconcileTestServer(t, reconciler, mockReg)
+	assert.Nil(t, upserted.AuthConfig, "backend without discovered auth stays unauthenticated when no config is supplied")
 }

--- a/pkg/vmcp/k8s/manager.go
+++ b/pkg/vmcp/k8s/manager.go
@@ -25,6 +25,7 @@ import (
 
 	mcpv1beta1 "github.com/stacklok/toolhive/cmd/thv-operator/api/v1beta1"
 	"github.com/stacklok/toolhive/pkg/vmcp"
+	"github.com/stacklok/toolhive/pkg/vmcp/config"
 	"github.com/stacklok/toolhive/pkg/vmcp/workloads"
 )
 
@@ -61,6 +62,10 @@ type BackendWatcher struct {
 	// registry is the DynamicRegistry to update when backends change
 	registry vmcp.DynamicRegistry
 
+	// outgoingAuth is the vMCP config-level outgoing auth configuration,
+	// applied to reconciled backends with startup-discovery semantics (may be nil)
+	outgoingAuth *config.OutgoingAuthConfig
+
 	// mu protects the started field for thread-safe access
 	mu sync.Mutex
 
@@ -79,6 +84,10 @@ type BackendWatcher struct {
 //   - namespace: Namespace to watch for resources
 //   - groupRef: MCPGroup reference in "namespace/name" format
 //   - registry: DynamicRegistry to update when backends change
+//   - outgoingAuth: vMCP config-level outgoing auth configuration, applied to
+//     every reconciled backend with the same precedence startup discovery uses
+//     (discovered CR-side auth first, then backends[<name>], then Default).
+//     May be nil: reconciled backends then keep only their discovered auth.
 //
 // Returns:
 //   - *BackendWatcher: Configured watcher ready to Start()
@@ -88,7 +97,7 @@ type BackendWatcher struct {
 //
 //	restConfig, _ := rest.InClusterConfig()
 //	registry := vmcp.NewDynamicRegistry(initialBackends)
-//	watcher, err := k8s.NewBackendWatcher(restConfig, "default", "default/my-group", registry)
+//	watcher, err := k8s.NewBackendWatcher(restConfig, "default", "default/my-group", registry, cfg.OutgoingAuth)
 //	if err != nil {
 //	    return err
 //	}
@@ -101,6 +110,7 @@ func NewBackendWatcher(
 	namespace string,
 	groupRef string,
 	registry vmcp.DynamicRegistry,
+	outgoingAuth *config.OutgoingAuthConfig,
 ) (*BackendWatcher, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("rest config cannot be nil")
@@ -151,11 +161,12 @@ func NewBackendWatcher(
 	}
 
 	return &BackendWatcher{
-		ctrlManager: ctrlManager,
-		namespace:   namespace,
-		groupRef:    groupRef,
-		registry:    registry,
-		started:     false,
+		ctrlManager:  ctrlManager,
+		namespace:    namespace,
+		groupRef:     groupRef,
+		registry:     registry,
+		outgoingAuth: outgoingAuth,
+		started:      false,
 	}, nil
 }
 
@@ -295,11 +306,12 @@ func (w *BackendWatcher) addBackendWatchController(ctx context.Context) error {
 
 	// Create backend reconciler with references to namespace, groupRef, and registry
 	reconciler := &BackendReconciler{
-		Client:     w.ctrlManager.GetClient(),
-		Namespace:  w.namespace,
-		GroupRef:   w.groupRef,
-		Registry:   w.registry,
-		Discoverer: discoverer,
+		Client:       w.ctrlManager.GetClient(),
+		Namespace:    w.namespace,
+		GroupRef:     w.groupRef,
+		Registry:     w.registry,
+		Discoverer:   discoverer,
+		OutgoingAuth: w.outgoingAuth,
 	}
 
 	// Register field indexes required by the reconciler's watch handlers.

--- a/pkg/vmcp/k8s/manager_test.go
+++ b/pkg/vmcp/k8s/manager_test.go
@@ -66,7 +66,7 @@ func TestNewBackendWatcher(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			mgr, err := k8s.NewBackendWatcher(tc.cfg, tc.namespace, tc.groupRef, tc.registry)
+			mgr, err := k8s.NewBackendWatcher(tc.cfg, tc.namespace, tc.groupRef, tc.registry, nil)
 
 			if tc.expectedError != "" {
 				require.Error(t, err)
@@ -98,7 +98,7 @@ func TestNewBackendWatcher_ValidInputs(t *testing.T) {
 		},
 	})
 
-	mgr, err := k8s.NewBackendWatcher(cfg, "default", "default/test-group", registry)
+	mgr, err := k8s.NewBackendWatcher(cfg, "default", "default/test-group", registry, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, mgr)
 }
@@ -113,7 +113,7 @@ func TestBackendWatcher_WaitForCacheSync_NotStarted(t *testing.T) {
 	}
 
 	registry := vmcp.NewDynamicRegistry([]vmcp.Backend{})
-	mgr, err := k8s.NewBackendWatcher(cfg, "default", "default/test-group", registry)
+	mgr, err := k8s.NewBackendWatcher(cfg, "default", "default/test-group", registry, nil)
 	require.NoError(t, err)
 
 	// Try to wait for cache sync without starting manager
@@ -133,7 +133,7 @@ func TestBackendWatcher_StartValidation(t *testing.T) {
 	}
 
 	registry := vmcp.NewDynamicRegistry([]vmcp.Backend{})
-	mgr, err := k8s.NewBackendWatcher(cfg, "default", "default/test-group-validation", registry)
+	mgr, err := k8s.NewBackendWatcher(cfg, "default", "default/test-group-validation", registry, nil)
 	require.NoError(t, err)
 
 	// Start watcher in background with a short timeout
@@ -213,7 +213,7 @@ func TestBackendWatcher_Lifecycle(t *testing.T) {
 		// Create watcher
 		cfg, _ := rest.InClusterConfig()
 		registry := vmcp.NewDynamicRegistry(backends)
-		watcher, _ := k8s.NewBackendWatcher(cfg, "default", "default/my-group", registry)
+		watcher, _ := k8s.NewBackendWatcher(cfg, "default", "default/my-group", registry, nil)
 
 		// Start in background
 		ctx, cancel := context.WithCancel(context.Background())
@@ -245,7 +245,7 @@ func TestBackendWatcher_ContextCancellation(t *testing.T) {
 	}
 
 	registry := vmcp.NewDynamicRegistry([]vmcp.Backend{})
-	mgr, err := k8s.NewBackendWatcher(cfg, "default", "default/test-group-cancellation", registry)
+	mgr, err := k8s.NewBackendWatcher(cfg, "default", "default/test-group-cancellation", registry, nil)
 	require.NoError(t, err)
 
 	// Create a context that's already cancelled


### PR DESCRIPTION
## Summary

In dynamic (Kubernetes) mode, `outgoingAuth.default` and `outgoingAuth.backends.<name>` are applied only by startup discovery. The backend watcher's reconciler rebuilds every backend from its resource references alone (`GetWorkloadAsVMCPBackend`) and upserts the result, so the first reconcile — which follows startup within about a second — silently strips config-level auth. Affected backends degrade to unauthenticated; with health monitoring enabled they are then excluded from aggregation. The mechanism and both affected shapes are detailed in https://github.com/stacklok/toolhive/issues/6454#issuecomment-5539826896.

- Extract the auth-resolution logic from the aggregator's `applyAuthConfigToBackend` into `config.OutgoingAuthConfig.ApplyToBackend`; the aggregator method now delegates to it, so the startup path keeps its behavior (and its existing unit tests now cover the shared implementation through the wrapper).
- Thread the outgoing auth config through `NewBackendWatcher` into `BackendReconciler`, which applies it before every upsert with the same precedence as startup discovery: discovered CR-side auth first, then `backends.<name>`, then `default`.
- Expose the config on the embedder constructor via `backendregistry.WithOutgoingAuth` (that wiring mirrors `cli/serve.go` per the sync note in `registry.go`).
- Add reconciler-level regression tests: `backends.<name>` and `default` survive a reconcile (both fail without the fix), discovered auth still wins over a conflicting config entry, and a nil config remains a no-op.

Fixes #6454

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Tests and lint were run for the affected packages (`pkg/vmcp/config`, `pkg/vmcp/aggregator`, `pkg/vmcp/k8s`, `pkg/vmcp/backendregistry`, `pkg/vmcp/cli`); lint reports 0 issues. The two new survival tests fail on unmodified `main` and pass with the fix. The only failing tests in those packages (`TestValidator_ValidateIncomingAuth`, `TestValidator_ValidateStaticBackends`, `TestInit_OutputFilePermissions`) are environment-specific and reproduce identically on a clean checkout of `main`, unrelated to this change.

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/config/config.go` | New `OutgoingAuthConfig.ApplyToBackend` (logic moved verbatim from the aggregator; nil-safe) |
| `pkg/vmcp/aggregator/discoverer.go` | `applyAuthConfigToBackend` delegates to the shared method |
| `pkg/vmcp/k8s/backend_reconciler.go` | New `OutgoingAuth` field; applied in `convertAndUpsertBackend` before the upsert |
| `pkg/vmcp/k8s/manager.go` | `NewBackendWatcher` accepts the outgoing auth config and passes it to the reconciler |
| `pkg/vmcp/cli/serve.go` | Passes `vmcpCfg.OutgoingAuth` to the watcher |
| `pkg/vmcp/backendregistry/registry.go` | New `WithOutgoingAuth` option, passed through to the watcher |
| `pkg/vmcp/k8s/backend_reconciler_test.go` | Four regression tests for the reconcile-path auth behavior |
| `pkg/vmcp/k8s/manager_test.go` | Updated `NewBackendWatcher` call sites |

## Does this introduce a user-facing change?

Yes. Virtual MCP servers in Kubernetes dynamic mode no longer lose `outgoingAuth.default` / `outgoingAuth.backends.<name>` authentication when the backend watcher reconciles a backend. Previously such backends silently fell back to unauthenticated after the first reconcile.

## Special notes for reviewers

- The watcher path deliberately mirrors the startup path's existing precedence; the open precedence question in #6329 is untouched.
- @jstar0 offered to pick #6454 up — happy to adjust the shape here or defer if you had a different approach in mind.
