### PR TITLE
Support Basic auth for OIDC upstreams

### DIFF
--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -400,6 +400,10 @@ const docTemplate = `{
                         "description": "SubjectClaim names the validated ID-token claim to use as the upstream\nsubject. Defaults to \"sub\" when empty. Set for IdPs where \"sub\" isn't\nstable per user (e.g. Entra/Azure AD's \"oid\"). See upstream.OIDCConfig.",
                         "type": "string"
                     },
+                    "token_endpoint_auth_method": {
+                        "description": "TokenEndpointAuthMethod is the client authentication method used at the token endpoint.\nWhen empty and a client secret is configured, client_secret_basic is used.",
+                        "type": "string"
+                    },
                     "userinfo_override": {
                         "$ref": "#/components/schemas/authserver.UserInfoRunConfig"
                     }

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -393,6 +393,10 @@
                         "description": "SubjectClaim names the validated ID-token claim to use as the upstream\nsubject. Defaults to \"sub\" when empty. Set for IdPs where \"sub\" isn't\nstable per user (e.g. Entra/Azure AD's \"oid\"). See upstream.OIDCConfig.",
                         "type": "string"
                     },
+                    "token_endpoint_auth_method": {
+                        "description": "TokenEndpointAuthMethod is the client authentication method used at the token endpoint.\nWhen empty and a client secret is configured, client_secret_basic is used.",
+                        "type": "string"
+                    },
                     "userinfo_override": {
                         "$ref": "#/components/schemas/authserver.UserInfoRunConfig"
                     }

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -470,6 +470,11 @@ components:
             subject. Defaults to "sub" when empty. Set for IdPs where "sub" isn't
             stable per user (e.g. Entra/Azure AD's "oid"). See upstream.OIDCConfig.
           type: string
+        token_endpoint_auth_method:
+          description: |-
+            TokenEndpointAuthMethod is the client authentication method used at the token endpoint.
+            When empty and a client secret is configured, client_secret_basic is used.
+          type: string
         userinfo_override:
           $ref: '#/components/schemas/authserver.UserInfoRunConfig'
       type: object

--- a/pkg/authserver/config.go
+++ b/pkg/authserver/config.go
@@ -637,6 +637,10 @@ type OIDCUpstreamRunConfig struct {
 	// Mutually exclusive with ClientSecretFile. Optional for public clients using PKCE.
 	ClientSecretEnvVar string `json:"client_secret_env_var,omitempty" yaml:"client_secret_env_var,omitempty"`
 
+	// TokenEndpointAuthMethod is the client authentication method used at the token endpoint.
+	// When empty and a client secret is configured, client_secret_basic is used.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty" yaml:"token_endpoint_auth_method,omitempty"`
+
 	// RedirectURI is the callback URL where the upstream IDP will redirect after authentication.
 	// When not specified, defaults to `{issuer}/oauth/callback`.
 	RedirectURI string `json:"redirect_uri,omitempty" yaml:"redirect_uri,omitempty"`
@@ -1368,6 +1372,32 @@ func (c *Config) warnTrustedIssuerAudiences() {
 				"issuer", ti.IssuerURL, "expected_audience", ti.ExpectedAudience)
 		}
 	}
+}
+
+// Validate checks that the OIDCUpstreamRunConfig has a supported token endpoint
+// authentication method and does not combine public-client authentication with a
+// configured client secret.
+func (c *OIDCUpstreamRunConfig) Validate() error {
+	hasSecretSource := c.ClientSecretFile != "" || c.ClientSecretEnvVar != ""
+
+	switch c.TokenEndpointAuthMethod {
+	case "":
+		// Resolved from the presence of a secret in buildOIDCConfig.
+	case oauthproto.TokenEndpointAuthMethodNone:
+		if hasSecretSource {
+			return fmt.Errorf("oidc upstream: token_endpoint_auth_method none cannot be used with a client secret")
+		}
+	case oauthproto.TokenEndpointAuthMethodClientSecretBasic, oauthproto.TokenEndpointAuthMethodClientSecretPost:
+		if !hasSecretSource {
+			return fmt.Errorf(
+				"oidc upstream: token_endpoint_auth_method %q requires client_secret_file or client_secret_env_var",
+				c.TokenEndpointAuthMethod)
+		}
+	default:
+		return fmt.Errorf("oidc upstream: unsupported token_endpoint_auth_method %q", c.TokenEndpointAuthMethod)
+	}
+
+	return nil
 }
 
 // Validate checks that the OAuth2UpstreamRunConfig is internally consistent.

--- a/pkg/authserver/config_test.go
+++ b/pkg/authserver/config_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/authserver/server/registration"
 	"github.com/stacklok/toolhive/pkg/authserver/server/tokenexchange"
 	"github.com/stacklok/toolhive/pkg/authserver/upstream"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 func TestValidateIssuerURL(t *testing.T) {
@@ -387,6 +388,67 @@ func assertError(t *testing.T, err error, wantErr bool, errMsg string) {
 		}
 	} else if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestOIDCUpstreamRunConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  OIDCUpstreamRunConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "empty method is valid", config: OIDCUpstreamRunConfig{}},
+		{name: "none is valid without secret", config: OIDCUpstreamRunConfig{TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodNone}},
+		{name: "basic is valid", config: OIDCUpstreamRunConfig{TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodClientSecretBasic}},
+		{name: "post is valid", config: OIDCUpstreamRunConfig{TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodClientSecretPost}},
+		{
+			name:    "unknown method rejects",
+			config:  OIDCUpstreamRunConfig{TokenEndpointAuthMethod: "private_key_jwt"},
+			wantErr: true,
+			errMsg:  "unsupported token_endpoint_auth_method",
+		},
+		{
+			name:    "none with secret file rejects",
+			config:  OIDCUpstreamRunConfig{TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodNone, ClientSecretFile: "secret"},
+			wantErr: true,
+			errMsg:  "none cannot be used with a client secret",
+		},
+		{
+			name:    "none with secret env rejects",
+			config:  OIDCUpstreamRunConfig{TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodNone, ClientSecretEnvVar: "SECRET"},
+			wantErr: true,
+			errMsg:  "none cannot be used with a client secret",
+		},
+		{
+			name:    "basic without a secret source rejects",
+			config:  OIDCUpstreamRunConfig{TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodClientSecretBasic},
+			wantErr: true,
+			errMsg:  `requires client_secret_file or client_secret_env_var`,
+		},
+		{
+			name:    "post without a secret source rejects",
+			config:  OIDCUpstreamRunConfig{TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodClientSecretPost},
+			wantErr: true,
+			errMsg:  `requires client_secret_file or client_secret_env_var`,
+		},
+		{
+			name: "basic with a client secret env var configured is valid",
+			config: OIDCUpstreamRunConfig{
+				TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodClientSecretBasic,
+				ClientSecretEnvVar:      "MY_CLIENT_SECRET",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.config.Validate()
+			assertError(t, err, tt.wantErr, tt.errMsg)
+		})
 	}
 }
 

--- a/pkg/authserver/runner/embeddedauthserver.go
+++ b/pkg/authserver/runner/embeddedauthserver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/authserver/storage"
 	"github.com/stacklok/toolhive/pkg/authserver/upstream"
 	"github.com/stacklok/toolhive/pkg/bodylimit"
+	"github.com/stacklok/toolhive/pkg/oauthproto"
 )
 
 // Redis ACL credential environment variable names.
@@ -689,6 +690,9 @@ func buildOIDCConfig(rc *authserver.UpstreamRunConfig, insecureAllowHTTP bool) (
 	}
 
 	oidc := rc.OIDCConfig
+	if err := oidc.Validate(); err != nil {
+		return nil, err
+	}
 
 	// Warn if UserInfoOverride is configured but won't be used
 	if oidc.UserInfoOverride != nil {
@@ -701,6 +705,16 @@ func buildOIDCConfig(rc *authserver.UpstreamRunConfig, insecureAllowHTTP bool) (
 	clientSecret, err := resolveSecret(oidc.ClientSecretFile, oidc.ClientSecretEnvVar)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve OIDC client secret: %w", err)
+	}
+
+	authMethod := oidc.TokenEndpointAuthMethod
+	if authMethod == "" && clientSecret != "" {
+		authMethod = oauthproto.TokenEndpointAuthMethodClientSecretBasic
+	}
+	if isConfidentialAuthMethod(authMethod) && clientSecret == "" {
+		return nil, fmt.Errorf(
+			"oidc upstream: token_endpoint_auth_method %q requires a non-empty client secret, "+
+				"but the configured secret resolved to an empty value", authMethod)
 	}
 
 	// Default scopes if not specified. The default includes offline_access
@@ -716,6 +730,7 @@ func buildOIDCConfig(rc *authserver.UpstreamRunConfig, insecureAllowHTTP bool) (
 		CommonOAuthConfig: upstream.CommonOAuthConfig{
 			ClientID:                      oidc.ClientID,
 			ClientSecret:                  clientSecret,
+			TokenEndpointAuthMethod:       authMethod,
 			RedirectURI:                   oidc.RedirectURI,
 			Scopes:                        scopes,
 			AdditionalAuthorizationParams: oidc.AdditionalAuthorizationParams,
@@ -782,6 +797,20 @@ func buildPureOAuth2Config(rc *authserver.UpstreamRunConfig, insecureAllowHTTP b
 	}
 
 	return cfg, nil
+}
+
+// isConfidentialAuthMethod reports whether method requires a client secret to
+// be presented at the token endpoint. Used to catch a secret file that reads
+// successfully but is empty after trimming -- a case Validate cannot see, since
+// it only knows whether a secret source is configured, not what it resolves to.
+// Shared by buildPureOAuth2Config and buildOIDCConfig.
+func isConfidentialAuthMethod(method string) bool {
+	switch method {
+	case oauthproto.TokenEndpointAuthMethodClientSecretBasic, oauthproto.TokenEndpointAuthMethodClientSecretPost:
+		return true
+	default:
+		return false
+	}
 }
 
 // resolveSecret reads a secret from file or environment variable.

--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -1100,6 +1100,7 @@ func TestBuildOIDCConfig(t *testing.T) {
 		// Verify client config is passed through
 		assert.Equal(t, "test-client-id", cfg.ClientID)
 		assert.Equal(t, "http://localhost:8080/callback", cfg.RedirectURI)
+		assert.Empty(t, cfg.TokenEndpointAuthMethod)
 		assert.Equal(t, []string{"openid", "profile"}, cfg.Scopes)
 	})
 
@@ -1147,6 +1148,43 @@ func TestBuildOIDCConfig(t *testing.T) {
 		require.NotNil(t, cfg)
 
 		assert.Equal(t, "my-oidc-client-secret", cfg.ClientSecret)
+		assert.Equal(t, oauthproto.TokenEndpointAuthMethodClientSecretBasic, cfg.TokenEndpointAuthMethod)
+	})
+
+	t.Run("preserves explicit client_secret_post", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Type: authserver.UpstreamProviderTypeOIDC,
+			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
+				IssuerURL:               "https://example.com",
+				ClientID:                "test-client-id",
+				TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodClientSecretPost,
+				RedirectURI:             "http://localhost:8080/callback",
+			},
+		}
+
+		cfg, err := buildOIDCConfig(rc, false)
+		require.NoError(t, err)
+		assert.Equal(t, oauthproto.TokenEndpointAuthMethodClientSecretPost, cfg.TokenEndpointAuthMethod)
+	})
+
+	t.Run("rejects invalid token endpoint auth method", func(t *testing.T) {
+		t.Parallel()
+
+		rc := &authserver.UpstreamRunConfig{
+			Type: authserver.UpstreamProviderTypeOIDC,
+			OIDCConfig: &authserver.OIDCUpstreamRunConfig{
+				IssuerURL:               "https://example.com",
+				ClientID:                "test-client-id",
+				TokenEndpointAuthMethod: "private_key_jwt",
+				RedirectURI:             "http://localhost:8080/callback",
+			},
+		}
+
+		_, err := buildOIDCConfig(rc, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported token_endpoint_auth_method")
 	})
 
 	t.Run("missing secret file returns error", func(t *testing.T) {

--- a/pkg/authserver/upstream/oauth2.go
+++ b/pkg/authserver/upstream/oauth2.go
@@ -109,6 +109,12 @@ type CommonOAuthConfig struct {
 	// after authentication.
 	RedirectURI string `json:"redirect_uri" yaml:"redirect_uri"`
 
+	// TokenEndpointAuthMethod is the RFC 7591 client authentication method used
+	// at the token endpoint; see authStyleFromMethod for the mapping to
+	// oauth2.AuthStyle and the rationale.
+	//nolint:lll // field tags require full JSON+YAML names
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty" yaml:"token_endpoint_auth_method,omitempty"`
+
 	// AdditionalAuthorizationParams are extra query parameters to include in the
 	// authorization URL. This is useful for providers that require custom parameters
 	// such as Google's access_type=offline for obtaining refresh tokens.
@@ -146,18 +152,6 @@ type OAuth2Config struct {
 
 	// TokenEndpoint is the URL for the OAuth token endpoint.
 	TokenEndpoint string `json:"token_endpoint" yaml:"token_endpoint"`
-
-	// TokenEndpointAuthMethod is the RFC 7591 client authentication method used
-	// at the token endpoint; see authStyleFromMethod for the mapping to
-	// oauth2.AuthStyle and the rationale. When empty, the historical default
-	// (POST body) is used.
-	//
-	// Only the DCR path populates this, via applyResolutionToOAuth2Config.
-	// OAuth2UpstreamRunConfig has no corresponding field, so a statically-
-	// configured upstream cannot set it and always gets the default — an
-	// intentional limitation scoped to issue #5865 (DCR-negotiated clients).
-	//nolint:lll // field tags require full JSON+YAML names
-	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty" yaml:"token_endpoint_auth_method,omitempty"`
 
 	// UserInfo contains configuration for fetching user information (optional).
 	// When nil, the provider does not support UserInfo fetching.

--- a/pkg/authserver/upstream/oauth2_test.go
+++ b/pkg/authserver/upstream/oauth2_test.go
@@ -231,13 +231,13 @@ func TestNewOAuth2Provider(t *testing.T) {
 
 		config := &OAuth2Config{
 			CommonOAuthConfig: CommonOAuthConfig{
-				ClientID:     "test-client",
-				ClientSecret: "test-secret",
-				RedirectURI:  "http://localhost:8080/callback",
+				ClientID:                "test-client",
+				ClientSecret:            "test-secret",
+				RedirectURI:             "http://localhost:8080/callback",
+				TokenEndpointAuthMethod: "private_key_jwt",
 			},
-			AuthorizationEndpoint:   mock.URL + "/authorize",
-			TokenEndpoint:           mock.URL + "/token",
-			TokenEndpointAuthMethod: "private_key_jwt",
+			AuthorizationEndpoint: mock.URL + "/authorize",
+			TokenEndpoint:         mock.URL + "/token",
 		}
 
 		_, err := NewOAuth2Provider(config)
@@ -357,13 +357,13 @@ func TestNewOAuth2Provider_TokenEndpointAuthMethod(t *testing.T) {
 
 			config := &OAuth2Config{
 				CommonOAuthConfig: CommonOAuthConfig{
-					ClientID:     clientID,
-					ClientSecret: clientSecret,
-					RedirectURI:  "http://localhost:8080/callback",
+					ClientID:                clientID,
+					ClientSecret:            clientSecret,
+					RedirectURI:             "http://localhost:8080/callback",
+					TokenEndpointAuthMethod: tt.authMethod,
 				},
-				AuthorizationEndpoint:   mock.URL + "/authorize",
-				TokenEndpoint:           mock.URL + "/token",
-				TokenEndpointAuthMethod: tt.authMethod,
+				AuthorizationEndpoint: mock.URL + "/authorize",
+				TokenEndpoint:         mock.URL + "/token",
 			}
 
 			provider, err := NewOAuth2Provider(config)
@@ -429,13 +429,13 @@ func TestBaseOAuth2Provider_RefreshTokens_TokenEndpointAuthMethod(t *testing.T) 
 
 	config := &OAuth2Config{
 		CommonOAuthConfig: CommonOAuthConfig{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
-			RedirectURI:  "http://localhost:8080/callback",
+			ClientID:                clientID,
+			ClientSecret:            clientSecret,
+			RedirectURI:             "http://localhost:8080/callback",
+			TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodClientSecretBasic,
 		},
-		AuthorizationEndpoint:   mock.URL + "/authorize",
-		TokenEndpoint:           mock.URL + "/token",
-		TokenEndpointAuthMethod: oauthproto.TokenEndpointAuthMethodClientSecretBasic,
+		AuthorizationEndpoint: mock.URL + "/authorize",
+		TokenEndpoint:         mock.URL + "/token",
 	}
 
 	provider, err := NewOAuth2Provider(config)

--- a/pkg/authserver/upstream/oidc.go
+++ b/pkg/authserver/upstream/oidc.go
@@ -277,11 +277,14 @@ func NewOIDCProvider(
 	}
 	p.config = oauth2Config
 
-	// Create the oauth2.Config for use with golang.org/x/oauth2 library
-	// Use go-oidc's endpoint which handles discovery, but explicitly set AuthStyle
-	// to ensure client credentials are sent in the request body (not Basic auth header)
-	// for consistent behavior across different IDP implementations.
+	// Create the oauth2.Config for use with golang.org/x/oauth2 library.
+	// Use go-oidc's discovered endpoint URLs, but explicitly set AuthStyle from
+	// the configured method so client authentication is consistent across IDPs.
 	providerEndpoint := oidcProvider.Endpoint()
+	authStyle, err := authStyleFromMethod(config.TokenEndpointAuthMethod)
+	if err != nil {
+		return nil, err
+	}
 	p.oauth2Config = &oauth2.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
@@ -290,7 +293,7 @@ func NewOIDCProvider(
 		Endpoint: oauth2.Endpoint{
 			AuthURL:   providerEndpoint.AuthURL,
 			TokenURL:  providerEndpoint.TokenURL,
-			AuthStyle: oauth2.AuthStyleInParams,
+			AuthStyle: authStyle,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Confidential OIDC upstream clients had no way to authenticate at the token endpoint with `client_secret_basic`. Unlike the sibling OAuth2 upstream path, this wasn't a lossy config translation — `NewOIDCProvider` hardcoded `AuthStyle: oauth2.AuthStyleInParams` as a literal, and neither `OIDCUpstreamRunConfig` nor `upstream.OIDCConfig` had a field to override it.

- Move `TokenEndpointAuthMethod` onto the shared `CommonOAuthConfig` (embedded by both `OAuth2Config` and `OIDCConfig`), so both provider types consume the same field and the same `authStyleFromMethod` mapping instead of parallel, drifting logic.
- Add `TokenEndpointAuthMethod` to `OIDCUpstreamRunConfig`, defaulting to `client_secret_basic` when a secret is configured and the field is left empty (matches the RFC 7591 §2 default already applied on the OAuth2 path).
- Propagate it through `buildOIDCConfig`, and replace `NewOIDCProvider`'s hardcoded `AuthStyleInParams` literal with `authStyleFromMethod(config.TokenEndpointAuthMethod)` — `AuthURL`/`TokenURL` still come from go-oidc's discovered endpoint, only `AuthStyle` is now driven by the configured/defaulted method.
- `OIDCUpstreamRunConfig.Validate()` rejects unsupported methods, `none` combined with a configured secret, and (mirroring the hardening a maintainer requested on the sibling OAuth2 fix, #6536) a confidential method with no secret source configured. `buildOIDCConfig` also rejects a confidential method whose resolved secret is empty.
- Explicit `client_secret_post` continues to work unchanged.

Fixes #6542

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)

Added/extended cases: `TestOIDCUpstreamRunConfigValidate` (unsupported method, none+secret, confidential-without-secret-source, valid combinations) and `TestBuildOIDCConfig` (defaults to `client_secret_basic`, preserves explicit `client_secret_post`, rejects invalid method).

## API Compatibility

Not applicable — this PR does not touch operator CRD/API surface.

## Does this introduce a user-facing change?

Yes: confidential OIDC upstream clients with a configured secret now authenticate at the upstream token endpoint using HTTP Basic auth by default, instead of always sending the secret in the POST body. Operators who need the previous behavior can set `token_endpoint_auth_method: client_secret_post` explicitly on the upstream config.

## Special notes for reviewers

This is the OIDC-side counterpart to #6536/PR #6543 (pure OAuth2 upstreams) — same fix shape, applied to the other provider type. That PR is not yet merged to main; this branch was cut before its review-fixup commits landed, so it doesn't build on top of them (no shared history) but implements the equivalent hardening independently. Once both merge, worth a quick check that `isConfidentialAuthMethod`/`validateTokenEndpointAuthMethod`-style logic hasn't ended up duplicated in a way worth consolidating.