### PR TITLE
Guard rotating refresh-token writes with compare-and-swap

### DIFF
--- a/docs/arch/11-auth-server-storage.md
+++ b/docs/arch/11-auth-server-storage.md
@@ -202,10 +202,21 @@ distinct rows would cross credentials between sessions. This prevents
 duplicate redemption from stale concurrent callers served by the same
 process; the identity is not persisted, logged, or exposed.
 
-This is deliberately narrower than #4122: it does not provide distributed
-coordination across replicas, row-addressed mutation, compare-and-swap, or any
-other cross-process consistency guarantee. Redis remains the durable storage
-backend, while each replica coordinates only its own in-flight refreshes.
+This is deliberately narrower than #4122's original in-process-only scope: it
+does not by itself provide distributed coordination across replicas. That
+coordination now exists as a second, independent layer:
+`UpstreamTokenStorage.CompareAndSwapUpstreamTokens` conditions a refresh write
+on the refresh token currently stored still matching the value the caller
+redeemed with, failing the write (`ErrConcurrentRefresh`) instead of
+overwriting when another replica already rotated the row first. `refreshAndStore`
+writes through this method rather than an unconditional `StoreUpstreamTokens`.
+Redis implements the comparison and the write as one atomic Lua script;
+`MemoryStorage` implements it under its existing mutex. `singleflight` remains
+the process-local optimization described above — it avoids a redundant
+upstream call and Redis round-trip for concurrent requests inside one
+process — while the CAS write is what makes concurrent redemption safe across
+processes. Redis remains the durable storage backend and source of truth for
+which redemption, if more than one raced, actually won.
 
 ### Serialization
 

--- a/docs/arch/11-auth-server-storage.md
+++ b/docs/arch/11-auth-server-storage.md
@@ -214,9 +214,27 @@ Redis implements the comparison and the write as one atomic Lua script;
 `MemoryStorage` implements it under its existing mutex. `singleflight` remains
 the process-local optimization described above — it avoids a redundant
 upstream call and Redis round-trip for concurrent requests inside one
-process — while the CAS write is what makes concurrent redemption safe across
-processes. Redis remains the durable storage backend and source of truth for
-which redemption, if more than one raced, actually won.
+process — while the CAS write is what makes the *stored* row deterministic
+across processes: whichever replica's write lands first wins, and every
+losing replica's write fails instead of silently clobbering it.
+
+This is a storage-ordering guarantee, not a guarantee that concurrent
+redemption is safe at the upstream provider. Both replicas still call
+`provider.RefreshTokens` before either one's CAS write runs, so for a
+provider enforcing strict single-use rotation (RFC 9700 §4.14.2 replay
+detection), two concurrent redemptions of the same refresh token can still
+be indistinguishable from a replay at the IdP, which may revoke the grant
+regardless of which replica's write wins here. CAS is fully sufficient only
+where the provider tolerates a short grace/leeway window in which more than
+one redeemed child stays valid (e.g. Read.ai's stated behavior) — outside
+that window, closing the gap requires serializing the *redemption* itself
+(a distributed lock around the read-redeem-write sequence), not just the
+write. That lock is a deliberate follow-up, not implemented here: this layer
+only prevents storage corruption from a lost write race, and its own log
+distinguishes a genuine lost race (an unexpired row on re-read) from a row
+that is simply gone (deleted by logout or evicted by TTL, `ErrNotFound` on
+re-read) — the latter is expected behavior, not a race, and refuses to
+resurrect the deleted row.
 
 ### Serialization
 

--- a/pkg/authserver/refresher.go
+++ b/pkg/authserver/refresher.go
@@ -198,7 +198,7 @@ func (r *upstreamTokenRefresher) refreshAndStore(
 
 	// OIDC Core 1.0 §12.2 permits but does not require a new id_token on refresh.
 	// When the provider omits one, keep the ID token captured at the initial login
-	// so it is not erased from storage. StoreUpstreamTokens replaces the whole row,
+	// so it is not erased from storage. The write below replaces the whole row,
 	// so without this the persisted IDToken would be overwritten with "" and the
 	// original login ID token would be lost for the remainder of the session.
 	// Mirrors the RefreshToken carry-forward above.
@@ -298,7 +298,14 @@ func (r *upstreamTokenRefresher) resolveConcurrentRefreshConflict(
 		"the redeemed refresh token is unrecoverable for this attempt",
 		"session_id", sessionID,
 		"provider_id", providerID,
+		"error", err,
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"concurrent upstream token refresh for session %q provider %q: %w: %w",
+			sessionID, providerID, storage.ErrConcurrentRefresh, err,
+		)
+	}
 	return nil, fmt.Errorf(
 		"concurrent upstream token refresh for session %q provider %q: %w",
 		sessionID, providerID, storage.ErrConcurrentRefresh,

--- a/pkg/authserver/refresher.go
+++ b/pkg/authserver/refresher.go
@@ -37,8 +37,20 @@ const upstreamDeleteTimeout = 5 * time.Second
 // a set of upstream OAuth2Providers (keyed by provider name) and
 // UpstreamTokenStorage (for persisting the refreshed tokens). On each refresh
 // call it dispatches to the correct provider based on the expired token's
-// ProviderID. It deduplicates concurrent refreshes by the opaque storage-row
-// identity returned by UpstreamTokenStorage, within this process only.
+// ProviderID.
+//
+// Two layers cooperate to make redeeming a single-use, rotating upstream
+// refresh token safe under concurrency:
+//   - sfGroup deduplicates concurrent refreshes by the opaque storage-row
+//     identity returned by UpstreamTokenStorage, but only WITHIN THIS PROCESS
+//     — it saves redundant upstream calls and redis round-trips when this
+//     process alone receives several concurrent requests for the same row.
+//   - CompareAndSwapUpstreamTokens (see refreshAndStore) is what actually
+//     protects correctness ACROSS PROCESSES: every write is conditioned on
+//     the refresh token this call redeemed still being the one stored, so a
+//     replica that loses a cross-process race fails its write instead of
+//     clobbering a winning replica's rotated token. singleflight is an
+//     optimization layered on top of that guarantee, not a substitute for it.
 type upstreamTokenRefresher struct {
 	providers            map[string]upstream.OAuth2Provider
 	storage              storage.UpstreamTokenStorage
@@ -194,7 +206,21 @@ func (r *upstreamTokenRefresher) refreshAndStore(
 		updated.IDToken = expired.IDToken
 	}
 
-	if err := r.storeWithRetry(ctx, sessionID, expired.ProviderID, updated); err != nil {
+	// expectedRefreshToken is the value this call actually redeemed with the
+	// upstream provider. Writing through CompareAndSwapUpstreamTokens (rather
+	// than an unconditional StoreUpstreamTokens) protects against another
+	// process — a different replica of this auth server sharing this storage —
+	// having already redeemed and persisted a rotation of the SAME refresh
+	// token concurrently: only the replica whose expected value still matches
+	// the stored row may write, so a losing replica cannot clobber the
+	// winner's rotated token with its own now-stale redemption.
+	expectedRefreshToken := expired.RefreshToken
+
+	if err := r.compareAndSwapWithRetry(ctx, sessionID, expired.ProviderID, expectedRefreshToken, updated); err != nil {
+		if errors.Is(err, storage.ErrConcurrentRefresh) {
+			return r.resolveConcurrentRefreshConflict(ctx, sessionID, expired.ProviderID)
+		}
+
 		if !rotated {
 			// The old refresh token is still valid in storage; the caller can
 			// proceed with the refreshed access token for this request.
@@ -236,22 +262,73 @@ func (r *upstreamTokenRefresher) refreshAndStore(
 	return updated, nil
 }
 
-// storeWithRetry attempts to store updated tokens up to upstreamStoreMaxAttempts times,
-// waiting upstreamStoreRetryBackoff between attempts. Returns nil on first success.
-// Returns the last error after all attempts are exhausted. Ctx-cancellation short-circuits
-// between attempts and returns the last store error (not ctx.Err()).
-func (r *upstreamTokenRefresher) storeWithRetry(
+// resolveConcurrentRefreshConflict is reached when this call's redemption
+// lost a compare-and-swap race against another process (typically a
+// different replica of this auth server) that refreshed and persisted the same
+// row concurrently — CompareAndSwapUpstreamTokens returned
+// storage.ErrConcurrentRefresh because the stored refresh token had already
+// moved past the value this call redeemed with.
+//
+// It re-reads the authoritative row: if that read is unexpired, the other
+// process's write is the correct result for this call to hand back — this
+// call's own redemption produced an access/refresh token pair the IdP (or the
+// winning replica) has already superseded, so it must not be used or written.
+// If the re-read is still expired, missing, or otherwise unusable, the loss is
+// unrecoverable for this attempt: the refresh token this call redeemed is now
+// dead both at the IdP (which enforces single-use) and in storage (the winner
+// overwrote it before this call's CAS ran), so the caller must surface an
+// error — retrying would only redeem the same already-consumed refresh token
+// again.
+func (r *upstreamTokenRefresher) resolveConcurrentRefreshConflict(
+	ctx context.Context, sessionID, providerID string,
+) (*storage.UpstreamTokens, error) {
+	readCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
+	defer cancel()
+
+	winner, err := r.storage.GetUpstreamTokens(readCtx, sessionID, providerID)
+	if err == nil && winner != nil && !winner.IsExpired(time.Now()) {
+		slog.Debug("lost concurrent upstream token refresh race; using winning replica's tokens",
+			"session_id", sessionID,
+			"provider_id", providerID,
+		)
+		return winner, nil
+	}
+
+	slog.Error("lost concurrent upstream token refresh race and re-read found no usable winner; "+
+		"the redeemed refresh token is unrecoverable for this attempt",
+		"session_id", sessionID,
+		"provider_id", providerID,
+	)
+	return nil, fmt.Errorf(
+		"concurrent upstream token refresh for session %q provider %q: %w",
+		sessionID, providerID, storage.ErrConcurrentRefresh,
+	)
+}
+
+// compareAndSwapWithRetry attempts CompareAndSwapUpstreamTokens up to
+// upstreamStoreMaxAttempts times, waiting upstreamStoreRetryBackoff between
+// attempts. Returns nil on first success. A storage.ErrConcurrentRefresh
+// result is returned immediately without retrying: the comparison failed
+// because expectedRefreshToken is now definitively stale, and retrying the
+// identical compare-and-swap cannot change that outcome. For any other error,
+// returns the last error after all attempts are exhausted; ctx-cancellation
+// short-circuits between attempts and returns the last store error (not
+// ctx.Err()).
+func (r *upstreamTokenRefresher) compareAndSwapWithRetry(
 	ctx context.Context,
-	sessionID, providerID string,
+	sessionID, providerID, expectedRefreshToken string,
 	updated *storage.UpstreamTokens,
 ) error {
 	var lastErr error
 	for attempt := 1; attempt <= upstreamStoreMaxAttempts; attempt++ {
-		storeErr := r.storage.StoreUpstreamTokens(ctx, sessionID, providerID, updated)
-		if storeErr == nil {
+		casErr := r.storage.CompareAndSwapUpstreamTokens(ctx, sessionID, providerID, expectedRefreshToken, updated)
+		if casErr == nil {
 			return nil
 		}
-		lastErr = storeErr
+		if errors.Is(casErr, storage.ErrConcurrentRefresh) {
+			return casErr
+		}
+		lastErr = casErr
 		slog.Debug("failed to store refreshed upstream tokens",
 			"session_id", sessionID,
 			"provider_id", providerID,

--- a/pkg/authserver/refresher.go
+++ b/pkg/authserver/refresher.go
@@ -33,24 +33,39 @@ const upstreamStoreRetryBackoff = 50 * time.Millisecond
 // attempts does not also kill the delete, which would leave the stale row behind.
 const upstreamDeleteTimeout = 5 * time.Second
 
+// upstreamConflictReadTimeout bounds the single re-read resolveConcurrentRefreshConflict
+// performs after a CAS conflict. It is deliberately much shorter than refreshTimeout:
+// the caller of RefreshAndStore is already blocked on refreshTimeout (30s) via the
+// detached refreshCtx passed in here, so reusing refreshTimeout for this read would
+// stack a second independent 30s window on top — doubling the worst-case wait for no
+// benefit, since a single GetUpstreamTokens call needs nowhere near that budget.
+const upstreamConflictReadTimeout = 5 * time.Second
+
 // upstreamTokenRefresher implements storage.UpstreamTokenRefresher by wrapping
 // a set of upstream OAuth2Providers (keyed by provider name) and
 // UpstreamTokenStorage (for persisting the refreshed tokens). On each refresh
 // call it dispatches to the correct provider based on the expired token's
 // ProviderID.
 //
-// Two layers cooperate to make redeeming a single-use, rotating upstream
-// refresh token safe under concurrency:
+// Two layers cooperate to coordinate redeeming a single-use, rotating upstream
+// refresh token under concurrency:
 //   - sfGroup deduplicates concurrent refreshes by the opaque storage-row
 //     identity returned by UpstreamTokenStorage, but only WITHIN THIS PROCESS
 //     — it saves redundant upstream calls and redis round-trips when this
 //     process alone receives several concurrent requests for the same row.
-//   - CompareAndSwapUpstreamTokens (see refreshAndStore) is what actually
-//     protects correctness ACROSS PROCESSES: every write is conditioned on
-//     the refresh token this call redeemed still being the one stored, so a
-//     replica that loses a cross-process race fails its write instead of
-//     clobbering a winning replica's rotated token. singleflight is an
-//     optimization layered on top of that guarantee, not a substitute for it.
+//   - CompareAndSwapUpstreamTokens (see refreshAndStore) makes the STORED row
+//     deterministic ACROSS PROCESSES: every write is conditioned on the refresh
+//     token this call redeemed still being the one stored, so a replica whose
+//     write loses a cross-process race fails instead of clobbering a winning
+//     replica's rotated token with a stale one. This is a storage-ordering
+//     guarantee, not a guarantee that the redemption itself was safe: both
+//     replicas still call the upstream provider before either writes, so a
+//     strict single-use-rotation provider (RFC 9700 §4.14.2 replay detection)
+//     can still see this as two redemptions of the same refresh token and
+//     revoke the grant regardless of which write wins here — see
+//     docs/arch/11-auth-server-storage.md's "Refresh Coordination Scope" for
+//     the provider-behavior-dependent discussion. singleflight is an
+//     optimization layered on top of the CAS guarantee, not a substitute for it.
 type upstreamTokenRefresher struct {
 	providers            map[string]upstream.OAuth2Provider
 	storage              storage.UpstreamTokenStorage
@@ -208,12 +223,14 @@ func (r *upstreamTokenRefresher) refreshAndStore(
 
 	// expectedRefreshToken is the value this call actually redeemed with the
 	// upstream provider. Writing through CompareAndSwapUpstreamTokens (rather
-	// than an unconditional StoreUpstreamTokens) protects against another
-	// process — a different replica of this auth server sharing this storage —
-	// having already redeemed and persisted a rotation of the SAME refresh
-	// token concurrently: only the replica whose expected value still matches
-	// the stored row may write, so a losing replica cannot clobber the
-	// winner's rotated token with its own now-stale redemption.
+	// than an unconditional StoreUpstreamTokens) makes the STORED row
+	// deterministic when another process — a different replica of this auth
+	// server sharing this storage — is redeeming the same refresh token
+	// concurrently: only the replica whose expected value still matches the
+	// stored row may write, so a losing replica cannot clobber the winner's
+	// rotated token with its own now-stale redemption. This orders the writes;
+	// it does not by itself guarantee the upstream provider accepts both
+	// redemptions (see the type-level doc comment above).
 	expectedRefreshToken := expired.RefreshToken
 
 	if err := r.compareAndSwapWithRetry(ctx, sessionID, expired.ProviderID, expectedRefreshToken, updated); err != nil {
@@ -262,27 +279,36 @@ func (r *upstreamTokenRefresher) refreshAndStore(
 	return updated, nil
 }
 
-// resolveConcurrentRefreshConflict is reached when this call's redemption
-// lost a compare-and-swap race against another process (typically a
-// different replica of this auth server) that refreshed and persisted the same
-// row concurrently — CompareAndSwapUpstreamTokens returned
-// storage.ErrConcurrentRefresh because the stored refresh token had already
-// moved past the value this call redeemed with.
+// resolveConcurrentRefreshConflict is reached after CompareAndSwapUpstreamTokens
+// returns storage.ErrConcurrentRefresh: the stored refresh token no longer
+// matched the value this call redeemed with. That mismatch has two distinct
+// causes this function must tell apart on re-read, not just to pick the right
+// return value but to log something a human can act on:
+//   - Another process (typically a different replica of this auth server)
+//     redeemed and persisted a rotation of the same row first. This IS a
+//     genuine lost race, worth surfacing loudly.
+//   - The row no longer exists at all — deleted by a logout, evicted by TTL,
+//     or never created. This is NOT a race: nothing else needed to "win"
+//     against this call, the row was simply gone before the write. Logging it
+//     the same as the case above would send whoever is on call chasing a
+//     concurrency bug that didn't happen.
 //
-// It re-reads the authoritative row: if that read is unexpired, the other
-// process's write is the correct result for this call to hand back — this
-// call's own redemption produced an access/refresh token pair the IdP (or the
-// winning replica) has already superseded, so it must not be used or written.
-// If the re-read is still expired, missing, or otherwise unusable, the loss is
-// unrecoverable for this attempt: the refresh token this call redeemed is now
-// dead both at the IdP (which enforces single-use) and in storage (the winner
-// overwrote it before this call's CAS ran), so the caller must surface an
-// error — retrying would only redeem the same already-consumed refresh token
-// again.
+// The re-read result decides which happened: an unexpired row means the other
+// process's write is the correct result to hand back to this call — this
+// call's own redemption produced a token pair the IdP (or the winning
+// replica) already superseded, so it must not be used or written. A read that
+// comes back storage.ErrNotFound means the row is gone; CompareAndSwapUpstreamTokens
+// correctly refused to resurrect it (StoreUpstreamTokens would not have). Any
+// other outcome (still expired, or a genuine read error) is ambiguous and
+// treated as the loss it most likely is. In every non-recoverable case the
+// refresh token this call redeemed is unusable going forward — dead at the
+// IdP if it enforces single-use, and either superseded or deliberately absent
+// in storage — so the caller must surface an error rather than retry the same
+// redemption.
 func (r *upstreamTokenRefresher) resolveConcurrentRefreshConflict(
 	ctx context.Context, sessionID, providerID string,
 ) (*storage.UpstreamTokens, error) {
-	readCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
+	readCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), upstreamConflictReadTimeout)
 	defer cancel()
 
 	winner, err := r.storage.GetUpstreamTokens(readCtx, sessionID, providerID)
@@ -294,12 +320,20 @@ func (r *upstreamTokenRefresher) resolveConcurrentRefreshConflict(
 		return winner, nil
 	}
 
-	slog.Error("lost concurrent upstream token refresh race and re-read found no usable winner; "+
-		"the redeemed refresh token is unrecoverable for this attempt",
-		"session_id", sessionID,
-		"provider_id", providerID,
-		"error", err,
-	)
+	if errors.Is(err, storage.ErrNotFound) {
+		slog.Warn("upstream token row no longer exists after a concurrent-refresh conflict; "+
+			"this is expected on logout or TTL eviction and is not necessarily a lost race",
+			"session_id", sessionID,
+			"provider_id", providerID,
+		)
+	} else {
+		slog.Error("lost concurrent upstream token refresh race and re-read found no usable winner; "+
+			"the redeemed refresh token is unrecoverable for this attempt",
+			"session_id", sessionID,
+			"provider_id", providerID,
+			"error", err,
+		)
+	}
 	if err != nil {
 		return nil, fmt.Errorf(
 			"concurrent upstream token refresh for session %q provider %q: %w: %w",

--- a/pkg/authserver/refresher_test.go
+++ b/pkg/authserver/refresher_test.go
@@ -4,9 +4,11 @@
 package authserver
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -986,4 +988,67 @@ func TestUpstreamTokenRefresher_ConcurrentRefreshConflict(t *testing.T) {
 		assert.Nil(t, result)
 		assert.ErrorIs(t, err, storage.ErrConcurrentRefresh)
 	})
+}
+
+// TestUpstreamTokenRefresher_ConcurrentRefreshConflict_LogLevel proves
+// resolveConcurrentRefreshConflict logs a row that no longer exists
+// (ErrNotFound on re-read - e.g. deleted by logout or evicted by TTL) at WARN,
+// not ERROR: it is not a lost race and must not read as one in production
+// logs. Any other unrecoverable re-read outcome still logs at ERROR.
+//
+//nolint:paralleltest // captures the package-global slog.Default(); must not run concurrently with parallel tests
+func TestUpstreamTokenRefresher_ConcurrentRefreshConflict_LogLevel(t *testing.T) {
+	expired := &storage.UpstreamTokens{ProviderID: "github", RefreshToken: "stale", UpstreamSubject: "subject"}
+	redeemed := &upstream.Tokens{AccessToken: "redeemed", RefreshToken: "redeemed-rt", ExpiresAt: time.Now().Add(time.Hour)}
+
+	tests := []struct {
+		name      string
+		reReadErr error
+		wantLevel string
+		wantNot   string
+	}{
+		{
+			name:      "row absent on re-read logs at WARN",
+			reReadErr: fmt.Errorf("%w: row evicted", storage.ErrNotFound),
+			wantLevel: "WARN",
+			wantNot:   "ERROR",
+		},
+		{
+			name:      "other re-read failure logs at ERROR",
+			reReadErr: errors.New("redis timeout"),
+			wantLevel: "ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			t.Cleanup(func() { slog.SetDefault(prev) })
+
+			ctrl := gomock.NewController(t)
+			store := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+			provider := upstreammocks.NewMockOAuth2Provider(ctrl)
+
+			store.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session", "github").
+				Return(storage.UpstreamTokenRowID("row"), nil)
+			gomock.InOrder(
+				store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Return(expired, storage.ErrExpired),
+				store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Return(nil, tt.reReadErr),
+			)
+			provider.EXPECT().RefreshTokens(gomock.Any(), "stale", "subject").Return(redeemed, nil)
+			store.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session", "github", "stale", gomock.Any()).
+				Return(storage.ErrConcurrentRefresh)
+
+			refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
+			_, err := refresher.RefreshAndStore(context.Background(), "session", expired)
+			require.Error(t, err)
+
+			assert.Contains(t, buf.String(), "level="+tt.wantLevel)
+			if tt.wantNot != "" {
+				assert.NotContains(t, buf.String(), "level="+tt.wantNot)
+			}
+		})
+	}
 }

--- a/pkg/authserver/refresher_test.go
+++ b/pkg/authserver/refresher_test.go
@@ -6,6 +6,7 @@ package authserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -63,8 +64,8 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 					}, nil)
 			},
 			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
-				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-1", "github", gomock.Any()).
-					DoAndReturn(func(_ context.Context, _, _ string, tokens *storage.UpstreamTokens) error {
+				s.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-1", "github", "old-refresh", gomock.Any()).
+					DoAndReturn(func(_ context.Context, _, _, _ string, tokens *storage.UpstreamTokens) error {
 						// Verify binding fields are preserved from expired tokens
 						assert.Equal(t, "github", tokens.ProviderID)
 						assert.Equal(t, "user-123", tokens.UserID)
@@ -105,8 +106,8 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 					}, nil)
 			},
 			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
-				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-2", "github", gomock.Any()).
-					DoAndReturn(func(_ context.Context, _, _ string, tokens *storage.UpstreamTokens) error {
+				s.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-2", "github", "old-refresh", gomock.Any()).
+					DoAndReturn(func(_ context.Context, _, _, _ string, tokens *storage.UpstreamTokens) error {
 						assert.Equal(t, "old-refresh", tokens.RefreshToken)
 						return nil
 					})
@@ -134,8 +135,8 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 					}, nil)
 			},
 			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
-				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-bound", "github", gomock.Any()).
-					DoAndReturn(func(_ context.Context, _, _ string, tokens *storage.UpstreamTokens) error {
+				s.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-bound", "github", "old-refresh", gomock.Any()).
+					DoAndReturn(func(_ context.Context, _, _, _ string, tokens *storage.UpstreamTokens) error {
 						assert.Equal(t, sessionBound, tokens.SessionExpiresAt,
 							"refresher must carry SessionExpiresAt forward unchanged")
 						assert.True(t, tokens.ExpiresAt.IsZero(),
@@ -181,8 +182,8 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 					}, nil)
 			},
 			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
-				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-legacy", "github", gomock.Any()).
-					DoAndReturn(func(_ context.Context, _, _ string, tokens *storage.UpstreamTokens) error {
+				s.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-legacy", "github", "old-refresh", gomock.Any()).
+					DoAndReturn(func(_ context.Context, _, _, _ string, tokens *storage.UpstreamTokens) error {
 						assert.False(t, tokens.SessionExpiresAt.IsZero(),
 							"refresher must re-anchor SessionExpiresAt for legacy zero/zero rows")
 						assert.True(t, tokens.ExpiresAt.IsZero(),
@@ -269,7 +270,7 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 					}, nil)
 			},
 			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
-				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-6", "github", gomock.Any()).
+				s.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-6", "github", "old-refresh", gomock.Any()).
 					Times(3).
 					Return(errors.New("redis connection lost"))
 				s.EXPECT().DeleteUpstreamTokensForProvider(gomock.Any(), "session-6", "github").
@@ -294,7 +295,7 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 					}, nil)
 			},
 			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
-				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-7", "github", gomock.Any()).
+				s.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-7", "github", "old-refresh", gomock.Any()).
 					Times(3).
 					Return(errors.New("redis connection lost"))
 				// No DeleteUpstreamTokensForProvider call expected.
@@ -323,9 +324,9 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 			},
 			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
 				gomock.InOrder(
-					s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-8", "github", gomock.Any()).
+					s.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-8", "github", "old-refresh", gomock.Any()).
 						Return(errors.New("transient error")),
-					s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-8", "github", gomock.Any()).
+					s.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-8", "github", "old-refresh", gomock.Any()).
 						Return(nil),
 				)
 				// No DeleteUpstreamTokensForProvider expected.
@@ -339,7 +340,7 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 		{
 			// Regression: when the provider omits id_token on a refresh (common — e.g. Google),
 			// the refresher must carry the original login ID token forward into storage rather
-			// than overwriting the persisted row with an empty string. StoreUpstreamTokens
+			// than overwriting the persisted row with an empty string. CompareAndSwapUpstreamTokens
 			// replaces the whole row, so without the carry-forward the login ID token is
 			// permanently lost after the first refresh cycle.
 			name:      "provider omits id_token on refresh - keeps login ID token",
@@ -355,8 +356,8 @@ func TestUpstreamTokenRefresher_RefreshAndStore(t *testing.T) {
 					}, nil)
 			},
 			setupStorage: func(_ *testing.T, s *storagemocks.MockUpstreamTokenStorage) {
-				s.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-9", "github", gomock.Any()).
-					DoAndReturn(func(_ context.Context, _, _ string, tokens *storage.UpstreamTokens) error {
+				s.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-9", "github", "old-refresh", gomock.Any()).
+					DoAndReturn(func(_ context.Context, _, _, _ string, tokens *storage.UpstreamTokens) error {
 						assert.Equal(t, "old-id-token", tokens.IDToken,
 							"refresher must carry forward the login ID token when provider omits one")
 						return nil
@@ -506,7 +507,7 @@ func TestUpstreamTokenRefresher_SingleflightDedup(t *testing.T) {
 				}, nil
 			})
 		mockStorage.EXPECT().
-			StoreUpstreamTokens(gomock.Any(), "session-1", "github", gomock.Any()).
+			CompareAndSwapUpstreamTokens(gomock.Any(), "session-1", "github", "old-refresh", gomock.Any()).
 			Times(1).
 			Return(nil)
 
@@ -605,7 +606,7 @@ func TestUpstreamTokenRefresher_SingleflightDedup(t *testing.T) {
 					ExpiresAt:   newExpiry,
 				}, nil)
 			mockStorage.EXPECT().
-				StoreUpstreamTokens(gomock.Any(), "session-x", providerID, gomock.Any()).
+				CompareAndSwapUpstreamTokens(gomock.Any(), "session-x", providerID, "rt-"+providerID, gomock.Any()).
 				Times(1).
 				Return(nil)
 			providers[providerID] = mockProvider
@@ -682,8 +683,8 @@ func TestUpstreamTokenRefresher_SingleflightDedup(t *testing.T) {
 					return nil, ctx.Err()
 				}
 			})
-		mockStorage.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-a", "github", gomock.Any()).Times(1).Return(nil)
-		mockStorage.EXPECT().StoreUpstreamTokens(gomock.Any(), "session-b", "github", gomock.Any()).Times(1).Return(nil)
+		mockStorage.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-a", "github", "old-refresh", gomock.Any()).Times(1).Return(nil)
+		mockStorage.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session-b", "github", "old-refresh", gomock.Any()).Times(1).Return(nil)
 
 		refresher := &upstreamTokenRefresher{
 			providers:            map[string]upstream.OAuth2Provider{"github": mockProvider},
@@ -750,7 +751,7 @@ func TestUpstreamTokenRefresher_RowIdentity(t *testing.T) {
 					return nil, ctx.Err()
 				}
 			})
-		store.EXPECT().StoreUpstreamTokens(gomock.Any(), "leader", "github", gomock.Any()).Times(1).Return(nil)
+		store.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "leader", "github", "stale", gomock.Any()).Times(1).Return(nil)
 
 		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
 		var wg sync.WaitGroup
@@ -803,7 +804,7 @@ func TestUpstreamTokenRefresher_RowIdentity(t *testing.T) {
 		store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Times(1).Return(fresh, nil)
 		provider.EXPECT().RefreshTokens(gomock.Any(), "stale", "subject").Times(1).
 			Return(&upstream.Tokens{AccessToken: "fresh", RefreshToken: "rotated", ExpiresAt: time.Now().Add(time.Hour)}, nil)
-		store.EXPECT().StoreUpstreamTokens(gomock.Any(), "session", "github", gomock.Any()).Times(1).Return(nil)
+		store.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session", "github", "stale", gomock.Any()).Times(1).Return(nil)
 
 		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
 		_, err := refresher.RefreshAndStore(context.Background(), "session", expired)
@@ -838,7 +839,7 @@ func TestUpstreamTokenRefresher_RowIdentity(t *testing.T) {
 		store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Times(1).Return(staleButUnflagged, nil)
 		provider.EXPECT().RefreshTokens(gomock.Any(), "stale", "subject").Times(2).
 			Return(&upstream.Tokens{AccessToken: "fresh", RefreshToken: "rotated", ExpiresAt: time.Now().Add(time.Hour)}, nil)
-		store.EXPECT().StoreUpstreamTokens(gomock.Any(), "session", "github", gomock.Any()).Times(2).Return(nil)
+		store.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session", "github", "stale", gomock.Any()).Times(2).Return(nil)
 
 		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
 		_, err := refresher.RefreshAndStore(context.Background(), "session", expired)
@@ -889,5 +890,71 @@ func TestUpstreamTokenRefresher_RowIdentity(t *testing.T) {
 				require.Error(t, err)
 			})
 		}
+	})
+}
+
+// TestUpstreamTokenRefresher_ConcurrentRefreshConflict proves the cross-process
+// coordination path: CompareAndSwapUpstreamTokens failing with
+// storage.ErrConcurrentRefresh means another process (e.g. a different
+// replica of this auth server sharing the same storage) already redeemed and
+// persisted a rotation of the same refresh token this call just redeemed.
+// singleflight cannot catch this — it only dedups within one process — so this
+// exercises the CAS-based cross-process path directly.
+func TestUpstreamTokenRefresher_ConcurrentRefreshConflict(t *testing.T) {
+	t.Parallel()
+
+	expired := &storage.UpstreamTokens{ProviderID: "github", RefreshToken: "stale", UpstreamSubject: "subject"}
+	redeemed := &upstream.Tokens{AccessToken: "redeemed-but-superseded", RefreshToken: "redeemed-rt", ExpiresAt: time.Now().Add(time.Hour)}
+
+	t.Run("winner already refreshed - returns the winner's tokens", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		store := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		provider := upstreammocks.NewMockOAuth2Provider(ctrl)
+		winner := &storage.UpstreamTokens{ProviderID: "github", AccessToken: "winner-access", RefreshToken: "winner-rt", ExpiresAt: time.Now().Add(time.Hour)}
+
+		store.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session", "github").
+			Return(storage.UpstreamTokenRowID("row"), nil)
+		gomock.InOrder(
+			store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Return(expired, storage.ErrExpired),
+			store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Return(winner, nil),
+		)
+		provider.EXPECT().RefreshTokens(gomock.Any(), "stale", "subject").Return(redeemed, nil)
+		store.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session", "github", "stale", gomock.Any()).
+			Return(storage.ErrConcurrentRefresh)
+
+		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
+		result, err := refresher.RefreshAndStore(context.Background(), "session", expired)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, "winner-access", result.AccessToken,
+			"a call that loses the CAS race must return the winning replica's tokens, not its own superseded redemption")
+		assert.Equal(t, "winner-rt", result.RefreshToken)
+	})
+
+	t.Run("winner unavailable - surfaces an error instead of retrying the dead refresh token", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		store := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		provider := upstreammocks.NewMockOAuth2Provider(ctrl)
+
+		store.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session", "github").
+			Return(storage.UpstreamTokenRowID("row"), nil)
+		gomock.InOrder(
+			store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Return(expired, storage.ErrExpired),
+			// The post-conflict re-read finds nothing usable: absent, or still
+			// expired. Either way this call cannot recover a usable token.
+			store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").
+				Return(nil, fmt.Errorf("%w: row evicted", storage.ErrNotFound)),
+		)
+		provider.EXPECT().RefreshTokens(gomock.Any(), "stale", "subject").Return(redeemed, nil)
+		store.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session", "github", "stale", gomock.Any()).
+			Return(storage.ErrConcurrentRefresh)
+
+		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
+		result, err := refresher.RefreshAndStore(context.Background(), "session", expired)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, storage.ErrConcurrentRefresh)
 	})
 }

--- a/pkg/authserver/refresher_test.go
+++ b/pkg/authserver/refresher_test.go
@@ -957,4 +957,33 @@ func TestUpstreamTokenRefresher_ConcurrentRefreshConflict(t *testing.T) {
 		assert.Nil(t, result)
 		assert.ErrorIs(t, err, storage.ErrConcurrentRefresh)
 	})
+
+	t.Run("winner still expired on re-read - surfaces an error instead of retrying the dead refresh token", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		store := storagemocks.NewMockUpstreamTokenStorage(ctrl)
+		provider := upstreammocks.NewMockOAuth2Provider(ctrl)
+		// The re-read succeeds (no error) but returns a row that is itself still
+		// expired - a materially different shape than the "not found" case above
+		// (nil, err) - and must be treated the same way: unrecoverable for this call.
+		stillExpired := &storage.UpstreamTokens{
+			ProviderID: "github", RefreshToken: "someone-elses-rt", ExpiresAt: time.Now().Add(-time.Hour),
+		}
+
+		store.EXPECT().ResolveUpstreamTokenRowID(gomock.Any(), "session", "github").
+			Return(storage.UpstreamTokenRowID("row"), nil)
+		gomock.InOrder(
+			store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Return(expired, storage.ErrExpired),
+			store.EXPECT().GetUpstreamTokens(gomock.Any(), "session", "github").Return(stillExpired, nil),
+		)
+		provider.EXPECT().RefreshTokens(gomock.Any(), "stale", "subject").Return(redeemed, nil)
+		store.EXPECT().CompareAndSwapUpstreamTokens(gomock.Any(), "session", "github", "stale", gomock.Any()).
+			Return(storage.ErrConcurrentRefresh)
+
+		refresher := &upstreamTokenRefresher{providers: map[string]upstream.OAuth2Provider{"github": provider}, storage: store}
+		result, err := refresher.RefreshAndStore(context.Background(), "session", expired)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, storage.ErrConcurrentRefresh)
+	})
 }

--- a/pkg/authserver/storage/memory.go
+++ b/pkg/authserver/storage/memory.go
@@ -1051,6 +1051,44 @@ func (s *MemoryStorage) StoreUpstreamTokens(_ context.Context, sessionID, provid
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.storeUpstreamTokensLocked(upstreamKey{sessionID, providerName}, tokens)
+	return nil
+}
+
+// CompareAndSwapUpstreamTokens stores tokens for (sessionID, providerName)
+// only if the refresh token currently held there equals expectedRefreshToken.
+// See the interface doc (UpstreamTokenStorage.CompareAndSwapUpstreamTokens)
+// for the coordination contract. The compare-then-write happens under s.mu,
+// so it is atomic with respect to every other reader/writer of this backend.
+func (s *MemoryStorage) CompareAndSwapUpstreamTokens(
+	_ context.Context, sessionID, providerName, expectedRefreshToken string, tokens *UpstreamTokens,
+) error {
+	if sessionID == "" {
+		return fosite.ErrInvalidRequest.WithHint("session ID cannot be empty")
+	}
+	if providerName == "" {
+		return fosite.ErrInvalidRequest.WithHint("provider name cannot be empty")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := upstreamKey{sessionID, providerName}
+	var currentRefreshToken string
+	if entry, ok := s.upstreamTokens[key]; ok && entry.value != nil {
+		currentRefreshToken = entry.value.RefreshToken
+	}
+	if currentRefreshToken != expectedRefreshToken {
+		return ErrConcurrentRefresh
+	}
+
+	s.storeUpstreamTokensLocked(key, tokens)
+	return nil
+}
+
+// storeUpstreamTokensLocked writes tokens for key, replacing any existing
+// entry. Callers must hold s.mu for writing.
+func (s *MemoryStorage) storeUpstreamTokensLocked(key upstreamKey, tokens *UpstreamTokens) {
 	now := time.Now()
 	// Add DefaultRefreshTokenTTL beyond access token expiry so the refresh token
 	// survives in storage for transparent token refresh by the middleware.
@@ -1068,28 +1106,11 @@ func (s *MemoryStorage) StoreUpstreamTokens(_ context.Context, sessionID, provid
 		return time.Time{} // non-expiring token with no known session bound
 	}()
 
-	// Make a defensive copy to prevent aliasing issues
-	var tokensCopy *UpstreamTokens
-	if tokens != nil {
-		tokensCopy = &UpstreamTokens{
-			ProviderID:       tokens.ProviderID,
-			AccessToken:      tokens.AccessToken,
-			RefreshToken:     tokens.RefreshToken,
-			IDToken:          tokens.IDToken,
-			ExpiresAt:        tokens.ExpiresAt,
-			SessionExpiresAt: tokens.SessionExpiresAt,
-			UserID:           tokens.UserID,
-			UpstreamSubject:  tokens.UpstreamSubject,
-			ClientID:         tokens.ClientID,
-		}
-	}
-
-	s.upstreamTokens[upstreamKey{sessionID, providerName}] = &timedEntry[*UpstreamTokens]{
-		value:     tokensCopy,
+	s.upstreamTokens[key] = &timedEntry[*UpstreamTokens]{
+		value:     cloneUpstreamTokens(tokens),
 		createdAt: now,
 		expiresAt: expiresAt,
 	}
-	return nil
 }
 
 // cloneUpstreamTokens returns a field-by-field copy of t, or nil if t is nil.

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -1230,6 +1230,26 @@ func TestMemoryStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
 		})
 	})
 
+	t.Run("empty expected value against an already-populated row returns ErrConcurrentRefresh", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
+				AccessToken: "existing-access", RefreshToken: "existing-refresh",
+			}))
+
+			// "" must never be usable to silently overwrite a row that already
+			// carries a refresh token - it only matches a genuinely absent row.
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "", &UpstreamTokens{
+				AccessToken: "attacker-access", RefreshToken: "attacker-refresh",
+			})
+			require.ErrorIs(t, err, ErrConcurrentRefresh)
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "session", "provider-a")
+			require.NoError(t, err)
+			assert.Equal(t, "existing-access", retrieved.AccessToken,
+				"the existing row must survive a mismatched empty-expected CAS attempt")
+		})
+	})
+
 	t.Run("empty session ID or provider name is rejected", func(t *testing.T) {
 		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 			assert.Error(t, s.CompareAndSwapUpstreamTokens(ctx, "", "provider-a", "", &UpstreamTokens{}))

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -1217,6 +1217,28 @@ func TestMemoryStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
 		})
 	})
 
+	t.Run("does not resurrect a row deleted between read and write", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
+				AccessToken: "old-access", RefreshToken: "old-refresh",
+			}))
+
+			// Simulates a logout (or TTL eviction) racing a refresh: the row is
+			// gone by the time the refresher's redemption tries to persist.
+			require.NoError(t, s.DeleteUpstreamTokensForProvider(ctx, "session", "provider-a"))
+
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "old-refresh", &UpstreamTokens{
+				AccessToken: "redeemed-access", RefreshToken: "redeemed-refresh",
+			})
+			require.ErrorIs(t, err, ErrConcurrentRefresh,
+				"CAS must refuse to write over an absent row rather than resurrect it "+
+					"(unlike StoreUpstreamTokens, which would happily recreate it)")
+
+			_, err = s.GetUpstreamTokens(ctx, "session", "provider-a")
+			requireNotFoundError(t, err)
+		})
+	})
+
 	t.Run("empty expected value matches an absent row - first write succeeds", func(t *testing.T) {
 		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
 			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "", &UpstreamTokens{
@@ -1237,7 +1259,9 @@ func TestMemoryStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
 			}))
 
 			// "" must never be usable to silently overwrite a row that already
-			// carries a refresh token - it only matches a genuinely absent row.
+			// carries a non-empty refresh token. ("" also matches a present row
+			// whose RefreshToken is itself empty, or a nil-tokens row - this test
+			// pins only the has-a-real-refresh-token case, which must be rejected.)
 			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "", &UpstreamTokens{
 				AccessToken: "attacker-access", RefreshToken: "attacker-refresh",
 			})

--- a/pkg/authserver/storage/memory_test.go
+++ b/pkg/authserver/storage/memory_test.go
@@ -1171,6 +1171,73 @@ func TestMemoryStorage_UpstreamTokens(t *testing.T) {
 	})
 }
 
+// TestMemoryStorage_CompareAndSwapUpstreamTokens exercises the coordination
+// primitive for redeeming a single-use, rotating upstream refresh
+// token safely: a write only lands if the caller's expected refresh token
+// still matches what is currently stored.
+func TestMemoryStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matching expected value writes and returns nil", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
+				AccessToken: "old-access", RefreshToken: "old-refresh",
+			}))
+
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "old-refresh", &UpstreamTokens{
+				AccessToken: "new-access", RefreshToken: "new-refresh",
+			})
+			require.NoError(t, err)
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "session", "provider-a")
+			require.NoError(t, err)
+			assert.Equal(t, "new-access", retrieved.AccessToken)
+			assert.Equal(t, "new-refresh", retrieved.RefreshToken)
+		})
+	})
+
+	t.Run("stale expected value returns ErrConcurrentRefresh and leaves the row untouched", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
+				AccessToken: "winner-access", RefreshToken: "winner-refresh",
+			}))
+
+			// A loser redeemed "old-refresh" (the value before the winner's write
+			// above) and now tries to persist its own rotation.
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "old-refresh", &UpstreamTokens{
+				AccessToken: "loser-access", RefreshToken: "loser-refresh",
+			})
+			require.ErrorIs(t, err, ErrConcurrentRefresh)
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "session", "provider-a")
+			require.NoError(t, err)
+			assert.Equal(t, "winner-access", retrieved.AccessToken,
+				"the winner's write must survive a losing CAS attempt")
+			assert.Equal(t, "winner-refresh", retrieved.RefreshToken)
+		})
+	})
+
+	t.Run("empty expected value matches an absent row - first write succeeds", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "", &UpstreamTokens{
+				AccessToken: "first-access", RefreshToken: "first-refresh",
+			})
+			require.NoError(t, err)
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "session", "provider-a")
+			require.NoError(t, err)
+			assert.Equal(t, "first-access", retrieved.AccessToken)
+		})
+	})
+
+	t.Run("empty session ID or provider name is rejected", func(t *testing.T) {
+		withStorage(t, func(ctx context.Context, s *MemoryStorage) {
+			assert.Error(t, s.CompareAndSwapUpstreamTokens(ctx, "", "provider-a", "", &UpstreamTokens{}))
+			assert.Error(t, s.CompareAndSwapUpstreamTokens(ctx, "session", "", "", &UpstreamTokens{}))
+		})
+	})
+}
+
 func TestMemoryStorage_GetLatestUpstreamTokensForUser(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/authserver/storage/mocks/mock_storage.go
+++ b/pkg/authserver/storage/mocks/mock_storage.go
@@ -325,6 +325,20 @@ func (m *MockUpstreamTokenStorage) EXPECT() *MockUpstreamTokenStorageMockRecorde
 	return m.recorder
 }
 
+// CompareAndSwapUpstreamTokens mocks base method.
+func (m *MockUpstreamTokenStorage) CompareAndSwapUpstreamTokens(ctx context.Context, sessionID, providerName, expectedRefreshToken string, tokens *storage.UpstreamTokens) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CompareAndSwapUpstreamTokens", ctx, sessionID, providerName, expectedRefreshToken, tokens)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CompareAndSwapUpstreamTokens indicates an expected call of CompareAndSwapUpstreamTokens.
+func (mr *MockUpstreamTokenStorageMockRecorder) CompareAndSwapUpstreamTokens(ctx, sessionID, providerName, expectedRefreshToken, tokens any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompareAndSwapUpstreamTokens", reflect.TypeOf((*MockUpstreamTokenStorage)(nil).CompareAndSwapUpstreamTokens), ctx, sessionID, providerName, expectedRefreshToken, tokens)
+}
+
 // DeleteUpstreamTokens mocks base method.
 func (m *MockUpstreamTokenStorage) DeleteUpstreamTokens(ctx context.Context, sessionID string) error {
 	m.ctrl.T.Helper()
@@ -641,6 +655,20 @@ func (m *MockStorage) Close() error {
 func (mr *MockStorageMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStorage)(nil).Close))
+}
+
+// CompareAndSwapUpstreamTokens mocks base method.
+func (m *MockStorage) CompareAndSwapUpstreamTokens(ctx context.Context, sessionID, providerName, expectedRefreshToken string, tokens *storage.UpstreamTokens) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CompareAndSwapUpstreamTokens", ctx, sessionID, providerName, expectedRefreshToken, tokens)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CompareAndSwapUpstreamTokens indicates an expected call of CompareAndSwapUpstreamTokens.
+func (mr *MockStorageMockRecorder) CompareAndSwapUpstreamTokens(ctx, sessionID, providerName, expectedRefreshToken, tokens any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompareAndSwapUpstreamTokens", reflect.TypeOf((*MockStorage)(nil).CompareAndSwapUpstreamTokens), ctx, sessionID, providerName, expectedRefreshToken, tokens)
 }
 
 // CreateAccessTokenSession mocks base method.

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1297,6 +1297,87 @@ end
 return 1
 `)
 
+// casUpstreamTokensScript is the compare-and-swap sibling of
+// storeUpstreamTokensScript: it additionally gates the write on the existing
+// row's refresh_token matching ARGV[5] before doing anything else, returning
+// 0 (no write performed) on a mismatch instead of 1. This is what makes
+// CompareAndSwapUpstreamTokens safe for redeeming a single-use, rotating
+// upstream refresh token across multiple replicas of an application sharing
+// this Redis: a replica whose read is stale by the time it tries to write
+// loses the CAS instead of clobbering a winning replica's rotated token.
+//
+// KEYS[1] = per-provider token key
+// KEYS[2] = session index set key
+// ARGV[1] = new token data (JSON or "null" marker)
+// ARGV[2] = TTL in milliseconds
+// ARGV[3] = new UserID ("" if no user)
+// ARGV[4] = user upstream set key prefix
+// ARGV[5] = expected refresh token ("" means "no row exists yet, or the
+//
+//	existing row carries no refresh token")
+//
+// The write-and-index body below (from "local ttlMs" through "return 1") is
+// intentionally identical to storeUpstreamTokensScript's — see that script's
+// doc comment for the index-TTL invariants and the Cluster hash-tag
+// requirement, both of which apply here unchanged. Keep the two bodies in
+// sync if either changes.
+var casUpstreamTokensScript = redis.NewScript(`
+local oldUserID = ""
+local existingRefreshToken = ""
+local existing = redis.call('GET', KEYS[1])
+if existing and existing ~= "null" then
+    local ok, decoded = pcall(cjson.decode, existing)
+    if ok and type(decoded) == "table" then
+        if decoded.user_id and decoded.user_id ~= "" then
+            oldUserID = decoded.user_id
+        end
+        if decoded.refresh_token then
+            existingRefreshToken = decoded.refresh_token
+        end
+    end
+end
+
+if existingRefreshToken ~= ARGV[5] then
+    return 0
+end
+
+local ttlMs = tonumber(ARGV[2])
+if ttlMs > 0 then
+    redis.call('SET', KEYS[1], ARGV[1], 'PX', ttlMs)
+else
+    redis.call('SET', KEYS[1], ARGV[1])
+end
+
+local idxExisted = redis.call('EXISTS', KEYS[2])
+redis.call('SADD', KEYS[2], KEYS[1])
+
+if ttlMs == 0 then
+    redis.call('PERSIST', KEYS[2])
+elseif idxExisted == 0 then
+    redis.call('PEXPIRE', KEYS[2], ttlMs)
+else
+    local idxTTL = redis.call('PTTL', KEYS[2])
+    if idxTTL == -1 then
+        -- A previous non-expiring write PERSIST'd it. Leave it alone.
+    elseif idxTTL < ttlMs then
+        redis.call('PEXPIRE', KEYS[2], ttlMs)
+    end
+end
+
+local newUserID = ARGV[3]
+local setPrefix = ARGV[4]
+
+if oldUserID ~= "" and oldUserID ~= newUserID then
+    redis.call('SREM', setPrefix .. oldUserID, KEYS[1])
+end
+
+if newUserID ~= "" then
+    redis.call('SADD', setPrefix .. newUserID, KEYS[1])
+end
+
+return 1
+`)
+
 // marshalUpstreamTokensWithTTL marshals tokens and calculates TTL.
 func marshalUpstreamTokensWithTTL(tokens *UpstreamTokens) ([]byte, time.Duration, error) {
 	if tokens == nil {
@@ -1389,6 +1470,55 @@ func (s *RedisStorage) StoreUpstreamTokens(ctx context.Context, sessionID, provi
 	).Result()
 	if err != nil {
 		return fmt.Errorf("failed to store upstream tokens: %w", err)
+	}
+
+	return nil
+}
+
+// CompareAndSwapUpstreamTokens stores tokens for (sessionID, providerName)
+// only if the refresh token currently stored there equals
+// expectedRefreshToken; see the interface doc
+// (UpstreamTokenStorage.CompareAndSwapUpstreamTokens) for the coordination
+// contract. Uses casUpstreamTokensScript so the comparison and the write (and
+// its index maintenance) happen as one atomic Redis operation.
+func (s *RedisStorage) CompareAndSwapUpstreamTokens(
+	ctx context.Context, sessionID, providerName, expectedRefreshToken string, tokens *UpstreamTokens,
+) error {
+	if sessionID == "" {
+		return fosite.ErrInvalidRequest.WithHint("session ID cannot be empty")
+	}
+	if providerName == "" {
+		return fosite.ErrInvalidRequest.WithHint("provider name cannot be empty")
+	}
+
+	key := redisUpstreamKey(s.keyPrefix, sessionID, providerName)
+	idxKey := redisSetKey(s.keyPrefix, KeyTypeUpstreamIdx, sessionID)
+
+	data, ttl, err := marshalUpstreamTokensWithTTL(tokens)
+	if err != nil {
+		return err
+	}
+
+	newUserID := ""
+	if tokens != nil {
+		newUserID = tokens.UserID
+	}
+
+	userSetKeyPrefix := s.keyPrefix + KeyTypeUserUpstream + ":"
+
+	wrote, err := casUpstreamTokensScript.Run(ctx, s.client,
+		[]string{key, idxKey},
+		string(data),
+		ttl.Milliseconds(),
+		newUserID,
+		userSetKeyPrefix,
+		expectedRefreshToken,
+	).Int64()
+	if err != nil {
+		return fmt.Errorf("failed to compare-and-swap upstream tokens: %w", err)
+	}
+	if wrote == 0 {
+		return ErrConcurrentRefresh
 	}
 
 	return nil

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1312,10 +1312,13 @@ return 1
 // storeUpstreamTokensScript: it additionally gates the write on the existing
 // row's refresh_token matching ARGV[5] before doing anything else, returning
 // 0 (no write performed) on a mismatch instead of 1. This is what makes
-// CompareAndSwapUpstreamTokens safe for redeeming a single-use, rotating
-// upstream refresh token across multiple replicas of an application sharing
-// this Redis: a replica whose read is stale by the time it tries to write
-// loses the CAS instead of clobbering a winning replica's rotated token.
+// CompareAndSwapUpstreamTokens's stored row deterministic when redeeming a
+// single-use, rotating upstream refresh token across multiple replicas of an
+// application sharing this Redis: a replica whose read is stale by the time
+// it tries to write loses the CAS instead of clobbering a winning replica's
+// rotated token. (This orders writes to storage; it is not by itself a
+// guarantee that the redemption is safe at the upstream provider — see the
+// CompareAndSwapUpstreamTokens interface doc.)
 //
 // KEYS[1] = per-provider token key
 // KEYS[2] = session index set key

--- a/pkg/authserver/storage/redis.go
+++ b/pkg/authserver/storage/redis.go
@@ -1227,7 +1227,18 @@ if existing and existing ~= "null" then
         oldUserID = decoded.user_id
     end
 end
+` + upstreamRowWriteAndIndexScriptBody)
 
+// upstreamRowWriteAndIndexScriptBody is the write-and-index Lua fragment
+// shared verbatim by storeUpstreamTokensScript (unconditional overwrite) and
+// casUpstreamTokensScript (compare-and-swap): it SETs the new value, then
+// maintains the session index set's TTL/PERSIST invariants (see the comment
+// above), then updates the user reverse-index sets. Both scripts read the
+// existing row into oldUserID (and, for the CAS script, existingRefreshToken)
+// before this fragment runs, so it is textually identical between the two —
+// concatenated in Go rather than duplicated, so a future change to one script's
+// write/index behavior cannot silently drift from the other's.
+const upstreamRowWriteAndIndexScriptBody = `
 local ttlMs = tonumber(ARGV[2])
 if ttlMs > 0 then
     redis.call('SET', KEYS[1], ARGV[1], 'PX', ttlMs)
@@ -1295,7 +1306,7 @@ if newUserID ~= "" then
 end
 
 return 1
-`)
+`
 
 // casUpstreamTokensScript is the compare-and-swap sibling of
 // storeUpstreamTokensScript: it additionally gates the write on the existing
@@ -1316,11 +1327,8 @@ return 1
 //
 //	existing row carries no refresh token")
 //
-// The write-and-index body below (from "local ttlMs" through "return 1") is
-// intentionally identical to storeUpstreamTokensScript's — see that script's
-// doc comment for the index-TTL invariants and the Cluster hash-tag
-// requirement, both of which apply here unchanged. Keep the two bodies in
-// sync if either changes.
+// The write-and-index body is shared verbatim with storeUpstreamTokensScript
+// via upstreamRowWriteAndIndexScriptBody — see that constant's doc comment.
 var casUpstreamTokensScript = redis.NewScript(`
 local oldUserID = ""
 local existingRefreshToken = ""
@@ -1340,43 +1348,7 @@ end
 if existingRefreshToken ~= ARGV[5] then
     return 0
 end
-
-local ttlMs = tonumber(ARGV[2])
-if ttlMs > 0 then
-    redis.call('SET', KEYS[1], ARGV[1], 'PX', ttlMs)
-else
-    redis.call('SET', KEYS[1], ARGV[1])
-end
-
-local idxExisted = redis.call('EXISTS', KEYS[2])
-redis.call('SADD', KEYS[2], KEYS[1])
-
-if ttlMs == 0 then
-    redis.call('PERSIST', KEYS[2])
-elseif idxExisted == 0 then
-    redis.call('PEXPIRE', KEYS[2], ttlMs)
-else
-    local idxTTL = redis.call('PTTL', KEYS[2])
-    if idxTTL == -1 then
-        -- A previous non-expiring write PERSIST'd it. Leave it alone.
-    elseif idxTTL < ttlMs then
-        redis.call('PEXPIRE', KEYS[2], ttlMs)
-    end
-end
-
-local newUserID = ARGV[3]
-local setPrefix = ARGV[4]
-
-if oldUserID ~= "" and oldUserID ~= newUserID then
-    redis.call('SREM', setPrefix .. oldUserID, KEYS[1])
-end
-
-if newUserID ~= "" then
-    redis.call('SADD', setPrefix .. newUserID, KEYS[1])
-end
-
-return 1
-`)
+` + upstreamRowWriteAndIndexScriptBody)
 
 // marshalUpstreamTokensWithTTL marshals tokens and calculates TTL.
 func marshalUpstreamTokensWithTTL(tokens *UpstreamTokens) ([]byte, time.Duration, error) {

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -2117,6 +2117,28 @@ func TestRedisStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
 		})
 	})
 
+	t.Run("does not resurrect a row deleted between read and write", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
+				AccessToken: "old-access", RefreshToken: "old-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			}))
+
+			// Simulates a logout (or TTL eviction) racing a refresh: the row is
+			// gone by the time the refresher's redemption tries to persist.
+			require.NoError(t, s.DeleteUpstreamTokensForProvider(ctx, "session", "provider-a"))
+
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "old-refresh", &UpstreamTokens{
+				AccessToken: "redeemed-access", RefreshToken: "redeemed-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			})
+			require.ErrorIs(t, err, ErrConcurrentRefresh,
+				"CAS must refuse to write over an absent row rather than resurrect it "+
+					"(unlike StoreUpstreamTokens, which would happily recreate it)")
+
+			_, err = s.GetUpstreamTokens(ctx, "session", "provider-a")
+			requireRedisNotFoundError(t, err)
+		})
+	})
+
 	t.Run("empty expected value matches an absent row - first write succeeds", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
 			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "", &UpstreamTokens{
@@ -2137,7 +2159,9 @@ func TestRedisStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
 			}))
 
 			// "" must never be usable to silently overwrite a row that already
-			// carries a refresh token - it only matches a genuinely absent row.
+			// carries a non-empty refresh token. ("" also matches a present row
+			// whose RefreshToken is itself empty, or a nil-tokens row - this test
+			// pins only the has-a-real-refresh-token case, which must be rejected.)
 			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "", &UpstreamTokens{
 				AccessToken: "attacker-access", RefreshToken: "attacker-refresh", ExpiresAt: time.Now().Add(time.Hour),
 			})

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -2046,6 +2046,120 @@ func TestRedisStorage_UpstreamTokens(t *testing.T) {
 
 }
 
+// TestRedisStorage_CompareAndSwapUpstreamTokens exercises the coordination
+// primitive for redeeming a single-use, rotating upstream refresh
+// token safely across multiple replicas of an application sharing this Redis:
+// a write only lands if the caller's expected refresh token still matches
+// what is currently stored, via casUpstreamTokensScript.
+func TestRedisStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matching expected value writes and returns nil", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
+				AccessToken: "old-access", RefreshToken: "old-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			}))
+
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "old-refresh", &UpstreamTokens{
+				AccessToken: "new-access", RefreshToken: "new-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			})
+			require.NoError(t, err)
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "session", "provider-a")
+			require.NoError(t, err)
+			assert.Equal(t, "new-access", retrieved.AccessToken)
+			assert.Equal(t, "new-refresh", retrieved.RefreshToken)
+		})
+	})
+
+	t.Run("stale expected value returns ErrConcurrentRefresh and leaves the row untouched", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
+				AccessToken: "winner-access", RefreshToken: "winner-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			}))
+
+			// A loser redeemed "old-refresh" (the value before the winner's write
+			// above) and now tries to persist its own rotation.
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "old-refresh", &UpstreamTokens{
+				AccessToken: "loser-access", RefreshToken: "loser-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			})
+			require.ErrorIs(t, err, ErrConcurrentRefresh)
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "session", "provider-a")
+			require.NoError(t, err)
+			assert.Equal(t, "winner-access", retrieved.AccessToken,
+				"the winner's write must survive a losing CAS attempt")
+			assert.Equal(t, "winner-refresh", retrieved.RefreshToken)
+		})
+	})
+
+	t.Run("empty expected value matches an absent row - first write succeeds", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "", &UpstreamTokens{
+				AccessToken: "first-access", RefreshToken: "first-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			})
+			require.NoError(t, err)
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "session", "provider-a")
+			require.NoError(t, err)
+			assert.Equal(t, "first-access", retrieved.AccessToken)
+		})
+	})
+
+	t.Run("concurrent CAS attempts against the same row - exactly one wins", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
+				AccessToken: "old-access", RefreshToken: "shared-old-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			}))
+
+			const n = 10
+			errs := make([]error, n)
+			var wg sync.WaitGroup
+			wg.Add(n)
+			for i := range n {
+				go func(i int) {
+					defer wg.Done()
+					errs[i] = s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "shared-old-refresh", &UpstreamTokens{
+						AccessToken:  fmt.Sprintf("access-%d", i),
+						RefreshToken: fmt.Sprintf("refresh-%d", i),
+						ExpiresAt:    time.Now().Add(time.Hour),
+					})
+				}(i)
+			}
+			wg.Wait()
+
+			successes, conflicts := 0, 0
+			for _, err := range errs {
+				switch {
+				case err == nil:
+					successes++
+				case errors.Is(err, ErrConcurrentRefresh):
+					conflicts++
+				default:
+					require.NoError(t, err, "unexpected error from concurrent CAS")
+				}
+			}
+			assert.Equal(t, 1, successes,
+				"exactly one of %d concurrent CAS attempts against the same row must win", n)
+			assert.Equal(t, n-1, conflicts,
+				"every other attempt must observe ErrConcurrentRefresh, never silently overwrite the winner")
+
+			// The stored row must be exactly one of the attempted writes, never a
+			// mix (which would be impossible anyway under SET, but pins the intent).
+			retrieved, err := s.GetUpstreamTokens(ctx, "session", "provider-a")
+			require.NoError(t, err)
+			assert.Contains(t, retrieved.RefreshToken, "refresh-")
+		})
+	})
+
+	t.Run("empty session ID or provider name is rejected", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			assert.Error(t, s.CompareAndSwapUpstreamTokens(ctx, "", "provider-a", "", &UpstreamTokens{}))
+			assert.Error(t, s.CompareAndSwapUpstreamTokens(ctx, "session", "", "", &UpstreamTokens{}))
+		})
+	})
+}
+
 // --- Bulk Migration Tests ---
 
 func TestRedisStorage_MigrateLegacyUpstreamData(t *testing.T) {

--- a/pkg/authserver/storage/redis_test.go
+++ b/pkg/authserver/storage/redis_test.go
@@ -2055,13 +2055,13 @@ func TestRedisStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
 	t.Parallel()
 
 	t.Run("matching expected value writes and returns nil", func(t *testing.T) {
-		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, mr *miniredis.Miniredis) {
 			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
-				AccessToken: "old-access", RefreshToken: "old-refresh", ExpiresAt: time.Now().Add(time.Hour),
+				AccessToken: "old-access", RefreshToken: "old-refresh", UserID: "user-1", ExpiresAt: time.Now().Add(time.Hour),
 			}))
 
 			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "old-refresh", &UpstreamTokens{
-				AccessToken: "new-access", RefreshToken: "new-refresh", ExpiresAt: time.Now().Add(time.Hour),
+				AccessToken: "new-access", RefreshToken: "new-refresh", UserID: "user-2", ExpiresAt: time.Now().Add(time.Hour),
 			})
 			require.NoError(t, err)
 
@@ -2069,6 +2069,30 @@ func TestRedisStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "new-access", retrieved.AccessToken)
 			assert.Equal(t, "new-refresh", retrieved.RefreshToken)
+
+			// A successful CAS write must run the same index/TTL maintenance as
+			// StoreUpstreamTokens: the shared Lua body (see
+			// upstreamTokenWriteAndIndexScriptBody) must have applied the session
+			// index TTL and rolled the user reverse-index from the old to the new
+			// UserID.
+			key := redisUpstreamKey(s.keyPrefix, "session", "provider-a")
+			idxKey := redisSetKey(s.keyPrefix, KeyTypeUpstreamIdx, "session")
+			assert.Greater(t, mr.TTL(idxKey), time.Duration(0),
+				"session index set must carry a TTL after an expiring CAS write")
+			members, err := mr.SMembers(idxKey)
+			require.NoError(t, err)
+			assert.Contains(t, members, key, "session index set must reference the written row")
+
+			oldUserSetKey := redisSetKey(s.keyPrefix, KeyTypeUserUpstream, "user-1")
+			oldMembers, _ := mr.SMembers(oldUserSetKey)
+			assert.NotContains(t, oldMembers, key,
+				"the old UserID's reverse index must be cleared by a CAS write that changes UserID")
+
+			newUserSetKey := redisSetKey(s.keyPrefix, KeyTypeUserUpstream, "user-2")
+			newMembers, err := mr.SMembers(newUserSetKey)
+			require.NoError(t, err)
+			assert.Contains(t, newMembers, key,
+				"the new UserID's reverse index must be updated by the CAS write")
 		})
 	})
 
@@ -2106,6 +2130,26 @@ func TestRedisStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
 		})
 	})
 
+	t.Run("empty expected value against an already-populated row returns ErrConcurrentRefresh", func(t *testing.T) {
+		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
+			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
+				AccessToken: "existing-access", RefreshToken: "existing-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			}))
+
+			// "" must never be usable to silently overwrite a row that already
+			// carries a refresh token - it only matches a genuinely absent row.
+			err := s.CompareAndSwapUpstreamTokens(ctx, "session", "provider-a", "", &UpstreamTokens{
+				AccessToken: "attacker-access", RefreshToken: "attacker-refresh", ExpiresAt: time.Now().Add(time.Hour),
+			})
+			require.ErrorIs(t, err, ErrConcurrentRefresh)
+
+			retrieved, err := s.GetUpstreamTokens(ctx, "session", "provider-a")
+			require.NoError(t, err)
+			assert.Equal(t, "existing-access", retrieved.AccessToken,
+				"the existing row must survive a mismatched empty-expected CAS attempt")
+		})
+	})
+
 	t.Run("concurrent CAS attempts against the same row - exactly one wins", func(t *testing.T) {
 		withRedisStorage(t, func(ctx context.Context, s *RedisStorage, _ *miniredis.Miniredis) {
 			require.NoError(t, s.StoreUpstreamTokens(ctx, "session", "provider-a", &UpstreamTokens{
@@ -2126,7 +2170,17 @@ func TestRedisStorage_CompareAndSwapUpstreamTokens(t *testing.T) {
 					})
 				}(i)
 			}
-			wg.Wait()
+
+			done := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timeout waiting for concurrent CAS attempts")
+			}
 
 			successes, conflicts := 0, 0
 			for _, err := range errs {

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -65,6 +65,15 @@ var (
 	// fosite.ErrAccessDenied instead of treating the refusal as an internal
 	// server error.
 	ErrUserNotProvisioned = errors.New("storage: user not provisioned")
+
+	// ErrConcurrentRefresh is returned by
+	// UpstreamTokenStorage.CompareAndSwapUpstreamTokens when the currently
+	// stored refresh token no longer equals the caller's expected value,
+	// meaning another writer (a concurrent refresh in this process or another
+	// replica sharing the same storage) already moved the row past it. The
+	// caller's own redemption is stale and must not be written; see
+	// CompareAndSwapUpstreamTokens for the coordination contract.
+	ErrConcurrentRefresh = errors.New("storage: upstream token row changed concurrently")
 )
 
 // DefaultPendingAuthorizationTTL is the default TTL for pending authorization requests.
@@ -780,7 +789,49 @@ type UpstreamTokenStorage interface {
 
 	// StoreUpstreamTokens stores the upstream IDP tokens for a session and provider.
 	// The providerName identifies which upstream provider these tokens belong to.
+	//
+	// This is an unconditional overwrite: it does not check what is currently
+	// stored. A refresher redeeming a single-use, rotating refresh token MUST
+	// use CompareAndSwapUpstreamTokens instead, so that a redemption raced by
+	// another process cannot silently clobber a winning write with a stale
+	// one. StoreUpstreamTokens remains correct for every other writer (initial
+	// login, the OAuth callback), which has no prior row to race against.
 	StoreUpstreamTokens(ctx context.Context, sessionID, providerName string, tokens *UpstreamTokens) error
+
+	// CompareAndSwapUpstreamTokens stores tokens for (sessionID, providerName)
+	// only if the refresh token currently stored there equals
+	// expectedRefreshToken (pass "" to require that no row currently exists,
+	// or that the existing row carries no refresh token). Returns
+	// ErrConcurrentRefresh, and leaves the stored row untouched, when the
+	// comparison fails.
+	//
+	// # Purpose
+	//
+	// This is the coordination primitive for redeeming a single-use, rotating
+	// upstream refresh token safely across MULTIPLE PROCESSES sharing the same
+	// storage backend (e.g. several horizontally-scaled replicas of an
+	// application embedding this auth server, behind the same Redis).
+	// ResolveUpstreamTokenRowID's singleflight dedup is process-local
+	// only; it prevents redundant redemptions within one process but cannot
+	// stop two different processes from redeeming the same refresh token at
+	// the same time. Read the row, redeem it with the upstream provider, then
+	// write with expectedRefreshToken set to the RefreshToken value that was
+	// actually redeemed. If another process's redemption already rotated the
+	// row in the meantime, this call fails instead of silently overwriting
+	// that process's (valid) rotated token with this caller's now-stale one.
+	// The caller must then re-read the row: if it is unexpired, another
+	// process already won the race and its tokens are the correct result;
+	// otherwise the loss is unrecoverable for this attempt (the refresh token
+	// this call redeemed is now dead both at the IdP, which enforces
+	// single-use, and in storage) and the caller must surface an error rather
+	// than retry the same redemption.
+	//
+	// Implementations must perform the comparison and the write atomically
+	// with respect to any other writer of the same row (e.g. a Lua script on
+	// Redis, or a mutex-guarded read-modify-write in memory).
+	CompareAndSwapUpstreamTokens(
+		ctx context.Context, sessionID, providerName, expectedRefreshToken string, tokens *UpstreamTokens,
+	) error
 
 	// GetUpstreamTokens retrieves the upstream IDP tokens for a session and provider.
 	// Returns ErrNotFound if the session/provider combination does not exist.

--- a/pkg/authserver/storage/types.go
+++ b/pkg/authserver/storage/types.go
@@ -68,11 +68,15 @@ var (
 
 	// ErrConcurrentRefresh is returned by
 	// UpstreamTokenStorage.CompareAndSwapUpstreamTokens when the currently
-	// stored refresh token no longer equals the caller's expected value,
-	// meaning another writer (a concurrent refresh in this process or another
-	// replica sharing the same storage) already moved the row past it. The
-	// caller's own redemption is stale and must not be written; see
-	// CompareAndSwapUpstreamTokens for the coordination contract.
+	// stored refresh token no longer equals the caller's expected value.
+	// This covers two distinct situations: another writer (a concurrent
+	// refresh in this process or another replica sharing the same storage)
+	// already moved the row past it, or the row no longer exists at all
+	// (deleted by logout, evicted by TTL, or never created). The caller's own
+	// redemption is stale either way and must not be written; callers that
+	// need to tell the two situations apart must re-read the row afterward
+	// (ErrNotFound means there was no race to lose — see
+	// CompareAndSwapUpstreamTokens for the full coordination contract).
 	ErrConcurrentRefresh = errors.New("storage: upstream token row changed concurrently")
 )
 
@@ -800,31 +804,45 @@ type UpstreamTokenStorage interface {
 
 	// CompareAndSwapUpstreamTokens stores tokens for (sessionID, providerName)
 	// only if the refresh token currently stored there equals
-	// expectedRefreshToken (pass "" to require that no row currently exists,
-	// or that the existing row carries no refresh token). Returns
+	// expectedRefreshToken. Pass "" to match a row with no refresh token: no
+	// row exists yet, an existing row's RefreshToken field is itself empty, or
+	// an existing row was stored as an explicit no-token placeholder (a nil
+	// UpstreamTokens, persisted as the backend's null marker). Returns
 	// ErrConcurrentRefresh, and leaves the stored row untouched, when the
-	// comparison fails.
+	// comparison fails — whether because another writer moved the row past
+	// expectedRefreshToken, or because the row no longer exists at all (e.g.
+	// deleted by logout or evicted by TTL between the caller's read and this
+	// write). Callers that need to distinguish those two cases must re-read
+	// the row afterward: an unexpired row means a genuine race was lost to
+	// another writer; ErrNotFound on that re-read means there was no race to
+	// lose — the row was simply gone.
 	//
 	// # Purpose
 	//
-	// This is the coordination primitive for redeeming a single-use, rotating
-	// upstream refresh token safely across MULTIPLE PROCESSES sharing the same
-	// storage backend (e.g. several horizontally-scaled replicas of an
-	// application embedding this auth server, behind the same Redis).
-	// ResolveUpstreamTokenRowID's singleflight dedup is process-local
-	// only; it prevents redundant redemptions within one process but cannot
-	// stop two different processes from redeeming the same refresh token at
-	// the same time. Read the row, redeem it with the upstream provider, then
-	// write with expectedRefreshToken set to the RefreshToken value that was
-	// actually redeemed. If another process's redemption already rotated the
-	// row in the meantime, this call fails instead of silently overwriting
-	// that process's (valid) rotated token with this caller's now-stale one.
-	// The caller must then re-read the row: if it is unexpired, another
-	// process already won the race and its tokens are the correct result;
-	// otherwise the loss is unrecoverable for this attempt (the refresh token
-	// this call redeemed is now dead both at the IdP, which enforces
-	// single-use, and in storage) and the caller must surface an error rather
-	// than retry the same redemption.
+	// This is the coordination primitive that makes the STORED row
+	// deterministic under concurrent writers across MULTIPLE PROCESSES
+	// sharing the same storage backend (e.g. several horizontally-scaled
+	// replicas of an application embedding this auth server, behind the same
+	// Redis): whichever writer's expected value still matches when its write
+	// lands wins, and every losing writer fails instead of silently
+	// clobbering the winner. ResolveUpstreamTokenRowID's singleflight dedup is
+	// process-local only; it prevents redundant redemptions within one
+	// process but cannot stop two different processes from redeeming the same
+	// refresh token at the same time. Read the row, redeem it with the
+	// upstream provider, then write with expectedRefreshToken set to the
+	// RefreshToken value that was actually redeemed.
+	//
+	// This orders writes to storage; it is NOT by itself a guarantee that
+	// concurrent redemption is safe at the upstream provider. Both processes
+	// still call the provider before either one's write lands here, so for a
+	// provider enforcing strict single-use rotation the provider may see two
+	// redemptions of the same refresh token regardless of which process wins
+	// the write below, and may revoke the grant. This primitive is fully
+	// sufficient only where the provider tolerates a grace/leeway window in
+	// which more than one redeemed child stays valid; otherwise closing the
+	// gap requires serializing the redemption itself (a lock around the whole
+	// read-redeem-write sequence), which is a separate mechanism this method
+	// does not provide.
 	//
 	// Implementations must perform the comparison and the write atomically
 	// with respect to any other writer of the same row (e.g. a Lua script on


### PR DESCRIPTION
## Summary

- Multiple replicas of an application embedding this auth server, sharing the same Redis-backed `UpstreamTokenStorage`, can redeem and persist the same single-use, rotating upstream refresh token concurrently (some OAuth providers issue short-lived access tokens together with single-use refresh tokens that rotate on every redemption). The existing `singleflight` dedup in `upstreamTokenRefresher` only coordinates refreshes within one process, and `StoreUpstreamTokens` is an unconditional overwrite — so a losing replica's write can silently clobber a winning replica's already-rotated refresh token, permanently breaking the refresh chain and forcing the user back through re-authentication.
- Adds `UpstreamTokenStorage.CompareAndSwapUpstreamTokens(ctx, sessionID, providerName, expectedRefreshToken, tokens)`, which only writes if the refresh token currently stored still equals `expectedRefreshToken`, returning the new `ErrConcurrentRefresh` sentinel otherwise. Implemented for both backends: a new CAS Lua script (`casUpstreamTokensScript`) for `RedisStorage`, and a mutex-guarded compare-then-write for `MemoryStorage`.
- `upstreamTokenRefresher.refreshAndStore` now writes through the CAS method (expected value = the refresh token it just redeemed with the provider) instead of the old unconditional `StoreUpstreamTokens`. On `ErrConcurrentRefresh` it re-reads the row: if another replica's write left it unexpired, that replica's tokens are returned to the caller; otherwise it surfaces a clear error rather than retrying an already-dead redemption. The re-read also distinguishes a genuine lost race (unexpired row) from a row that's simply gone (`ErrNotFound` — deleted by logout or evicted by TTL), logging the latter at `Warn` rather than `Error` so it isn't mistaken for a race in production logs.
- `singleflight` remains a same-process optimization (avoids redundant upstream calls / Redis round-trips for concurrent requests inside one process). The CAS write is what makes the *stored row* deterministic across processes — it is **not** a guarantee that concurrent redemption is safe at the upstream provider: both replicas still call the provider before either write lands, so a provider enforcing strict single-use rotation can still see two redemptions of the same refresh token regardless of which write wins here. CAS is fully sufficient only where the provider tolerates a grace/leeway window in which more than one redeemed child stays valid; closing the gap for a stricter provider needs a lock around the whole read-redeem-write sequence, which is a real follow-up, not implemented here (see below).

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Added:
- `TestMemoryStorage_CompareAndSwapUpstreamTokens` / `TestRedisStorage_CompareAndSwapUpstreamTokens` — matching/stale/absent-row CAS cases, a security-positive case (CAS refuses to resurrect a row deleted between read and write, unlike `StoreUpstreamTokens`), plus a 10-goroutine concurrent-write race against a real (miniredis-backed) Lua script proving exactly one write wins and losers never clobber it.
- `TestUpstreamTokenRefresher_ConcurrentRefreshConflict` — the refresher's conflict-resolution path: returns the winning replica's tokens when the re-read is unexpired, and a wrapped `ErrConcurrentRefresh` error when no usable winner exists (both the row-absent and still-expired re-read shapes are covered).
- `TestUpstreamTokenRefresher_ConcurrentRefreshConflict_LogLevel` — proves the lost-race vs. row-absent distinction actually logs at different levels.

Updated all existing `refresher_test.go` mock expectations from `StoreUpstreamTokens` to `CompareAndSwapUpstreamTokens`. Mocks regenerated via `task gen`.

## API Compatibility

- [x] This PR does not break the `v1beta1` API, OR the `api-break-allowed` label is applied and the migration guidance is described above.

## Does this introduce a user-facing change?

No — this is an internal storage-layer/refresher change. It hardens an existing reliability gap; no public API changes beyond the additive `UpstreamTokenStorage` interface method.

## Special notes for reviewers

- `UpstreamTokenStorage.CompareAndSwapUpstreamTokens` is an additive interface method — any external implementation of this interface will need the new method to satisfy the interface (only `RedisStorage` and `MemoryStorage` implement it in this repo).
- No distributed lock (e.g. `SET NX` mutex) was introduced. CAS makes the stored row deterministic and prevents a stale write from clobbering a newer one, but for a provider that enforces strict single-use rotation with no grace window, a lock around the whole read-redeem-write sequence is a correctness requirement, not just an optimization — CAS alone doesn't stop both replicas from calling the provider before either writes. This matters concretely for Read.ai (the motivating provider): its access tokens are 10 minutes, so this race gets exercised often, and its refresh-token grace period is still an open item on its public roadmap (not documented as guaranteed today). Treating the follow-up lock as a real correctness item, not a nice-to-have.
- Not included in this PR: a hermetic OAuth test double modeling single-use rotating refresh tokens with a grace period, and a two-replica staging/e2e test against a real provider — left as potential follow-up work.

Generated with [Claude Code](https://claude.com/claude-code)