### PR TITLE
Cancel superseded main validation runs

### DIFF
--- a/.github/workflows/run-on-main.yml
+++ b/.github/workflows/run-on-main.yml
@@ -9,18 +9,40 @@ on:
 permissions:
   contents: read
 
+# Concurrency is set per job, not per workflow, so that a newer push to main
+# cancels only the *validation* of an older push. A workflow-level group would
+# also cancel image publishing part-way through, leaving pushed-but-unsigned
+# tags in the registry. Each validation job has its own group keyed on the ref:
+# when several PRs merge close together, the newest commit contains them all,
+# so its checks validate the combined result and the older runs are redundant.
+#
+# Publishing is never cancelled once started. Instead, publish-gate checks
+# right before publishing whether this commit is still the tip of the branch
+# and skips publishing for commits that have already been superseded.
+#
+# Tagged releases are unaffected: they run from releaser.yml, not this file.
+
 jobs:
   linting:
     name: Linting
+    concurrency:
+      group: main-linting-${{ github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/lint.yml
   security-scan:
     name: Security Scan
+    concurrency:
+      group: main-security-scan-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
       security-events: write
     uses: ./.github/workflows/security-scan.yml
   tests:
     name: Tests
+    concurrency:
+      group: main-tests-${{ github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/test.yml
     # Named rather than inherited: this job runs the Go test suite, and so
     # executes repository code and its dependency tree. It has no business
@@ -29,25 +51,68 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   codegen:
     name: Codegen
+    concurrency:
+      group: main-codegen-${{ github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/verify-gen.yml
   # Tier 2: Expensive integration tests - only run after all fast checks pass
   helm-charts:
     name: Helm Charts
+    concurrency:
+      group: main-helm-charts-${{ github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/helm-charts-test.yml
   e2e-tests:
     name: E2E Tests
     needs: [linting, tests, codegen]
+    concurrency:
+      group: main-e2e-tests-${{ github.ref }}
+      cancel-in-progress: true
     uses: ./.github/workflows/e2e-tests.yml
   operator-ci:
     name: Operator CI
     needs: [linting, tests, codegen]
+    concurrency:
+      group: main-operator-ci-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
     uses: ./.github/workflows/operator-ci.yml
   # Tier 3: Build and publish images - only after all tests pass
+  #
+  # Cancelled validation above already skips publishing for the older run via
+  # `needs`. This gate covers the remaining window: an older run whose
+  # validation finished before the newer push arrived. Publishing that commit
+  # would waste five multi-arch builds on an image nobody will deploy.
+  publish-gate:
+    name: Publish Gate
+    needs: [linting, security-scan, tests, e2e-tests, codegen, operator-ci]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      publish: ${{ steps.check.outputs.publish }}
+    steps:
+      - name: Check this commit is still the tip of the branch
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          tip=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$REF_NAME" --jq .object.sha)
+          if [[ "$tip" == "$SHA" ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Skipping publish: $SHA was superseded by $tip on $REF_NAME"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
   image-build-and-push:
     name: Build and Sign Image
-    needs: [linting, security-scan, tests, e2e-tests, codegen, operator-ci]
+    # No concurrency group here on purpose: once publishing starts it runs to
+    # completion, so every pushed tag is also signed.
+    needs: [publish-gate]
+    if: needs.publish-gate.outputs.publish == 'true'
     permissions:
       contents: write
       packages: write
@@ -58,12 +123,18 @@ jobs:
   skills-build:
     name: Build Skills
     needs: [linting, tests, codegen]
+    concurrency:
+      group: main-skills-build-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
     uses: ./.github/workflows/skills-build.yml
   skills-keyless-e2e:
     name: Skills Keyless Signing E2E (staging)
     needs: [linting, tests, codegen]
+    concurrency:
+      group: main-skills-keyless-e2e-${{ github.ref }}
+      cancel-in-progress: true
     # Informational, not a merge gate: it signs against Sigstore's public
     # staging instance, whose outages this repository does not control. The
     # continue-on-error that makes it non-blocking lives on the called


### PR DESCRIPTION
## Summary

Follow-up to #6533, which cancels superseded pull request checks. Pushes to `main` were left alone because that workflow also publishes and signs container images, and a workflow-level `cancel-in-progress` would abort a publish half-way through, leaving pushed-but-unsigned tags in GHCR.

This applies the same "only the latest validation matters" idea to `main` without touching in-flight publishing. When PRs A, B, and C merge close together, C already contains all three changes, so its checks validate the combined result and the older runs are redundant.

Behaviour after this change:

- **Validation**: a newer push to `main` cancels the older run's in-progress lint, tests, codegen, security scan, Helm, E2E, operator CI, and skills jobs. Each job has its own concurrency group keyed on the ref, so jobs in different tiers do not cancel each other.
- **Publishing not yet started**: a new `publish-gate` job runs after validation and checks whether the commit is still the tip of the branch. If it has been superseded, the five multi-arch image builds are skipped. A cancelled validation job also skips publishing for that run via `needs`.
- **Publishing already started**: the image job has no concurrency group and always runs to completion, so every pushed tag is also signed.
- **Tagged releases**: unaffected. They run from `releaser.yml` on the `release` event, not from this workflow.

## Type of change

- [x] Other: CI/CD

## Test plan

- [x] `actionlint` on the changed workflow: no diagnostics.
- [x] `git diff --check`: clean.
- [ ] After merge: watch two pushes to `main` landing within a few minutes of each other. Expect the older run's unfinished validation jobs to end as cancelled and its publish job to be skipped, while the newer run publishes.

## Does this introduce a user-facing change?

No. Dev images for superseded `main` commits will no longer be published; the newer commit's image contains their changes.

## Special notes for reviewers

- Job-level `concurrency` is one of the keys GitHub permits on a job that calls a reusable workflow (`uses:`), and cancelling the caller job cancels its nested jobs. The called workflows carry no concurrency groups of their own that would interfere; `security-scan.yml` has one from #6533 but it only cancels on `pull_request`.
- A superseded commit on `main` will show as **cancelled** rather than green in the commit list and on the README build badge until the newer run finishes. That is the intended trade-off.
- `workflow_dispatch` on a non-`main` branch keeps working: groups include `github.ref`, and the gate compares against that branch's tip.

Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
