### PR TITLE
Wire OIDC transport flags into thv run auth middleware config

### DIFF
--- a/cmd/thv/app/run_flags.go
+++ b/cmd/thv/app/run_flags.go
@@ -466,7 +466,8 @@ func setupOIDCConfiguration(cmd *cobra.Command, runFlags *RunFlags) (*auth.Token
 	}
 
 	return createOIDCConfig(oidcIssuer, oidcAudience, oidcJwksURL, oidcIntrospectionURL,
-		oidcClientID, oidcClientSecret, runFlags.ResourceURL, runFlags.JWKSAllowPrivateIP, oidcScopes), nil
+		oidcClientID, oidcClientSecret, runFlags.ResourceURL, runFlags.ThvCABundle, runFlags.JWKSAuthTokenFile,
+		runFlags.JWKSAllowPrivateIP, runFlags.InsecureAllowHTTP, oidcScopes), nil
 }
 
 // resolveMetricsOnTransportPort turns the bound bool into a tri-state. Only an
@@ -1207,19 +1208,23 @@ func getTelemetryFromFlags(cmd *cobra.Command, config *cfg.Config, otelEndpoint 
 
 // createOIDCConfig creates an OIDC configuration if any OIDC parameters are provided
 func createOIDCConfig(oidcIssuer, oidcAudience, oidcJwksURL, oidcIntrospectionURL,
-	oidcClientID, oidcClientSecret, resourceURL string, allowPrivateIP bool, scopes []string) *auth.TokenValidatorConfig {
+	oidcClientID, oidcClientSecret, resourceURL, caCertPath, authTokenFile string,
+	allowPrivateIP, insecureAllowHTTP bool, scopes []string) *auth.TokenValidatorConfig {
 	if oidcIssuer != "" || oidcAudience != "" || oidcJwksURL != "" || oidcIntrospectionURL != "" ||
 		oidcClientID != "" || oidcClientSecret != "" || resourceURL != "" {
 		return &auth.TokenValidatorConfig{
-			Issuer:           oidcIssuer,
-			Audience:         oidcAudience,
-			JWKSURL:          oidcJwksURL,
-			IntrospectionURL: oidcIntrospectionURL,
-			ClientID:         oidcClientID,
-			ClientSecret:     oidcClientSecret,
-			ResourceURL:      resourceURL,
-			AllowPrivateIP:   allowPrivateIP,
-			Scopes:           scopes,
+			Issuer:            oidcIssuer,
+			Audience:          oidcAudience,
+			JWKSURL:           oidcJwksURL,
+			IntrospectionURL:  oidcIntrospectionURL,
+			ClientID:          oidcClientID,
+			ClientSecret:      oidcClientSecret,
+			ResourceURL:       resourceURL,
+			CACertPath:        caCertPath,
+			AuthTokenFile:     authTokenFile,
+			AllowPrivateIP:    allowPrivateIP,
+			InsecureAllowHTTP: insecureAllowHTTP,
+			Scopes:            scopes,
 		}
 	}
 	return nil

--- a/cmd/thv/app/run_flags_test.go
+++ b/cmd/thv/app/run_flags_test.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/stacklok/toolhive-core/logging"
 	regtypes "github.com/stacklok/toolhive-core/registry/types"
+	"github.com/stacklok/toolhive/pkg/auth"
 	"github.com/stacklok/toolhive/pkg/config"
 	"github.com/stacklok/toolhive/pkg/runner"
 	"github.com/stacklok/toolhive/pkg/webhook"
@@ -915,4 +917,58 @@ func TestBuildRunnerConfig_MaxRequestBodySizeWiring(t *testing.T) {
 			assert.Equal(t, tt.want, cfg.MaxRequestBodySize)
 		})
 	}
+}
+
+// TestSetupOIDCConfiguration_MiddlewareFlagWiring guards the JWKS/OIDC
+// transport flags (--thv-ca-bundle, --jwks-auth-token-file,
+// --jwks-allow-private-ip, --oidc-insecure-allow-http) from being dropped on
+// the way into the auth middleware config. The runtime validator is built
+// from the middleware config, not the deprecated top-level OIDCConfig, so a
+// value that only reaches the latter is silently ignored. See #6522.
+func TestSetupOIDCConfiguration_MiddlewareFlagWiring(t *testing.T) {
+	t.Parallel()
+
+	runFlags := &RunFlags{}
+	cmd := &cobra.Command{}
+	AddRunFlags(cmd, runFlags)
+	AddOIDCFlags(cmd)
+
+	for flag, value := range map[string]string{
+		"permission-profile":       "none",
+		"transport":                "stdio",
+		"oidc-issuer":              "http://localhost:8099",
+		"oidc-audience":            "test",
+		"thv-ca-bundle":            "/path/to/ca.pem",
+		"jwks-auth-token-file":     "/path/to/token",
+		"jwks-allow-private-ip":    "true",
+		"oidc-insecure-allow-http": "true",
+	} {
+		require.NoError(t, cmd.Flags().Set(flag, value))
+	}
+
+	oidcConfig, err := setupOIDCConfiguration(cmd, runFlags)
+	require.NoError(t, err)
+	require.NotNil(t, oidcConfig)
+
+	cfg, err := buildRunnerConfig(
+		t.Context(), runFlags, nil, false, "127.0.0.1", nil, "test:latest", nil,
+		map[string]string{}, &runner.DetachedEnvVarValidator{}, oidcConfig, nil, &config.Config{},
+	)
+	require.NoError(t, err)
+
+	var authParams auth.MiddlewareParams
+	for _, mw := range cfg.MiddlewareConfigs {
+		if mw.Type == auth.MiddlewareType {
+			require.NoError(t, json.Unmarshal(mw.Parameters, &authParams))
+			break
+		}
+	}
+	got := authParams.OIDCConfig
+	require.NotNil(t, got, "auth middleware must be present")
+
+	assert.Equal(t, "http://localhost:8099", got.Issuer)
+	assert.Equal(t, "/path/to/ca.pem", got.CACertPath)
+	assert.Equal(t, "/path/to/token", got.AuthTokenFile)
+	assert.True(t, got.AllowPrivateIP)
+	assert.True(t, got.InsecureAllowHTTP)
 }


### PR DESCRIPTION
## Summary

`thv run` accepts `--thv-ca-bundle`, `--jwks-auth-token-file` and `--oidc-insecure-allow-http`, but none of them reach the token validator. The CLI builds the OIDC config twice: `WithOIDCConfig` fills the deprecated top-level `RunConfig.OIDCConfig` with every field, while `setupOIDCConfiguration` → `createOIDCConfig` builds the `TokenValidatorConfig` that `WithMiddlewareFromFlags` serializes into the auth middleware config. That second struct only carried `AllowPrivateIP` (wired in #1470), so at runtime `auth.CreateMiddleware` unmarshals `InsecureAllowHTTP: false` / `CACertPath: ""` / `AuthTokenFile: ""` and OIDC discovery against a local HTTP or private-CA issuer fails with a 401.

- Pass `runFlags.ThvCABundle`, `runFlags.JWKSAuthTokenFile` and `runFlags.InsecureAllowHTTP` through `setupOIDCConfiguration` into `createOIDCConfig`, and set the corresponding `TokenValidatorConfig` fields there (same shape as #1470).
- Add `TestSetupOIDCConfiguration_MiddlewareFlagWiring`, which runs the flags through `setupOIDCConfiguration` and `buildRunnerConfig` and asserts the serialized auth middleware parameters carry all four transport fields. It fails on `main` for the three fields this PR wires.

Fixes #6522

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`go test ./cmd/thv/app/`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`golangci-lint run ./cmd/thv/app/...`, `go vet`)
- [ ] Manual testing (describe below)

## Does this introduce a user-facing change?

Yes. `thv run --thv-ca-bundle`, `--jwks-auth-token-file` and `--oidc-insecure-allow-http` now take effect for the request-time token validator, so a local HTTP issuer or an issuer with a private CA can be used for `thv run` as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
