### PR TITLE
Run short CI jobs on the standard runner

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,7 +43,11 @@ jobs:
 
   e2e-tests-core:
     name: E2E Tests Core (${{ matrix.title }})
-    runs-on: ubuntu-8cores-32gb
+    # Shards default to the large runner. Shards whose test phase runs for
+    # only a couple of minutes are container- and network-bound rather than
+    # CPU-bound, and set `runner` to the standard runner, which is free for
+    # this public repo. Long shards keep the large runner for wall time.
+    runs-on: ${{ matrix.runner || 'ubuntu-8cores-32gb' }}
     needs: build-binary
     strategy:
       fail-fast: false
@@ -53,6 +57,7 @@ jobs:
             label_filter: core
             artifact: e2e-test-results-core
             procs: 4
+            runner: ubuntu-latest
           - title: mcp-run
             label_filter: mcp-run
             artifact: e2e-test-results-mcp-run
@@ -72,10 +77,12 @@ jobs:
           - title: api-registry
             label_filter: api-registry
             artifact: e2e-test-results-api-registry
+            runner: ubuntu-latest
           - title: api-workloads
             label_filter: "api-workloads && !lifecycle"
             artifact: e2e-test-results-api-workloads
             test_timeout: 25m
+            runner: ubuntu-latest
           - title: api-workloads-lifecycle
             label_filter: "api-workloads && lifecycle"
             artifact: e2e-test-results-api-workloads-lifecycle
@@ -83,15 +90,18 @@ jobs:
           - title: api-clients
             label_filter: api-clients
             artifact: e2e-test-results-api-clients
+            runner: ubuntu-latest
           - title: api-misc
             label_filter: api-misc
             artifact: e2e-test-results-api-misc
+            runner: ubuntu-latest
           - title: vmcp
             label_filter: vmcp
             artifact: e2e-test-results-vmcp
           - title: llm
             label_filter: llm
             artifact: e2e-test-results-llm
+            runner: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
@@ -123,7 +133,7 @@ jobs:
 
       - name: Set up container runtime (Docker)
         run: |
-          # Docker is already installed on ubuntu-8cores-32gb
+          # Docker is preinstalled on both runner sizes used by this matrix
           docker --version
           # Start Docker daemon if not running
           sudo systemctl start docker
@@ -197,7 +207,8 @@ jobs:
 
   conformance:
     name: MCP Conformance
-    runs-on: ubuntu-8cores-32gb
+    # Runs for about a minute; the standard runner is free for this public repo.
+    runs-on: ubuntu-latest
     needs: build-binary
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,10 @@ permissions:
 jobs:
   lint-go-code:
     name: Lint Go Code
-    runs-on: ubuntu-8cores-32gb
+    # golangci-lint itself runs for well under a minute here; the job is
+    # dominated by checkout, toolchain setup and cache restore, none of which
+    # scale with cores. The standard runner is free for this public repo.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -10,7 +10,9 @@ permissions:
 jobs:
   operator-tests:
     name: Operator Tests
-    runs-on: ubuntu-8cores-32gb
+    # Short, setup-dominated job; the standard runner is free for this
+    # public repo. Integration and E2E jobs below keep the large runner.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
@@ -56,7 +58,9 @@ jobs:
 
   build-operator:
     name: Build Operator
-    runs-on: ubuntu-8cores-32gb
+    # Short, setup-dominated job; the standard runner is free for this
+    # public repo.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:


### PR DESCRIPTION
## Summary

Every job in PR Checks and Main build runs on the paid `ubuntu-8cores-32gb` runner, including jobs that finish in one to three minutes and spend most of that on checkout, toolchain setup and image pulls. Those steps do not scale with cores. The standard `ubuntu-latest` runner is free for this public repository and has 4 vCPUs and 16 GB.

Move the setup-dominated jobs to the standard runner and keep the large runner where cores or the critical path matter.

| Moved to `ubuntu-latest` | Large-runner minutes today |
|---|---|
| Linting / Lint Go Code | 2.2 |
| Operator CI / Operator Tests | 2.2 |
| Operator CI / Build Operator | 1.3 |
| E2E Tests / MCP Conformance (proxy, vmcp) | 1.6 |
| E2E Tests Core: core, api-workloads, api-clients, api-registry, api-misc, llm | 14.1 |
| **Total** | **~21 of ~100 per run** |

Kept on the large runner: Go tests, Helm chart tests, operator integration and E2E, the E2E binary build (root of the E2E critical path), and the proxy, mcp-protocol, middleware, lifecycle, mcp-run, network-isolation and vmcp shards.

Expected saving: about 21 large-runner minutes per run, roughly $650 to $700 per month across PR and main runs.

## Type of change

- [x] Other: CI/CD

## Test plan

- [x] `actionlint` on the three changed workflows with the repo's custom runner labels declared: clean.
- [x] `git diff --check`: clean.
- [ ] Compare job durations on this PR's own run against a recent main run. The moved jobs are expected to take up to about twice as long individually, without extending the overall PR Checks wall time, since none of them is on the critical path.

## Does this introduce a user-facing change?

No.

## Special notes for reviewers

- Shard runner selection is `runs-on: ${{ matrix.runner || 'ubuntu-8cores-32gb' }}`, so shards without a `runner` field are unchanged. Moving a shard back is a one-line revert on that entry.
- The `core` shard runs Ginkgo with four processes; the standard runner's four vCPUs cover that.
- If a moved E2E shard turns out to be materially slower or flakier on the smaller runner, the intended fix is to move that one shard back, not to revert the PR.

Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
