### PR TITLE
Run operator E2E on one Kubernetes version per PR

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -156,14 +156,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Pull requests run against the newest Kubernetes version only; pushes
+        # to main and manual dispatches run the full set. Cross-version
+        # compatibility rarely breaks within a single PR, and the full matrix
+        # still runs on every merge, so a regression surfaces on main within
+        # one CI cycle instead of costing three E2E runs on every PR update.
+        #
         # Before someone says it, yes we could just put the number here and not the full image name,
         # but we want to make sure renovate bumps the versions when new ones are released. Doing that with
-        # just the number is a bit more difficult and i like simple things.
-        version: [
-          "kindest/node:v1.33.7",
-          "kindest/node:v1.34.3",
-          "kindest/node:v1.35.1"
-        ]
+        # just the number is a bit more difficult and i like simple things. The newest version appears in
+        # both lists so renovate keeps them in step.
+        version: ${{ github.event_name == 'pull_request'
+          && fromJSON('["kindest/node:v1.35.1"]')
+          || fromJSON('["kindest/node:v1.33.7", "kindest/node:v1.34.3", "kindest/node:v1.35.1"]') }}
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary

Every pull request update runs the operator E2E suite against three kind node versions. That is about 20 large-runner minutes per PR Checks run, roughly a fifth of the suite's cost, and cross-version compatibility almost never breaks within a single PR.

Run only the newest version (1.35) on `pull_request` events. Pushes to main and manual dispatches keep the full three-version matrix, so a version-specific regression still surfaces on main within one CI cycle rather than never.

Expected saving: about 13 large-runner minutes per PR run, roughly $330 per month at current PR volume.

## Type of change

- [x] Other: CI/CD

## Test plan

- [x] `actionlint` on the changed workflow with the repo's custom runner labels declared: clean.
- [x] Verified the renovate regex manager for `kindest/node` still matches every occurrence, including the one inside the `fromJSON` string, so both lists are bumped together.
- [x] Branch rulesets only require the CRD Schema Compatibility check, so the changed job names do not block merges.
- [ ] This PR's own Operator CI shows a single `E2E Tests Operator (kindest/node:v1.35.1)` job.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

`github.event_name` inside a reusable workflow is the caller's event, so `pull_request` here means PR Checks and `push` means Main build. The matrix expression is the smallest way to make the list conditional without a separate matrix-preparation job.

Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
