### PR TITLE
Evict vMCP sessions when a backend is dropped

### DIFF
--- a/pkg/cache/validating_cache.go
+++ b/pkg/cache/validating_cache.go
@@ -188,6 +188,36 @@ func (c *ValidatingCache[K, V]) Len() int {
 	return c.lruCache.Len()
 }
 
+// RemoveMatching evicts every entry for which pred reports true, invoking the
+// eviction callback (onEvict) for each removed entry, and returns the number
+// removed.
+//
+// pred and onEvict both run while the cache's internal lock is held — the same
+// lock Set contends for — matching the eviction path in getHit. pred must
+// therefore not call back into the cache, and a slow onEvict blocks concurrent
+// Set calls. This is intended for infrequent bulk eviction (e.g. reconciling
+// sessions after a backend is removed from the registry), not a hot path.
+func (c *ValidatingCache[K, V]) RemoveMatching(pred func(K, V) bool) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var removed int
+	// Keys() returns a snapshot slice, so removing entries while ranging over it
+	// is safe. Peek does not update recency, so evaluating pred leaves the LRU
+	// order of surviving entries unchanged.
+	for _, key := range c.lruCache.Keys() {
+		val, ok := c.lruCache.Peek(key)
+		if !ok {
+			continue
+		}
+		if pred(key, val) {
+			c.lruCache.Remove(key) // fires onEvict synchronously
+			removed++
+		}
+	}
+	return removed
+}
+
 // sameEntry reports whether a and b are the same cache entry.
 // For pointer types it compares addresses (identity), so a concurrent Set that
 // stores a distinct new value is never mistaken for the stale entry. For

--- a/pkg/cache/validating_cache.go
+++ b/pkg/cache/validating_cache.go
@@ -192,28 +192,38 @@ func (c *ValidatingCache[K, V]) Len() int {
 // eviction callback (onEvict) for each removed entry, and returns the number
 // removed.
 //
-// pred and onEvict both run while the cache's internal lock is held — the same
-// lock Set contends for — matching the eviction path in getHit. pred must
-// therefore not call back into the cache, and a slow onEvict blocks concurrent
-// Set calls. This is intended for infrequent bulk eviction (e.g. reconciling
-// sessions after a backend is removed from the registry), not a hot path.
+// pred and onEvict run while the cache's internal lock is held — the same lock
+// Set contends for — so pred must not call back into the cache. The lock is
+// acquired and released once per matched entry rather than held across the whole
+// scan, so a bulk eviction whose onEvict does slow teardown (e.g. closing backend
+// connections) does not starve concurrent Set for the full duration; the
+// per-entry hold matches the single-entry eviction path in getHit. This is
+// intended for infrequent bulk eviction (e.g. reconciling sessions after a
+// backend is removed from the registry), not a hot path.
 func (c *ValidatingCache[K, V]) RemoveMatching(pred func(K, V) bool) int {
+	// Snapshot the candidate keys under a short lock. Keys() returns a copy and
+	// Peek does not update recency, so evaluating pred here leaves the LRU order
+	// of surviving entries unchanged.
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	var candidates []K
+	for _, key := range c.lruCache.Keys() {
+		if val, ok := c.lruCache.Peek(key); ok && pred(key, val) {
+			candidates = append(candidates, key)
+		}
+	}
+	c.mu.Unlock()
 
 	var removed int
-	// Keys() returns a snapshot slice, so removing entries while ranging over it
-	// is safe. Peek does not update recency, so evaluating pred leaves the LRU
-	// order of surviving entries unchanged.
-	for _, key := range c.lruCache.Keys() {
-		val, ok := c.lruCache.Peek(key)
-		if !ok {
-			continue
-		}
-		if pred(key, val) {
+	for _, key := range candidates {
+		c.mu.Lock()
+		// Re-check under the lock: a concurrent Set may have replaced the entry
+		// with a value pred no longer selects, or another path may have evicted
+		// it. Peek+pred both guards that race and keeps eviction correct.
+		if val, ok := c.lruCache.Peek(key); ok && pred(key, val) {
 			c.lruCache.Remove(key) // fires onEvict synchronously
 			removed++
 		}
+		c.mu.Unlock()
 	}
 	return removed
 }

--- a/pkg/cache/validating_cache.go
+++ b/pkg/cache/validating_cache.go
@@ -20,6 +20,12 @@ import (
 // cached entry has definitively expired and should be evicted.
 var ErrExpired = errors.New("cache entry expired")
 
+// evictedEntry is a key/value pair buffered for deferred onEvict invocation.
+type evictedEntry[K comparable, V any] struct {
+	key K
+	val V
+}
+
 // ValidatingCache is a node-local write-through cache backed by a
 // capacity-bounded LRU map, with singleflight-deduplicated Get operations and
 // lazy liveness validation on cache hit.
@@ -31,16 +37,37 @@ var ErrExpired = errors.New("cache entry expired")
 // singleflight group so at most one operation executes concurrently per key.
 // Concurrent callers for the same key share the result, coalescing both
 // liveness checks and storage round-trips into a single operation per key.
+//
+// # onEvict runs off the cache lock
+//
+// The user onEvict may perform slow teardown (e.g. closing network
+// connections). To keep that work off the shared cache lock, the LRU's own
+// eviction callback only *buffers* each evicted entry (bufferEvicted); every
+// mutating operation then drains the buffer and invokes the user onEvict via
+// drainEvictions after releasing mu. onEvict therefore never runs while mu is
+// held, so a slow onEvict never blocks Get/Set/RemoveMatching on other keys.
 type ValidatingCache[K comparable, V any] struct {
 	lruCache *lru.Cache[K, V]
 	flight   singleflight.Group
 	load     func(ctx context.Context, key K) (V, error)
 	check    func(ctx context.Context, key K, val V) error
 	onEvict  func(K, V)
-	// mu serializes Set against the conditional eviction in getHit.
-	// check() runs outside the lock to avoid holding it during I/O; the lock
-	// is only held for the short Peek+Remove sequence.
+
+	// mu serializes Set against the conditional eviction in getHit and the
+	// per-entry eviction in RemoveMatching. check() runs outside the lock to
+	// avoid holding it during I/O; the lock is only held for short
+	// Peek+Remove / Add sequences, never across onEvict.
 	mu sync.Mutex
+
+	// evictMu guards pending. It is only ever acquired on its own (in
+	// bufferEvicted and drainEvictions), never while another lock is being
+	// acquired, so it introduces no lock-ordering cycle with mu even though
+	// bufferEvicted may run while mu is held.
+	evictMu sync.Mutex
+	// pending holds entries evicted by the LRU but not yet handed to the user
+	// onEvict. Drained (and the user onEvict invoked) by drainEvictions after
+	// mu is released. Always nil when onEvict is nil.
+	pending []evictedEntry[K, V]
 }
 
 // New creates a ValidatingCache with the given capacity and callbacks.
@@ -54,7 +81,9 @@ type ValidatingCache[K comparable, V any] struct {
 // key and the cached value so callers can inspect the value without a separate
 // read. Returning ErrExpired evicts the entry; any other error is transient
 // (cached value returned unchanged). It must not be nil.
-// onEvict is called after any eviction (LRU or expiry); it may be nil.
+// onEvict is called after any eviction (LRU or expiry); it may be nil. It is
+// always invoked outside the cache lock (see the type doc), so it is safe for
+// onEvict to perform slow teardown without blocking other cache operations.
 func New[K comparable, V any](
 	capacity int,
 	load func(context.Context, K) (V, error),
@@ -71,24 +100,60 @@ func New[K comparable, V any](
 		panic("cache.New: check must not be nil")
 	}
 
-	c, err := lru.NewWithEvict(capacity, onEvict)
+	c := &ValidatingCache[K, V]{
+		load:    load,
+		check:   check,
+		onEvict: onEvict,
+	}
+
+	// When onEvict is nil there is nothing to defer, so the LRU gets no
+	// callback and evicted values are simply dropped. Otherwise the LRU
+	// callback only buffers; drainEvictions runs the real onEvict off the lock.
+	var lruEvict func(K, V)
+	if onEvict != nil {
+		lruEvict = c.bufferEvicted
+	}
+	lruCache, err := lru.NewWithEvict(capacity, lruEvict)
 	if err != nil {
 		// Only possible if size < 0, which we have already ruled out above.
 		panic(fmt.Sprintf("cache.New: lru.NewWithEvict: %v", err))
 	}
+	c.lruCache = lruCache
+	return c
+}
 
-	return &ValidatingCache[K, V]{
-		lruCache: c,
-		load:     load,
-		check:    check,
-		onEvict:  onEvict,
+// bufferEvicted is the LRU's eviction callback. The LRU fires it from Add/Remove
+// while the caller may still hold mu (getHit, Set, RemoveMatching), so it must
+// not run the user onEvict inline. It records the entry for drainEvictions to
+// hand to onEvict after mu is released. Only installed when onEvict is non-nil.
+func (c *ValidatingCache[K, V]) bufferEvicted(key K, val V) {
+	c.evictMu.Lock()
+	c.pending = append(c.pending, evictedEntry[K, V]{key: key, val: val})
+	c.evictMu.Unlock()
+}
+
+// drainEvictions invokes the user onEvict for every entry buffered since the
+// last drain. Callers MUST NOT hold mu, so onEvict runs off the cache lock. It
+// is safe to call when onEvict is nil (nothing is ever buffered) and when there
+// is nothing pending.
+func (c *ValidatingCache[K, V]) drainEvictions() {
+	if c.onEvict == nil {
+		return
+	}
+	c.evictMu.Lock()
+	pending := c.pending
+	c.pending = nil
+	c.evictMu.Unlock()
+
+	for _, e := range pending {
+		c.onEvict(e.key, e.val)
 	}
 }
 
 // getHit validates a known-present cache entry and returns its value.
-// If the entry has definitively expired it is evicted and (zero, false) is
-// returned. Transient check errors leave the entry in place and return the
-// cached value.
+// If the entry has definitively expired it is removed (its eviction buffered
+// for the caller to drain) and (zero, false) is returned. Transient check
+// errors leave the entry in place and return the cached value.
 func (c *ValidatingCache[K, V]) getHit(ctx context.Context, key K, val V) (V, bool) {
 	if err := c.check(ctx, key, val); err != nil {
 		if errors.Is(err, ErrExpired) {
@@ -98,7 +163,7 @@ func (c *ValidatingCache[K, V]) getHit(ctx context.Context, key K, val V) (V, bo
 			// freshly-written value that the caller intended to keep.
 			c.mu.Lock()
 			if current, ok := c.lruCache.Peek(key); ok && sameEntry(current, val) {
-				// Remove fires the eviction callback automatically.
+				// Remove buffers the eviction; Get drains it after mu is released.
 				c.lruCache.Remove(key)
 			}
 			c.mu.Unlock()
@@ -153,19 +218,26 @@ func (c *ValidatingCache[K, V]) Get(ctx context.Context, key K) (V, bool) {
 		// their value wins and we return it instead.
 		if alreadySet, _ := c.lruCache.ContainsOrAdd(key, v); alreadySet {
 			if winner, ok := c.lruCache.Get(key); ok {
-				// Winner confirmed: v is definitively discarded — release its resources.
+				// Winner confirmed: v is definitively discarded — release its
+				// resources. v was never stored, so it is not buffered; invoke
+				// onEvict directly (this runs outside mu, so it is off the lock).
 				if c.onEvict != nil {
 					c.onEvict(key, v)
 				}
 				return result{v: winner}, nil
 			}
 			// The concurrent winner was itself evicted by LRU pressure between
-			// ContainsOrAdd and Get. Fall back to storing v — do NOT call onEvict
-			// since v has not been released and is still valid.
+			// ContainsOrAdd and Get. Fall back to storing v — do NOT release v
+			// since it has not been discarded and is still valid.
 			c.lruCache.Add(key, v)
 		}
 		return result{v: v}, nil
 	})
+	// Drain any evictions buffered by getHit's Remove or the miss path's
+	// ContainsOrAdd/Add (LRU capacity eviction). mu is not held here, so onEvict
+	// runs off the lock. Coalesced singleflight waiters also drain; a drain that
+	// finds nothing pending is a cheap no-op.
+	c.drainEvictions()
 	if err != nil {
 		var zero V
 		return zero, false
@@ -176,11 +248,13 @@ func (c *ValidatingCache[K, V]) Get(ctx context.Context, key K) (V, bool) {
 
 // Set stores value under key, moving the entry to the MRU position. If the
 // cache is at capacity, the least-recently-used entry is evicted first and
-// onEvict is called for it.
+// onEvict is called for it — after mu is released, so a slow onEvict does not
+// block concurrent cache operations.
 func (c *ValidatingCache[K, V]) Set(key K, value V) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.lruCache.Add(key, value)
+	c.mu.Unlock()
+	c.drainEvictions()
 }
 
 // Len returns the number of entries currently in the cache.
@@ -189,17 +263,15 @@ func (c *ValidatingCache[K, V]) Len() int {
 }
 
 // RemoveMatching evicts every entry for which pred reports true, invoking the
-// eviction callback (onEvict) for each removed entry, and returns the number
-// removed.
+// user onEvict for each removed entry, and returns the number removed.
 //
-// pred and onEvict run while the cache's internal lock is held — the same lock
-// Set contends for — so pred must not call back into the cache. The lock is
-// acquired and released once per matched entry rather than held across the whole
-// scan, so a bulk eviction whose onEvict does slow teardown (e.g. closing backend
-// connections) does not starve concurrent Set for the full duration; the
-// per-entry hold matches the single-entry eviction path in getHit. This is
-// intended for infrequent bulk eviction (e.g. reconciling sessions after a
-// backend is removed from the registry), not a hot path.
+// pred runs under the cache lock (the same lock Set contends for) and must not
+// call back into the cache. onEvict, however, runs via drainEvictions after all
+// removals complete and the lock is released, so a slow onEvict (e.g. closing a
+// hung backend connection) delays only the drain, never the shared cache lock:
+// a concurrent Set/Get on any key proceeds while a slow teardown is in flight.
+// This is intended for infrequent bulk eviction (e.g. reconciling sessions
+// after a backend is removed from the registry), not a hot path.
 func (c *ValidatingCache[K, V]) RemoveMatching(pred func(K, V) bool) int {
 	// Snapshot the candidate keys under a short lock. Keys() returns a copy and
 	// Peek does not update recency, so evaluating pred here leaves the LRU order
@@ -220,11 +292,14 @@ func (c *ValidatingCache[K, V]) RemoveMatching(pred func(K, V) bool) int {
 		// with a value pred no longer selects, or another path may have evicted
 		// it. Peek+pred both guards that race and keeps eviction correct.
 		if val, ok := c.lruCache.Peek(key); ok && pred(key, val) {
-			c.lruCache.Remove(key) // fires onEvict synchronously
+			c.lruCache.Remove(key) // buffers the eviction; drained below
 			removed++
 		}
 		c.mu.Unlock()
 	}
+	// Run onEvict for the removed entries off the lock, so a slow teardown of one
+	// session never blocks Get/Set for the rest of the node.
+	c.drainEvictions()
 	return removed
 }
 

--- a/pkg/cache/validating_cache_test.go
+++ b/pkg/cache/validating_cache_test.go
@@ -640,3 +640,92 @@ func TestRemoveMatching_NoMatch(t *testing.T) {
 	assert.Zero(t, evictCount)
 	assert.Equal(t, 2, c.Len())
 }
+
+// TestRemoveMatching_SkipsEntryNoLongerMatchingOnRecheck exercises the phase-2
+// re-check guard: a key selected during the snapshot whose predicate verdict
+// flips to false before removal (modeling a concurrent Set that replaced the
+// value with one pred no longer selects) must be left in place and not counted
+// or closed.
+func TestRemoveMatching_SkipsEntryNoLongerMatchingOnRecheck(t *testing.T) {
+	t.Parallel()
+
+	var evicted []string
+	c := newStringCache(
+		func(_ context.Context, key string) (string, error) { return "reloaded-" + key, nil },
+		alwaysAliveCheck,
+		func(key, _ string) { evicted = append(evicted, key) },
+	)
+	c.Set("flip", "v")
+	c.Set("drop", "v")
+
+	// pred selects each key on its first evaluation (the phase-1 snapshot) but
+	// rejects "flip" on its second (the phase-2 re-check), standing in for a
+	// value concurrently replaced with one pred no longer selects.
+	seen := map[string]int{}
+	pred := func(key, _ string) bool {
+		seen[key]++
+		return key != "flip" || seen[key] < 2
+	}
+
+	removed := c.RemoveMatching(pred)
+
+	assert.Equal(t, 1, removed, "only 'drop' should be removed; 'flip' is skipped on re-check")
+	assert.Equal(t, []string{"drop"}, evicted, "onEvict must fire only for 'drop'")
+
+	v, ok := c.Get(context.Background(), "flip")
+	require.True(t, ok)
+	assert.Equal(t, "v", v, "'flip' must remain the cached value, not evicted or reloaded")
+}
+
+// TestRemoveMatching_ConcurrentWithSetAndGet stresses RemoveMatching against
+// concurrent Set/Get on overlapping keys. Run under -race (task test), it locks
+// in the no-deadlock / no-panic / no-double-panic guarantees of the split-lock
+// rework; eviction counts are nondeterministic and deliberately not asserted.
+func TestRemoveMatching_ConcurrentWithSetAndGet(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	evictions := 0
+	c := New[int, int](
+		1000,
+		func(_ context.Context, k int) (int, error) { return k, nil },
+		func(context.Context, int, int) error { return nil },
+		func(int, int) { mu.Lock(); evictions++; mu.Unlock() },
+	)
+
+	const iterations = 300
+	const keyspace = 50
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			c.Set(i%keyspace, i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations / 10 {
+			c.RemoveMatching(func(k, _ int) bool { return k%2 == 0 })
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			c.Get(context.Background(), i%keyspace)
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: RemoveMatching concurrent with Set/Get appears deadlocked")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.GreaterOrEqual(t, evictions, 0) // sanity: onEvict never negative/paniced
+}

--- a/pkg/cache/validating_cache_test.go
+++ b/pkg/cache/validating_cache_test.go
@@ -729,3 +729,64 @@ func TestRemoveMatching_ConcurrentWithSetAndGet(t *testing.T) {
 	defer mu.Unlock()
 	assert.GreaterOrEqual(t, evictions, 0) // sanity: onEvict never negative/paniced
 }
+
+// TestRemoveMatching_SlowOnEvictDoesNotBlockOtherKeys proves onEvict runs off
+// the cache lock: while RemoveMatching's onEvict for one key is deliberately
+// blocked mid-teardown, a Set on a different key must still complete promptly.
+// If onEvict ran under the cache lock, the Set would block until the slow
+// teardown finished and this test would time out.
+func TestRemoveMatching_SlowOnEvictDoesNotBlockOtherKeys(t *testing.T) {
+	t.Parallel()
+
+	const slowKey, otherKey = 1, 2
+	closing := make(chan struct{}) // closed when the slow onEvict starts
+	release := make(chan struct{}) // test releases the slow onEvict
+
+	c := New[int, int](
+		1000,
+		func(_ context.Context, k int) (int, error) { return k, nil },
+		func(context.Context, int, int) error { return nil },
+		func(k, _ int) {
+			if k == slowKey {
+				close(closing)
+				<-release
+			}
+		},
+	)
+	c.Set(slowKey, 1)
+	c.Set(otherKey, 1)
+
+	removeDone := make(chan struct{})
+	go func() {
+		defer close(removeDone)
+		c.RemoveMatching(func(k, _ int) bool { return k == slowKey })
+	}()
+
+	// Wait until the slow onEvict is in progress (RemoveMatching is past the
+	// cache lock and blocked inside onEvict).
+	select {
+	case <-closing:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for slow onEvict to start")
+	}
+
+	// The cache lock must be free now: a Set on an unrelated key completes.
+	setDone := make(chan struct{})
+	go func() {
+		defer close(setDone)
+		c.Set(otherKey, 2)
+	}()
+	select {
+	case <-setDone:
+	case <-time.After(5 * time.Second):
+		close(release) // unblock so the test can exit cleanly before failing
+		t.Fatal("Set blocked while onEvict of another key was in progress: onEvict is holding the cache lock")
+	}
+
+	close(release) // let the slow onEvict finish
+	select {
+	case <-removeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for RemoveMatching to finish")
+	}
+}

--- a/pkg/cache/validating_cache_test.go
+++ b/pkg/cache/validating_cache_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -581,4 +582,61 @@ func TestValidatingCache_Singleflight_DeduplicatesConcurrentMisses(t *testing.T)
 		assert.True(t, oks[i], "all goroutines should get ok=true")
 		assert.Equal(t, "v", results[i])
 	}
+}
+
+// TestRemoveMatching verifies that RemoveMatching evicts exactly the entries the
+// predicate selects, fires onEvict for each, returns the count, and leaves
+// non-matching entries in place.
+func TestRemoveMatching(t *testing.T) {
+	t.Parallel()
+
+	var evicted []string
+	c := newStringCache(
+		func(_ context.Context, key string) (string, error) { return "loaded-" + key, nil },
+		alwaysAliveCheck,
+		func(key, _ string) { evicted = append(evicted, key) },
+	)
+
+	// "drop-*" entries should be removed; "keep-*" entries retained.
+	c.Set("drop-a", "va")
+	c.Set("keep-b", "vb")
+	c.Set("drop-c", "vc")
+	c.Set("keep-d", "vd")
+
+	removed := c.RemoveMatching(func(key, _ string) bool {
+		return strings.HasPrefix(key, "drop-")
+	})
+
+	assert.Equal(t, 2, removed, "two drop-* entries should be removed")
+	assert.ElementsMatch(t, []string{"drop-a", "drop-c"}, evicted,
+		"onEvict should fire once per removed entry")
+	assert.Equal(t, 2, c.Len(), "only keep-* entries should remain")
+
+	// Surviving entries are still cache hits (no reload).
+	for _, key := range []string{"keep-b", "keep-d"} {
+		v, ok := c.Get(context.Background(), key)
+		require.True(t, ok)
+		assert.NotEqual(t, "loaded-"+key, v, "%s should be served from cache, not reloaded", key)
+	}
+}
+
+// TestRemoveMatching_NoMatch verifies RemoveMatching is a no-op (and fires no
+// eviction) when the predicate matches nothing.
+func TestRemoveMatching_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	evictCount := 0
+	c := newStringCache(
+		func(_ context.Context, key string) (string, error) { return key, nil },
+		alwaysAliveCheck,
+		func(string, string) { evictCount++ },
+	)
+	c.Set("a", "va")
+	c.Set("b", "vb")
+
+	removed := c.RemoveMatching(func(string, string) bool { return false })
+
+	assert.Zero(t, removed)
+	assert.Zero(t, evictCount)
+	assert.Equal(t, 2, c.Len())
 }

--- a/pkg/cache/validating_cache_test.go
+++ b/pkg/cache/validating_cache_test.go
@@ -727,7 +727,7 @@ func TestRemoveMatching_ConcurrentWithSetAndGet(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	assert.GreaterOrEqual(t, evictions, 0) // sanity: onEvict never negative/paniced
+	assert.GreaterOrEqual(t, evictions, 0) // sanity: onEvict never went negative/panicked
 }
 
 // TestRemoveMatching_SlowOnEvictDoesNotBlockOtherKeys proves onEvict runs off

--- a/pkg/vmcp/server/serve_list_changed_test.go
+++ b/pkg/vmcp/server/serve_list_changed_test.go
@@ -184,6 +184,7 @@ func (*stubSessionManager) DecorateSession(string, func(vmcpsession.MultiSession
 	panic("stubSessionManager: DecorateSession unexpected")
 }
 func (*stubSessionManager) NotifyBackendExpired(string, string, map[string]string) {}
+func (*stubSessionManager) EvictStaleSessions(context.Context) int                 { return 0 }
 
 var _ SessionManager = (*stubSessionManager)(nil)
 

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -841,6 +841,18 @@ func (s *Server) Start(ctx context.Context) error {
 	// The backend health monitor is owned by the core (built and started in core.New, stopped
 	// in core.Close), so the server no longer starts or stops it here.
 
+	// Evict sessions whose backends are dropped from a dynamic registry so their
+	// lingering per-session connections (e.g. SSE streams) are reclaimed promptly
+	// (#6546). Runs independently of status reporting; a no-op for static registries.
+	if _, isDynamic := s.backendRegistry.(vmcp.DynamicRegistry); isDynamic && s.vmcpSessionMgr != nil {
+		reconcileCtx, reconcileCancel := context.WithCancel(ctx)
+		go s.reconcileSessionsOnRegistryChange(reconcileCtx)
+		s.shutdownFuncs = append(s.shutdownFuncs, func(context.Context) error {
+			reconcileCancel()
+			return nil
+		})
+	}
+
 	// Start status reporter if configured
 	if s.statusReporter != nil {
 		shutdown, err := s.statusReporter.Start(ctx)

--- a/pkg/vmcp/server/server.go
+++ b/pkg/vmcp/server/server.go
@@ -846,7 +846,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// (#6546). Runs independently of status reporting; a no-op for static registries.
 	if _, isDynamic := s.backendRegistry.(vmcp.DynamicRegistry); isDynamic && s.vmcpSessionMgr != nil {
 		reconcileCtx, reconcileCancel := context.WithCancel(ctx)
-		go s.reconcileSessionsOnRegistryChange(reconcileCtx)
+		go s.reconcileSessionsOnRegistryChange(reconcileCtx, versionPollInterval)
 		s.shutdownFuncs = append(s.shutdownFuncs, func(context.Context) error {
 			reconcileCancel()
 			return nil

--- a/pkg/vmcp/server/session_manager_interface.go
+++ b/pkg/vmcp/server/session_manager_interface.go
@@ -59,4 +59,11 @@ type SessionManager interface {
 	// or health-monitoring components when they detect that a backend session has
 	// expired or been lost. Storage errors are logged but not returned.
 	NotifyBackendExpired(sessionID, workloadID string, metadata map[string]string)
+
+	// EvictStaleSessions evicts every live session that still holds a connection to
+	// a backend no longer present in the registry, closing those connections
+	// (including lingering server-push streams). Each evicted session is rebuilt
+	// without the dropped backend on its next access. It is idempotent and a no-op
+	// when no session is stale. Returns the number of sessions evicted.
+	EvictStaleSessions(ctx context.Context) int
 }

--- a/pkg/vmcp/server/session_reconcile.go
+++ b/pkg/vmcp/server/session_reconcile.go
@@ -22,14 +22,16 @@ import (
 // enabled. Only a DynamicRegistry can drop a backend; for a static registry
 // membership never changes, so this returns immediately.
 //
-// The loop runs until ctx is cancelled (on server Stop).
-func (s *Server) reconcileSessionsOnRegistryChange(ctx context.Context) {
+// The loop runs until ctx is cancelled (on server Stop). pollInterval is passed
+// in (rather than read from the package-level versionPollInterval) so tests can
+// drive it without mutating shared state that a parallel test also touches.
+func (s *Server) reconcileSessionsOnRegistryChange(ctx context.Context, pollInterval time.Duration) {
 	dynamicReg, isDynamic := s.backendRegistry.(vmcp.DynamicRegistry)
 	if !isDynamic || s.vmcpSessionMgr == nil {
 		return
 	}
 
-	ticker := time.NewTicker(versionPollInterval)
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
 	lastVersion := dynamicReg.Version()

--- a/pkg/vmcp/server/session_reconcile.go
+++ b/pkg/vmcp/server/session_reconcile.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// reconcileSessionsOnRegistryChange watches a DynamicRegistry for membership
+// changes and evicts live sessions that still hold a connection to a backend the
+// registry no longer lists, so a dropped backend's lingering per-session
+// connection (e.g. an SSE server-push stream) is reclaimed promptly rather than
+// persisting until the owning client session ends (#6546).
+//
+// It follows the same version-counter poll pattern as periodicStatusReporting,
+// but with its own independent version tracker so a change can never be absorbed
+// by another observer, and it runs regardless of whether status reporting is
+// enabled. Only a DynamicRegistry can drop a backend; for a static registry
+// membership never changes, so this returns immediately.
+//
+// The loop runs until ctx is cancelled (on server Stop).
+func (s *Server) reconcileSessionsOnRegistryChange(ctx context.Context) {
+	dynamicReg, isDynamic := s.backendRegistry.(vmcp.DynamicRegistry)
+	if !isDynamic || s.vmcpSessionMgr == nil {
+		return
+	}
+
+	ticker := time.NewTicker(versionPollInterval)
+	defer ticker.Stop()
+
+	lastVersion := dynamicReg.Version()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			v := dynamicReg.Version()
+			if v == lastVersion {
+				continue
+			}
+			// A single new version may fold together several Upserts and Removes.
+			// EvictStaleSessions reconciles against current membership, so it
+			// handles every drop the new version carries in one pass and is a
+			// no-op when the change added backends without removing any.
+			lastVersion = v
+			s.vmcpSessionMgr.EvictStaleSessions(ctx)
+		}
+	}
+}

--- a/pkg/vmcp/server/session_reconcile_test.go
+++ b/pkg/vmcp/server/session_reconcile_test.go
@@ -32,10 +32,6 @@ func (m *evictCountingSessionManager) EvictStaleSessions(context.Context) int {
 func TestReconcileSessionsOnRegistryChange_EvictsOnVersionChange(t *testing.T) {
 	t.Parallel()
 
-	orig := versionPollInterval
-	versionPollInterval = 10 * time.Millisecond
-	t.Cleanup(func() { versionPollInterval = orig })
-
 	reg := &testDynamicRegistry{}
 	mgr := &evictCountingSessionManager{}
 	srv := &Server{backendRegistry: reg, vmcpSessionMgr: mgr}
@@ -43,10 +39,12 @@ func TestReconcileSessionsOnRegistryChange_EvictsOnVersionChange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
+	// Pass the poll interval directly rather than mutating the package-level
+	// versionPollInterval, which a parallel test (status reporting) also drives.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		srv.reconcileSessionsOnRegistryChange(ctx)
+		srv.reconcileSessionsOnRegistryChange(ctx, 10*time.Millisecond)
 	}()
 
 	// No change yet -> no eviction.
@@ -78,7 +76,7 @@ func TestReconcileSessionsOnRegistryChange_StaticRegistryReturns(t *testing.T) {
 	go func() {
 		defer close(done)
 		// A never-cancelled context would hang here if the loop kept running.
-		srv.reconcileSessionsOnRegistryChange(context.Background())
+		srv.reconcileSessionsOnRegistryChange(context.Background(), 10*time.Millisecond)
 	}()
 
 	select {

--- a/pkg/vmcp/server/session_reconcile_test.go
+++ b/pkg/vmcp/server/session_reconcile_test.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive/pkg/vmcp"
+)
+
+// evictCountingSessionManager records how many times EvictStaleSessions is
+// called. It reuses stubSessionManager for every other method.
+type evictCountingSessionManager struct {
+	stubSessionManager
+	evictCalls atomic.Int64
+}
+
+func (m *evictCountingSessionManager) EvictStaleSessions(context.Context) int {
+	m.evictCalls.Add(1)
+	return 0
+}
+
+// TestReconcileSessionsOnRegistryChange_EvictsOnVersionChange verifies that a
+// registry membership change (a backend dropped, bumping the version) triggers
+// EvictStaleSessions without waiting for any longer interval (#6546).
+func TestReconcileSessionsOnRegistryChange_EvictsOnVersionChange(t *testing.T) {
+	t.Parallel()
+
+	orig := versionPollInterval
+	versionPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { versionPollInterval = orig })
+
+	reg := &testDynamicRegistry{}
+	mgr := &evictCountingSessionManager{}
+	srv := &Server{backendRegistry: reg, vmcpSessionMgr: mgr}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.reconcileSessionsOnRegistryChange(ctx)
+	}()
+
+	// No change yet -> no eviction.
+	time.Sleep(50 * time.Millisecond)
+	require.Zero(t, mgr.evictCalls.Load(), "no eviction should occur before any registry change")
+
+	// Drop a backend: the version bumps and the next poll must reconcile.
+	require.NoError(t, reg.Remove("some-backend"))
+	require.Eventually(t, func() bool {
+		return mgr.evictCalls.Load() >= 1
+	}, time.Second, 5*time.Millisecond, "a registry change should trigger EvictStaleSessions")
+
+	cancel()
+	<-done
+}
+
+// TestReconcileSessionsOnRegistryChange_StaticRegistryReturns verifies that the
+// loop exits immediately for a static (non-dynamic) registry, whose membership
+// never changes, rather than polling for the server's lifetime.
+func TestReconcileSessionsOnRegistryChange_StaticRegistryReturns(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		backendRegistry: vmcp.NewImmutableRegistry(nil),
+		vmcpSessionMgr:  &evictCountingSessionManager{},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// A never-cancelled context would hang here if the loop kept running.
+		srv.reconcileSessionsOnRegistryChange(context.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reconcile loop should return immediately for a static registry")
+	}
+}

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -681,7 +681,10 @@ func (sm *Manager) EvictStaleSessions(ctx context.Context) int {
 		return referencesMissingBackend(sess.GetMetadata()[vmcpsession.MetadataKeyBackendIDs], present)
 	})
 	if evicted > 0 {
-		slog.Info("evicted sessions referencing backends removed from the registry",
+		// DEBUG for consistency with New's eviction closure: a backend leaving
+		// the registry is a routine lifecycle transition, not a fault, and the
+		// project convention is "INFO sparingly".
+		slog.Debug("evicted sessions referencing backends removed from the registry",
 			"evicted_sessions", evicted)
 	}
 	return evicted
@@ -691,11 +694,7 @@ func (sm *Manager) EvictStaleSessions(ctx context.Context) int {
 // MetadataKeyBackendIDs value) names at least one backend absent from present.
 // An empty or whitespace-only list references no backend and is never stale.
 func referencesMissingBackend(backendIDs string, present map[string]struct{}) bool {
-	for _, id := range strings.Split(backendIDs, ",") {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			continue
-		}
+	for _, id := range vmcpsession.ParseBackendIDs(backendIDs) {
 		if _, ok := present[id]; !ok {
 			return true
 		}

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -635,6 +635,59 @@ func (sm *Manager) NotifyBackendExpired(sessionID, workloadID string, metadata m
 	}
 }
 
+// EvictStaleSessions proactively evicts every live cached session that still
+// holds a connection to a backend no longer present in the registry — for
+// example a backend dropped by a dynamic-registry generation swap (#6546).
+// Eviction closes the session's backend connections through the cache's onEvict
+// hook, reclaiming any lingering server-push (SSE) stream to the dropped backend
+// that would otherwise persist until the owning client session ended. The next
+// GetMultiSession for an evicted session rebuilds it via RestoreSession against
+// the current registry (which no longer lists the dropped backend), so only the
+// surviving backends reconnect and the storage metadata is refreshed on that path.
+//
+// It compares each cached session's MetadataKeyBackendIDs against current
+// registry membership, so it is idempotent and a no-op when nothing is stale
+// (e.g. after an Upsert that only adds a backend). Returns the number of
+// sessions evicted.
+//
+// Trade-off: rebuilding the whole session briefly disconnects and reconnects the
+// surviving backends on the next request. This deliberately reuses the existing
+// lazy-eviction/RestoreSession machinery rather than mutating a live session in
+// place to close a single connection (vMCP anti-pattern #10: reconstruct, don't
+// mutate).
+func (sm *Manager) EvictStaleSessions(ctx context.Context) int {
+	raw := sm.backendReg.List(ctx)
+	present := make(map[string]struct{}, len(raw))
+	for i := range raw {
+		present[raw[i].ID] = struct{}{}
+	}
+
+	evicted := sm.sessions.RemoveMatching(func(_ string, sess vmcpsession.MultiSession) bool {
+		return referencesMissingBackend(sess.GetMetadata()[vmcpsession.MetadataKeyBackendIDs], present)
+	})
+	if evicted > 0 {
+		slog.Info("evicted sessions referencing backends removed from the registry",
+			"evicted_sessions", evicted)
+	}
+	return evicted
+}
+
+// referencesMissingBackend reports whether backendIDs (the comma-separated
+// MetadataKeyBackendIDs value) names at least one backend absent from present.
+// An empty or whitespace-only list references no backend and is never stale.
+func referencesMissingBackend(backendIDs string, present map[string]struct{}) bool {
+	for _, id := range strings.Split(backendIDs, ",") {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := present[id]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
 // updateMetadata writes a complete metadata snapshot to storage using a
 // conditional Update (SET XX). If the key is absent at update time (concurrent
 // Delete), the call is a no-op. The cache self-heals on the next GetMultiSession

--- a/pkg/vmcp/server/sessionmanager/session_manager.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager.go
@@ -163,7 +163,12 @@ func New(
 				slog.Warn("session cache: error closing evicted session",
 					"session_id", id, "error", closeErr)
 			}
-			slog.Warn("session cache: session evicted from node-local cache",
+			// Eviction is a routine lifecycle transition (LRU capacity, TTL
+			// expiry, or a backend dropped from the registry), not a fault: the
+			// session is recoverable from storage via RestoreSession. Log at
+			// DEBUG so a generation swap that evicts many sessions does not emit
+			// a burst of WARNs (a real close failure is still surfaced above).
+			slog.Debug("session cache: session evicted from node-local cache",
 				"session_id", id)
 		},
 	)
@@ -655,6 +660,16 @@ func (sm *Manager) NotifyBackendExpired(sessionID, workloadID string, metadata m
 // lazy-eviction/RestoreSession machinery rather than mutating a live session in
 // place to close a single connection (vMCP anti-pattern #10: reconstruct, don't
 // mutate).
+//
+// Residual window: eviction operates on sessions already in the cache. A session
+// whose RestoreSession is in flight when the drop commits may have read the
+// pre-drop registry and opened a connection to the soon-dropped backend; it is
+// cached only after this pass has scanned, so it escapes this eviction. Such a
+// session's stale connection is reclaimed on the next registry change, on
+// checkSession metadata drift, or ultimately at session end — i.e. it falls back
+// to the original session-lifetime bound, never worse. Closing this window fully
+// would require re-filtering each restored session against current membership
+// before caching it; it is left as the accepted best-effort of a polling model.
 func (sm *Manager) EvictStaleSessions(ctx context.Context) int {
 	raw := sm.backendReg.List(ctx)
 	present := make(map[string]struct{}, len(raw))

--- a/pkg/vmcp/server/sessionmanager/session_manager_test.go
+++ b/pkg/vmcp/server/sessionmanager/session_manager_test.go
@@ -1921,3 +1921,73 @@ func TestTerminate_LegacyFormatSession_TakesPlaceholderPath(t *testing.T) {
 	assert.Equal(t, MetadataValTrue, metadata[MetadataKeyTerminated],
 		"legacy session Terminate must set MetadataKeyTerminated rather than deleting")
 }
+
+// ---------------------------------------------------------------------------
+// Tests: EvictStaleSessions
+// ---------------------------------------------------------------------------
+
+// newEvictionTestSession builds a MockMultiSession whose MetadataKeyBackendIDs
+// lists backendIDs. It only wires the methods EvictStaleSessions touches
+// (GetMetadata via the eviction predicate, Close via onEvict); Close is expected
+// exactly wantClose times so tests pin whether a session was evicted.
+func newEvictionTestSession(
+	t *testing.T, ctrl *gomock.Controller, backendIDs string, wantClose int,
+) *sessionmocks.MockMultiSession {
+	t.Helper()
+	sess := sessionmocks.NewMockMultiSession(ctrl)
+	sess.EXPECT().GetMetadata().Return(map[string]string{
+		vmcpsession.MetadataKeyBackendIDs: backendIDs,
+	}).AnyTimes()
+	sess.EXPECT().Close().Return(nil).Times(wantClose)
+	return sess
+}
+
+// TestSessionManager_EvictStaleSessions verifies that EvictStaleSessions closes
+// exactly the sessions holding a backend absent from the registry — tearing down
+// the dropped backend's lingering connection — while leaving sessions whose
+// backends are all still present untouched (#6546).
+func TestSessionManager_EvictStaleSessions(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	// Registry currently lists backend-a and backend-b; backend-c has been dropped.
+	registry := &fakeBackendRegistry{backends: []vmcp.Backend{{ID: "backend-a"}, {ID: "backend-b"}}}
+	factory := newMockFactory(t, ctrl, nil)
+	sm, _ := newTestSessionManager(t, factory, registry)
+
+	// allPresent references only surviving backends -> not stale, not evicted.
+	allPresent := newEvictionTestSession(t, ctrl, "backend-a,backend-b", 0)
+	// holdsDropped references the dropped backend-c -> stale, evicted (Close once).
+	holdsDropped := newEvictionTestSession(t, ctrl, "backend-a,backend-c", 1)
+	// zeroBackends holds no connections -> never stale, not evicted.
+	zeroBackends := newEvictionTestSession(t, ctrl, "", 0)
+
+	sm.sessions.Set("s-all-present", allPresent)
+	sm.sessions.Set("s-holds-dropped", holdsDropped)
+	sm.sessions.Set("s-zero-backends", zeroBackends)
+
+	evicted := sm.EvictStaleSessions(context.Background())
+
+	assert.Equal(t, 1, evicted, "only the session holding the dropped backend should be evicted")
+	assert.Equal(t, 2, sm.sessions.Len(), "the two unaffected sessions must remain cached")
+}
+
+// TestSessionManager_EvictStaleSessions_NoStale verifies EvictStaleSessions is a
+// no-op (no session closed, none evicted) when every session's backends are
+// still present — e.g. after an Upsert that only adds a backend.
+func TestSessionManager_EvictStaleSessions_NoStale(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	registry := &fakeBackendRegistry{backends: []vmcp.Backend{{ID: "backend-a"}, {ID: "backend-b"}}}
+	factory := newMockFactory(t, ctrl, nil)
+	sm, _ := newTestSessionManager(t, factory, registry)
+
+	sm.sessions.Set("s1", newEvictionTestSession(t, ctrl, "backend-a", 0))
+	sm.sessions.Set("s2", newEvictionTestSession(t, ctrl, "backend-a,backend-b", 0))
+
+	assert.Zero(t, sm.EvictStaleSessions(context.Background()))
+	assert.Equal(t, 2, sm.sessions.Len())
+}

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -43,6 +43,23 @@ const (
 	MetadataKeyBackendSessionPrefix = "vmcp.backend.session."
 )
 
+// ParseBackendIDs decodes the MetadataKeyBackendIDs wire format — a
+// comma-separated list of backend workload IDs — into a slice of trimmed,
+// non-empty IDs, preserving order. It is the single decoder for that format
+// (populateBackendMetadata is the matching encoder); callers that need set
+// membership build a map from the result. An empty or whitespace-only input
+// yields an empty slice.
+func ParseBackendIDs(csv string) []string {
+	parts := strings.Split(csv, ",")
+	ids := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			ids = append(ids, t)
+		}
+	}
+	return ids
+}
+
 // MultiSessionFactory creates new MultiSessions for connecting clients.
 type MultiSessionFactory interface {
 	// MakeSessionWithID creates a new MultiSession with a specific session ID.
@@ -660,15 +677,13 @@ func (f *defaultMultiSessionFactory) RestoreSession(
 // omit the key entirely (corrupted/absent metadata) must be handled by the caller before
 // invoking this function — relying on empty-string to mean "all backends" is a footgun.
 func filterBackendsByStoredIDs(allBackends []*vmcp.Backend, storedIDs string) []*vmcp.Backend {
-	if storedIDs == "" {
+	ids := ParseBackendIDs(storedIDs)
+	if len(ids) == 0 {
 		return nil
 	}
-	parts := strings.Split(storedIDs, ",")
-	idSet := make(map[string]struct{}, len(parts))
-	for _, p := range parts {
-		if t := strings.TrimSpace(p); t != "" {
-			idSet[t] = struct{}{}
-		}
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
 	}
 	filtered := make([]*vmcp.Backend, 0, len(idSet))
 	for _, b := range allBackends {


### PR DESCRIPTION
## Summary

When a backend is removed from a `vmcp.DynamicRegistry` (a generation swap), any
already-open per-session connection to that dropped backend — most visibly a
long-lived SSE server-push stream — persisted until the owning client session
ended. New routing stopped correctly, but nothing reclaimed the live connection,
leaking a resource for the remaining lifetime of every affected session.

This reclaims those connections promptly by reusing the existing
lazy-eviction / `RestoreSession` machinery, rather than mutating the read-only
`MultiSession` in place (vMCP anti-pattern #10, "reconstruct, don't mutate"):

- **`ValidatingCache.RemoveMatching`** — predicate-based bulk eviction. The LRU's
  eviction callback only *buffers* evicted entries; every mutating path drains the
  buffer and invokes `onEvict` after releasing the cache lock, so slow teardown
  work in `onEvict` (such as closing a hung backend connection) never runs under
  the lock and cannot stall concurrent session creation on other keys.
- **`SessionManager.EvictStaleSessions`** — evicts every live session holding a
  backend absent from the current registry; `onEvict` closes its connections and
  the next request rebuilds the session minus the dropped backend via
  `RestoreSession`.
- **`reconcileSessionsOnRegistryChange`** — a background loop that watches the
  `DynamicRegistry` version counter and evicts on change, independent of status
  reporting, and a no-op for static registries.

Closes #6546

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Unit tests added for:

- `RemoveMatching` — happy path, no-match no-op, phase-2 re-check guard against a
  concurrent replacement, a `-race` concurrency smoke test, and a slow-`onEvict`
  test proving an unaffected key's `Set` completes while a slow eviction is in
  flight (i.e. `onEvict` is off the lock).
- `EvictStaleSessions` — evicts stale sessions while leaving unaffected sessions
  in place.
- `reconcileSessionsOnRegistryChange` — evicts on a registry version change and
  returns immediately for a static (non-dynamic) registry.

`task lint-fix` is clean and the affected packages' tests pass, including full
`-race` runs of `pkg/cache` and `pkg/vmcp/server`.

## Changes

| File | Change |
|------|--------|
| `pkg/cache/validating_cache.go` | Add `RemoveMatching` predicate-based bulk eviction; run `onEvict` off the cache lock via buffer-and-drain on all eviction paths. |
| `pkg/vmcp/session/factory.go` | Add `ParseBackendIDs`, the single decoder for the `MetadataKeyBackendIDs` wire format; use it in `filterBackendsByStoredIDs`. |
| `pkg/vmcp/server/sessionmanager/session_manager.go` | Add `EvictStaleSessions` + `referencesMissingBackend` (using `ParseBackendIDs`); downgrade routine eviction logs from WARN/INFO to DEBUG. |
| `pkg/vmcp/server/session_manager_interface.go` | Add `EvictStaleSessions` to the `SessionManager` interface. |
| `pkg/vmcp/server/session_reconcile.go` | New background reconcile loop watching the `DynamicRegistry` version; poll interval injected as a parameter. |
| `pkg/vmcp/server/server.go` | Start/stop the reconcile loop for dynamic registries during `Start`. |

## Does this introduce a user-facing change?

No. Behavior is internal to vMCP session management; there is no API or
configuration change.

## Special notes for reviewers

**Accepted deviation from the issue's acceptance criteria.** The issue lists
"Other backends in the same session are unaffected" as a done-when criterion.
That is not literally met here. The maintainer explicitly chose the "A'" approach
(reuse eviction + `RestoreSession`) over the issue's Option A (a targeted
per-backend `CloseBackend`), so evicting a session rebuilds it and its surviving
backends briefly disconnect and reconnect on the next request. This trade-off was
deliberately accepted to avoid adding a mutating method to the read-only
`MultiSession` (anti-pattern #10). Recommend updating the issue's acceptance
criteria to record this decision.

**Residual window.** Eviction operates on sessions already in the cache. A
session whose `RestoreSession` is in flight when the drop commits may open a
connection to the soon-dropped backend and escape a given pass; its stale
connection is then reclaimed on the next registry change, on `checkSession`
metadata drift, or ultimately at session end — i.e. it never regresses past the
original session-lifetime bound. This is the accepted best-effort of a polling
model and is documented at the method.

Generated with [Claude Code](https://claude.com/claude-code)
