### PR TITLE
Add dial-control option to vMCP session factory

### DIFF
--- a/pkg/networking/backend_transport_test.go
+++ b/pkg/networking/backend_transport_test.go
@@ -10,10 +10,17 @@ import (
 	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// roundTripperFunc adapts a plain function to http.RoundTripper so a test can
+// replace http.DefaultTransport with a value that is NOT a *http.Transport.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 // TestCloneDefaultTransportWithDialControl verifies the shared backend
 // transport construction: a nil control clones DefaultTransport (a distinct
@@ -60,5 +67,49 @@ func TestCloneDefaultTransportWithDialControl(t *testing.T) {
 		_, err := (&http.Client{Transport: transport}).Get(srv.URL)
 		require.Error(t, err, "deny-all dial control must block the request")
 		assert.Zero(t, hits.Load(), "a blocked dial must not reach the server")
+	})
+}
+
+// TestCloneDefaultTransportWithDialControl_ReconstructsWhenDefaultReplaced covers
+// the fallback branch taken when http.DefaultTransport is not a *http.Transport
+// (e.g. replaced by a test or third-party library): the helper must reconstruct
+// the Go standard-library defaults rather than silently drop them. This test is
+// intentionally NOT parallel — it mutates the process-global http.DefaultTransport
+// and restores it via t.Cleanup, which runs before any parallel test starts.
+//
+//nolint:paralleltest // Mutates the process-global http.DefaultTransport, so neither this test nor its subtests may run in parallel.
+func TestCloneDefaultTransportWithDialControl_ReconstructsWhenDefaultReplaced(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("replaced transport should not be used")
+	})
+
+	t.Run("nil control reconstructs the stdlib defaults", func(t *testing.T) {
+		transport := CloneDefaultTransportWithDialControl(nil)
+		require.NotNil(t, transport)
+		assert.NotNil(t, transport.Proxy, "proxy must be preserved")
+		assert.NotNil(t, transport.DialContext, "dial context must be set")
+		assert.True(t, transport.ForceAttemptHTTP2, "HTTP/2 must be preserved")
+		assert.Equal(t, maxIdleConns, transport.MaxIdleConns)
+		assert.Equal(t, idleConnTimeout, transport.IdleConnTimeout)
+		assert.Equal(t, 10*time.Second, transport.TLSHandshakeTimeout)
+		assert.Equal(t, 1*time.Second, transport.ExpectContinueTimeout)
+	})
+
+	t.Run("non-nil control reconstructs and installs the hook", func(t *testing.T) {
+		var hits atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		transport := CloneDefaultTransportWithDialControl(func(_, _ string, _ syscall.RawConn) error {
+			return errors.New("dial blocked by test policy")
+		})
+		_, err := (&http.Client{Transport: transport}).Get(srv.URL)
+		require.Error(t, err, "the reconstructed transport must still honor the dial control")
+		assert.Zero(t, hits.Load())
 	})
 }

--- a/pkg/networking/backend_transport_test.go
+++ b/pkg/networking/backend_transport_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package networking
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloneDefaultTransportWithDialControl verifies the shared backend
+// transport construction: a nil control clones DefaultTransport (a distinct
+// value that still reaches the server), and a non-nil control's hook fires on
+// the dial so a deny-all hook blocks the request before it leaves the client.
+func TestCloneDefaultTransportWithDialControl(t *testing.T) {
+	t.Parallel()
+
+	denyAll := func(_, _ string, _ syscall.RawConn) error {
+		return errors.New("dial blocked by test policy")
+	}
+
+	t.Run("nil control clones a reachable transport", func(t *testing.T) {
+		t.Parallel()
+
+		var hits atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		transport := CloneDefaultTransportWithDialControl(nil)
+		require.NotNil(t, transport)
+		assert.NotSame(t, http.DefaultTransport, transport, "must be a clone, not the shared DefaultTransport")
+
+		resp, err := (&http.Client{Transport: transport}).Get(srv.URL)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, int32(1), hits.Load())
+	})
+
+	t.Run("non-nil control fires on the dial", func(t *testing.T) {
+		t.Parallel()
+
+		var hits atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			hits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		transport := CloneDefaultTransportWithDialControl(denyAll)
+		_, err := (&http.Client{Transport: transport}).Get(srv.URL)
+		require.Error(t, err, "deny-all dial control must block the request")
+		assert.Zero(t, hits.Load(), "a blocked dial must not reach the server")
+	})
+}

--- a/pkg/networking/http_client.go
+++ b/pkg/networking/http_client.go
@@ -125,6 +125,59 @@ func NewPrivateIPBlockingDialContext() func(ctx context.Context, network, addr s
 	return (&net.Dialer{Control: protectedDialerControl}).DialContext
 }
 
+// Dial timeouts applied to backend connections. Both match the Go standard
+// library's http.DefaultTransport dialer.
+const (
+	backendDialTimeout   = 30 * time.Second
+	backendDialKeepAlive = 30 * time.Second
+)
+
+// CloneDefaultTransportWithDialControl returns an *http.Transport equivalent to
+// http.DefaultTransport, optionally carrying a per-connection dial Control hook.
+//
+// When http.DefaultTransport is the standard *http.Transport it is cloned
+// (preserving proxy, HTTP/2, and idle-connection settings). If it has been
+// replaced (e.g. in tests) a transport with the Go standard-library defaults is
+// reconstructed instead, so proxy/timeout/HTTP2 settings are not silently
+// dropped.
+//
+// When control is non-nil, a net.Dialer carrying it — with the standard backend
+// dial timeout and keep-alive — is installed as DialContext. The hook fires on
+// the resolved peer IP before the TCP handshake, which is what lets callers
+// defeat DNS-rebinding: a name-based check cannot, because the name can resolve
+// to a blocked IP after the check passes. A nil control leaves the cloned
+// dialer untouched.
+//
+// This is the single construction point for the vMCP backend transport, shared
+// by the per-call backend client and the persistent session connector so the
+// two dial paths cannot drift.
+func CloneDefaultTransportWithDialControl(
+	control func(network, address string, c syscall.RawConn) error,
+) *http.Transport {
+	var t *http.Transport
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		t = dt.Clone()
+	} else {
+		t = &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: backendDialTimeout, KeepAlive: backendDialKeepAlive}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          maxIdleConns,
+			IdleConnTimeout:       idleConnTimeout,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
+	}
+	if control != nil {
+		t.DialContext = (&net.Dialer{
+			Timeout:   backendDialTimeout,
+			KeepAlive: backendDialKeepAlive,
+			Control:   control,
+		}).DialContext
+	}
+	return t
+}
+
 // IdleConnectionCloser is the capability http.Client discovers on its outermost
 // transport to drain pooled connections (it asserts an identical unexported
 // interface). Any RoundTripper in this repo that wraps another must implement it

--- a/pkg/networking/http_client.go
+++ b/pkg/networking/http_client.go
@@ -148,9 +148,10 @@ const (
 // to a blocked IP after the check passes. A nil control leaves the cloned
 // dialer untouched.
 //
-// This is the single construction point for the vMCP backend transport, shared
-// by the per-call backend client and the persistent session connector so the
-// two dial paths cannot drift.
+// This is the single construction point for the backend transport used by every
+// caller that needs a dial-control hook, so callers building similar transports
+// cannot drift apart. Currently used by pkg/vmcp/client and
+// pkg/vmcp/session/internal/backend.
 func CloneDefaultTransportWithDialControl(
 	control func(network, address string, c syscall.RawConn) error,
 ) *http.Transport {

--- a/pkg/vmcp/client/client.go
+++ b/pkg/vmcp/client/client.go
@@ -283,23 +283,13 @@ func (h *httpBackendClient) requestContext(
 	return context.WithTimeout(ctx, h.requestTimeout(target.WorkloadID))
 }
 
-// backendDialer returns a net.Dialer with the standard backend timeouts and an
-// optional Control hook. Centralising the timeout constants here ensures the
-// fallback-construction branch and the dial-control replacement branch always
-// stay in sync — no "kept in sync with the branch below" promise required.
-func backendDialer(control func(network, address string, c syscall.RawConn) error) *net.Dialer {
-	return &net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-		Control:   control,
-	}
-}
-
-// newBackendTransport creates a *http.Transport with the same defaults as http.DefaultTransport.
-// If http.DefaultTransport is a *http.Transport, it is cloned directly (preserving any
-// environment-specific settings like TLS config or proxy overrides). Otherwise a transport
-// with the standard Go defaults is constructed, preserving proxy, dial timeout, HTTP/2, and
-// idle-connection settings that a zero-value &http.Transport{} would drop.
+// newBackendTransport creates a *http.Transport with the same defaults as http.DefaultTransport,
+// optionally carrying a per-connection dial Control hook, then layers CA-bundle handling on top.
+//
+// The base transport (clone-or-reconstruct plus the optional dial-control dialer) is built by
+// networking.CloneDefaultTransportWithDialControl, the single construction point shared with the
+// persistent session connector (pkg/vmcp/session/internal/backend) so the two dial paths — and
+// their timeout constants — cannot drift. See that helper for the DNS-rebinding rationale.
 //
 // If caBundlePath is non-empty, a custom TLS configuration is applied that trusts both
 // the system root CAs and the certificate(s) in the specified file. This is used for
@@ -308,39 +298,12 @@ func backendDialer(control func(network, address string, c syscall.RawConn) erro
 // If caBundleData is non-empty, the raw PEM bytes are used directly instead of reading
 // from a file. This is used in dynamic mode where CA bundles are fetched from K8s
 // ConfigMaps at discovery time. caBundleData takes precedence over caBundlePath.
-//
-// If dialControl is non-nil, a fresh net.Dialer carrying the hook is installed on the
-// transport. The hook fires per-connection on the resolved peer IP, which is what
-// defeats DNS-rebinding attacks — a name-based check cannot, because the name can
-// resolve to a blocked IP after the check passes. A cloned *http.Transport exposes
-// DialContext only as an opaque func, so we cannot read back the original dialer's
-// settings; we reconstruct the dialer via backendDialer instead.
 func newBackendTransport(
 	caBundlePath string,
 	caBundleData []byte,
 	dialControl func(network, address string, c syscall.RawConn) error,
 ) (*http.Transport, error) {
-	var t *http.Transport
-	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
-		t = dt.Clone()
-	} else {
-		// http.DefaultTransport has been replaced (e.g. in tests or by a third-party library).
-		// Construct a transport with the same defaults as the Go standard library uses for
-		// http.DefaultTransport so we don't silently drop proxy, timeout, or HTTP/2 settings.
-		t = &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			DialContext:           backendDialer(nil).DialContext,
-			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		}
-	}
-
-	if dialControl != nil {
-		t.DialContext = backendDialer(dialControl).DialContext
-	}
+	t := networking.CloneDefaultTransportWithDialControl(dialControl)
 
 	// Resolve CA certificate PEM data: caBundleData takes precedence over caBundlePath
 	var caPEM []byte

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/stacklok/toolhive/pkg/auth"
@@ -136,6 +137,7 @@ type defaultMultiSessionFactory struct {
 	backendInitTimeout     time.Duration
 	revisionLookup         func(workloadID string) (mcpparser.Revision, bool)
 	requestTimeoutResolver func(workloadID string) time.Duration
+	dialControl            func(network, address string, c syscall.RawConn) error
 }
 
 // MultiSessionFactoryOption configures a defaultMultiSessionFactory.
@@ -204,6 +206,26 @@ func WithRevisionLookup(lookup func(workloadID string) (mcpparser.Revision, bool
 	}
 }
 
+// WithDialControl installs a per-connection Control hook on the dialer used to
+// open the per-backend connections this factory establishes at session init
+// (MakeSessionWithID and RestoreSession). The hook fires after DNS resolution
+// and before the TCP handshake, receiving the resolved peer IP — so it can
+// enforce a dial policy (e.g. refuse dials into private ranges to blunt SSRF /
+// DNS-rebinding) on backend endpoints that may be operator- or
+// attacker-influenceable.
+//
+// It is the session-factory counterpart to pkg/vmcp/client.WithDialControl,
+// which guards the aggregation and tool-call paths; without this option those
+// paths could be guarded while session-init dials were not. The signature
+// matches net.Dialer.Control exactly, and a nil control (the default) leaves
+// the dial path unchanged. See backend.WithDialControl for the full security
+// caveats (per-TCP-dial not per-request, proxy transparency, both IP families).
+func WithDialControl(control func(network, address string, c syscall.RawConn) error) MultiSessionFactoryOption {
+	return func(f *defaultMultiSessionFactory) {
+		f.dialControl = control
+	}
+}
+
 // NewSessionFactory creates a MultiSessionFactory that connects to backends
 // over HTTP using the given outgoing auth registry.
 func NewSessionFactory(registry vmcpauth.OutgoingAuthRegistry, opts ...MultiSessionFactoryOption) MultiSessionFactory {
@@ -211,6 +233,7 @@ func NewSessionFactory(registry vmcpauth.OutgoingAuthRegistry, opts ...MultiSess
 	f.connector = backend.NewHTTPConnector(
 		registry,
 		backend.WithRequestTimeoutResolver(f.requestTimeoutResolver),
+		backend.WithDialControl(f.dialControl),
 	)
 	return f
 }

--- a/pkg/vmcp/session/factory_dialcontrol_test.go
+++ b/pkg/vmcp/session/factory_dialcontrol_test.go
@@ -6,6 +6,8 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/url"
 	"syscall"
 	"testing"
 
@@ -48,4 +50,89 @@ func TestSessionFactory_WithDialControl_GuardsSessionInit(t *testing.T) {
 	assert.Empty(t, sess.Tools(), "guarded session-init dial must not discover backend tools")
 	assert.Empty(t, sess.Resources(), "guarded session-init dial must not discover backend resources")
 	assert.Empty(t, sess.Prompts(), "guarded session-init dial must not discover backend prompts")
+}
+
+// TestSessionFactory_WithDialControl_GuardsRestoreSession proves the option
+// also covers the RestoreSession path (which has its own filtering and
+// identity-binding restore logic), not just MakeSessionWithID. A guarded
+// factory restoring from valid stored metadata must not reach the backend.
+func TestSessionFactory_WithDialControl_GuardsRestoreSession(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startInProcessMCPServer(t)
+	backend := &vmcp.Backend{
+		ID:            "guarded-backend",
+		Name:          "guarded-backend",
+		BaseURL:       baseURL,
+		TransportType: "streamable-http",
+	}
+
+	// Produce valid stored metadata (backend IDs + identity binding) from a real
+	// unguarded session.
+	seed := NewSessionFactory(newUnauthenticatedRegistry(t))
+	orig, err := seed.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, orig.Tools(), "sanity: the unguarded seed session must reach the backend")
+	storedMeta := orig.GetMetadata()
+	require.NoError(t, orig.Close())
+
+	// A guarded factory restoring from that metadata must not reach the backend.
+	guarded := NewSessionFactory(newUnauthenticatedRegistry(t),
+		WithDialControl(func(_, _ string, _ syscall.RawConn) error {
+			return errors.New("dial blocked by test policy")
+		}))
+	restored, err := guarded.RestoreSession(context.Background(), uuid.New().String(), storedMeta, []*vmcp.Backend{backend})
+	require.NoError(t, err)
+	require.NotNil(t, restored)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+
+	assert.Empty(t, restored.Tools(), "guarded restore must not discover backend tools")
+	assert.Empty(t, restored.BackendSessions(), "guarded restore must hold no backend connection")
+}
+
+// TestSessionFactory_WithDialControl_AppliesPerBackend proves the control is
+// applied per-backend within a single session: with two backends and a control
+// that blocks only one address, the allowed backend connects and the blocked
+// one is excluded. This is the production scenario the feature exists for.
+func TestSessionFactory_WithDialControl_AppliesPerBackend(t *testing.T) {
+	t.Parallel()
+
+	allowedURL := startInProcessMCPServer(t)
+	blockedURL := startInProcessMCPServer(t)
+	blockedHost := mustHost(t, blockedURL)
+
+	allowed := &vmcp.Backend{
+		ID: "allowed-backend", Name: "allowed-backend", BaseURL: allowedURL, TransportType: "streamable-http",
+	}
+	blocked := &vmcp.Backend{
+		ID: "blocked-backend", Name: "blocked-backend", BaseURL: blockedURL, TransportType: "streamable-http",
+	}
+
+	factory := NewSessionFactory(newUnauthenticatedRegistry(t),
+		WithDialControl(func(_, address string, _ syscall.RawConn) error {
+			if address == blockedHost {
+				return fmt.Errorf("dial blocked by test policy: %s", address)
+			}
+			return nil
+		}))
+
+	sess, err := factory.MakeSessionWithID(
+		context.Background(), uuid.New().String(), nil, []*vmcp.Backend{allowed, blocked}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+	conns := sess.BackendSessions()
+	assert.Contains(t, conns, "allowed-backend", "the allowed backend must be connected")
+	assert.NotContains(t, conns, "blocked-backend", "the blocked backend must be excluded by the dial control")
+	assert.NotEmpty(t, sess.Tools(), "the allowed backend's capabilities must still be discovered")
+}
+
+// mustHost returns the host:port of rawURL for matching against the address a
+// net.Dialer.Control hook receives.
+func mustHost(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return u.Host
 }

--- a/pkg/vmcp/session/factory_dialcontrol_test.go
+++ b/pkg/vmcp/session/factory_dialcontrol_test.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// TestSessionFactory_WithDialControl_GuardsSessionInit proves the option is
+// threaded from the public NewSessionFactory API down to the per-backend
+// session-init dial: with a deny-all control the real backend is never reached,
+// so the (partial-failure) session is created but holds no capabilities. The
+// unguarded TestSessionFactory_Integration_CapabilityDiscovery shows the same
+// backend IS reached and discovered without the option.
+func TestSessionFactory_WithDialControl_GuardsSessionInit(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startInProcessMCPServer(t)
+	backend := &vmcp.Backend{
+		ID:            "guarded-backend",
+		Name:          "guarded-backend",
+		BaseURL:       baseURL,
+		TransportType: "streamable-http",
+	}
+
+	factory := NewSessionFactory(newUnauthenticatedRegistry(t),
+		WithDialControl(func(_, _ string, _ syscall.RawConn) error {
+			return errors.New("dial blocked by test policy")
+		}))
+
+	// A blocked backend is a partial failure: the backend is excluded and the
+	// session is still created, just with no held connection or capabilities.
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, []*vmcp.Backend{backend}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+	assert.Empty(t, sess.Tools(), "guarded session-init dial must not discover backend tools")
+	assert.Empty(t, sess.Resources(), "guarded session-init dial must not discover backend resources")
+	assert.Empty(t, sess.Prompts(), "guarded session-init dial must not discover backend prompts")
+}

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
+	"syscall"
 	"time"
 
 	mcpclient "github.com/stacklok/toolhive-core/mcpcompat/client"
@@ -46,6 +48,7 @@ type HTTPConnectorOption func(*httpConnectorConfig)
 
 type httpConnectorConfig struct {
 	requestTimeoutResolver func(workloadID string) time.Duration
+	dialControl            func(network, address string, c syscall.RawConn) error
 }
 
 // WithRequestTimeoutResolver configures the timeout used for each backend
@@ -61,6 +64,39 @@ func WithRequestTimeoutResolver(resolver func(workloadID string) time.Duration) 
 		if resolver != nil {
 			cfg.requestTimeoutResolver = resolver
 		}
+	}
+}
+
+// WithDialControl installs a per-connection Control hook on the dialer used to
+// open every backend connection at session init (the MCP handshake and
+// capability listing). The hook fires after DNS resolution and before the TCP
+// handshake, receiving the resolved peer IP in address — which is why it
+// defeats DNS-rebinding attacks that a host-name–based check cannot: a hostname
+// can legitimately resolve to a blocked IP after the name-based check passes.
+//
+// It is the session-init twin of pkg/vmcp/client.WithDialControl (which guards
+// the aggregation and tool-call paths); the two share the same signature and
+// the same standard 30 s dial timeouts. A nil control (the default) leaves the
+// dial path byte-for-byte identical to before this hook existed.
+//
+// The signature matches net.Dialer.Control exactly.
+//
+// Security limitations embedders must understand:
+//
+//   - Per-TCP-dial, not per-request: the hook fires once per TCP connection.
+//     A pooled connection is reused without re-invoking the hook until it is
+//     recycled.
+//   - Proxy transparency: when http.ProxyFromEnvironment selects a proxy
+//     (HTTP_PROXY/HTTPS_PROXY set), the dial target is the proxy server, so the
+//     hook receives the proxy's IP, not the backend's. Embedders relying on this
+//     hook for SSRF or IP allow-listing must either unset the proxy env vars or
+//     additionally validate the backend URL's host before dialing.
+//   - Both IP families: the address argument may be an IPv4 or IPv6 literal
+//     (host:port form); embedders must handle both — including IPv4-mapped IPv6
+//     such as ::ffff:127.0.0.1 — in their check.
+func WithDialControl(control func(network, address string, c syscall.RawConn) error) HTTPConnectorOption {
+	return func(cfg *httpConnectorConfig) {
+		cfg.dialControl = control
 	}
 }
 
@@ -146,6 +182,44 @@ func newListChangedNotificationHandler(workloadID string, sink ListChangedSink) 
 type httpRoundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f httpRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// backendBaseTransport returns the innermost RoundTripper for backend
+// connections. With a nil dialControl it returns http.DefaultTransport
+// unchanged, so the no-hook path is byte-for-byte identical to before
+// WithDialControl existed. With a non-nil hook it clones DefaultTransport
+// (preserving proxy, HTTP/2, and idle-connection settings) and installs a
+// net.Dialer whose Control hook fires on the resolved peer IP before the TCP
+// handshake. The 30 s dial timeouts match backendDialer in pkg/vmcp/client —
+// keep the two in sync (this is the session-init twin of that path's
+// newBackendTransport, minus the CA-bundle handling the session path does not
+// use).
+func backendBaseTransport(dialControl func(network, address string, c syscall.RawConn) error) http.RoundTripper {
+	if dialControl == nil {
+		return http.DefaultTransport
+	}
+	var t *http.Transport
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		t = dt.Clone()
+	} else {
+		// http.DefaultTransport has been replaced (e.g. in tests). Reconstruct
+		// the Go standard-library defaults so proxy/timeout/HTTP2 settings are
+		// not silently dropped.
+		t = &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
+	}
+	t.DialContext = (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   dialControl,
+	}).DialContext
+	return t
+}
 
 // authRoundTripper adds pre-resolved authentication to outgoing backend requests.
 type authRoundTripper struct {
@@ -414,7 +488,7 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry, opts ...HTTPConnec
 		}
 
 		c, err := createMCPClient(
-			ctx, target, identity, registry, sessionHint, provider, sink, transportTimeout,
+			ctx, target, identity, registry, sessionHint, provider, sink, connectorConfig.dialControl, transportTimeout,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create MCP client for backend %s: %w", target.WorkloadID, err)
@@ -472,6 +546,7 @@ func createMCPClient(
 	sessionHint string,
 	provider secrets.Provider,
 	sink ListChangedSink,
+	dialControl func(network, address string, c syscall.RawConn) error,
 	requestTimeout time.Duration,
 ) (*mcpclient.Client, error) {
 	// Resolve and validate the auth strategy once at client creation time.
@@ -490,7 +565,10 @@ func createMCPClient(
 	slog.Debug("Applied authentication strategy", "strategy", strategy.Name(), "backendID", target.WorkloadID)
 
 	// Build shared transport chain (innermost first → outermost):
-	//   http.DefaultTransport → authRoundTripper → identityRoundTripper → headerForwardRoundTripper
+	//   backendBaseTransport → authRoundTripper → identityRoundTripper → headerForwardRoundTripper
+	// The innermost stage is http.DefaultTransport unless a dial-control hook is
+	// configured (see WithDialControl), in which case it is a cloned transport
+	// carrying that hook on its dialer.
 	// On an outbound request, the outermost stage runs first: header-forward
 	// injects its headers onto a request that does not yet carry auth/identity
 	// headers, then inner stages run and call Set() unconditionally so any
@@ -499,7 +577,7 @@ func createMCPClient(
 	// rejected at resolve time by resolveHeaderForward, so user-supplied
 	// HeaderForward cannot inject them in the first place.
 	// The per-transport sections below may add a size-limiting wrapper on top.
-	base := http.RoundTripper(http.DefaultTransport)
+	base := backendBaseTransport(dialControl)
 	base = &authRoundTripper{
 		base:         base,
 		authStrategy: strategy,

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -50,6 +50,22 @@ type httpConnectorConfig struct {
 	dialControl            func(network, address string, c syscall.RawConn) error
 }
 
+// mcpClientParams carries the per-connection options NewHTTPConnector's closure
+// threads into createMCPClient. They are grouped into a struct — rather than
+// passed positionally — because sink and dialControl are both func-typed and
+// frequently nil, so as bare adjacent arguments a future reorder could
+// transpose them with no compiler error. Named fields remove that risk.
+type mcpClientParams struct {
+	// sink, when non-nil, enables persistent backend-notification consumption
+	// (see createMCPClient); nil leaves it disabled.
+	sink ListChangedSink
+	// dialControl, when non-nil, installs a net.Dialer.Control hook on the
+	// backend transport (see WithDialControl); nil uses http.DefaultTransport.
+	dialControl func(network, address string, c syscall.RawConn) error
+	// requestTimeout bounds each backend operation and the transport dial.
+	requestTimeout time.Duration
+}
+
 // WithRequestTimeoutResolver configures the timeout used for each backend
 // operation. The resolver receives the backend workload ID and may return a
 // workload-specific duration. A nil resolver, or a non-positive result, uses
@@ -87,6 +103,7 @@ func WithRequestTimeoutResolver(resolver func(workloadID string) time.Duration) 
 //     recycled. Because each backend gets its own isolated transport and
 //     connection pool, a reused connection is always one this hook already
 //     approved on its first dial — reuse cannot reach an unclassified peer.
+//     This connector does not offer per-request re-classification.
 //   - Proxy transparency: when http.ProxyFromEnvironment selects a proxy
 //     (HTTP_PROXY/HTTPS_PROXY set), the dial target is the proxy server, so the
 //     hook receives the proxy's IP, not the backend's. Embedders relying on this
@@ -94,7 +111,9 @@ func WithRequestTimeoutResolver(resolver func(workloadID string) time.Duration) 
 //     additionally validate the backend URL's host before dialing.
 //   - Both IP families: the address argument may be an IPv4 or IPv6 literal
 //     (host:port form); embedders must handle both — including IPv4-mapped IPv6
-//     such as ::ffff:127.0.0.1 — in their check.
+//     such as ::ffff:127.0.0.1 — in their check. See the OWASP SSRF Prevention
+//     Cheat Sheet for the full set of ranges to deny (loopback, RFC 1918,
+//     link-local 169.254/16, CGNAT 100.64/10, IPv6 ULA).
 func WithDialControl(control func(network, address string, c syscall.RawConn) error) HTTPConnectorOption {
 	return func(cfg *httpConnectorConfig) {
 		cfg.dialControl = control
@@ -466,7 +485,12 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry, opts ...HTTPConnec
 		}
 
 		c, err := createMCPClient(
-			ctx, target, identity, registry, sessionHint, provider, sink, connectorConfig.dialControl, transportTimeout,
+			ctx, target, identity, registry, sessionHint, provider,
+			mcpClientParams{
+				sink:           sink,
+				dialControl:    connectorConfig.dialControl,
+				requestTimeout: transportTimeout,
+			},
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create MCP client for backend %s: %w", target.WorkloadID, err)
@@ -523,10 +547,15 @@ func createMCPClient(
 	registry vmcpauth.OutgoingAuthRegistry,
 	sessionHint string,
 	provider secrets.Provider,
-	sink ListChangedSink,
-	dialControl func(network, address string, c syscall.RawConn) error,
-	requestTimeout time.Duration,
+	params mcpClientParams,
 ) (*mcpclient.Client, error) {
+	// Destructure once so the body below reads unchanged. The named fields on
+	// mcpClientParams are what protect the two adjacent nil-able func members
+	// (sink, dialControl) from being silently transposed at call sites.
+	sink := params.sink
+	dialControl := params.dialControl
+	requestTimeout := params.requestTimeout
+
 	// Resolve and validate the auth strategy once at client creation time.
 	strategyName := authtypes.StrategyTypeUnauthenticated
 	if target.AuthConfig != nil {

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"syscall"
 	"time"
@@ -85,7 +84,9 @@ func WithRequestTimeoutResolver(resolver func(workloadID string) time.Duration) 
 //
 //   - Per-TCP-dial, not per-request: the hook fires once per TCP connection.
 //     A pooled connection is reused without re-invoking the hook until it is
-//     recycled.
+//     recycled. Because each backend gets its own isolated transport and
+//     connection pool, a reused connection is always one this hook already
+//     approved on its first dial — reuse cannot reach an unclassified peer.
 //   - Proxy transparency: when http.ProxyFromEnvironment selects a proxy
 //     (HTTP_PROXY/HTTPS_PROXY set), the dial target is the proxy server, so the
 //     hook receives the proxy's IP, not the backend's. Embedders relying on this
@@ -186,39 +187,16 @@ func (f httpRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, erro
 // backendBaseTransport returns the innermost RoundTripper for backend
 // connections. With a nil dialControl it returns http.DefaultTransport
 // unchanged, so the no-hook path is byte-for-byte identical to before
-// WithDialControl existed. With a non-nil hook it clones DefaultTransport
-// (preserving proxy, HTTP/2, and idle-connection settings) and installs a
-// net.Dialer whose Control hook fires on the resolved peer IP before the TCP
-// handshake. The 30 s dial timeouts match backendDialer in pkg/vmcp/client —
-// keep the two in sync (this is the session-init twin of that path's
-// newBackendTransport, minus the CA-bundle handling the session path does not
-// use).
+// WithDialControl existed. With a non-nil hook it delegates to
+// networking.CloneDefaultTransportWithDialControl — the single backend
+// transport construction point shared with pkg/vmcp/client — which clones
+// DefaultTransport and installs a net.Dialer whose Control hook fires on the
+// resolved peer IP before the TCP handshake.
 func backendBaseTransport(dialControl func(network, address string, c syscall.RawConn) error) http.RoundTripper {
 	if dialControl == nil {
 		return http.DefaultTransport
 	}
-	var t *http.Transport
-	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
-		t = dt.Clone()
-	} else {
-		// http.DefaultTransport has been replaced (e.g. in tests). Reconstruct
-		// the Go standard-library defaults so proxy/timeout/HTTP2 settings are
-		// not silently dropped.
-		t = &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		}
-	}
-	t.DialContext = (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-		Control:   dialControl,
-	}).DialContext
-	return t
+	return networking.CloneDefaultTransportWithDialControl(dialControl)
 }
 
 // authRoundTripper adds pre-resolved authentication to outgoing backend requests.

--- a/pkg/vmcp/session/internal/backend/mcp_session_dialcontrol_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_dialcontrol_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// denyAllDial is a net.Dialer.Control hook that refuses every dial, standing in
+// for an SSRF/private-address guard an embedder would install.
+func denyAllDial(_, _ string, _ syscall.RawConn) error {
+	return errors.New("dial blocked by test policy")
+}
+
+// TestHTTPConnector_DialControlGuardsSessionInit proves that a Control hook
+// supplied via WithDialControl fires on the session-init dial for every backend
+// transport: a deny-all hook makes the connect fail before any request reaches
+// the backend. The companion unguarded connector against the same server shows
+// the target IS dialed without the hook, so it is the guard — not an
+// unreachable server — that blocks the request.
+func TestHTTPConnector_DialControlGuardsSessionInit(t *testing.T) {
+	t.Parallel()
+
+	for _, transport := range []string{"streamable-http", "sse"} {
+		t.Run(transport, func(t *testing.T) {
+			t.Parallel()
+
+			var hits atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				hits.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+
+			target := &vmcp.BackendTarget{
+				WorkloadID:    "guarded-backend",
+				WorkloadName:  "guarded-backend",
+				BaseURL:       srv.URL,
+				TransportType: transport,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			t.Cleanup(cancel)
+
+			// Guarded: the deny-all hook must block the dial before any request.
+			guarded := NewHTTPConnector(newTestRegistry(t), WithDialControl(denyAllDial))
+			sess, _, err := guarded(ctx, target, nil, "", nil)
+			if sess != nil {
+				_ = sess.Close()
+			}
+			require.Error(t, err, "deny-all dial control must fail session init")
+			assert.Zero(t, hits.Load(), "guarded session-init dial must not reach the backend")
+
+			// Unguarded: the same target IS dialed, proving the server is
+			// reachable and the guard above is what stopped the dial.
+			unguarded := NewHTTPConnector(newTestRegistry(t))
+			sess2, _, _ := unguarded(ctx, target, nil, "", nil)
+			if sess2 != nil {
+				_ = sess2.Close()
+			}
+			assert.Positive(t, hits.Load(), "unguarded session-init dial must reach the backend")
+		})
+	}
+}
+
+// TestBackendBaseTransport_NilHookReturnsDefault pins the no-op guarantee: with
+// no dial control the base transport is http.DefaultTransport itself (not a
+// clone), so the dial path is byte-for-byte identical to before the hook
+// existed.
+func TestBackendBaseTransport_NilHookReturnsDefault(t *testing.T) {
+	t.Parallel()
+
+	assert.Same(t, http.DefaultTransport, backendBaseTransport(nil),
+		"a nil dial control must leave http.DefaultTransport untouched")
+	assert.NotSame(t, http.DefaultTransport, backendBaseTransport(denyAllDial),
+		"a non-nil dial control must yield a distinct transport carrying the hook")
+}

--- a/pkg/vmcp/session/internal/backend/mcp_session_dialcontrol_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_dialcontrol_test.go
@@ -55,13 +55,23 @@ func TestHTTPConnector_DialControlGuardsSessionInit(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			t.Cleanup(cancel)
 
-			// Guarded: the deny-all hook must block the dial before any request.
-			guarded := NewHTTPConnector(newTestRegistry(t), WithDialControl(denyAllDial))
+			// Guarded: the deny-all hook must fire and block the dial before any
+			// request. Recording invocation (rather than only asserting error +
+			// zero hits) ensures an unrelated earlier failure — transport
+			// construction, auth, URL parsing — cannot pass this test for the
+			// wrong reason.
+			var fired atomic.Bool
+			control := func(_, _ string, _ syscall.RawConn) error {
+				fired.Store(true)
+				return errors.New("dial blocked by test policy")
+			}
+			guarded := NewHTTPConnector(newTestRegistry(t), WithDialControl(control))
 			sess, _, err := guarded(ctx, target, nil, "", nil)
 			if sess != nil {
 				_ = sess.Close()
 			}
 			require.Error(t, err, "deny-all dial control must fail session init")
+			assert.True(t, fired.Load(), "the dial-control hook must have been invoked")
 			assert.Zero(t, hits.Load(), "guarded session-init dial must not reach the backend")
 
 			// Unguarded: the same target IS dialed, proving the server is

--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -114,7 +114,7 @@ func TestCreateMCPClient_UnsupportedTransport(t *testing.T) {
 
 			_, err := createMCPClient(
 				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), nil,
-				defaultBackendRequestTimeout,
+				nil, defaultBackendRequestTimeout,
 			)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, vmcp.ErrUnsupportedTransport,
@@ -375,7 +375,7 @@ func TestCreateMCPClient_ContinuousListeningGatedOnSink(t *testing.T) {
 
 			c, err := createMCPClient(
 				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), tc.sink,
-				defaultBackendRequestTimeout,
+				nil, defaultBackendRequestTimeout,
 			)
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = c.Close() })
@@ -443,7 +443,7 @@ func TestCreateMCPClient_ListChangedSink_FiresOnBackendNotification(t *testing.T
 
 			c, err := createMCPClient(
 				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), sink,
-				defaultBackendRequestTimeout,
+				nil, defaultBackendRequestTimeout,
 			)
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = c.Close() })
@@ -515,7 +515,7 @@ func TestCreateMCPClient_ListChangedSink_DoesNotStallInFlightCall(t *testing.T) 
 
 	c, err := createMCPClient(
 		context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), sink,
-		defaultBackendRequestTimeout,
+		nil, defaultBackendRequestTimeout,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })

--- a/pkg/vmcp/session/internal/backend/mcp_session_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_test.go
@@ -113,8 +113,8 @@ func TestCreateMCPClient_UnsupportedTransport(t *testing.T) {
 			}
 
 			_, err := createMCPClient(
-				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), nil,
-				nil, defaultBackendRequestTimeout,
+				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(),
+				mcpClientParams{requestTimeout: defaultBackendRequestTimeout},
 			)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, vmcp.ErrUnsupportedTransport,
@@ -374,8 +374,8 @@ func TestCreateMCPClient_ContinuousListeningGatedOnSink(t *testing.T) {
 			t.Parallel()
 
 			c, err := createMCPClient(
-				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), tc.sink,
-				nil, defaultBackendRequestTimeout,
+				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(),
+				mcpClientParams{sink: tc.sink, requestTimeout: defaultBackendRequestTimeout},
 			)
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = c.Close() })
@@ -442,8 +442,8 @@ func TestCreateMCPClient_ListChangedSink_FiresOnBackendNotification(t *testing.T
 			}
 
 			c, err := createMCPClient(
-				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), sink,
-				nil, defaultBackendRequestTimeout,
+				context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(),
+				mcpClientParams{sink: sink, requestTimeout: defaultBackendRequestTimeout},
 			)
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = c.Close() })
@@ -514,8 +514,8 @@ func TestCreateMCPClient_ListChangedSink_DoesNotStallInFlightCall(t *testing.T) 
 	}
 
 	c, err := createMCPClient(
-		context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(), sink,
-		nil, defaultBackendRequestTimeout,
+		context.Background(), target, nil, newTestRegistry(t), "", secrets.NewEnvironmentProvider(),
+		mcpClientParams{sink: sink, requestTimeout: defaultBackendRequestTimeout},
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })


### PR DESCRIPTION
## Summary

The vMCP `MultiSessionFactory` opens a persistent connection to every backend
during session `initialize` (the MCP handshake plus capability listing), but
those session-init dials used `http.DefaultTransport` with no
`net.Dialer.Control` hook, and `NewSessionFactory` exposed no way to inject
one. This is asymmetric with the per-call backend client in `pkg/vmcp/client`,
which already offers `WithDialControl`. As a result, an embedder that installs
a dial guard on the backend client (for example, an SSRF / DNS-rebinding guard
that refuses dials resolving into private IP ranges) covered the aggregation
and tool-call paths but could not cover the session-init dials — so
`initialize` would still dial and handshake against an operator- or
attacker-influenceable backend endpoint.

- **Add `session.WithDialControl`** (`MultiSessionFactoryOption`) and its
  counterpart `backend.WithDialControl` (`HTTPConnectorOption`), threaded
  through `createMCPClient` so the hook fires on session-init dials for **both**
  the `streamable-http` and `sse` transports, on both the `MakeSessionWithID`
  and `RestoreSession` paths. The signature matches `net.Dialer.Control` and
  `vmcpclient.WithDialControl` exactly and carries the same security caveats
  (per-TCP-dial not per-request, proxy transparency, both IP families, OWASP
  range list).
- **Centralize backend transport construction** by extracting
  `networking.CloneDefaultTransportWithDialControl` as the single shared
  construction point used by both the per-call client and the session
  connector, removing the duplicated clone-or-reconstruct + dialer logic that
  previously lived in `pkg/vmcp/client`.
- **Group `createMCPClient`'s option parameters into an `mcpClientParams`
  struct** so the two adjacent, frequently-nil func members (`sink`,
  `dialControl`) cannot be silently transposed at a call site.
- **Preserve existing behavior**: a nil control (the default) leaves the dial
  path byte-for-byte identical to `http.DefaultTransport` — the session
  connector returns `http.DefaultTransport` unchanged when no hook is set.

Closes #6545

## Type of change

- [x] New feature

## Test plan

- [x] Unit tests (`task test`)

Ran the affected packages (`pkg/networking`, `pkg/vmcp/client`,
`pkg/vmcp/session`, and `pkg/vmcp/session/internal/backend`) with the Taskfile
flags. Coverage added:

- A deny-all dial control yields **zero** backend requests during session
  `initialize` for both the `streamable-http` and `sse` transports, and the
  control's hook is asserted to have actually fired (so an unrelated earlier
  failure cannot pass the test for the wrong reason).
- The dial control also guards the `RestoreSession` path (its distinct
  filtering / identity-binding restore logic).
- A two-backend session where the control blocks one backend's address proves
  the control is applied **per-backend**: the allowed backend connects and the
  blocked one is excluded.
- A nil control returns `http.DefaultTransport` unchanged.
- The shared `networking.CloneDefaultTransportWithDialControl` helper is covered
  directly, including the reconstruction branch taken when `http.DefaultTransport`
  has been replaced by a non-`*http.Transport`.
- The pre-existing client transport tests still pass.

## Changes

| File | Change |
|------|--------|
| `pkg/networking/http_client.go` | Add `CloneDefaultTransportWithDialControl`, the single shared backend-transport construction point (clone-or-reconstruct + optional dial-control dialer). |
| `pkg/networking/backend_transport_test.go` | Tests for the shared helper, including the `DefaultTransport`-replaced reconstruction branch. |
| `pkg/vmcp/client/client.go` | Replace inlined `backendDialer` / transport construction with the shared helper. |
| `pkg/vmcp/session/factory.go` | Add `WithDialControl` factory option; thread it into the HTTP connector. |
| `pkg/vmcp/session/factory_dialcontrol_test.go` | Test the factory option across `MakeSessionWithID`, `RestoreSession`, and the mixed per-backend allow/block scenario. |
| `pkg/vmcp/session/internal/backend/mcp_session.go` | Add `WithDialControl` connector option and `backendBaseTransport`; group `createMCPClient`'s option params into `mcpClientParams`; thread the hook through for streamable-http and sse. |
| `pkg/vmcp/session/internal/backend/mcp_session_dialcontrol_test.go` | Deny-all dial-control tests for both transports, asserting the hook fired. |
| `pkg/vmcp/session/internal/backend/mcp_session_test.go` | Update for the new `createMCPClient` signature. |

## Does this introduce a user-facing change?

No end-user behavior changes by default. This adds an opt-in embedder API: a
new `session.WithDialControl` option that lets a deployment enforce a
per-connection dial policy on the connections opened at vMCP session
initialization, closing a gap relative to the existing backend-client guard.

## Special notes for reviewers

- The no-hook path is intentionally byte-for-byte identical to before:
  `backendBaseTransport(nil)` returns `http.DefaultTransport` directly rather
  than a clone, so nothing changes for deployments that do not opt in.
- Timeout constants for the backend dialer now live in one place
  (`pkg/networking`), so the client and session-connector dial paths can no
  longer drift.
- The reconstruction-branch test mutates the process-global
  `http.DefaultTransport` and is therefore non-parallel (restored via
  `t.Cleanup`); it carries a justified `//nolint:paralleltest`.
- Follow-up (item 4 in the issue, deliberately out of scope here): wiring the
  option into `pkg/vmcp/cli/serve.go` so a production deployment can opt into a
  guard. This PR adds the plumbing; the CLI wiring can land separately.

Generated with [Claude Code](https://claude.com/claude-code)
