### PR TITLE
feat(ratelimit): attribute rate limit decisions to a tool and caller

### DIFF
--- a/pkg/ratelimit/limiter.go
+++ b/pkg/ratelimit/limiter.go
@@ -159,6 +159,11 @@ type limitCheck struct {
 	bucket        *bucket.TokenBucket
 	scope         string
 	operationType string
+
+	// toolName is set only for tool-scoped checks. Cardinality is bounded by the
+	// configured per-tool buckets, so it is safe as a metric attribute; server-scoped
+	// checks leave it empty and the attribute is omitted rather than emitted blank.
+	toolName string
 }
 
 func (c limitCheck) rejectionIdentifier() string {
@@ -186,6 +191,10 @@ func (l *limiter) recordFailOpen(ctx context.Context) {
 // Tokens are only consumed if ALL buckets have sufficient capacity, preventing
 // a rejected per-tool or per-user call from draining other budgets.
 func (l *limiter) Allow(ctx context.Context, toolName, userID string) (*Decision, error) {
+	// Attribution for the caller and tool goes on the span, not the metric: userID is
+	// unbounded, so it would multiply the decisions counter by the size of the user base.
+	recordRateLimitSpanAttribution(ctx, toolName, userID)
+
 	// Collect applicable buckets in priority order.
 	var checks []limitCheck
 	if l.serverBucket != nil {
@@ -201,6 +210,7 @@ func (l *limiter) Allow(ctx context.Context, toolName, userID string) (*Decision
 				bucket:        tb,
 				scope:         rateLimitScopeShared,
 				operationType: rateLimitOperationTool,
+				toolName:      toolName,
 			})
 		}
 	}
@@ -238,6 +248,7 @@ func (l *limiter) Allow(ctx context.Context, toolName, userID string) (*Decision
 					),
 					scope:         rateLimitScopePerUser,
 					operationType: rateLimitOperationTool,
+					toolName:      toolName,
 				})
 			}
 		}

--- a/pkg/ratelimit/observability.go
+++ b/pkg/ratelimit/observability.go
@@ -121,13 +121,19 @@ func (t *rateLimitTelemetry) recordRejected(ctx context.Context, check limitChec
 }
 
 func (t *rateLimitTelemetry) recordDecision(ctx context.Context, decision string, check limitCheck) {
-	t.decisions.Add(ctx, 1, metric.WithAttributes(
+	attrs := []attribute.KeyValue{
 		attribute.String("namespace", t.namespace),
 		attribute.String("server", t.serverName),
 		attribute.String("decision", decision),
 		attribute.String("scope", check.scope),
 		attribute.String("operation_type", check.operationType),
-	))
+	}
+	// Only tool-scoped checks carry a tool name. Emitting it blank for server-scoped
+	// decisions would add a label to every series for no information.
+	if check.toolName != "" {
+		attrs = append(attrs, attribute.String("tool_name", check.toolName))
+	}
+	t.decisions.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 func (t *rateLimitTelemetry) recordRedisError(ctx context.Context, err error) {
@@ -159,6 +165,25 @@ func (t *rateLimitTelemetry) recordCheckLatency(ctx context.Context, duration ti
 		attribute.String("namespace", t.namespace),
 		attribute.String("server", t.serverName),
 	))
+}
+
+// recordRateLimitSpanAttribution records who the request belonged to and which tool it
+// targeted. This lives on the span rather than on toolhive_rate_limit_decisions_total
+// because user identity is unbounded: as a metric attribute it would create one time
+// series per caller per bucket. On a span it costs nothing and answers "which user is
+// being throttled", which the counter alone cannot.
+func recordRateLimitSpanAttribution(ctx context.Context, toolName, userID string) {
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if toolName != "" {
+		attrs = append(attrs, attribute.String("rate_limit.tool_name", toolName))
+	}
+	if userID != "" {
+		attrs = append(attrs, attribute.String("rate_limit.user_id", userID))
+	}
+	if len(attrs) == 0 {
+		return
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attrs...)
 }
 
 func recordRateLimitSpanOutcome(ctx context.Context, decision, rejectedBy string, failOpen bool) {

--- a/pkg/ratelimit/observability_test.go
+++ b/pkg/ratelimit/observability_test.go
@@ -709,3 +709,93 @@ func stringAttributeMap(attributes attribute.Set) map[string]string {
 	}
 	return result
 }
+
+func TestRateLimitMetrics_ToolAttribution(t *testing.T) {
+	t.Parallel()
+	client, _ := newTestClient(t)
+	reader, meterProvider := newRateLimitMeterProvider()
+
+	limiter, err := newLimiter(client, "test-ns", "test-server", &v1beta1.RateLimitConfig{
+		Shared: &v1beta1.RateLimitBucket{
+			MaxTokens:    10,
+			RefillPeriod: metav1.Duration{Duration: time.Minute},
+		},
+		Tools: []v1beta1.ToolRateLimitConfig{
+			{
+				Name: "search",
+				PerUser: &v1beta1.RateLimitBucket{
+					MaxTokens:    1,
+					RefillPeriod: metav1.Duration{Duration: time.Minute},
+				},
+			},
+		},
+	}, meterProvider)
+	require.NoError(t, err)
+
+	first, err := limiter.Allow(t.Context(), "search", "user-1")
+	require.NoError(t, err)
+	require.True(t, first.Allowed)
+
+	second, err := limiter.Allow(t.Context(), "search", "user-1")
+	require.NoError(t, err)
+	require.False(t, second.Allowed, "the per-user tool bucket holds a single token")
+
+	metrics := collectRateLimitMetrics(t, reader)
+	decisions := requireRateLimitMetric(t, metrics, "toolhive_rate_limit_decisions")
+
+	// The rejection is attributable to the tool that caused it.
+	assert.Equal(t, int64(1), counterValueWithAttributes(t, decisions, map[string]string{
+		"decision":       rateLimitDecisionRejected,
+		"scope":          rateLimitScopePerUser,
+		"operation_type": rateLimitOperationTool,
+		"tool_name":      "search",
+	}))
+
+	// Server-scoped decisions carry no tool_name at all, rather than an empty one.
+	sum, ok := decisions.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	var sawServerScoped bool
+	for _, point := range sum.DataPoints {
+		operationType, found := point.Attributes.Value(attribute.Key("operation_type"))
+		if !found || operationType.AsString() != rateLimitOperationServer {
+			continue
+		}
+		sawServerScoped = true
+		_, hasTool := point.Attributes.Value(attribute.Key("tool_name"))
+		assert.False(t, hasTool, "server-scoped decisions must not carry tool_name")
+	}
+	assert.True(t, sawServerScoped, "expected at least one server-scoped decision")
+}
+
+func TestRateLimitMetrics_UnconfiguredToolCarriesNoAttribute(t *testing.T) {
+	t.Parallel()
+	client, _ := newTestClient(t)
+	reader, meterProvider := newRateLimitMeterProvider()
+
+	// Only a server-wide bucket is configured: no tool has a bucket of its own.
+	limiter, err := newLimiter(client, "test-ns", "test-server", &v1beta1.RateLimitConfig{
+		Shared: &v1beta1.RateLimitBucket{
+			MaxTokens:    10,
+			RefillPeriod: metav1.Duration{Duration: time.Minute},
+		},
+	}, meterProvider)
+	require.NoError(t, err)
+
+	// A caller-supplied tool name that matches no configured bucket must never reach
+	// the metric: tool_name is only ever set from a successful bucket-map lookup, so
+	// its value set is the operator's configuration, not caller input. This is the
+	// property that keeps the attribute bounded in both cardinality and value length.
+	allowed, err := limiter.Allow(t.Context(), strings.Repeat("a", 4096), "user-1")
+	require.NoError(t, err)
+	require.True(t, allowed.Allowed)
+
+	metrics := collectRateLimitMetrics(t, reader)
+	decisions := requireRateLimitMetric(t, metrics, "toolhive_rate_limit_decisions")
+	sum, ok := decisions.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.NotEmpty(t, sum.DataPoints)
+	for _, point := range sum.DataPoints {
+		_, hasTool := point.Attributes.Value(attribute.Key("tool_name"))
+		assert.False(t, hasTool, "an unconfigured tool name must not become a label value")
+	}
+}


### PR DESCRIPTION
## Summary

`toolhive_rate_limit_decisions_total` records `scope` and `operation_type`, but nothing that says *which* tool or *which* caller a decision belongs to. With more than one entry in `rateLimiting.tools`, every per-tool bucket collapses into a single `operation_type="tool"` series, so an operator watching rejections cannot tell which configured cap is firing, and has no way to see who is hitting it.

- `limitCheck` now carries the tool name, and `recordDecision` emits it as `tool_name` on tool-scoped decisions. The attribute is omitted (not emitted blank) for server-scoped decisions, so existing series keep their shape.
- Caller identity goes on the span instead: `Allow` sets `rate_limit.tool_name` and `rate_limit.user_id` via a new `recordRateLimitSpanAttribution`. `userID` is unbounded — as a metric attribute it would multiply the decisions counter by the size of the user base — but on a span it costs nothing and answers "who is being throttled", which the counter alone cannot.

This keeps the metric answer bounded and puts the unbounded dimension where unbounded values belong.

### On label cardinality (related to #6271)

#6271 is open on telemetry hardening, including tool/prompt cardinality and unbounded label *value length*, so it is worth being explicit that this attribute is safe on both counts.

`tool_name` is only ever set inside a successful bucket-map lookup — `if tb, ok := l.toolBuckets[toolName]; ok` and `if s, ok := l.perUserTools[toolName]; ok`. A tool name supplied by a caller that matches no configured bucket never reaches the attribute. The value set is therefore exactly the operator's configured tool names: bounded in count by `len(rateLimiting.tools)`, and bounded in length by the CRD the operator wrote. `TestRateLimitMetrics_UnconfiguredToolCarriesNoAttribute` pins this by calling `Allow` with a 4096-character tool name and asserting no datapoint gains a `tool_name` key.

Span attributes are exported per-span rather than aggregated cumulatively, so `rate_limit.user_id` does not carry the residency concern that motivates #6271. Happy to truncate or drop it if you would rather keep identity out of spans entirely.

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`) — `go test ./pkg/ratelimit/...` passes. Two new tests: `TestRateLimitMetrics_ToolAttribution` drives a per-user tool bucket to rejection and asserts the rejection carries `tool_name` while server-scoped decisions carry no such key; `TestRateLimitMetrics_UnconfiguredToolCarriesNoAttribute` asserts caller-supplied tool names never become label values.
- [x] Linting (`task lint-fix`) — `golangci-lint run pkg/ratelimit/...` reports 0 issues; `gofmt` clean.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

Yes — `toolhive_rate_limit_decisions_total` gains a `tool_name` attribute on tool-scoped decisions, and rate-limit spans gain `rate_limit.tool_name` / `rate_limit.user_id`. Dashboards that aggregate the counter without grouping are unaffected; those that sum over `operation_type="tool"` will now see one series per configured tool.
