### PR TITLE
Reduce cached token restore complexity to fix CI

### DIFF
--- a/pkg/auth/remote/handler.go
+++ b/pkg/auth/remote/handler.go
@@ -501,25 +501,8 @@ func (h *Handler) tryRestoreFromCachedTokens(
 
 	slog.Debug("Restored OAuth session from cached tokens", "issuer", issuer)
 
-	// A legacy bare-string token just verified against effectiveIssuer/tokenURL:
-	// persist the bound envelope now rather than waiting for a future refresh,
-	// so the migration is deterministic and happens exactly once. Use whatever
-	// refresh token/expiry the AS just returned, falling back to the
-	// pre-verification values if it didn't rotate them.
 	if migrated {
-		newRefreshToken := tok.RefreshToken
-		if newRefreshToken == "" {
-			newRefreshToken = refreshToken
-		}
-		expiry := tok.Expiry
-		if expiry.IsZero() {
-			expiry = h.config.CachedTokenExpiry
-		}
-		if persister := h.tokenPersisterFor(effectiveIssuer, tokenURL); persister != nil {
-			if err := persister(newRefreshToken, expiry); err != nil {
-				slog.Warn("Failed to persist migrated cached refresh token", "error", err)
-			}
-		}
+		h.persistMigratedRefreshToken(tok, refreshToken, effectiveIssuer, tokenURL)
 	}
 
 	// Wrap with a persisting token source to save refreshed tokens bound to the
@@ -529,6 +512,26 @@ func (h *Handler) tryRestoreFromCachedTokens(
 	}
 
 	return baseSource, nil
+}
+
+// persistMigratedRefreshToken persists a bound envelope after a legacy bare-string
+// token has been verified against issuer/tokenURL, rather than waiting for a
+// future refresh. It uses the refresh token/expiry the AS just returned, falling
+// back to the pre-verification values if it didn't rotate them.
+func (h *Handler) persistMigratedRefreshToken(tok *oauth2.Token, refreshToken, issuer, tokenURL string) {
+	newRefreshToken := tok.RefreshToken
+	if newRefreshToken == "" {
+		newRefreshToken = refreshToken
+	}
+	expiry := tok.Expiry
+	if expiry.IsZero() {
+		expiry = h.config.CachedTokenExpiry
+	}
+	if persister := h.tokenPersisterFor(issuer, tokenURL); persister != nil {
+		if err := persister(newRefreshToken, expiry); err != nil {
+			slog.Warn("Failed to persist migrated cached refresh token", "error", err)
+		}
+	}
 }
 
 // discoverIssuerAndScopes attempts to discover the OAuth issuer and scopes from various sources


### PR DESCRIPTION
## Summary

Latest main (`c4f6cb4a3`) fails [Go linting](https://github.com/stacklok/toolhive/actions/runs/34211100349/job/102012036940) because `tryRestoreFromCachedTokens` has cyclomatic complexity 18, exceeding the limit of 15. Extract legacy token migration persistence into a private helper, reducing the function's complexity to 14 while preserving token verification order, authorization-server binding, fallback values, and error handling.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`) — running locally
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`) — passed with CI's golangci-lint v2.13.2
- [ ] Manual testing (describe below)

Existing cached-token migration tests exercise the extracted path and verify the persisted issuer and token endpoint binding. Code review confirmed this is a behavior-preserving extraction.

## Does this introduce a user-facing change?

No.
