### PR TITLE
Fail closed on malformed protected list responses

### DIFF
--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -697,11 +697,14 @@ func (rfw *ResponseFilteringWriter) filterListResponse(response *jsonrpc2.Respon
 
 // filterToolsResponse filters tools based on call_tool authorization
 func (rfw *ResponseFilteringWriter) filterToolsResponse(response *jsonrpc2.Response) (*jsonrpc2.Response, error) {
+	if err := validateListResult(response.Result, "tools", "name"); err != nil {
+		return nil, fmt.Errorf("validating tools list response: %w", err)
+	}
+
 	// Parse the result as a ListToolsResult
 	var listResult mcp.ListToolsResult
 	if err := json.Unmarshal(response.Result, &listResult); err != nil {
-		// If we can't parse it as a list response, just return it as-is
-		return response, nil
+		return nil, fmt.Errorf("decoding tools list response: %w", err)
 	}
 
 	// Populate annotation cache from tools/list response so that
@@ -757,11 +760,14 @@ func (rfw *ResponseFilteringWriter) filterToolsResponse(response *jsonrpc2.Respo
 
 // filterPromptsResponse filters prompts based on get_prompt authorization
 func (rfw *ResponseFilteringWriter) filterPromptsResponse(response *jsonrpc2.Response) (*jsonrpc2.Response, error) {
+	if err := validateListResult(response.Result, "prompts", "name"); err != nil {
+		return nil, fmt.Errorf("validating prompts list response: %w", err)
+	}
+
 	// Parse the result as a ListPromptsResult
 	var listResult mcp.ListPromptsResult
 	if err := json.Unmarshal(response.Result, &listResult); err != nil {
-		// If we can't parse it as a list response, just return it as-is
-		return response, nil
+		return nil, fmt.Errorf("decoding prompts list response: %w", err)
 	}
 
 	// Note: instantiating the list ensures that no null value is sent over the wire.
@@ -818,11 +824,14 @@ func (rfw *ResponseFilteringWriter) filterPromptsResponse(response *jsonrpc2.Res
 
 // filterResourcesResponse filters resources based on read_resource authorization
 func (rfw *ResponseFilteringWriter) filterResourcesResponse(response *jsonrpc2.Response) (*jsonrpc2.Response, error) {
+	if err := validateListResult(response.Result, "resources", "uri"); err != nil {
+		return nil, fmt.Errorf("validating resources list response: %w", err)
+	}
+
 	// Parse the result as a ListResourcesResult
 	var listResult mcp.ListResourcesResult
 	if err := json.Unmarshal(response.Result, &listResult); err != nil {
-		// If we can't parse it as a list response, just return it as-is
-		return response, nil
+		return nil, fmt.Errorf("decoding resources list response: %w", err)
 	}
 
 	// Note: instantiating the list ensures that no null value is sent over the wire.
@@ -976,6 +985,54 @@ func decodeResourceTemplatesListResult(
 		return nil, nil, nil, err
 	}
 	return result, resourceTemplates, uriTemplates, nil
+}
+
+// validateListResult rejects malformed list results and ambiguous spellings
+// of the fields used to decide authorization. encoding/json otherwise accepts
+// case-folded aliases and resolves duplicate members using the last value,
+// which could make authorization inspect a different list or identifier than
+// a client consuming the response.
+func validateListResult(data json.RawMessage, listField, identifierField string) error {
+	members, err := decodeJSONObjectMembers(data)
+	if err != nil {
+		return err
+	}
+	rawItems, ok, err := uniqueCanonicalMember(members, listField)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("result is missing %q", listField)
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(rawItems, &items); err != nil {
+		return fmt.Errorf("decoding %s: %w", listField, err)
+	}
+	if items == nil {
+		return fmt.Errorf("field %q must be an array", listField)
+	}
+	for i, item := range items {
+		itemMembers, err := decodeJSONObjectMembers(item)
+		if err != nil {
+			return fmt.Errorf("decoding %s item at index %d: %w", listField, i, err)
+		}
+		rawIdentifier, ok, err := uniqueCanonicalMember(itemMembers, identifierField)
+		if err != nil {
+			return fmt.Errorf("%s item at index %d: %w", listField, i, err)
+		}
+		if !ok {
+			return fmt.Errorf("%s item at index %d is missing %q", listField, i, identifierField)
+		}
+		var identifier *string
+		if err := json.Unmarshal(rawIdentifier, &identifier); err != nil {
+			return fmt.Errorf("%s item at index %d has an invalid %s: %w", listField, i, identifierField, err)
+		}
+		if identifier == nil {
+			return fmt.Errorf("%s item at index %d is missing a string %s", listField, i, identifierField)
+		}
+	}
+	return nil
 }
 
 // decodeResourceTemplateURIs validates every descriptor before any

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -427,6 +427,158 @@ func TestResponseFilteringWriter(t *testing.T) {
 	}
 }
 
+func TestResponseFilteringWriter_LegacyListsRejectMalformedOrAmbiguousResults(t *testing.T) {
+	t.Parallel()
+
+	const protectedDescriptor = "protected-descriptor-sentinel"
+	type listMethod struct {
+		name               string
+		method             string
+		listField          string
+		identifier         string
+		typedInvalidMember string
+	}
+	methods := []listMethod{
+		{
+			name: "tools", method: string(mcp.MethodToolsList), listField: "tools", identifier: "name",
+			typedInvalidMember: `"inputSchema":17,"annotations":{"readOnlyHint":true}`,
+		},
+		{
+			name: "prompts", method: string(mcp.MethodPromptsList), listField: "prompts", identifier: "name",
+			typedInvalidMember: `"arguments":17`,
+		},
+		{
+			name: "resources", method: string(mcp.MethodResourcesList), listField: "resources", identifier: "uri",
+			typedInvalidMember: `"size":"bad"`,
+		},
+	}
+
+	testCases := []struct {
+		name   string
+		result func(listMethod) json.RawMessage
+	}{
+		{
+			name: "result is not an object",
+			result: func(_ listMethod) json.RawMessage {
+				return json.RawMessage(`["` + protectedDescriptor + `"]`)
+			},
+		},
+		{
+			name: "list is not an array",
+			result: func(method listMethod) json.RawMessage {
+				return json.RawMessage(`{"` + method.listField + `":{"` +
+					method.identifier + `":"` + protectedDescriptor + `"}}`)
+			},
+		},
+		{
+			name: "case-folded list alias",
+			result: func(method listMethod) json.RawMessage {
+				return json.RawMessage(`{"` + method.listField + `":[],"` +
+					strings.ToUpper(method.listField) + `":[{"` + method.identifier + `":"` +
+					protectedDescriptor + `"}]}`)
+			},
+		},
+		{
+			name: "duplicate list member",
+			result: func(method listMethod) json.RawMessage {
+				return json.RawMessage(`{"` + method.listField + `":[],"` + method.listField +
+					`":[{"` + method.identifier + `":"` + protectedDescriptor + `"}]}`)
+			},
+		},
+		{
+			name: "list item is not an object",
+			result: func(method listMethod) json.RawMessage {
+				return json.RawMessage(`{"` + method.listField + `":["` + protectedDescriptor + `"]}`)
+			},
+		},
+		{
+			name: "case-folded identifier alias",
+			result: func(method listMethod) json.RawMessage {
+				return json.RawMessage(`{"` + method.listField + `":[{"` + method.identifier + `":"` +
+					protectedDescriptor + `","` + strings.ToUpper(method.identifier) + `":"allowed"}]}`)
+			},
+		},
+		{
+			name: "duplicate identifier member",
+			result: func(method listMethod) json.RawMessage {
+				return json.RawMessage(`{"` + method.listField + `":[{"` + method.identifier + `":"` +
+					protectedDescriptor + `","` + method.identifier + `":"allowed"}]}`)
+			},
+		},
+		{
+			name: "identifier is not a string",
+			result: func(method listMethod) json.RawMessage {
+				return json.RawMessage(`{"` + method.listField + `":[{"` + method.identifier +
+					`":17,"description":"` + protectedDescriptor + `"}]}`)
+			},
+		},
+		{
+			name: "descriptor fails typed MCP decoding",
+			result: func(method listMethod) json.RawMessage {
+				return json.RawMessage(`{"` + method.listField + `":[{"` + method.identifier + `":"` +
+					protectedDescriptor + `",` + method.typedInvalidMember + `}]}`)
+			},
+		},
+	}
+
+	for _, method := range methods {
+		for _, tc := range testCases {
+			t.Run(method.name+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				responseBytes, err := jsonrpc2.EncodeMessage(&jsonrpc2.Response{
+					ID:     jsonrpc2.Int64ID(103),
+					Result: tc.result(method),
+				})
+				require.NoError(t, err)
+
+				authorizer := &mockAuthorizer{results: map[string]mockResult{
+					"allowed":           {authorized: true},
+					protectedDescriptor: {authorized: false},
+				}}
+				annotationCache := NewAnnotationCache()
+				cachedAnnotations := &authorizers.ToolAnnotations{}
+				annotationCache.Set("previously-cached-tool", cachedAnnotations)
+				rr := httptest.NewRecorder()
+				rfw := NewResponseFilteringWriter(
+					rr, authorizer, newUser1Request(t), method.method, annotationCache, nil,
+				)
+				rfw.ResponseWriter.Header().Set("Content-Type", "application/json")
+				_, err = rfw.Write(responseBytes)
+				require.NoError(t, err)
+				require.NoError(t, rfw.FlushAndFilter())
+
+				assert.Equal(t, http.StatusInternalServerError, rr.Code)
+				assert.NotContains(t, rr.Body.String(), protectedDescriptor,
+					"an invalid list result must not expose an unfiltered descriptor")
+				assert.Empty(t, authorizer.calls,
+					"the whole list must be validated before any authorization decision")
+				assert.Same(t, cachedAnnotations, annotationCache.Get("previously-cached-tool"),
+					"a malformed response must not replace the existing annotation cache")
+				assert.Nil(t, annotationCache.Get(protectedDescriptor),
+					"a malformed descriptor must not be partially added to the annotation cache")
+
+				message, err := jsonrpc2.DecodeMessage(rr.Body.Bytes())
+				require.NoError(t, err)
+				response, ok := message.(*jsonrpc2.Response)
+				require.True(t, ok)
+				require.NotNil(t, response.Error)
+				assert.Nil(t, response.Result)
+
+				var envelope struct {
+					Error struct {
+						Code    int64  `json:"code"`
+						Message string `json:"message"`
+					} `json:"error"`
+				}
+				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &envelope))
+				assert.Equal(t, mcpparser.CodeInternalError, envelope.Error.Code)
+				assert.Equal(t, "internal error", envelope.Error.Message)
+			})
+		}
+	}
+}
+
 // TestResponseFilteringWriter_ResourceTemplatesList is the regression test for
 // GHSA-5vxv-9f7g-x8j2. Resource-template enumeration is admitted before any
 // individual resource ID is known, so every descriptor must be filtered against

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -579,10 +579,9 @@ func TestResponseFilteringWriter_LegacyListsRejectMalformedOrAmbiguousResults(t 
 	}
 }
 
-// TestResponseFilteringWriter_ResourceTemplatesList is the regression test for
-// GHSA-5vxv-9f7g-x8j2. Resource-template enumeration is admitted before any
-// individual resource ID is known, so every descriptor must be filtered against
-// the same read_resource authorization used when resources are read.
+// TestResponseFilteringWriter_ResourceTemplatesList verifies that resource-
+// template enumeration filters every descriptor against the same read_resource
+// authorization used when resources are read.
 func TestResponseFilteringWriter_ResourceTemplatesList(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Protected tool, prompt, and resource lists were decoded permissively, so malformed, duplicate, or case-folded authorization fields could be interpreted differently by the filter and the client.
- Validate list containers and per-item identifiers before policy evaluation, return a generic internal error for invalid responses, and leave the tool annotation cache unchanged when validation fails.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Does this introduce a user-facing change?

Malformed or ambiguously encoded protected list results now return a generic internal JSON-RPC error instead of passing through unfiltered.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

1. Strictly validate the list field and authorization identifier for existing protected list responses.
2. Reject malformed or ambiguous results before authorization or cache mutation.
3. Add table-driven coverage across tools, prompts, and resources.
4. Run repository verification and independent code review.

</details>

## Special notes for reviewers

- The changed `pkg/authz` package passes within the race-enabled `task test` run. The repository-wide command currently fails only in unrelated existing `pkg/plugins/pluginsvc` tests.
- `task lint` reports no findings in changed files; it remains non-zero because of existing `gci` findings in `pkg/authserver/server/provider.go` and `pkg/authserver/server_impl.go`.
