### PR TITLE
Fix issue-triage workflow model for Stacklok gateway

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -43,7 +43,7 @@ jobs:
             - DO NOT add the "good-first-issue" label.
             - DO NOT post comments or otherwise communicate with the issue author.
             - If no labels are clearly applicable, do not apply any.
-          claude_args: --model claude-sonnet-4-6
+          claude_args: --model claude-sonnet-5
           anthropic_api_key: ${{ secrets.STACKLOK_GATEWAY_KEY_ISSUE_TRIAGE }}
           allowed_non_write_users: "*"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The issue-triage workflow has been failing since the switchover to the Stacklok gateway because `claude-sonnet-4-6` isn't an available model on the gateway.

- Bump the `--model` argument in `.github/workflows/issue-triage.yml` from `claude-sonnet-4-6` to `claude-sonnet-5`.

## Type of change

- [x] Bug fix

## Test plan

- [x] Manual testing (describe below)

Verified the model ID matches what the Stacklok gateway currently serves. The workflow itself can only be fully validated by a live run against a real issue once merged.

## Does this introduce a user-facing change?

No.
