### PR TITLE
Harden find tool response filtering

### DIFF
--- a/pkg/authz/response_filter.go
+++ b/pkg/authz/response_filter.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"golang.org/x/exp/jsonrpc2"
@@ -1197,58 +1198,48 @@ func (rfw *ResponseFilteringWriter) requestID() jsonrpc2.ID {
 }
 
 // filterFindToolResponse filters the tools list embedded in a find_tool tools/call
-// response. The response is a CallToolResult whose first text content item contains
-// a JSON-encoded optimizer.FindToolOutput. Only tools the caller is authorized to
-// call are retained.
-//
-// mcp.CallToolResult is used directly with its built-in UnmarshalJSON so that the
-// Content interface slice is deserialized correctly into concrete types
-// (TextContent, ImageContent, etc.) without a bespoke minimal struct.
-//
-// To identify which content item carries the find_tool output, each TextContent item
-// is tentatively unmarshaled as optimizer.FindToolOutput. A successful unmarshal is a
-// stronger signal than checking tc.Type == "text" alone — it confirms the item actually
-// carries a find_tool result rather than an arbitrary text payload (e.g. an error string).
+// response. Successful output must have exactly one text content item containing a
+// JSON-encoded optimizer.FindToolOutput. Modern responses may repeat that output in
+// structuredContent; when present, both representations must agree.
 func (rfw *ResponseFilteringWriter) filterFindToolResponse(response *jsonrpc2.Response) (*jsonrpc2.Response, error) {
-	// Use mcp.CallToolResult's built-in UnmarshalJSON for correct Content interface dispatch.
-	var callResult mcp.CallToolResult
-	if err := json.Unmarshal(response.Result, &callResult); err != nil || callResult.IsError {
-		return response, nil
+	callResult, err := decodeFindToolCallResult(response.Result)
+	if err != nil {
+		return nil, fmt.Errorf("validating find_tool response: %w", err)
 	}
 
-	// Find the first TextContent item that successfully unmarshals as optimizer.FindToolOutput.
-	textIdx := -1
-	var output optimizer.FindToolOutput
-	for i, c := range callResult.Content {
-		tc, ok := c.(mcp.TextContent)
-		if !ok {
-			continue
+	if callResult.isError {
+		if len(callResult.outputs) != 0 || callResult.structuredContent != nil {
+			return nil, errors.New("find_tool error result carried output")
 		}
-		if err := json.Unmarshal([]byte(tc.Text), &output); err == nil {
-			textIdx = i
-			break
-		}
-	}
-	if textIdx == -1 {
 		return response, nil
+	}
+	if len(callResult.content) != 1 {
+		return nil, fmt.Errorf("find_tool result must contain exactly one content item, got %d", len(callResult.content))
+	}
+	if len(callResult.outputs) != 1 {
+		return nil, fmt.Errorf("find_tool result must contain exactly one text output, got %d", len(callResult.outputs))
+	}
+
+	textOutput := callResult.outputs[0]
+	if callResult.structuredContent != nil {
+		equivalent, err := equivalentJSONValues(textOutput.rawOutput, callResult.structuredContent.rawOutput)
+		if err != nil {
+			return nil, fmt.Errorf("comparing find_tool output representations: %w", err)
+		}
+		if !equivalent {
+			return nil, errors.New("find_tool text and structured outputs differ")
+		}
 	}
 
 	// Populate annotation cache before filtering, mirroring filterToolsResponse.
 	// Subsequent call_tool requests use these annotations for Cedar when-clause evaluation
 	// (e.g. resource.readOnlyHint). The cache is populated from the unfiltered list so
 	// that annotations are available even for tools that Cedar will deny.
-	rfw.annotationCache.SetFromToolsList(output.Tools)
+	rfw.annotationCache.SetFromToolsList(textOutput.output.Tools)
 
-	output.Tools = filterToolsByPolicy(rfw.request.Context(), rfw.authorizer, output.Tools)
+	authorizedIndexes := authorizedToolIndexes(rfw.request.Context(), rfw.authorizer, textOutput.output.Tools)
 
-	filteredText, err := json.Marshal(output)
-	if err != nil {
-		return nil, fmt.Errorf("re-encoding find_tool output: %w", err)
-	}
-	original := callResult.Content[textIdx].(mcp.TextContent)
-	callResult.Content[textIdx] = mcp.TextContent{Type: original.Type, Text: string(filteredText)}
-
-	filteredResult, err := json.Marshal(callResult)
+	filteredResult, err := callResult.withFilteredToolIndexes(authorizedIndexes)
 	if err != nil {
 		return nil, fmt.Errorf("re-encoding call result: %w", err)
 	}
@@ -1257,4 +1248,307 @@ func (rfw *ResponseFilteringWriter) filterFindToolResponse(response *jsonrpc2.Re
 		ID:     response.ID,
 		Result: json.RawMessage(filteredResult),
 	}, nil
+}
+
+type findToolOutputCarrier struct {
+	contentIndex   int
+	contentMembers []jsonObjectMember
+	rawOutput      json.RawMessage
+	outputMembers  []jsonObjectMember
+	rawTools       []json.RawMessage
+	output         optimizer.FindToolOutput
+}
+
+type decodedFindToolCallResult struct {
+	members           []jsonObjectMember
+	content           []json.RawMessage
+	isError           bool
+	outputs           []findToolOutputCarrier
+	structuredContent *findToolOutputCarrier
+}
+
+type findToolCallResultEnvelope struct {
+	members       []jsonObjectMember
+	content       []json.RawMessage
+	isError       bool
+	rawStructured json.RawMessage
+	hasStructured bool
+}
+
+// decodeFindToolCallResult validates every output representation before any
+// authorization or cache mutation while retaining raw metadata and extensions.
+func decodeFindToolCallResult(data json.RawMessage) (*decodedFindToolCallResult, error) {
+	envelope, err := decodeFindToolCallResultEnvelope(data)
+	if err != nil {
+		return nil, err
+	}
+
+	decoded := &decodedFindToolCallResult{
+		members: envelope.members,
+		content: envelope.content,
+		isError: envelope.isError,
+		outputs: make([]findToolOutputCarrier, 0, 1),
+	}
+	for i, item := range envelope.content {
+		carrier, ok, err := decodeFindToolTextContent(i, item)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			decoded.outputs = append(decoded.outputs, *carrier)
+		}
+	}
+
+	if envelope.hasStructured {
+		carrier, ok, err := decodeFindToolOutput(envelope.rawStructured)
+		if err != nil {
+			return nil, fmt.Errorf("decoding find_tool structuredContent: %w", err)
+		}
+		if !ok {
+			if !envelope.isError {
+				return nil, errors.New("find_tool structuredContent is missing tools")
+			}
+			return decoded, nil
+		}
+		decoded.structuredContent = carrier
+	}
+
+	return decoded, nil
+}
+
+func decodeFindToolCallResultEnvelope(data json.RawMessage) (*findToolCallResultEnvelope, error) {
+	members, err := decodeJSONObjectMembers(data)
+	if err != nil {
+		return nil, err
+	}
+
+	rawContent, ok, err := uniqueCanonicalMember(members, "content")
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errors.New("find_tool result is missing content")
+	}
+	rawIsError, hasIsError, err := uniqueCanonicalMember(members, "isError")
+	if err != nil {
+		return nil, err
+	}
+	rawStructured, hasStructured, err := uniqueCanonicalMember(members, "structuredContent")
+	if err != nil {
+		return nil, err
+	}
+
+	var content []json.RawMessage
+	if err := json.Unmarshal(rawContent, &content); err != nil {
+		return nil, fmt.Errorf("decoding find_tool content: %w", err)
+	}
+	if content == nil {
+		return nil, errors.New("find_tool content must be an array")
+	}
+
+	isError := false
+	if hasIsError {
+		var value *bool
+		if err := json.Unmarshal(rawIsError, &value); err != nil {
+			return nil, fmt.Errorf("decoding find_tool isError: %w", err)
+		}
+		if value == nil {
+			return nil, errors.New("find_tool isError must be a boolean")
+		}
+		isError = *value
+	}
+
+	return &findToolCallResultEnvelope{
+		members:       members,
+		content:       content,
+		isError:       isError,
+		rawStructured: rawStructured,
+		hasStructured: hasStructured,
+	}, nil
+}
+
+func decodeFindToolTextContent(index int, data json.RawMessage) (*findToolOutputCarrier, bool, error) {
+	members, err := decodeJSONObjectMembers(data)
+	if err != nil {
+		return nil, false, fmt.Errorf("decoding find_tool content at index %d: %w", index, err)
+	}
+	rawType, ok, err := uniqueCanonicalMember(members, "type")
+	if err != nil {
+		return nil, false, fmt.Errorf("find_tool content at index %d: %w", index, err)
+	}
+	if !ok {
+		return nil, false, fmt.Errorf("find_tool content at index %d is missing type", index)
+	}
+	var contentType *string
+	if err := json.Unmarshal(rawType, &contentType); err != nil || contentType == nil {
+		return nil, false, fmt.Errorf("find_tool content at index %d has an invalid type", index)
+	}
+	if *contentType != "text" {
+		return nil, false, nil
+	}
+
+	rawText, ok, err := uniqueCanonicalMember(members, "text")
+	if err != nil {
+		return nil, false, fmt.Errorf("find_tool text content at index %d: %w", index, err)
+	}
+	if !ok {
+		return nil, false, fmt.Errorf("find_tool text content at index %d is missing text", index)
+	}
+	var text *string
+	if err := json.Unmarshal(rawText, &text); err != nil || text == nil {
+		return nil, false, fmt.Errorf("find_tool text content at index %d has invalid text", index)
+	}
+
+	carrier, isOutput, err := decodeFindToolOutput(json.RawMessage(*text))
+	if err != nil {
+		return nil, false, fmt.Errorf("decoding find_tool text content at index %d: %w", index, err)
+	}
+	if !isOutput {
+		return nil, false, nil
+	}
+	carrier.contentIndex = index
+	carrier.contentMembers = members
+	return carrier, true, nil
+}
+
+// decodeFindToolOutput returns ok=false for ancillary text that is not a JSON
+// object or does not contain a tools member. A tools-bearing object is always
+// validated strictly and decoded into the concrete output type.
+func decodeFindToolOutput(data json.RawMessage) (*findToolOutputCarrier, bool, error) {
+	members, err := decodeJSONObjectMembers(data)
+	if err != nil {
+		if trimmed := bytes.TrimSpace(data); len(trimmed) != 0 && trimmed[0] == '{' {
+			return nil, false, fmt.Errorf("decoding tools-bearing object: %w", err)
+		}
+		return nil, false, nil
+	}
+	rawToolsValue, ok, err := uniqueCanonicalMember(members, "tools")
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	if err := validateListResult(data, "tools", "name"); err != nil {
+		return nil, false, err
+	}
+	var rawTools []json.RawMessage
+	if err := json.Unmarshal(rawToolsValue, &rawTools); err != nil {
+		return nil, false, fmt.Errorf("decoding raw find_tool tools: %w", err)
+	}
+
+	var output optimizer.FindToolOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		return nil, false, fmt.Errorf("decoding typed find_tool output: %w", err)
+	}
+	return &findToolOutputCarrier{
+		rawOutput:     data,
+		outputMembers: members,
+		rawTools:      rawTools,
+		output:        output,
+	}, true, nil
+}
+
+func equivalentJSONValues(left, right json.RawMessage) (bool, error) {
+	var leftValue any
+	leftDecoder := json.NewDecoder(bytes.NewReader(left))
+	leftDecoder.UseNumber()
+	if err := leftDecoder.Decode(&leftValue); err != nil {
+		return false, err
+	}
+	var rightValue any
+	rightDecoder := json.NewDecoder(bytes.NewReader(right))
+	rightDecoder.UseNumber()
+	if err := rightDecoder.Decode(&rightValue); err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(leftValue, rightValue), nil
+}
+
+func (result *decodedFindToolCallResult) withFilteredToolIndexes(indexes []int) ([]byte, error) {
+	textCarrier := result.outputs[0]
+	filteredTextOutput, err := textCarrier.withFilteredToolIndexes(indexes)
+	if err != nil {
+		return nil, err
+	}
+	textValue, err := json.Marshal(string(filteredTextOutput))
+	if err != nil {
+		return nil, err
+	}
+	filteredTextContent, err := encodeJSONObjectMembers(
+		textCarrier.contentMembers,
+		map[string]json.RawMessage{"text": textValue},
+	)
+	if err != nil {
+		return nil, err
+	}
+	result.content[textCarrier.contentIndex] = filteredTextContent
+
+	filteredContent, err := json.Marshal(result.content)
+	if err != nil {
+		return nil, err
+	}
+	replacements := map[string]json.RawMessage{"content": filteredContent}
+	if result.structuredContent != nil {
+		filteredStructuredOutput, err := result.structuredContent.withFilteredToolIndexes(indexes)
+		if err != nil {
+			return nil, err
+		}
+		replacements["structuredContent"] = filteredStructuredOutput
+	}
+	return encodeJSONObjectMembers(result.members, replacements)
+}
+
+func (carrier *findToolOutputCarrier) withFilteredToolIndexes(indexes []int) ([]byte, error) {
+	filteredTools := make([]json.RawMessage, 0, len(indexes))
+	for _, index := range indexes {
+		if index < 0 || index >= len(carrier.rawTools) {
+			return nil, fmt.Errorf("authorized tool index %d is out of range", index)
+		}
+		filteredTools = append(filteredTools, carrier.rawTools[index])
+	}
+	return encodeJSONObjectMembers(
+		carrier.outputMembers,
+		map[string]json.RawMessage{"tools": encodeJSONArrayValues(filteredTools)},
+	)
+}
+
+func encodeJSONArrayValues(values []json.RawMessage) json.RawMessage {
+	var encoded bytes.Buffer
+	encoded.WriteByte('[')
+	for i, value := range values {
+		if i != 0 {
+			encoded.WriteByte(',')
+		}
+		encoded.Write(value)
+	}
+	encoded.WriteByte(']')
+	return encoded.Bytes()
+}
+
+// encodeJSONObjectMembers replaces canonical values while retaining raw extensions.
+func encodeJSONObjectMembers(
+	members []jsonObjectMember,
+	replacements map[string]json.RawMessage,
+) ([]byte, error) {
+	var encoded bytes.Buffer
+	encoded.WriteByte('{')
+	for i, member := range members {
+		if i != 0 {
+			encoded.WriteByte(',')
+		}
+		name, err := json.Marshal(member.name)
+		if err != nil {
+			return nil, err
+		}
+		encoded.Write(name)
+		encoded.WriteByte(':')
+		value := member.value
+		if replacement, ok := replacements[member.name]; ok {
+			value = replacement
+		}
+		encoded.Write(value)
+	}
+	encoded.WriteByte('}')
+	return encoded.Bytes(), nil
 }

--- a/pkg/authz/response_filter_test.go
+++ b/pkg/authz/response_filter_test.go
@@ -31,204 +31,355 @@ import (
 	"github.com/stacklok/toolhive/pkg/vmcp/session/optimizerdec"
 )
 
-// buildFindToolJSONRPCResponse creates a JSON-RPC tools/call response whose content
-// text is a serialised find_tool output containing the given tools.
-func buildFindToolJSONRPCResponse(t *testing.T, tools []mcp.Tool) []byte {
+// findToolJSONRPCResponse wraps a raw CallToolResult in a JSON-RPC response.
+// Keeping the result raw lets malformed/ambiguous JSON reach the filter exactly
+// as an upstream server emitted it instead of being normalized by a Go map.
+func findToolJSONRPCResponse(t *testing.T, result string) []byte {
 	t.Helper()
-	output := optimizer.FindToolOutput{Tools: tools}
-	outputJSON, err := json.Marshal(output)
-	require.NoError(t, err)
-
-	callResult := map[string]interface{}{
-		"content": []map[string]interface{}{
-			{"type": "text", "text": string(outputJSON)},
-		},
-		"isError": false,
-	}
-	resultJSON, err := json.Marshal(callResult)
-	require.NoError(t, err)
-
-	resp := &jsonrpc2.Response{
-		ID:     jsonrpc2.Int64ID(1),
-		Result: json.RawMessage(resultJSON),
-	}
-	encoded, err := jsonrpc2.EncodeMessage(resp)
-	require.NoError(t, err)
-	return encoded
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":` + result + `}`)
+	require.True(t, json.Valid(body), "test fixture must be valid JSON: %s", body)
+	return body
 }
 
-// decodeFindToolOutput decodes a JSON-RPC response produced by buildFindToolJSONRPCResponse
-// and returns the optimizer.FindToolOutput embedded in the first text content item.
-func decodeFindToolOutput(t *testing.T, body []byte) optimizer.FindToolOutput {
+func runFindToolResponseFilter(
+	t *testing.T, body []byte, authorizer authorizers.Authorizer, cache *AnnotationCache,
+) *httptest.ResponseRecorder {
 	t.Helper()
-	msg, err := jsonrpc2.DecodeMessage(body)
+	rr := httptest.NewRecorder()
+	rfw := NewResponseFilteringWriter(
+		rr,
+		authorizer,
+		newParsedUser1Request(t, `{"jsonrpc":"2.0","id":1,"method":"tools/call"}`),
+		optimizerdec.FindToolName,
+		cache,
+		nil,
+	)
+	rfw.ResponseWriter.Header().Set("Content-Type", "application/json")
+	_, err := rfw.Write(body)
 	require.NoError(t, err)
-	rpcResp, ok := msg.(*jsonrpc2.Response)
+	require.NoError(t, rfw.FlushAndFilter())
+	return rr
+}
+
+func decodeFindToolResultMap(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	message, err := jsonrpc2.DecodeMessage(body)
+	require.NoError(t, err)
+	response, ok := message.(*jsonrpc2.Response)
 	require.True(t, ok)
-	require.Nil(t, rpcResp.Error)
-
-	var callResult struct {
-		Content []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	require.NoError(t, json.Unmarshal(rpcResp.Result, &callResult))
-	require.NotEmpty(t, callResult.Content)
-
-	var output optimizer.FindToolOutput
-	require.NoError(t, json.Unmarshal([]byte(callResult.Content[0].Text), &output))
-	return output
+	require.Nil(t, response.Error)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(response.Result, &result))
+	return result
 }
 
-// TestFindToolResponseFilter verifies that find_tool results are filtered by Cedar
-// policy before being returned to the caller.
-func TestFindToolResponseFilter(t *testing.T) {
+func assertFindToolFilterFailedClosed(
+	t *testing.T, rr *httptest.ResponseRecorder, authorizer *mockAuthorizer,
+	cache *AnnotationCache, cachedAnnotations *authorizers.ToolAnnotations,
+) {
+	t.Helper()
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Empty(t, authorizer.calls, "invalid output must be rejected before authorization")
+	assert.Same(t, cachedAnnotations, cache.Get("previously-cached-tool"),
+		"invalid output must not replace the annotation cache")
+
+	message, err := jsonrpc2.DecodeMessage(rr.Body.Bytes())
+	require.NoError(t, err)
+	response, ok := message.(*jsonrpc2.Response)
+	require.True(t, ok)
+	require.NotNil(t, response.Error)
+	assert.Nil(t, response.Result)
+
+	var envelope struct {
+		Error struct {
+			Code    int64  `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &envelope))
+	assert.Equal(t, mcpparser.CodeInternalError, envelope.Error.Code)
+	assert.Equal(t, "internal error", envelope.Error.Message)
+}
+
+func TestFindToolResponseFilter_FiltersEveryOutputRepresentation(t *testing.T) {
 	t.Parallel()
 
-	authorizer, err := cedar.NewCedarAuthorizer(cedar.ConfigOptions{
-		Policies: []string{
-			`permit(principal, action == Action::"call_tool", resource == Tool::"weather");`,
-		},
-		EntitiesJSON: `[]`,
-	}, "")
+	const protectedDescriptor = "protected-find-tool-sentinel"
+	const output = `{"tools":[` +
+		`{"name":"weather","description":"Get weather","annotations":{"readOnlyHint":true}},` +
+		`{"name":"` + protectedDescriptor + `","description":"restricted",` +
+		`"annotations":{"readOnlyHint":true}}],` +
+		`"token_metrics":{"baseline_tokens":20,"returned_tokens":10,"savings_percent":50}}`
+	escapedOutput, err := json.Marshal(output)
 	require.NoError(t, err)
 
-	identity := &auth.Identity{PrincipalInfo: auth.PrincipalInfo{
-		Subject: "user1",
-		Claims:  map[string]interface{}{"sub": "user1"},
-	}}
-	newReq := func(t *testing.T) *http.Request {
-		t.Helper()
-		req, err := http.NewRequest(http.MethodPost, "/messages", nil)
-		require.NoError(t, err)
-		return req.WithContext(auth.WithIdentity(req.Context(), identity))
-	}
-	newWriter := func(t *testing.T, cache *AnnotationCache) (*httptest.ResponseRecorder, *ResponseFilteringWriter) {
-		t.Helper()
-		rr := httptest.NewRecorder()
-		rr.Header().Set("Content-Type", "application/json")
-		fw := NewResponseFilteringWriter(rr, authorizer, newReq(t), optimizerdec.FindToolName, cache, nil)
-		fw.ResponseWriter.Header().Set("Content-Type", "application/json")
-		return rr, fw
+	testCases := []struct {
+		name   string
+		result string
+		dual   bool
+	}{
+		{
+			name: "text and structured content",
+			result: `{"content":[{"type":"text","text":` + string(escapedOutput) + `}],` +
+				`"structuredContent":` + output + `}`,
+			dual: true,
+		},
+		{
+			name:   "legacy text only",
+			result: `{"content":[{"type":"text","text":` + string(escapedOutput) + `}]}`,
+		},
 	}
 
-	t.Run("Cedar policy filters unauthorized tools", func(t *testing.T) {
-		t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			authorizer := &mockAuthorizer{results: map[string]mockResult{
+				"weather":           {authorized: true},
+				protectedDescriptor: {authorized: false},
+			}}
+			cache := NewAnnotationCache()
+			rr := runFindToolResponseFilter(t, findToolJSONRPCResponse(t, tc.result), authorizer, cache)
 
-		// The optimizer returns two tools but the caller is only permitted "weather".
-		responseBytes := buildFindToolJSONRPCResponse(t, []mcp.Tool{
-			{Name: "weather", Description: "Get weather"},
-			{Name: "admin_tool", Description: "Admin operations"},
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.NotContains(t, rr.Body.String(), protectedDescriptor,
+				"an unauthorized tool must be removed from the whole wire response")
+			result := decodeFindToolResultMap(t, rr.Body.Bytes())
+			content, ok := result["content"].([]any)
+			require.True(t, ok)
+			require.Len(t, content, 1)
+			textContent, ok := content[0].(map[string]any)
+			require.True(t, ok)
+			text, ok := textContent["text"].(string)
+			require.True(t, ok)
+			var textOutput optimizer.FindToolOutput
+			require.NoError(t, json.Unmarshal([]byte(text), &textOutput))
+			require.Len(t, textOutput.Tools, 1)
+			assert.Equal(t, "weather", textOutput.Tools[0].Name)
+
+			if tc.dual {
+				structured, ok := result["structuredContent"].(map[string]any)
+				require.True(t, ok)
+				tools, ok := structured["tools"].([]any)
+				require.True(t, ok)
+				require.Len(t, tools, 1)
+				tool, ok := tools[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "weather", tool["name"])
+			}
+
+			assert.NotNil(t, cache.Get("weather"))
+			assert.NotNil(t, cache.Get(protectedDescriptor),
+				"authorization needs annotations from the unfiltered output")
 		})
+	}
+}
 
-		rr, fw := newWriter(t, nil)
-		_, err := fw.Write(responseBytes)
-		require.NoError(t, err)
-		require.NoError(t, fw.FlushAndFilter())
+func TestFindToolResponseFilter_RejectsMalformedOrAmbiguousSuccessfulOutput(t *testing.T) {
+	t.Parallel()
 
-		output := decodeFindToolOutput(t, rr.Body.Bytes())
-		require.Len(t, output.Tools, 1, "only the permitted tool should remain")
-		assert.Equal(t, "weather", output.Tools[0].Name)
-	})
+	const protectedDescriptor = "protected-find-tool-sentinel"
+	testCases := []struct {
+		name   string
+		result string
+	}{
+		{name: "outer result is not an object", result: `[]`},
+		{name: "outer result is empty", result: `{}`},
+		{name: "content is not an array", result: `{"content":{}}`},
+		{name: "duplicate content member", result: `{"content":[],"content":[]}`},
+		{name: "case-folded content alias", result: `{"content":[],"CONTENT":[]}`},
+		{name: "duplicate isError member", result: `{"content":[],"isError":false,"isError":true}`},
+		{name: "case-folded isError alias", result: `{"content":[],"isError":false,"ISERROR":true}`},
+		{name: "duplicate structuredContent member", result: `{"content":[],` +
+			`"structuredContent":{"tools":[]},"structuredContent":{"tools":[` +
+			`{"name":"` + protectedDescriptor + `"}]}}`},
+		{name: "case-folded structuredContent alias", result: `{"content":[],` +
+			`"structuredContent":{"tools":[]},"STRUCTUREDCONTENT":{"tools":[` +
+			`{"name":"` + protectedDescriptor + `"}]}}`},
+		{name: "permissive empty embedded object", result: `{"content":[{"type":"text","text":"{}"}]}`},
+		{name: "duplicate content type member", result: `{"content":[{"type":"text","type":"image",` +
+			`"text":"{\"tools\":[{\"name\":\"` + protectedDescriptor + `\"}]}"}]}`},
+		{name: "case-folded content type alias", result: `{"content":[{"type":"text","TYPE":"image",` +
+			`"text":"{\"tools\":[{\"name\":\"` + protectedDescriptor + `\"}]}"}]}`},
+		{name: "duplicate content text member", result: `{"content":[{"type":"text",` +
+			`"text":"{\"tools\":[]}","text":"{\"tools\":[{\"name\":\"` +
+			protectedDescriptor + `\"}]}"}]}`},
+		{name: "case-folded content text alias", result: `{"content":[{"type":"text",` +
+			`"text":"{\"tools\":[]}","TEXT":"{\"tools\":[{\"name\":\"` +
+			protectedDescriptor + `\"}]}"}]}`},
+		{name: "embedded tools is not an array", result: `{"content":[{"type":"text",` +
+			`"text":"{\"tools\":{}}"}]}`},
+		{name: "embedded tool name is not a string", result: `{"content":[{"type":"text",` +
+			`"text":"{\"tools\":[{\"name\":17}]}"}]}`},
+		{name: "duplicate embedded tools member", result: `{"content":[{"type":"text",` +
+			`"text":"{\"tools\":[],\"tools\":[{\"name\":\"` + protectedDescriptor + `\"}]}"}]}`},
+		{name: "case-folded embedded tools alias", result: `{"content":[{"type":"text",` +
+			`"text":"{\"tools\":[],\"TOOLS\":[{\"name\":\"` + protectedDescriptor + `\"}]}"}]}`},
+		{name: "duplicate embedded name member", result: `{"content":[{"type":"text",` +
+			`"text":"{\"tools\":[{\"name\":\"weather\",\"name\":\"` + protectedDescriptor + `\"}]}"}]}`},
+		{name: "case-folded embedded name alias", result: `{"content":[{"type":"text",` +
+			`"text":"{\"tools\":[{\"name\":\"weather\",\"NAME\":\"` + protectedDescriptor + `\"}]}"}]}`},
+		{name: "no find tool output", result: `{"content":[{"type":"text","text":"no matching tools"}]}`},
+		{name: "multiple tools-bearing text carriers", result: `{"content":[` +
+			`{"type":"text","text":"{\"tools\":[{\"name\":\"weather\"}]}"},` +
+			`{"type":"text","text":"{\"tools\":[{\"name\":\"` + protectedDescriptor + `\"}]}"}]}`},
+		{name: "valid output plus ancillary text", result: `{"content":[` +
+			`{"type":"text","text":"{\"tools\":[{\"name\":\"weather\"}]}"},` +
+			`{"type":"text","text":"additional explanation"}]}`},
+		{name: "valid output plus ancillary non-text content", result: `{"content":[` +
+			`{"type":"text","text":"{\"tools\":[{\"name\":\"weather\"}]}"},` +
+			`{"type":"image","data":"aGVsbG8=","mimeType":"image/png"}]}`},
+	}
 
-	t.Run("isError response passes through unfiltered", func(t *testing.T) {
-		t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			authorizer := &mockAuthorizer{results: map[string]mockResult{
+				"weather":           {authorized: true},
+				protectedDescriptor: {authorized: false},
+			}}
+			cache := NewAnnotationCache()
+			cachedAnnotations := &authorizers.ToolAnnotations{}
+			cache.Set("previously-cached-tool", cachedAnnotations)
+			rr := runFindToolResponseFilter(t, findToolJSONRPCResponse(t, tc.result), authorizer, cache)
 
-		// Build a CallToolResult with IsError set — the filter must not touch it.
-		errorResult := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{"type": "text", "text": "tool execution failed"},
-			},
-			"isError": true,
-		}
-		resultJSON, err := json.Marshal(errorResult)
-		require.NoError(t, err)
-		resp := &jsonrpc2.Response{ID: jsonrpc2.Int64ID(1), Result: json.RawMessage(resultJSON)}
-		responseBytes, err := jsonrpc2.EncodeMessage(resp)
-		require.NoError(t, err)
-
-		rr, fw := newWriter(t, nil)
-		_, err = fw.Write(responseBytes)
-		require.NoError(t, err)
-		require.NoError(t, fw.FlushAndFilter())
-
-		assert.Equal(t, responseBytes, rr.Body.Bytes(), "error response must pass through unchanged")
-	})
-
-	t.Run("response with no text content passes through unfiltered", func(t *testing.T) {
-		t.Parallel()
-
-		// A CallToolResult with no content items at all.
-		emptyResult := map[string]interface{}{"content": []interface{}{}, "isError": false}
-		resultJSON, err := json.Marshal(emptyResult)
-		require.NoError(t, err)
-		resp := &jsonrpc2.Response{ID: jsonrpc2.Int64ID(1), Result: json.RawMessage(resultJSON)}
-		responseBytes, err := jsonrpc2.EncodeMessage(resp)
-		require.NoError(t, err)
-
-		rr, fw := newWriter(t, nil)
-		_, err = fw.Write(responseBytes)
-		require.NoError(t, err)
-		require.NoError(t, fw.FlushAndFilter())
-
-		assert.Equal(t, responseBytes, rr.Body.Bytes(), "response with no content must pass through unchanged")
-	})
-
-	t.Run("text content that is not a FindToolOutput passes through unfiltered", func(t *testing.T) {
-		t.Parallel()
-
-		// A plain text content item that is not a valid FindToolOutput JSON.
-		plainText := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{"type": "text", "text": "this is a plain string, not a find_tool result"},
-			},
-			"isError": false,
-		}
-		resultJSON, err := json.Marshal(plainText)
-		require.NoError(t, err)
-		resp := &jsonrpc2.Response{ID: jsonrpc2.Int64ID(1), Result: json.RawMessage(resultJSON)}
-		responseBytes, err := jsonrpc2.EncodeMessage(resp)
-		require.NoError(t, err)
-
-		rr, fw := newWriter(t, nil)
-		_, err = fw.Write(responseBytes)
-		require.NoError(t, err)
-		require.NoError(t, fw.FlushAndFilter())
-
-		assert.Equal(t, responseBytes, rr.Body.Bytes(), "non-FindToolOutput text content must pass through unchanged")
-	})
-
-	t.Run("annotation cache is populated from unfiltered tool list", func(t *testing.T) {
-		t.Parallel()
-
-		readOnly := true
-		responseBytes := buildFindToolJSONRPCResponse(t, []mcp.Tool{
-			{
-				Name:        "weather",
-				Description: "Get weather",
-				Annotations: mcp.ToolAnnotation{ReadOnlyHint: &readOnly},
-			},
-			// admin_tool is not permitted by Cedar, but its annotations must still
-			// be cached so that a subsequent call_tool request can evaluate Cedar
-			// when-clauses against them.
-			{
-				Name:        "admin_tool",
-				Description: "Admin operations",
-				Annotations: mcp.ToolAnnotation{ReadOnlyHint: &readOnly},
-			},
+			assert.NotContains(t, rr.Body.String(), protectedDescriptor)
+			assertFindToolFilterFailedClosed(t, rr, authorizer, cache, cachedAnnotations)
 		})
+	}
+}
 
+func TestFindToolResponseFilter_RejectsMalformedOrDivergentStructuredContent(t *testing.T) {
+	t.Parallel()
+
+	const protectedDescriptor = "protected-find-tool-sentinel"
+	const textOutput = `"{\"tools\":[{\"name\":\"weather\"}],` +
+		`\"token_metrics\":{\"baseline_tokens\":10,\"returned_tokens\":5,\"savings_percent\":50}}"`
+	testCases := []struct {
+		name              string
+		structuredContent string
+	}{
+		{name: "empty object", structuredContent: `{}`},
+		{name: "tools is not an array", structuredContent: `{"tools":{}}`},
+		{name: "tool name is not a string", structuredContent: `{"tools":[{"name":17}]}`},
+		{name: "duplicate tools member", structuredContent: `{"tools":[],"tools":[` +
+			`{"name":"` + protectedDescriptor + `"}]}`},
+		{name: "case-folded tools alias", structuredContent: `{"tools":[],"TOOLS":[` +
+			`{"name":"` + protectedDescriptor + `"}]}`},
+		{name: "diverges from text output", structuredContent: `{"tools":[` +
+			`{"name":"` + protectedDescriptor + `"}],` +
+			`"token_metrics":{"baseline_tokens":10,"returned_tokens":5,"savings_percent":50}}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := `{"content":[{"type":"text","text":` + textOutput + `}],` +
+				`"structuredContent":` + tc.structuredContent + `}`
+			authorizer := &mockAuthorizer{results: map[string]mockResult{
+				"weather":           {authorized: true},
+				protectedDescriptor: {authorized: false},
+			}}
+			cache := NewAnnotationCache()
+			cachedAnnotations := &authorizers.ToolAnnotations{}
+			cache.Set("previously-cached-tool", cachedAnnotations)
+			rr := runFindToolResponseFilter(t, findToolJSONRPCResponse(t, result), authorizer, cache)
+
+			assert.NotContains(t, rr.Body.String(), protectedDescriptor)
+			assertFindToolFilterFailedClosed(t, rr, authorizer, cache, cachedAnnotations)
+		})
+	}
+}
+
+func TestFindToolResponseFilter_ErrorResultsDoNotBypassOutputValidation(t *testing.T) {
+	t.Parallel()
+
+	const protectedDescriptor = "protected-find-tool-sentinel"
+	t.Run("plain tool error passes through", func(t *testing.T) {
+		t.Parallel()
+		body := findToolJSONRPCResponse(t,
+			`{"content":[{"type":"text","text":"tool execution failed"}],"isError":true}`)
+		authorizer := &mockAuthorizer{results: map[string]mockResult{}}
 		cache := NewAnnotationCache()
-		_, fw := newWriter(t, cache)
-		_, err := fw.Write(responseBytes)
-		require.NoError(t, err)
-		require.NoError(t, fw.FlushAndFilter())
+		cachedAnnotations := &authorizers.ToolAnnotations{}
+		cache.Set("previously-cached-tool", cachedAnnotations)
+		rr := runFindToolResponseFilter(t, body, authorizer, cache)
 
-		// Both tools must be in the cache even though admin_tool is filtered from the response.
-		assert.NotNil(t, cache.Get("weather"), "permitted tool annotation must be cached")
-		assert.NotNil(t, cache.Get("admin_tool"), "denied tool annotation must still be cached for future call_tool Cedar evaluation")
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.JSONEq(t, string(body), rr.Body.String())
+		assert.Empty(t, authorizer.calls)
+		assert.Same(t, cachedAnnotations, cache.Get("previously-cached-tool"))
 	})
+
+	t.Run("tool error containing a tools payload fails closed", func(t *testing.T) {
+		t.Parallel()
+		result := `{"content":[{"type":"text","text":"{\"tools\":[{\"name\":\"` +
+			protectedDescriptor + `\"}]}"}],"isError":true}`
+		authorizer := &mockAuthorizer{results: map[string]mockResult{
+			protectedDescriptor: {authorized: false},
+		}}
+		cache := NewAnnotationCache()
+		cachedAnnotations := &authorizers.ToolAnnotations{}
+		cache.Set("previously-cached-tool", cachedAnnotations)
+		rr := runFindToolResponseFilter(t, findToolJSONRPCResponse(t, result), authorizer, cache)
+
+		assert.NotContains(t, rr.Body.String(), protectedDescriptor)
+		assertFindToolFilterFailedClosed(t, rr, authorizer, cache, cachedAnnotations)
+	})
+}
+
+func TestFindToolResponseFilter_PreservesUnrelatedResultAndContentFields(t *testing.T) {
+	t.Parallel()
+
+	const protectedDescriptor = "protected-find-tool-sentinel"
+	const output = `{"tools":[{"name":"weather","toolExtension":{"keep":"tool"}},` +
+		`{"name":"` + protectedDescriptor + `"}],` +
+		`"token_metrics":{"baseline_tokens":10,"returned_tokens":5,"savings_percent":50},` +
+		`"outputExtension":{"keep":"output"}}`
+	escapedOutput, err := json.Marshal(output)
+	require.NoError(t, err)
+	result := `{"_meta":{"trace":"result-meta"},"resultExtension":{"keep":true},"content":[` +
+		`{"type":"text","text":` + string(escapedOutput) + `,"annotations":{"audience":["assistant"]},` +
+		`"_meta":{"trace":"content-meta"},"contentExtension":"keep"}],` +
+		`"structuredContent":` + output + `}`
+	authorizer := &mockAuthorizer{results: map[string]mockResult{
+		"weather":           {authorized: true},
+		protectedDescriptor: {authorized: false},
+	}}
+	rr := runFindToolResponseFilter(t, findToolJSONRPCResponse(t, result), authorizer, nil)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.NotContains(t, rr.Body.String(), protectedDescriptor)
+	filtered := decodeFindToolResultMap(t, rr.Body.Bytes())
+	assert.Equal(t, map[string]any{"trace": "result-meta"}, filtered["_meta"])
+	assert.Equal(t, map[string]any{"keep": true}, filtered["resultExtension"])
+	content, ok := filtered["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, content, 1)
+	carrier, ok := content[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"audience": []any{"assistant"}}, carrier["annotations"])
+	assert.Equal(t, map[string]any{"trace": "content-meta"}, carrier["_meta"])
+	assert.Equal(t, "keep", carrier["contentExtension"])
+
+	text, ok := carrier["text"].(string)
+	require.True(t, ok)
+	var textOutput map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &textOutput))
+	structuredOutput, ok := filtered["structuredContent"].(map[string]any)
+	require.True(t, ok)
+	for representation, filteredOutput := range map[string]map[string]any{
+		"text":       textOutput,
+		"structured": structuredOutput,
+	} {
+		assert.Equal(t, map[string]any{"keep": "output"}, filteredOutput["outputExtension"], representation)
+		tools, ok := filteredOutput["tools"].([]any)
+		require.True(t, ok, representation)
+		require.Len(t, tools, 1, representation)
+		tool, ok := tools[0].(map[string]any)
+		require.True(t, ok, representation)
+		assert.Equal(t, "weather", tool["name"], representation)
+		assert.Equal(t, map[string]any{"keep": "tool"}, tool["toolExtension"], representation)
+	}
 }
 
 func TestResponseFilteringWriter(t *testing.T) {

--- a/pkg/authz/tool_filter.go
+++ b/pkg/authz/tool_filter.go
@@ -22,7 +22,25 @@ func filterToolsByPolicy(ctx context.Context, a authorizers.Authorizer, tools []
 
 	// Note: instantiating the list ensures that no null value is sent over the wire.
 	// This is basically defensive programming, but for clients.
-	filtered := make([]mcp.Tool, 0, len(tools))
+	indexes := authorizedToolIndexes(ctx, a, tools)
+	filtered := make([]mcp.Tool, 0, len(indexes))
+	for _, index := range indexes {
+		filtered = append(filtered, tools[index])
+	}
+	return filtered
+}
+
+// authorizedToolIndexes returns exact raw-list positions that may be exposed.
+func authorizedToolIndexes(ctx context.Context, a authorizers.Authorizer, tools []mcp.Tool) []int {
+	if a == nil {
+		indexes := make([]int, len(tools))
+		for i := range tools {
+			indexes[i] = i
+		}
+		return indexes
+	}
+
+	authorizedIndexes := make([]int, 0, len(tools))
 	for i, tool := range tools {
 		// Inject this tool's annotations into the context so Cedar policies
 		// that use when clauses on resource attributes (e.g. resource.readOnlyHint)
@@ -42,19 +60,19 @@ func filterToolsByPolicy(ctx context.Context, a authorizers.Authorizer, tools []
 		}
 
 		if authorized {
-			filtered = append(filtered, tool)
+			authorizedIndexes = append(authorizedIndexes, i)
 		} else {
 			slog.Debug("Tool denied by authorization policy",
 				"tool", tool.Name)
 		}
 	}
 
-	if denied := len(tools) - len(filtered); denied > 0 {
+	if denied := len(tools) - len(authorizedIndexes); denied > 0 {
 		slog.Debug("Authorization policy filtered tools",
-			"total", len(tools), "allowed", len(filtered), "denied", denied)
+			"total", len(tools), "allowed", len(authorizedIndexes), "denied", denied)
 	}
 
-	return filtered
+	return authorizedIndexes
 }
 
 // authorizeToolCall checks whether the caller is authorized to call a specific tool


### PR DESCRIPTION
## Summary

- Successful `find_tool` calls carry tool descriptors in serialized text and may repeat them in `structuredContent`; the response filter previously parsed only the first recognizable text payload, so malformed output could pass through and the structured representation remained unfiltered.
- Strictly validate the complete internal response shape before authorization or cache mutation, require text and structured representations to agree, and fail malformed or ambiguous results with the existing generic JSON-RPC error.
- Apply one set of positional authorization decisions to both raw representations so unauthorized descriptors are removed while metadata, extensions, and allowed descriptor fields remain intact.
- Follow up on review feedback from #6553.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)

## Does this introduce a user-facing change?

Malformed, ambiguous, or conflicting successful `find_tool` results now return a generic internal JSON-RPC error. Well-formed results expose authorized descriptors consistently through both text and structured content.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

1. Validate the raw `CallToolResult` envelope and every output representation before policy evaluation.
2. Require the trusted producer shape and reject malformed, ambiguous, or divergent output.
3. Authorize the validated tool list once and filter both representations by exact list position.
4. Preserve unrelated raw result, content, output, and allowed tool fields.
5. Add table-driven regressions and complete independent code, protocol, and security reviews.

</details>

## Special notes for reviewers

- ToolHive's producers emit exactly one text content item and optionally an equivalent `structuredContent` object; successful responses outside that contract now fail closed.
- The changed `pkg/authz` tests pass within the race-enabled `task test` run. The repository-wide command remains non-zero only because of unrelated existing `pkg/plugins/pluginsvc` failures.
- `task lint` reports no findings in changed files; it remains non-zero because of existing `gci` findings in `pkg/authserver/server/provider.go` and `pkg/authserver/server_impl.go`.
