### PR TITLE
Suppress OAuth callback Referer

### DIFF
--- a/pkg/authserver/server/handlers/callback.go
+++ b/pkg/authserver/server/handlers/callback.go
@@ -25,6 +25,10 @@ import (
 func (h *Handler) CallbackHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
+	// Do not forward the upstream identity provider as the Referer when the
+	// browser follows the final redirect to a native client's loopback listener.
+	w.Header().Set("Referrer-Policy", "no-referrer")
+
 	// Parse query parameters
 	code := req.URL.Query().Get("code")
 	internalState := req.URL.Query().Get("state")

--- a/pkg/authserver/server/handlers/callback_test.go
+++ b/pkg/authserver/server/handlers/callback_test.go
@@ -196,6 +196,7 @@ func TestCallbackHandler_Success(t *testing.T) {
 	storState.pendingAuths[internalState] = pending
 
 	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=upstream-code&state="+internalState, nil)
+	req.Header.Set("Referer", "https://accounts.google.com/")
 	rec := httptest.NewRecorder()
 
 	handler.CallbackHandler(rec, req)
@@ -203,6 +204,7 @@ func TestCallbackHandler_Success(t *testing.T) {
 	// Should redirect to client with our authorization code
 	// fosite uses 303 See Other for redirects per RFC 6749
 	assert.Equal(t, http.StatusSeeOther, rec.Code)
+	assert.Equal(t, "no-referrer", rec.Header().Get("Referrer-Policy"))
 	location := rec.Header().Get("Location")
 	assert.Contains(t, location, testAuthRedirectURI)
 	assert.Contains(t, location, "code=")


### PR DESCRIPTION
## Summary

- Set `Referrer-Policy: no-referrer` on embedded authorization server callback responses.
- Prevent an upstream identity provider from becoming the `Referer` when the browser follows the final redirect to a native client's loopback listener.
- Add regression coverage using an incoming Google OAuth `Referer`.

Fixes #6518

## Type of change

- [x] Bug fix

## Test plan

- [x] `go test ./pkg/authserver/server/handlers`
- [x] `go test -race ./pkg/authserver/server/handlers`
- [x] `go vet ./pkg/authserver/server/handlers`

## Does this introduce a user-facing change?

Yes. Browser-mediated OAuth callbacks to native loopback clients no longer receive the upstream identity provider as the `Referer`.

## Special notes for reviewers

The header is set at the start of `/oauth/callback`, before Fosite writes success or error responses and before ToolHive writes chained-provider redirects. This keeps the policy consistent across every redirect emitted from that endpoint.

The implementation and initial verification were prepared with Codex assistance and reviewed by the contributor before submission.
