### PR TITLE
Guard token exchange may_act CEL

### DIFF
--- a/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
+++ b/cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go
@@ -827,7 +827,7 @@ type TokenExchangeInboundGrantConfig struct {
 // TokenExchangeIssuerPolicyConfig binds RFC 8693 policy to a named trusted issuer.
 //
 // +kubebuilder:validation:XValidation:rule="!('*' in self.allowedDelegateClients) || size(self.allowedDelegateClients) == 1",message="allowedDelegateClients must not combine the wildcard \"*\" with specific client IDs"
-// +kubebuilder:validation:XValidation:rule="!(self.allowMayAct && '*' in self.allowedDelegateClients)",message="allowMayAct must not be enabled when allowedDelegateClients contains the wildcard \"*\""
+// +kubebuilder:validation:XValidation:rule="!(has(self.allowMayAct) && self.allowMayAct && '*' in self.allowedDelegateClients)",message="allowMayAct must not be enabled when allowedDelegateClients contains the wildcard \"*\""
 // +kubebuilder:validation:XValidation:rule="!has(self.actorClaim) || !(self.actorClaim in ['sub', 'iss', 'aud', 'exp', 'iat', 'nbf', 'jti', 'name', 'email', 'scope', 'scp', 'may_act'])",message="actorClaim must name a readable claim; use client_id or a non-reserved claim such as azp, appid, or cid"
 //
 //nolint:lll // CEL validation rules exceed line length limits.

--- a/cmd/thv-operator/test-integration/mcp-external-auth/inbound_grants_cel_test.go
+++ b/cmd/thv-operator/test-integration/mcp-external-auth/inbound_grants_cel_test.go
@@ -91,6 +91,14 @@ var _ = Describe("MCPExternalAuthConfig inbound grants CEL validation", func() {
 				}},
 			}}
 		}},
+		{name: "canonical token exchange wildcard delegate with omitted may_act", shouldAdmit: true, mutate: func(c *mcpv1beta1.EmbeddedAuthServerConfig) {
+			c.TrustedIssuers = []mcpv1beta1.TrustedIssuerConfig{{Name: "issuer", IssuerURL: "https://issuer.example.com"}}
+			c.InboundGrants = &mcpv1beta1.InboundGrantsConfig{TokenExchange: &mcpv1beta1.TokenExchangeInboundGrantConfig{
+				IssuerPolicies: []mcpv1beta1.TokenExchangeIssuerPolicyConfig{{
+					IssuerRef: "issuer", ExpectedAudience: "https://mcp.example.com", AllowedDelegateClients: []string{"*"},
+				}},
+			}}
+		}},
 		{name: "canonical JWT bearer", shouldAdmit: true, mutate: func(c *mcpv1beta1.EmbeddedAuthServerConfig) {
 			c.TrustedIssuers = []mcpv1beta1.TrustedIssuerConfig{{Name: "issuer", IssuerURL: "https://issuer.example.com"}}
 			c.InboundGrants = &mcpv1beta1.InboundGrantsConfig{JWTBearer: &mcpv1beta1.JWTBearerInboundGrantConfig{

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -775,7 +775,8 @@ spec:
                                   size(self.allowedDelegateClients) == 1'
                               - message: allowMayAct must not be enabled when allowedDelegateClients
                                   contains the wildcard "*"
-                                rule: '!(self.allowMayAct && ''*'' in self.allowedDelegateClients)'
+                                rule: '!(has(self.allowMayAct) && self.allowMayAct
+                                  && ''*'' in self.allowedDelegateClients)'
                               - message: actorClaim must name a readable claim; use
                                   client_id or a non-reserved claim such as azp, appid,
                                   or cid
@@ -3463,7 +3464,8 @@ spec:
                                   size(self.allowedDelegateClients) == 1'
                               - message: allowMayAct must not be enabled when allowedDelegateClients
                                   contains the wildcard "*"
-                                rule: '!(self.allowMayAct && ''*'' in self.allowedDelegateClients)'
+                                rule: '!(has(self.allowMayAct) && self.allowMayAct
+                                  && ''*'' in self.allowedDelegateClients)'
                               - message: actorClaim must name a readable claim; use
                                   client_id or a non-reserved claim such as azp, appid,
                                   or cid

--- a/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -651,7 +651,8 @@ spec:
                                   size(self.allowedDelegateClients) == 1'
                               - message: allowMayAct must not be enabled when allowedDelegateClients
                                   contains the wildcard "*"
-                                rule: '!(self.allowMayAct && ''*'' in self.allowedDelegateClients)'
+                                rule: '!(has(self.allowMayAct) && self.allowMayAct
+                                  && ''*'' in self.allowedDelegateClients)'
                               - message: actorClaim must name a readable claim; use
                                   client_id or a non-reserved claim such as azp, appid,
                                   or cid
@@ -5501,7 +5502,8 @@ spec:
                                   size(self.allowedDelegateClients) == 1'
                               - message: allowMayAct must not be enabled when allowedDelegateClients
                                   contains the wildcard "*"
-                                rule: '!(self.allowMayAct && ''*'' in self.allowedDelegateClients)'
+                                rule: '!(has(self.allowMayAct) && self.allowMayAct
+                                  && ''*'' in self.allowedDelegateClients)'
                               - message: actorClaim must name a readable claim; use
                                   client_id or a non-reserved claim such as azp, appid,
                                   or cid

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
@@ -778,7 +778,8 @@ spec:
                                   size(self.allowedDelegateClients) == 1'
                               - message: allowMayAct must not be enabled when allowedDelegateClients
                                   contains the wildcard "*"
-                                rule: '!(self.allowMayAct && ''*'' in self.allowedDelegateClients)'
+                                rule: '!(has(self.allowMayAct) && self.allowMayAct
+                                  && ''*'' in self.allowedDelegateClients)'
                               - message: actorClaim must name a readable claim; use
                                   client_id or a non-reserved claim such as azp, appid,
                                   or cid
@@ -3466,7 +3467,8 @@ spec:
                                   size(self.allowedDelegateClients) == 1'
                               - message: allowMayAct must not be enabled when allowedDelegateClients
                                   contains the wildcard "*"
-                                rule: '!(self.allowMayAct && ''*'' in self.allowedDelegateClients)'
+                                rule: '!(has(self.allowMayAct) && self.allowMayAct
+                                  && ''*'' in self.allowedDelegateClients)'
                               - message: actorClaim must name a readable claim; use
                                   client_id or a non-reserved claim such as azp, appid,
                                   or cid

--- a/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
+++ b/deploy/charts/operator-crds/templates/toolhive.stacklok.dev_virtualmcpservers.yaml
@@ -654,7 +654,8 @@ spec:
                                   size(self.allowedDelegateClients) == 1'
                               - message: allowMayAct must not be enabled when allowedDelegateClients
                                   contains the wildcard "*"
-                                rule: '!(self.allowMayAct && ''*'' in self.allowedDelegateClients)'
+                                rule: '!(has(self.allowMayAct) && self.allowMayAct
+                                  && ''*'' in self.allowedDelegateClients)'
                               - message: actorClaim must name a readable claim; use
                                   client_id or a non-reserved claim such as azp, appid,
                                   or cid
@@ -5504,7 +5505,8 @@ spec:
                                   size(self.allowedDelegateClients) == 1'
                               - message: allowMayAct must not be enabled when allowedDelegateClients
                                   contains the wildcard "*"
-                                rule: '!(self.allowMayAct && ''*'' in self.allowedDelegateClients)'
+                                rule: '!(has(self.allowMayAct) && self.allowMayAct
+                                  && ''*'' in self.allowedDelegateClients)'
                               - message: actorClaim must name a readable claim; use
                                   client_id or a non-reserved claim such as azp, appid,
                                   or cid


### PR DESCRIPTION
## Summary

- Canonical token-exchange issuer policies currently reject a valid wildcard delegate-client policy when `allowMayAct` is omitted, because the CEL rule dereferences the optional field without `has()`.
- Add the same `has(self.allowMayAct)` guard already used by the legacy issuer-policy rule, regenerate the CRDs/Helm-wrapped CRDs, and cover the omitted-`allowMayAct` wildcard case in the envtest CEL suite.

Fixes #6531

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

Commands run:

```bash
PATH=/tmp/go1.26/bin:/usr/local/go/bin:/root/go/bin:$PATH task -d cmd/thv-operator operator-manifests
# passed; regenerated CRDs and Helm-wrapped CRDs

PATH=/tmp/go1.26/bin:/usr/local/go/bin:/root/go/bin:$PATH \
KUBEBUILDER_ASSETS="$($(go env GOPATH)/bin/setup-envtest use 1.31.0 -p path)" \
go test -ldflags=-extldflags=-Wl,-w -v ./cmd/thv-operator/test-integration/mcp-external-auth \
  -run '^TestControllers$' \
  -args -ginkgo.focus='canonical token exchange wildcard delegate with omitted may_act'
# passed: 1 passed, 120 skipped

PATH=/tmp/go1.26/bin:/usr/local/go/bin:/root/go/bin:$PATH \
KUBEBUILDER_ASSETS="$($(go env GOPATH)/bin/setup-envtest use 1.31.0 -p path)" \
go test -ldflags=-extldflags=-Wl,-w -v ./cmd/thv-operator/test-integration/mcp-external-auth -run '^TestControllers$'
# passed: 121 passed

PATH=/tmp/go1.26/bin:/usr/local/go/bin:/root/go/bin:$PATH task operator-test
# passed

git diff --check origin/main..HEAD
# passed
```

I also ran `task lint`; it failed before reaching any changed file on two existing gci formatting findings in `pkg/authserver/server/provider.go` and `pkg/authserver/server_impl.go`, so I did not include lint-fix churn in this focused PR.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

This relaxes an admission rule so omitted `allowMayAct` is handled as false, matching the legacy issuer-policy rule. No fields are added, removed, or renamed.

## Changes

| File | Change |
|------|--------|
| `cmd/thv-operator/api/v1beta1/mcpexternalauthconfig_types.go` | Guard optional `allowMayAct` access in the canonical token-exchange CEL rule. |
| `cmd/thv-operator/test-integration/mcp-external-auth/inbound_grants_cel_test.go` | Add an envtest regression for wildcard delegate clients with omitted `allowMayAct`. |
| `deploy/charts/operator-crds/**` | Regenerate CRDs and Helm-wrapped CRDs. |

## Does this introduce a user-facing change?

Yes. A canonical `inboundGrants.tokenExchange.issuerPolicies[]` entry may now omit `allowMayAct` while using `allowedDelegateClients: ["*"]`; admission treats the omitted optional bool as false instead of failing with `no such key: allowMayAct`.
