### PR TITLE
Require a discovery capability for key signing

### DIFF
--- a/cmd/thv/app/server.go
+++ b/cmd/thv/app/server.go
@@ -131,12 +131,17 @@ var serveCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		keySigningCapability, err := s.GenerateKeySigningCapability()
+		if err != nil {
+			return err
+		}
 		builder := s.NewServerBuilder().
 			WithAddress(address).
 			WithUnixSocket(isUnixSocket).
 			WithDebugMode(debugMode).
 			WithDocs(enableDocs).
 			WithNonce(nonce).
+			WithKeySigningCapability(keySigningCapability).
 			WithOIDCConfig(oidcConfig).
 			WithOtelEnabled(otelEnabled)
 

--- a/cmd/thv/app/skill_push.go
+++ b/cmd/thv/app/skill_push.go
@@ -34,6 +34,7 @@ func init() {
 	skillCmd.AddCommand(skillPushCmd)
 	skillPushCmd.Flags().StringVar(&skillPushKey, "key", "",
 		"Path to a cosign private key to sign the pushed artifact. "+
+			"Requires the locally discovered ToolHive server; for a remote or manually configured API URL, use keyless signing. "+
 			"Encrypted keys are decrypted with COSIGN_PASSWORD read from the 'thv serve' process, "+
 			"which performs the signing. Consumers installing the result project-scoped must pass "+
 			"--public-key with the matching cosign public key the first time; distribute it "+

--- a/docs/arch/12-skills-system.md
+++ b/docs/arch/12-skills-system.md
@@ -193,7 +193,12 @@ mutually exclusive choices:
 
 - `--key <path>`: sign with a cosign private key (`COSIGN_PASSWORD`
   decrypts encrypted keys, read server-side by `thv serve`, which performs
-  the signing).
+  the signing). This is accepted only through automatic local server
+  discovery: the owner-protected discovery file supplies a separate random
+  capability that the CLI sends with the key-bearing request. Loopback or IPC
+  transport alone is not authorization, because a public reverse proxy can
+  make an untrusted caller appear local. Remote and manually configured API
+  URLs must use keyless signing instead.
 - `--identity-token <token-or-path>`: sign keylessly. The CLI acquires an
   OIDC identity token and forwards it in the push request; the server
   exchanges it with Fulcio for a short-lived certificate, signs, and records

--- a/docs/cli/thv_skill_push.md
+++ b/docs/cli/thv_skill_push.md
@@ -26,7 +26,7 @@ thv skill push [reference] [flags]
 ```
   -h, --help                    help for push
       --identity-token string   OIDC identity token (or a path to a file containing one) for keyless signing. Mutually exclusive with --key. If omitted, one is acquired automatically: from the ambient CI OIDC token when running with id-token: write permission, otherwise via an interactive browser sign-in
-      --key string              Path to a cosign private key to sign the pushed artifact. Encrypted keys are decrypted with COSIGN_PASSWORD read from the 'thv serve' process, which performs the signing. Consumers installing the result project-scoped must pass --public-key with the matching cosign public key the first time; distribute it alongside the artifact. Keyless signing needs no such out-of-band step, since the signer identity is verifiable from the artifact itself
+      --key string              Path to a cosign private key to sign the pushed artifact. Requires the locally discovered ToolHive server; for a remote or manually configured API URL, use keyless signing. Encrypted keys are decrypted with COSIGN_PASSWORD read from the 'thv serve' process, which performs the signing. Consumers installing the result project-scoped must pass --public-key with the matching cosign public key the first time; distribute it alongside the artifact. Keyless signing needs no such out-of-band step, since the signer identity is verifiable from the artifact itself
       --no-sign                 Push without signing (consumers will need an explicit unsigned exception to install project-scoped)
 ```
 

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -3863,7 +3863,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "key": {
-                        "description": "Key is the path to a cosign private key, resolved on the server's\nfilesystem. Accepted only from a caller on this machine (an IPC\ntransport or a loopback peer); a remote request naming a key is\nrefused with 403, since honoring it would let the caller have the\nserver sign with any key it can read. Use IdentityToken to have a\nremote server sign.",
+                        "description": "Key is the path to a cosign private key, resolved on the server's\nfilesystem. Accepted only when the request carries the secret capability\nfrom the owner-protected local server discovery file; other requests are\nrefused with 403, since honoring one would let an untrusted caller have\nthe server sign with any key it can read. Use IdentityToken when calling\na remote or manually configured server.",
                         "type": "string"
                     },
                     "no_sign": {
@@ -8579,6 +8579,16 @@ const docTemplate = `{
         "/api/v1beta/skills/push": {
             "post": {
                 "description": "Push a built skill artifact to a remote registry",
+                "parameters": [
+                    {
+                        "description": "Local discovery capability (required with request.key)",
+                        "in": "header",
+                        "name": "X-Toolhive-Key-Signing-Capability",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -8619,6 +8629,16 @@ const docTemplate = `{
                             }
                         },
                         "description": "Bad Request"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Forbidden (key signing requires the local discovery capability)"
                     },
                     "404": {
                         "content": {

--- a/docs/server/docs.go
+++ b/docs/server/docs.go
@@ -3863,7 +3863,7 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "key": {
-                        "description": "Key is the path to a cosign private key used to sign the pushed\nartifact",
+                        "description": "Key is the path to a cosign private key, resolved on the server's\nfilesystem. Accepted only from a caller on this machine (an IPC\ntransport or a loopback peer); a remote request naming a key is\nrefused with 403, since honoring it would let the caller have the\nserver sign with any key it can read. Use IdentityToken to have a\nremote server sign.",
                         "type": "string"
                     },
                     "no_sign": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -3856,7 +3856,7 @@
                         "type": "string"
                     },
                     "key": {
-                        "description": "Key is the path to a cosign private key, resolved on the server's\nfilesystem. Accepted only from a caller on this machine (an IPC\ntransport or a loopback peer); a remote request naming a key is\nrefused with 403, since honoring it would let the caller have the\nserver sign with any key it can read. Use IdentityToken to have a\nremote server sign.",
+                        "description": "Key is the path to a cosign private key, resolved on the server's\nfilesystem. Accepted only when the request carries the secret capability\nfrom the owner-protected local server discovery file; other requests are\nrefused with 403, since honoring one would let an untrusted caller have\nthe server sign with any key it can read. Use IdentityToken when calling\na remote or manually configured server.",
                         "type": "string"
                     },
                     "no_sign": {
@@ -8572,6 +8572,16 @@
         "/api/v1beta/skills/push": {
             "post": {
                 "description": "Push a built skill artifact to a remote registry",
+                "parameters": [
+                    {
+                        "description": "Local discovery capability (required with request.key)",
+                        "in": "header",
+                        "name": "X-Toolhive-Key-Signing-Capability",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -8612,6 +8622,16 @@
                             }
                         },
                         "description": "Bad Request"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Forbidden (key signing requires the local discovery capability)"
                     },
                     "404": {
                         "content": {

--- a/docs/server/swagger.json
+++ b/docs/server/swagger.json
@@ -3856,7 +3856,7 @@
                         "type": "string"
                     },
                     "key": {
-                        "description": "Key is the path to a cosign private key used to sign the pushed\nartifact",
+                        "description": "Key is the path to a cosign private key, resolved on the server's\nfilesystem. Accepted only from a caller on this machine (an IPC\ntransport or a loopback peer); a remote request naming a key is\nrefused with 403, since honoring it would let the caller have the\nserver sign with any key it can read. Use IdentityToken to have a\nremote server sign.",
                         "type": "string"
                     },
                     "no_sign": {

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -3603,8 +3603,12 @@ components:
           type: string
         key:
           description: |-
-            Key is the path to a cosign private key used to sign the pushed
-            artifact
+            Key is the path to a cosign private key, resolved on the server's
+            filesystem. Accepted only from a caller on this machine (an IPC
+            transport or a loopback peer); a remote request naming a key is
+            refused with 403, since honoring it would let the caller have the
+            server sign with any key it can read. Use IdentityToken to have a
+            remote server sign.
           type: string
         no_sign:
           description: NoSign pushes without signing

--- a/docs/server/swagger.yaml
+++ b/docs/server/swagger.yaml
@@ -3604,11 +3604,11 @@ components:
         key:
           description: |-
             Key is the path to a cosign private key, resolved on the server's
-            filesystem. Accepted only from a caller on this machine (an IPC
-            transport or a loopback peer); a remote request naming a key is
-            refused with 403, since honoring it would let the caller have the
-            server sign with any key it can read. Use IdentityToken to have a
-            remote server sign.
+            filesystem. Accepted only when the request carries the secret capability
+            from the owner-protected local server discovery file; other requests are
+            refused with 403, since honoring one would let an untrusted caller have
+            the server sign with any key it can read. Use IdentityToken when calling
+            a remote or manually configured server.
           type: string
         no_sign:
           description: NoSign pushes without signing
@@ -7286,6 +7286,12 @@ paths:
   /api/v1beta/skills/push:
     post:
       description: Push a built skill artifact to a remote registry
+      parameters:
+      - description: Local discovery capability (required with request.key)
+        in: header
+        name: X-Toolhive-Key-Signing-Capability
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -7310,6 +7316,12 @@ paths:
               schema:
                 type: string
           description: Bad Request
+        "403":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Forbidden (key signing requires the local discovery capability)
         "404":
           content:
             application/json:

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -449,7 +449,8 @@ func (b *ServerBuilder) setupDefaultRoutes(r *chi.Mux) {
 
 	// Skills router does the same: install, sync, and upgrade pull OCI
 	// artifacts, so a flat 60s cap would sever them mid-transfer.
-	r.Mount("/api/v1beta/skills", v1.SkillsRouter(b.skillManager))
+	r.Mount("/api/v1beta/skills", v1.SkillsRouter(b.skillManager,
+		v1.WithLocalTransport(b.isUnixSocket)))
 
 	// Plugins router likewise: install, build, and push move OCI artifacts.
 	r.Mount("/api/v1beta/plugins", v1.PluginsRouter(b.pluginManager))

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -77,30 +77,31 @@ const (
 	readTimeout        = 30 * time.Second
 	idleTimeout        = 120 * time.Second
 	shutdownTimeout    = 30 * time.Second
-	nonceBytes         = 16
+	randomTokenBytes   = 16
 	socketPermissions  = 0660    // Socket file permissions (owner/group read-write)
 	maxRequestBodySize = 1 << 20 // 1MB - Maximum request body size
 )
 
 // ServerBuilder provides a fluent interface for building and configuring the API server
 type ServerBuilder struct {
-	address           string
-	isUnixSocket      bool
-	debugMode         bool
-	enableDocs        bool
-	nonce             string
-	oidcConfig        *auth.TokenValidatorConfig
-	otelEnabled       bool
-	middlewares       []func(http.Handler) http.Handler
-	customRoutes      map[string]http.Handler
-	containerRuntime  runtime.Runtime
-	clientManager     client.Manager
-	workloadManager   workloads.Manager
-	groupManager      groups.Manager
-	skillManager      skills.SkillService
-	skillStoreCloser  io.Closer
-	pluginManager     plugins.PluginService
-	pluginStoreCloser io.Closer
+	address              string
+	isUnixSocket         bool
+	debugMode            bool
+	enableDocs           bool
+	nonce                string
+	keySigningCapability string
+	oidcConfig           *auth.TokenValidatorConfig
+	otelEnabled          bool
+	middlewares          []func(http.Handler) http.Handler
+	customRoutes         map[string]http.Handler
+	containerRuntime     runtime.Runtime
+	clientManager        client.Manager
+	workloadManager      workloads.Manager
+	groupManager         groups.Manager
+	skillManager         skills.SkillService
+	skillStoreCloser     io.Closer
+	pluginManager        plugins.PluginService
+	pluginStoreCloser    io.Closer
 }
 
 // NewServerBuilder creates a new ServerBuilder with default configuration
@@ -140,6 +141,13 @@ func (b *ServerBuilder) WithDocs(enableDocs bool) *ServerBuilder {
 // the nonce in the X-Toolhive-Nonce health check header.
 func (b *ServerBuilder) WithNonce(nonce string) *ServerBuilder {
 	b.nonce = nonce
+	return b
+}
+
+// WithKeySigningCapability sets the bearer capability required by requests
+// that ask the server to open a private signing key.
+func (b *ServerBuilder) WithKeySigningCapability(capability string) *ServerBuilder {
+	b.keySigningCapability = capability
 	return b
 }
 
@@ -450,7 +458,7 @@ func (b *ServerBuilder) setupDefaultRoutes(r *chi.Mux) {
 	// Skills router does the same: install, sync, and upgrade pull OCI
 	// artifacts, so a flat 60s cap would sever them mid-transfer.
 	r.Mount("/api/v1beta/skills", v1.SkillsRouter(b.skillManager,
-		v1.WithLocalTransport(b.isUnixSocket)))
+		v1.WithKeySigningCapability(b.keySigningCapability)))
 
 	// Plugins router likewise: install, build, and push move OCI artifacts.
 	r.Mount("/api/v1beta/plugins", v1.PluginsRouter(b.pluginManager))
@@ -586,14 +594,15 @@ func getComponentAndVersionFromRequest(r *http.Request) (string, string, bool) {
 
 // Server represents a configured HTTP server
 type Server struct {
-	httpServer        *http.Server
-	listener          net.Listener
-	address           string
-	isUnixSocket      bool
-	addrType          string
-	nonce             string
-	skillStoreCloser  io.Closer
-	pluginStoreCloser io.Closer
+	httpServer           *http.Server
+	listener             net.Listener
+	address              string
+	isUnixSocket         bool
+	addrType             string
+	nonce                string
+	keySigningCapability string
+	skillStoreCloser     io.Closer
+	pluginStoreCloser    io.Closer
 }
 
 // NewServer creates a new Server instance from a pre-configured builder
@@ -625,14 +634,15 @@ func NewServer(ctx context.Context, builder *ServerBuilder) (*Server, error) {
 	}
 
 	return &Server{
-		httpServer:        httpServer,
-		listener:          listener,
-		address:           builder.address,
-		isUnixSocket:      builder.isUnixSocket,
-		addrType:          addrType,
-		nonce:             builder.nonce,
-		skillStoreCloser:  builder.skillStoreCloser,
-		pluginStoreCloser: builder.pluginStoreCloser,
+		httpServer:           httpServer,
+		listener:             listener,
+		address:              builder.address,
+		isUnixSocket:         builder.isUnixSocket,
+		addrType:             addrType,
+		nonce:                builder.nonce,
+		keySigningCapability: builder.keySigningCapability,
+		skillStoreCloser:     builder.skillStoreCloser,
+		pluginStoreCloser:    builder.pluginStoreCloser,
 	}, nil
 }
 
@@ -727,10 +737,11 @@ func (s *Server) writeDiscoveryFile(ctx context.Context) error {
 		}
 
 		info := &discovery.ServerInfo{
-			URL:       s.ListenURL(),
-			PID:       os.Getpid(),
-			Nonce:     s.nonce,
-			StartedAt: time.Now().UTC(),
+			URL:                  s.ListenURL(),
+			PID:                  os.Getpid(),
+			Nonce:                s.nonce,
+			KeySigningCapability: s.keySigningCapability,
+			StartedAt:            time.Now().UTC(),
 		}
 		if err := discovery.WriteServerInfo(info); err != nil {
 			return fmt.Errorf("failed to write discovery file: %w", err)
@@ -1033,9 +1044,19 @@ func chiRouteSpanNamer(next http.Handler) http.Handler {
 
 // GenerateNonce generates a random nonce for server instance identification.
 func GenerateNonce() (string, error) {
-	b := make([]byte, nonceBytes)
+	return generateRandomToken("server nonce")
+}
+
+// GenerateKeySigningCapability generates a bearer capability for authorizing
+// requests that ask the API server to open a private signing key.
+func GenerateKeySigningCapability() (string, error) {
+	return generateRandomToken("key-signing capability")
+}
+
+func generateRandomToken(name string) (string, error) {
+	b := make([]byte, randomTokenBytes)
 	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("failed to generate server nonce: %w", err)
+		return "", fmt.Errorf("failed to generate %s: %w", name, err)
 	}
 	return hex.EncodeToString(b), nil
 }

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -51,6 +51,31 @@ func TestGenerateNonce(t *testing.T) {
 	})
 }
 
+func TestGenerateKeySigningCapability(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns valid 32-char hex string", func(t *testing.T) {
+		t.Parallel()
+
+		capability, err := GenerateKeySigningCapability()
+		require.NoError(t, err)
+
+		assert.Len(t, capability, 32)
+		assert.Regexp(t, regexp.MustCompile(`^[0-9a-f]{32}$`), capability)
+	})
+
+	t.Run("returns values independent from the discovery nonce", func(t *testing.T) {
+		t.Parallel()
+
+		nonce, err := GenerateNonce()
+		require.NoError(t, err)
+		capability, err := GenerateKeySigningCapability()
+		require.NoError(t, err)
+
+		assert.NotEqual(t, nonce, capability)
+	})
+}
+
 func TestListenURL(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/v1/healthcheck_test.go
+++ b/pkg/api/v1/healthcheck_test.go
@@ -115,6 +115,8 @@ func TestGetHealthcheck_ReturnsNonceHeader(t *testing.T) {
 	// Assert the response status and nonce header
 	assert.Equal(t, http.StatusNoContent, resp.Code)
 	assert.Equal(t, "test-nonce-value", resp.Header().Get(discovery.NonceHeader))
+	assert.Empty(t, resp.Header().Values(discovery.KeySigningCapabilityHeader),
+		"the owner-only key-signing capability must never be returned by health")
 }
 
 func TestGetHealthcheck_OmitsNonceHeaderWhenEmpty(t *testing.T) {

--- a/pkg/api/v1/key_signing_transport.go
+++ b/pkg/api/v1/key_signing_transport.go
@@ -62,9 +62,10 @@ func requireKeySigningCapability(r *http.Request, expectedCapability, key string
 	return httperr.WithCode(
 		errors.New("key names a cosign private key on the server's filesystem, but this request"+
 			" does not have the protected local discovery capability — accepting it would let an"+
-			" untrusted caller have the server sign with any key it can read. Use the locally"+
-			" discovered ToolHive server, or sign keylessly with identity_token, which carries a"+
-			" short-lived scoped credential instead"),
+			" untrusted caller have the server sign with any key it can read. Push through the"+
+			" locally discovered ToolHive server, or sign keylessly instead: drop --key and the CLI"+
+			" acquires a short-lived identity token itself, or hands one over with"+
+			" --identity-token; a direct API caller sends identity_token in place of key"),
 		http.StatusForbidden,
 	)
 }

--- a/pkg/api/v1/key_signing_transport.go
+++ b/pkg/api/v1/key_signing_transport.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"errors"
+	"net"
+	"net/http"
+
+	"github.com/stacklok/toolhive-core/httperr"
+)
+
+// localTransport records that this router is served over an IPC transport
+// (UNIX socket or Windows named pipe) rather than TCP. Set from the API
+// server's own listener configuration, which is the only authoritative
+// source: an IPC peer has no host:port RemoteAddr to inspect.
+type localTransport bool
+
+// RouterOption configures a v1 router.
+type RouterOption func(*routerConfig)
+
+type routerConfig struct {
+	localTransport bool
+}
+
+// WithLocalTransport declares that the router is served over an IPC
+// transport, which only processes on this machine can open.
+func WithLocalTransport(local bool) RouterOption {
+	return func(c *routerConfig) { c.localTransport = local }
+}
+
+func newRouterConfig(opts []RouterOption) routerConfig {
+	var c routerConfig
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
+// requireLocalKeySigning refuses a push that names a cosign private key
+// unless the caller is on this machine.
+//
+// SECURITY: the key path is resolved and read by THIS process, so accepting
+// one from an arbitrary caller turns the management API into a signing
+// oracle — a request can ask the server to sign and publish an artifact with
+// any key the server process can read, and the signature it produces is
+// indistinguishable from a legitimate release. The default API mode assigns
+// every request a synthetic local identity with no credential check, so on a
+// non-loopback bind an unauthenticated remote caller reaches this handler.
+//
+// A key is a local-workstation and CI credential, so a local-only rule costs
+// nothing that was reliably usable anyway: the path has to exist on the
+// server's filesystem, which a remote caller cannot arrange. Callers that
+// need a remote server to sign should use keyless signing, whose credential
+// is a short-lived scoped token rather than a key with no expiry.
+//
+// Locality is decided by the listener, not by anything in the request: an
+// IPC transport is local by construction (and its socket permissions bound
+// who can connect), and a TCP peer must be loopback. RemoteAddr is the
+// kernel's view of the peer rather than a header, so it cannot be forged by
+// the client — but it is only consulted for TCP, where it has that meaning.
+// Anything else fails closed.
+func requireLocalKeySigning(r *http.Request, local localTransport, key string) error {
+	if key == "" {
+		return nil
+	}
+	if bool(local) || callerIsLoopback(r) {
+		return nil
+	}
+	return httperr.WithCode(
+		errors.New("key names a cosign private key on the server's filesystem, and this request did"+
+			" not come from this machine — accepting it would let a remote caller have the server"+
+			" sign with any key it can read. Run the push where the key lives, or sign keylessly"+
+			" with identity_token, which carries a short-lived scoped credential instead"),
+		http.StatusForbidden,
+	)
+}
+
+// callerIsLoopback reports whether a TCP request came from this machine.
+// A RemoteAddr that is not a host:port pair means the peer did not arrive
+// over TCP, which this function cannot judge — it returns false so the
+// caller falls back to the listener's own configuration.
+func callerIsLoopback(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/pkg/api/v1/key_signing_transport.go
+++ b/pkg/api/v1/key_signing_transport.go
@@ -4,30 +4,25 @@
 package v1
 
 import (
+	"crypto/subtle"
 	"errors"
-	"net"
 	"net/http"
 
 	"github.com/stacklok/toolhive-core/httperr"
+	"github.com/stacklok/toolhive/pkg/server/discovery"
 )
-
-// localTransport records that this router is served over an IPC transport
-// (UNIX socket or Windows named pipe) rather than TCP. Set from the API
-// server's own listener configuration, which is the only authoritative
-// source: an IPC peer has no host:port RemoteAddr to inspect.
-type localTransport bool
 
 // RouterOption configures a v1 router.
 type RouterOption func(*routerConfig)
 
 type routerConfig struct {
-	localTransport bool
+	keySigningCapability string
 }
 
-// WithLocalTransport declares that the router is served over an IPC
-// transport, which only processes on this machine can open.
-func WithLocalTransport(local bool) RouterOption {
-	return func(c *routerConfig) { c.localTransport = local }
+// WithKeySigningCapability sets the secret capability that authorizes a push
+// to name a private key on the API server's filesystem.
+func WithKeySigningCapability(capability string) RouterOption {
+	return func(c *routerConfig) { c.keySigningCapability = capability }
 }
 
 func newRouterConfig(opts []RouterOption) routerConfig {
@@ -38,8 +33,8 @@ func newRouterConfig(opts []RouterOption) routerConfig {
 	return c
 }
 
-// requireLocalKeySigning refuses a push that names a cosign private key
-// unless the caller is on this machine.
+// requireKeySigningCapability refuses a push that names a cosign private key
+// unless the caller proves it read the owner-protected server discovery file.
 //
 // SECURITY: the key path is resolved and read by THIS process, so accepting
 // one from an arbitrary caller turns the management API into a signing
@@ -49,43 +44,27 @@ func newRouterConfig(opts []RouterOption) routerConfig {
 // every request a synthetic local identity with no credential check, so on a
 // non-loopback bind an unauthenticated remote caller reaches this handler.
 //
-// A key is a local-workstation and CI credential, so a local-only rule costs
-// nothing that was reliably usable anyway: the path has to exist on the
-// server's filesystem, which a remote caller cannot arrange. Callers that
-// need a remote server to sign should use keyless signing, whose credential
-// is a short-lived scoped token rather than a key with no expiry.
-//
-// Locality is decided by the listener, not by anything in the request: an
-// IPC transport is local by construction (and its socket permissions bound
-// who can connect), and a TCP peer must be loopback. RemoteAddr is the
-// kernel's view of the peer rather than a header, so it cannot be forged by
-// the client — but it is only consulted for TCP, where it has that meaning.
-// Anything else fails closed.
-func requireLocalKeySigning(r *http.Request, local localTransport, key string) error {
+// Listener locality is insufficient authorization: a public reverse proxy can
+// forward an untrusted request over loopback or an IPC listener, making its
+// backend peer appear local. Instead, the standard CLI obtains an independent
+// random capability from the owner-only discovery file. The nonce cannot be
+// reused because /health intentionally returns it to every caller.
+func requireKeySigningCapability(r *http.Request, expectedCapability, key string) error {
 	if key == "" {
 		return nil
 	}
-	if bool(local) || callerIsLoopback(r) {
+	suppliedCapability := r.Header.Get(discovery.KeySigningCapabilityHeader)
+	if expectedCapability != "" && subtle.ConstantTimeCompare(
+		[]byte(suppliedCapability), []byte(expectedCapability),
+	) == 1 {
 		return nil
 	}
 	return httperr.WithCode(
-		errors.New("key names a cosign private key on the server's filesystem, and this request did"+
-			" not come from this machine — accepting it would let a remote caller have the server"+
-			" sign with any key it can read. Run the push where the key lives, or sign keylessly"+
-			" with identity_token, which carries a short-lived scoped credential instead"),
+		errors.New("key names a cosign private key on the server's filesystem, but this request"+
+			" does not have the protected local discovery capability — accepting it would let an"+
+			" untrusted caller have the server sign with any key it can read. Use the locally"+
+			" discovered ToolHive server, or sign keylessly with identity_token, which carries a"+
+			" short-lived scoped credential instead"),
 		http.StatusForbidden,
 	)
-}
-
-// callerIsLoopback reports whether a TCP request came from this machine.
-// A RemoteAddr that is not a host:port pair means the peer did not arrive
-// over TCP, which this function cannot judge — it returns false so the
-// caller falls back to the listener's own configuration.
-func callerIsLoopback(r *http.Request) bool {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return false
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
 }

--- a/pkg/api/v1/key_signing_transport_test.go
+++ b/pkg/api/v1/key_signing_transport_test.go
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/toolhive-core/httperr"
+	skillsmocks "github.com/stacklok/toolhive/pkg/skills/mocks"
+)
+
+// TestRequireLocalKeySigning pins who may name a private key on the server's
+// filesystem. A key-bearing push is a request for THIS process to read a key
+// and sign with it, so the decision rests on the listener and the kernel's
+// view of the peer — never on anything the request can set.
+func TestRequireLocalKeySigning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		key        string
+		local      localTransport
+		remoteAddr string
+		wantAllow  bool
+	}{
+		{
+			name:       "no key is not a key-signing request",
+			remoteAddr: "203.0.113.7:44321",
+			wantAllow:  true,
+		},
+		{
+			// An IPC peer has no host:port to inspect, so the listener is
+			// the only thing that can vouch for it.
+			name:       "an IPC listener vouches for its peer",
+			key:        "/home/dev/cosign.key",
+			local:      true,
+			remoteAddr: "@",
+			wantAllow:  true,
+		},
+		{
+			name:       "a loopback TCP peer is on this machine",
+			key:        "/home/dev/cosign.key",
+			remoteAddr: "127.0.0.1:53124",
+			wantAllow:  true,
+		},
+		{
+			name:       "so is an IPv6 loopback peer",
+			key:        "/home/dev/cosign.key",
+			remoteAddr: "[::1]:53124",
+			wantAllow:  true,
+		},
+		{
+			// The exposure this guard exists for: a non-loopback bind gets
+			// no Origin allowlist and assigns a synthetic local identity, so
+			// this caller is unauthenticated.
+			name:       "a remote peer may not name a key",
+			key:        "/home/dev/cosign.key",
+			remoteAddr: "203.0.113.7:44321",
+			wantAllow:  false,
+		},
+		{
+			// Fail closed: a peer this function cannot judge is not local
+			// unless the listener says so.
+			name:      "an unjudgeable peer on a TCP listener is refused",
+			key:       "/home/dev/cosign.key",
+			wantAllow: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodPost, "/push", nil)
+			req.RemoteAddr = tc.remoteAddr
+
+			err := requireLocalKeySigning(req, tc.local, tc.key)
+			if tc.wantAllow {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, http.StatusForbidden, httperr.Code(err))
+			assert.Contains(t, err.Error(), "identity_token",
+				"the refusal must name the credential that does work remotely")
+		})
+	}
+}
+
+// TestRequireLocalKeySigning_HeadersCannotForgeLocality guards the obvious
+// bypass. RemoteAddr is the kernel's view of the peer; the headers a proxy
+// or a caller can set must not stand in for it.
+func TestRequireLocalKeySigning_HeadersCannotForgeLocality(t *testing.T) {
+	t.Parallel()
+
+	for _, header := range []string{"X-Forwarded-For", "X-Real-IP", "Forwarded"} {
+		t.Run(header, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodPost, "/push", nil)
+			req.RemoteAddr = "203.0.113.7:44321"
+			req.Header.Set(header, "127.0.0.1")
+
+			err := requireLocalKeySigning(req, false, "/home/dev/cosign.key")
+			require.Error(t, err, "%s must not make a remote caller local", header)
+			assert.Equal(t, http.StatusForbidden, httperr.Code(err))
+		})
+	}
+}
+
+// TestSkillsRouter_RemoteKeyPushRejectedBeforeDispatch runs the guard through
+// the real router. The mock has no expectations, so reaching the service at
+// all fails the test: the refusal has to land before anything opens the key.
+func TestSkillsRouter_RemoteKeyPushRejectedBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		opts       []RouterOption
+		remoteAddr string
+		body       string
+		wantStatus int
+	}{
+		{
+			name:       "remote caller naming a key",
+			remoteAddr: "203.0.113.7:44321",
+			body:       `{"reference":"ghcr.io/test/skill:v1","key":"/home/dev/cosign.key"}`,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "IPC listener permits the same request",
+			opts:       []RouterOption{WithLocalTransport(true)},
+			remoteAddr: "@",
+			body:       `{"reference":"ghcr.io/test/skill:v1","key":"/home/dev/cosign.key"}`,
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "loopback caller permits the same request",
+			remoteAddr: "127.0.0.1:53124",
+			body:       `{"reference":"ghcr.io/test/skill:v1","key":"/home/dev/cosign.key"}`,
+			wantStatus: http.StatusNoContent,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			svc := skillsmocks.NewMockSkillService(ctrl)
+			if tc.wantStatus == http.StatusNoContent {
+				svc.EXPECT().Push(gomock.Any(), gomock.Any()).Return(nil)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/push", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.RemoteAddr = tc.remoteAddr
+			rec := httptest.NewRecorder()
+			SkillsRouter(svc, tc.opts...).ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.wantStatus, rec.Code, "body: %s", rec.Body.String())
+		})
+	}
+}

--- a/pkg/api/v1/key_signing_transport_test.go
+++ b/pkg/api/v1/key_signing_transport_test.go
@@ -4,8 +4,11 @@
 package v1
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -14,64 +17,65 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/stacklok/toolhive-core/httperr"
+	"github.com/stacklok/toolhive/pkg/server/discovery"
 	skillsmocks "github.com/stacklok/toolhive/pkg/skills/mocks"
 )
 
-// TestRequireLocalKeySigning pins who may name a private key on the server's
-// filesystem. A key-bearing push is a request for THIS process to read a key
-// and sign with it, so the decision rests on the listener and the kernel's
-// view of the peer — never on anything the request can set.
-func TestRequireLocalKeySigning(t *testing.T) {
+func TestRequireKeySigningCapability(t *testing.T) {
 	t.Parallel()
 
+	const capability = "protected-discovery-capability"
 	tests := []struct {
-		name       string
-		key        string
-		local      localTransport
-		remoteAddr string
-		wantAllow  bool
+		name               string
+		key                string
+		expectedCapability string
+		suppliedCapability string
+		remoteAddr         string
+		wantAllow          bool
 	}{
 		{
-			name:       "no key is not a key-signing request",
+			name:       "no key needs no capability",
 			remoteAddr: "203.0.113.7:44321",
 			wantAllow:  true,
 		},
 		{
-			// An IPC peer has no host:port to inspect, so the listener is
-			// the only thing that can vouch for it.
-			name:       "an IPC listener vouches for its peer",
-			key:        "/home/dev/cosign.key",
-			local:      true,
-			remoteAddr: "@",
-			wantAllow:  true,
+			name:               "matching capability authorizes key signing",
+			key:                "/home/dev/cosign.key",
+			expectedCapability: capability,
+			suppliedCapability: capability,
+			remoteAddr:         "203.0.113.7:44321",
+			wantAllow:          true,
 		},
 		{
-			name:       "a loopback TCP peer is on this machine",
-			key:        "/home/dev/cosign.key",
-			remoteAddr: "127.0.0.1:53124",
-			wantAllow:  true,
+			name:               "missing capability is refused",
+			key:                "/home/dev/cosign.key",
+			expectedCapability: capability,
+			remoteAddr:         "203.0.113.7:44321",
 		},
 		{
-			name:       "so is an IPv6 loopback peer",
-			key:        "/home/dev/cosign.key",
-			remoteAddr: "[::1]:53124",
-			wantAllow:  true,
+			name:               "wrong capability is refused",
+			key:                "/home/dev/cosign.key",
+			expectedCapability: capability,
+			suppliedCapability: "wrong-capability",
+			remoteAddr:         "203.0.113.7:44321",
 		},
 		{
-			// The exposure this guard exists for: a non-loopback bind gets
-			// no Origin allowlist and assigns a synthetic local identity, so
-			// this caller is unauthenticated.
-			name:       "a remote peer may not name a key",
-			key:        "/home/dev/cosign.key",
-			remoteAddr: "203.0.113.7:44321",
-			wantAllow:  false,
+			name:               "empty configured capability fails closed",
+			key:                "/home/dev/cosign.key",
+			suppliedCapability: capability,
+			remoteAddr:         "203.0.113.7:44321",
 		},
 		{
-			// Fail closed: a peer this function cannot judge is not local
-			// unless the listener says so.
-			name:      "an unjudgeable peer on a TCP listener is refused",
-			key:       "/home/dev/cosign.key",
-			wantAllow: false,
+			name:               "loopback alone is not authorization",
+			key:                "/home/dev/cosign.key",
+			expectedCapability: capability,
+			remoteAddr:         "127.0.0.1:53124",
+		},
+		{
+			name:               "IPC-shaped peer alone is not authorization",
+			key:                "/home/dev/cosign.key",
+			expectedCapability: capability,
+			remoteAddr:         "@",
 		},
 	}
 	for _, tc := range tests {
@@ -79,8 +83,11 @@ func TestRequireLocalKeySigning(t *testing.T) {
 			t.Parallel()
 			req := httptest.NewRequest(http.MethodPost, "/push", nil)
 			req.RemoteAddr = tc.remoteAddr
+			if tc.suppliedCapability != "" {
+				req.Header.Set(discovery.KeySigningCapabilityHeader, tc.suppliedCapability)
+			}
 
-			err := requireLocalKeySigning(req, tc.local, tc.key)
+			err := requireKeySigningCapability(req, tc.expectedCapability, tc.key)
 			if tc.wantAllow {
 				assert.NoError(t, err)
 				return
@@ -89,61 +96,36 @@ func TestRequireLocalKeySigning(t *testing.T) {
 			assert.Equal(t, http.StatusForbidden, httperr.Code(err))
 			assert.Contains(t, err.Error(), "identity_token",
 				"the refusal must name the credential that does work remotely")
+			assert.NotContains(t, err.Error(), capability)
 		})
 	}
 }
 
-// TestRequireLocalKeySigning_HeadersCannotForgeLocality guards the obvious
-// bypass. RemoteAddr is the kernel's view of the peer; the headers a proxy
-// or a caller can set must not stand in for it.
-func TestRequireLocalKeySigning_HeadersCannotForgeLocality(t *testing.T) {
+func TestSkillsRouter_KeySigningCapabilityCheckedBeforeDispatch(t *testing.T) {
 	t.Parallel()
 
-	for _, header := range []string{"X-Forwarded-For", "X-Real-IP", "Forwarded"} {
-		t.Run(header, func(t *testing.T) {
-			t.Parallel()
-			req := httptest.NewRequest(http.MethodPost, "/push", nil)
-			req.RemoteAddr = "203.0.113.7:44321"
-			req.Header.Set(header, "127.0.0.1")
-
-			err := requireLocalKeySigning(req, false, "/home/dev/cosign.key")
-			require.Error(t, err, "%s must not make a remote caller local", header)
-			assert.Equal(t, http.StatusForbidden, httperr.Code(err))
-		})
-	}
-}
-
-// TestSkillsRouter_RemoteKeyPushRejectedBeforeDispatch runs the guard through
-// the real router. The mock has no expectations, so reaching the service at
-// all fails the test: the refusal has to land before anything opens the key.
-func TestSkillsRouter_RemoteKeyPushRejectedBeforeDispatch(t *testing.T) {
-	t.Parallel()
-
+	const capability = "protected-discovery-capability"
 	tests := []struct {
-		name       string
-		opts       []RouterOption
-		remoteAddr string
-		body       string
-		wantStatus int
+		name               string
+		suppliedCapability string
+		remoteAddr         string
+		wantStatus         int
 	}{
 		{
-			name:       "remote caller naming a key",
-			remoteAddr: "203.0.113.7:44321",
-			body:       `{"reference":"ghcr.io/test/skill:v1","key":"/home/dev/cosign.key"}`,
+			name:       "loopback caller without capability",
+			remoteAddr: "127.0.0.1:53124",
 			wantStatus: http.StatusForbidden,
 		},
 		{
-			name:       "IPC listener permits the same request",
-			opts:       []RouterOption{WithLocalTransport(true)},
+			name:       "IPC-shaped caller without capability",
 			remoteAddr: "@",
-			body:       `{"reference":"ghcr.io/test/skill:v1","key":"/home/dev/cosign.key"}`,
-			wantStatus: http.StatusNoContent,
+			wantStatus: http.StatusForbidden,
 		},
 		{
-			name:       "loopback caller permits the same request",
-			remoteAddr: "127.0.0.1:53124",
-			body:       `{"reference":"ghcr.io/test/skill:v1","key":"/home/dev/cosign.key"}`,
-			wantStatus: http.StatusNoContent,
+			name:               "caller with matching capability",
+			suppliedCapability: capability,
+			remoteAddr:         "203.0.113.7:44321",
+			wantStatus:         http.StatusNoContent,
 		},
 	}
 	for _, tc := range tests {
@@ -155,13 +137,56 @@ func TestSkillsRouter_RemoteKeyPushRejectedBeforeDispatch(t *testing.T) {
 				svc.EXPECT().Push(gomock.Any(), gomock.Any()).Return(nil)
 			}
 
-			req := httptest.NewRequest(http.MethodPost, "/push", strings.NewReader(tc.body))
+			body := `{"reference":"ghcr.io/test/skill:v1","key":"/home/dev/cosign.key"}`
+			req := httptest.NewRequest(http.MethodPost, "/push", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
+			if tc.suppliedCapability != "" {
+				req.Header.Set(discovery.KeySigningCapabilityHeader, tc.suppliedCapability)
+			}
 			req.RemoteAddr = tc.remoteAddr
 			rec := httptest.NewRecorder()
-			SkillsRouter(svc, tc.opts...).ServeHTTP(rec, req)
+			SkillsRouter(svc, WithKeySigningCapability(capability)).ServeHTTP(rec, req)
 
 			assert.Equal(t, tc.wantStatus, rec.Code, "body: %s", rec.Body.String())
 		})
 	}
+}
+
+// TestSkillsRouter_ReverseProxyCannotForgeKeySigningAuthorization covers the
+// deployment that defeats peer-address checks: an internet-facing reverse
+// proxy reaches the API over loopback, so the backend sees a local TCP peer.
+// The request must still be refused before the service can open the key.
+func TestSkillsRouter_ReverseProxyCannotForgeKeySigningAuthorization(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	svc := skillsmocks.NewMockSkillService(ctrl)
+	router := SkillsRouter(svc, WithKeySigningCapability("protected-discovery-capability"))
+
+	var backendRemoteAddr string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendRemoteAddr = r.RemoteAddr
+		router.ServeHTTP(w, r)
+	}))
+	t.Cleanup(backend.Close)
+
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+	proxy := httptest.NewServer(httputil.NewSingleHostReverseProxy(backendURL))
+	t.Cleanup(proxy.Close)
+
+	body := `{"reference":"ghcr.io/test/skill:v1","key":"/home/dev/cosign.key"}`
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, proxy.URL+"/push", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	host, _, err := net.SplitHostPort(backendRemoteAddr)
+	require.NoError(t, err)
+	ip := net.ParseIP(host)
+	require.NotNil(t, ip)
+	assert.True(t, ip.IsLoopback(), "backend peer %q should demonstrate the proxy appears local", backendRemoteAddr)
 }

--- a/pkg/api/v1/key_signing_transport_test.go
+++ b/pkg/api/v1/key_signing_transport_test.go
@@ -94,8 +94,14 @@ func TestRequireKeySigningCapability(t *testing.T) {
 			}
 			require.Error(t, err)
 			assert.Equal(t, http.StatusForbidden, httperr.Code(err))
+			// The CLI relays this body verbatim, so the remediation has to be
+			// runnable from a terminal, not only from a JSON request.
+			assert.Contains(t, err.Error(), "--identity-token",
+				"the refusal must name the CLI flag that does work remotely")
+			assert.Contains(t, err.Error(), "drop --key",
+				"omitting --key is the zero-config keyless path and must be offered")
 			assert.Contains(t, err.Error(), "identity_token",
-				"the refusal must name the credential that does work remotely")
+				"direct API callers need the request field named too")
 			assert.NotContains(t, err.Error(), capability)
 		})
 	}

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -19,11 +19,9 @@ import (
 
 // SkillsRoutes defines the routes for skill management.
 type SkillsRoutes struct {
-	skillService skills.SkillService
-	lockService  skills.SkillLockService
-	// localTransport is set when the router is served over IPC, where the
-	// peer is local by construction. See requireLocalKeySigning.
-	localTransport localTransport
+	skillService         skills.SkillService
+	lockService          skills.SkillLockService
+	keySigningCapability string
 }
 
 // SkillsRouter creates a new router for skill management endpoints. If
@@ -33,8 +31,8 @@ type SkillsRoutes struct {
 func SkillsRouter(skillService skills.SkillService, opts ...RouterOption) http.Handler {
 	cfg := newRouterConfig(opts)
 	routes := SkillsRoutes{
-		skillService:   skillService,
-		localTransport: localTransport(cfg.localTransport),
+		skillService:         skillService,
+		keySigningCapability: cfg.keySigningCapability,
 	}
 	if lockSvc, ok := skillService.(skills.SkillLockService); ok {
 		routes.lockService = lockSvc
@@ -292,8 +290,10 @@ func (s *SkillsRoutes) buildSkill(w http.ResponseWriter, r *http.Request) error 
 //	@Tags			skills
 //	@Accept			json
 //	@Param			request	body	pushSkillRequest	true	"Push request"
+//	@Param			X-Toolhive-Key-Signing-Capability	header	string	false	"Local discovery capability (required with request.key)"
 //	@Success		204		{string}	string	"No Content"
 //	@Failure		400		{string}	string	"Bad Request"
+//	@Failure		403		{string}	string	"Forbidden (key signing requires the local discovery capability)"
 //	@Failure		404		{string}	string	"Not Found"
 //	@Failure		500		{string}	string	"Internal Server Error"
 //	@Router			/api/v1beta/skills/push [post]
@@ -307,7 +307,7 @@ func (s *SkillsRoutes) pushSkill(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// Checked before dispatch: the service would otherwise open the key.
-	if err := requireLocalKeySigning(r, s.localTransport, req.Key); err != nil {
+	if err := requireKeySigningCapability(r, s.keySigningCapability, req.Key); err != nil {
 		return err
 	}
 

--- a/pkg/api/v1/skills.go
+++ b/pkg/api/v1/skills.go
@@ -21,15 +21,20 @@ import (
 type SkillsRoutes struct {
 	skillService skills.SkillService
 	lockService  skills.SkillLockService
+	// localTransport is set when the router is served over IPC, where the
+	// peer is local by construction. See requireLocalKeySigning.
+	localTransport localTransport
 }
 
 // SkillsRouter creates a new router for skill management endpoints. If
 // skillService's concrete implementation also satisfies skills.SkillLockService
 // (as skillsvc.New's does), /sync and /upgrade are served; otherwise both
 // return 501.
-func SkillsRouter(skillService skills.SkillService) http.Handler {
+func SkillsRouter(skillService skills.SkillService, opts ...RouterOption) http.Handler {
+	cfg := newRouterConfig(opts)
 	routes := SkillsRoutes{
-		skillService: skillService,
+		skillService:   skillService,
+		localTransport: localTransport(cfg.localTransport),
 	}
 	if lockSvc, ok := skillService.(skills.SkillLockService); ok {
 		routes.lockService = lockSvc
@@ -299,6 +304,11 @@ func (s *SkillsRoutes) pushSkill(w http.ResponseWriter, r *http.Request) error {
 			fmt.Errorf("invalid request body: %w", err),
 			http.StatusBadRequest,
 		)
+	}
+
+	// Checked before dispatch: the service would otherwise open the key.
+	if err := requireLocalKeySigning(r, s.localTransport, req.Key); err != nil {
+		return err
 	}
 
 	if err := s.skillService.Push(r.Context(), skills.PushOptions{

--- a/pkg/api/v1/skills_types.go
+++ b/pkg/api/v1/skills_types.go
@@ -83,11 +83,11 @@ type pushSkillRequest struct {
 	// OCI reference to push
 	Reference string `json:"reference"`
 	// Key is the path to a cosign private key, resolved on the server's
-	// filesystem. Accepted only from a caller on this machine (an IPC
-	// transport or a loopback peer); a remote request naming a key is
-	// refused with 403, since honoring it would let the caller have the
-	// server sign with any key it can read. Use IdentityToken to have a
-	// remote server sign.
+	// filesystem. Accepted only when the request carries the secret capability
+	// from the owner-protected local server discovery file; other requests are
+	// refused with 403, since honoring one would let an untrusted caller have
+	// the server sign with any key it can read. Use IdentityToken when calling
+	// a remote or manually configured server.
 	Key string `json:"key,omitempty"`
 	// IdentityToken is a short-lived OIDC identity token used for keyless
 	// signing, mutually exclusive with Key

--- a/pkg/api/v1/skills_types.go
+++ b/pkg/api/v1/skills_types.go
@@ -82,8 +82,12 @@ type buildSkillRequest struct {
 type pushSkillRequest struct {
 	// OCI reference to push
 	Reference string `json:"reference"`
-	// Key is the path to a cosign private key used to sign the pushed
-	// artifact
+	// Key is the path to a cosign private key, resolved on the server's
+	// filesystem. Accepted only from a caller on this machine (an IPC
+	// transport or a loopback peer); a remote request naming a key is
+	// refused with 403, since honoring it would let the caller have the
+	// server sign with any key it can read. Use IdentityToken to have a
+	// remote server sign.
 	Key string `json:"key,omitempty"`
 	// IdentityToken is a short-lived OIDC identity token used for keyless
 	// signing, mutually exclusive with Key

--- a/pkg/server/discovery/discover_test.go
+++ b/pkg/server/discovery/discover_test.go
@@ -34,13 +34,14 @@ func TestDiscover_Running(t *testing.T) {
 		w.Header().Set(NonceHeader, nonce)
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	info := &ServerInfo{
-		URL:       srv.URL,
-		PID:       os.Getpid(),
-		Nonce:     nonce,
-		StartedAt: time.Now().UTC(),
+		URL:                  srv.URL,
+		PID:                  os.Getpid(),
+		Nonce:                nonce,
+		KeySigningCapability: "protected-discovery-capability",
+		StartedAt:            time.Now().UTC(),
 	}
 	require.NoError(t, writeServerInfoTo(dir, info))
 
@@ -48,6 +49,7 @@ func TestDiscover_Running(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, StateRunning, result.State)
 	assert.Equal(t, nonce, result.Info.Nonce)
+	assert.Equal(t, info.KeySigningCapability, result.Info.KeySigningCapability)
 }
 
 func TestDiscover_Stale_DeadProcess(t *testing.T) {

--- a/pkg/server/discovery/discovery.go
+++ b/pkg/server/discovery/discovery.go
@@ -42,6 +42,11 @@ type ServerInfo struct {
 	// the discovery file refers to the expected server instance.
 	Nonce string `json:"nonce"`
 
+	// KeySigningCapability is a bearer secret authorizing requests that name a
+	// private key on the server's filesystem. It is distributed only through
+	// this owner-protected discovery file and is never returned by /health.
+	KeySigningCapability string `json:"key_signing_capability,omitempty"`
+
 	// StartedAt is the UTC timestamp when the server started.
 	StartedAt time.Time `json:"started_at"`
 }

--- a/pkg/server/discovery/discovery_test.go
+++ b/pkg/server/discovery/discovery_test.go
@@ -19,10 +19,11 @@ func TestWriteReadServerInfo_TCP(t *testing.T) {
 	dir := t.TempDir()
 
 	info := &ServerInfo{
-		URL:       "http://127.0.0.1:52341",
-		PID:       12345,
-		Nonce:     "test-nonce-tcp",
-		StartedAt: time.Date(2026, 3, 23, 10, 0, 0, 0, time.UTC),
+		URL:                  "http://127.0.0.1:52341",
+		PID:                  12345,
+		Nonce:                "test-nonce-tcp",
+		KeySigningCapability: "protected-discovery-capability",
+		StartedAt:            time.Date(2026, 3, 23, 10, 0, 0, 0, time.UTC),
 	}
 
 	require.NoError(t, writeServerInfoTo(dir, info))
@@ -32,6 +33,7 @@ func TestWriteReadServerInfo_TCP(t *testing.T) {
 	assert.Equal(t, info.URL, got.URL)
 	assert.Equal(t, info.PID, got.PID)
 	assert.Equal(t, info.Nonce, got.Nonce)
+	assert.Equal(t, info.KeySigningCapability, got.KeySigningCapability)
 	assert.True(t, info.StartedAt.Equal(got.StartedAt))
 }
 

--- a/pkg/server/discovery/health.go
+++ b/pkg/server/discovery/health.go
@@ -21,6 +21,10 @@ const (
 
 	// NonceHeader is the HTTP header used to return the server nonce.
 	NonceHeader = "X-Toolhive-Nonce"
+
+	// KeySigningCapabilityHeader carries the secret capability required for a
+	// request that asks the API server to open a private signing key.
+	KeySigningCapabilityHeader = "X-Toolhive-Key-Signing-Capability"
 )
 
 // NamedPipePrefix is the Windows named-pipe namespace prefix. The discovery

--- a/pkg/skills/client/client.go
+++ b/pkg/skills/client/client.go
@@ -60,8 +60,9 @@ var _ skills.SkillLockService = (*Client)(nil)
 
 // Client is an HTTP client for the ToolHive Skills API.
 type Client struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL              string
+	httpClient           *http.Client
+	keySigningCapability string
 }
 
 // Option configures a Client.
@@ -79,6 +80,14 @@ func WithTimeout(d time.Duration) Option {
 func WithHTTPClient(hc *http.Client) Option {
 	return func(c *Client) {
 		c.httpClient = hc
+	}
+}
+
+// WithKeySigningCapability sets the bearer capability required for pushes
+// that name a private key on the API server's filesystem.
+func WithKeySigningCapability(capability string) Option {
+	return func(c *Client) {
+		c.keySigningCapability = capability
 	}
 }
 
@@ -177,7 +186,10 @@ func resolveViaDiscovery(ctx context.Context) (string, []Option) {
 	}
 	client.Timeout = defaultTimeout
 
-	return baseURL, []Option{WithHTTPClient(client)}
+	return baseURL, []Option{
+		WithHTTPClient(client),
+		WithKeySigningCapability(result.Info.KeySigningCapability),
+	}
 }
 
 // --- SkillService implementation ---
@@ -286,15 +298,14 @@ func (c *Client) Build(ctx context.Context, opts skills.BuildOptions) (*skills.B
 
 // Push pushes a built skill artifact to a remote registry.
 func (c *Client) Push(ctx context.Context, opts skills.PushOptions) error {
-	// An identity token is a bearer credential redeemable at Fulcio for a
-	// signing certificate in the caller's name, so it must not cross a
-	// plaintext link to a remote API server. Checked before the body is
-	// marshaled: nothing should serialize the token until the destination has
-	// been cleared. The request is then issued through a client that refuses
-	// redirects, because clearing the base URL says nothing about where a
-	// 307/308 from that URL would replay the body.
+	// Identity tokens and key-signing capabilities are bearer credentials, so
+	// neither may cross a plaintext link to a remote API server or a redirect.
 	client := c
-	if opts.IdentityToken != "" {
+	headers := make(http.Header)
+	if opts.Key != "" && c.keySigningCapability != "" {
+		headers.Set(discovery.KeySigningCapabilityHeader, c.keySigningCapability)
+	}
+	if opts.IdentityToken != "" || len(headers) != 0 {
 		if err := identitytoken.CheckTransport(c.baseURL); err != nil {
 			return err
 		}
@@ -308,7 +319,7 @@ func (c *Client) Push(ctx context.Context, opts skills.PushOptions) error {
 		IdentityToken: opts.IdentityToken,
 		NoSign:        opts.NoSign,
 	}
-	return client.doJSONRequest(ctx, http.MethodPost, "/push", nil, body, nil)
+	return client.doJSONRequestWithHeaders(ctx, http.MethodPost, "/push", nil, body, nil, headers)
 }
 
 // ListBuilds returns all locally-built OCI skill artifacts in the local store.
@@ -394,6 +405,17 @@ func (c *Client) doJSONRequest(
 	reqBody any,
 	result any,
 ) error {
+	return c.doJSONRequestWithHeaders(ctx, method, path, query, reqBody, result, nil)
+}
+
+func (c *Client) doJSONRequestWithHeaders(
+	ctx context.Context,
+	method, path string,
+	query url.Values,
+	reqBody any,
+	result any,
+	headers http.Header,
+) error {
 	var bodyReader io.Reader
 	if reqBody != nil {
 		data, err := json.Marshal(reqBody)
@@ -414,6 +436,11 @@ func (c *Client) doJSONRequest(
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
 
 	resp, err := c.httpClient.Do(req) // #nosec G704 -- baseURL is a trusted local API server URL
 	if err != nil {

--- a/pkg/skills/client/client_test.go
+++ b/pkg/skills/client/client_test.go
@@ -20,6 +20,7 @@ import (
 
 	envmocks "github.com/stacklok/toolhive-core/env/mocks"
 	"github.com/stacklok/toolhive-core/httperr"
+	"github.com/stacklok/toolhive/pkg/server/discovery"
 	"github.com/stacklok/toolhive/pkg/skills"
 	"github.com/stacklok/toolhive/pkg/skills/identitytoken"
 )
@@ -507,17 +508,33 @@ func TestPush(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		opts       skills.PushOptions
-		wantBody   pushRequest
-		statusCode int
-		wantErr    bool
-		wantCode   int
+		name             string
+		opts             skills.PushOptions
+		clientCapability string
+		wantCapability   bool
+		wantBody         pushRequest
+		statusCode       int
+		wantErr          bool
+		wantCode         int
 	}{
 		{
 			name:       "success",
 			opts:       skills.PushOptions{Reference: "ghcr.io/org/my-skill:v1.0.0"},
 			wantBody:   pushRequest{Reference: "ghcr.io/org/my-skill:v1.0.0"},
+			statusCode: http.StatusNoContent,
+		},
+		{
+			name: "key push forwards signing capability",
+			opts: skills.PushOptions{
+				Reference: "ghcr.io/org/my-skill:v1.0.0",
+				Key:       "/home/user/cosign.key",
+			},
+			clientCapability: "protected-discovery-capability",
+			wantCapability:   true,
+			wantBody: pushRequest{
+				Reference: "ghcr.io/org/my-skill:v1.0.0",
+				Key:       "/home/user/cosign.key",
+			},
 			statusCode: http.StatusNoContent,
 		},
 		{
@@ -531,6 +548,20 @@ func TestPush(t *testing.T) {
 			wantBody: pushRequest{
 				Reference:     "ghcr.io/org/my-skill:v1.0.0",
 				IdentityToken: "a.b.c",
+			},
+			clientCapability: "must-not-be-sent",
+			statusCode:       http.StatusNoContent,
+		},
+		{
+			name: "no-sign push does not forward signing capability",
+			opts: skills.PushOptions{
+				Reference: "ghcr.io/org/my-skill:v1.0.0",
+				NoSign:    true,
+			},
+			clientCapability: "must-not-be-sent",
+			wantBody: pushRequest{
+				Reference: "ghcr.io/org/my-skill:v1.0.0",
+				NoSign:    true,
 			},
 			statusCode: http.StatusNoContent,
 		},
@@ -550,6 +581,11 @@ func TestPush(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodPost, r.Method)
 				assert.Equal(t, skillsBasePath+"/push", r.URL.Path)
+				if tt.wantCapability {
+					assert.Equal(t, tt.clientCapability, r.Header.Get(discovery.KeySigningCapabilityHeader))
+				} else {
+					assert.Empty(t, r.Header.Values(discovery.KeySigningCapabilityHeader))
+				}
 
 				if tt.wantBody.Reference != "" {
 					var got pushRequest
@@ -563,9 +599,9 @@ func TestPush(t *testing.T) {
 				}
 				w.WriteHeader(tt.statusCode)
 			}))
-			defer srv.Close()
+			t.Cleanup(srv.Close)
 
-			c := newTestClient(t, srv)
+			c := NewClient(srv.URL, WithKeySigningCapability(tt.clientCapability))
 			err := c.Push(t.Context(), tt.opts)
 
 			if tt.wantErr {
@@ -695,6 +731,7 @@ func TestNewDefaultClient(t *testing.T) {
 
 		c := newDefaultClientWithEnv(t.Context(), mockEnv, noDiscovery)
 		assert.Equal(t, defaultBaseURL, c.baseURL)
+		assert.Empty(t, c.keySigningCapability)
 	})
 
 	t.Run("uses TOOLHIVE_API_URL from env", func(t *testing.T) {
@@ -706,6 +743,8 @@ func TestNewDefaultClient(t *testing.T) {
 
 		c := newDefaultClientWithEnv(t.Context(), mockEnv, failDiscovery(t))
 		assert.Equal(t, "http://localhost:9999", c.baseURL)
+		assert.Empty(t, c.keySigningCapability,
+			"an arbitrary environment URL must not inherit a local discovery secret")
 	})
 
 	t.Run("uses discovered server when env is empty", func(t *testing.T) {
@@ -716,10 +755,13 @@ func TestNewDefaultClient(t *testing.T) {
 		mockEnv.EXPECT().Getenv(envAPITimeout).Return("").AnyTimes()
 
 		discover := func(context.Context) (string, []Option) {
-			return "http://127.0.0.1:54321", nil
+			return "http://127.0.0.1:54321", []Option{
+				WithKeySigningCapability("protected-discovery-capability"),
+			}
 		}
 		c := newDefaultClientWithEnv(t.Context(), mockEnv, discover)
 		assert.Equal(t, "http://127.0.0.1:54321", c.baseURL)
+		assert.Equal(t, "protected-discovery-capability", c.keySigningCapability)
 	})
 
 	t.Run("applies options", func(t *testing.T) {
@@ -1100,4 +1142,38 @@ func TestPushDoesNotFollowRedirectsWithIdentityToken(t *testing.T) {
 	assert.ErrorIs(t, err, identitytoken.ErrInsecureTransport)
 	assert.Zero(t, secondHits, "the redirect target must never be contacted")
 	assert.False(t, secondSawToken, "the identity token must never leave the approved origin")
+}
+
+// TestPushDoesNotFollowRedirectsWithKeySigningCapability proves a server
+// cannot redirect the discovery capability to another origin. A 307 would
+// otherwise preserve the push body and Go's default redirect handling copies
+// the custom header to the next request.
+func TestPushDoesNotFollowRedirectsWithKeySigningCapability(t *testing.T) {
+	t.Parallel()
+
+	var secondHits int
+	var secondSawCapability bool
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondHits++
+		secondSawCapability = r.Header.Get(discovery.KeySigningCapabilityHeader) != ""
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(second.Close)
+
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "protected-discovery-capability",
+			r.Header.Get(discovery.KeySigningCapabilityHeader))
+		http.Redirect(w, r, second.URL+r.URL.Path, http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(first.Close)
+
+	c := NewClient(first.URL, WithKeySigningCapability("protected-discovery-capability"))
+	err := c.Push(t.Context(), skills.PushOptions{
+		Reference: "ghcr.io/org/artifact:v1.0.0",
+		Key:       "/home/user/cosign.key",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, identitytoken.ErrInsecureTransport)
+	assert.Zero(t, secondHits, "the redirect target must never be contacted")
+	assert.False(t, secondSawCapability, "the capability must never leave the approved origin")
 }

--- a/pkg/skills/identitytoken/transport.go
+++ b/pkg/skills/identitytoken/transport.go
@@ -12,18 +12,19 @@ import (
 	"strings"
 )
 
-// ErrInsecureTransport is returned when an identity token would be sent over
-// a transport that does not protect it.
-var ErrInsecureTransport = errors.New("refusing to send an OIDC identity token over an unencrypted connection")
+// ErrInsecureTransport is returned when a signing credential would be sent
+// over a transport that does not protect it.
+var ErrInsecureTransport = errors.New("refusing to send a signing credential over an unencrypted connection")
 
-// CheckTransport reports whether baseURL is a safe destination for an OIDC
-// identity token.
+// CheckTransport reports whether baseURL is a safe destination for a signing
+// credential such as an OIDC identity token or key-signing capability.
 //
-// The token is a short-lived bearer credential that Fulcio will exchange for
-// a signing certificate attributed to its subject, so anyone who observes it
-// in flight can sign artifacts as the caller (CWE-319, RFC 6750 §5.1). The
-// API base URL is not necessarily local: TOOLHIVE_API_URL can point the CLI
-// at an arbitrary host, and plain http:// to a remote host puts the token on
+// Both values are bearer credentials: Fulcio will exchange the token for a
+// signing certificate attributed to its subject, while the capability lets
+// its holder ask the API server to sign with a private key. Anyone who observes
+// either value in flight can exercise that authority (CWE-319, RFC 6750 §5.1).
+// The API base URL is not necessarily local: TOOLHIVE_API_URL can point the CLI
+// at an arbitrary host, and plain http:// to a remote host puts a credential on
 // the wire in cleartext.
 //
 // HTTPS is accepted, as is plaintext HTTP to a loopback host — the Unix
@@ -31,9 +32,9 @@ var ErrInsecureTransport = errors.New("refusing to send an OIDC identity token o
 // on those the bytes never reach a network interface at all. Everything else
 // is refused.
 //
-// Callers must only invoke this when a token is actually present: an unsigned
-// (--no-sign) push over plaintext HTTP carries no credential and is not this
-// function's business to block.
+// Callers must only invoke this when a credential is actually present: an
+// unsigned (--no-sign) push over plaintext HTTP carries no credential and is
+// not this function's business to block.
 func CheckTransport(baseURL string) error {
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -71,7 +72,7 @@ func isLoopbackHost(host string) bool {
 }
 
 // NoRedirectClient returns a shallow copy of base that refuses to follow
-// redirects, for requests that carry an identity token in their body.
+// redirects for requests that carry a signing credential.
 //
 // CheckTransport alone is not enough: it clears the base URL, but an accepted
 // HTTPS or loopback endpoint can answer with a 307 or 308, and those preserve
@@ -84,13 +85,13 @@ func isLoopbackHost(host string) bool {
 // Refusing outright rather than re-checking each hop: the ToolHive API does
 // not redirect its own endpoints, so there is no legitimate case to preserve,
 // and "no redirects" is a property that cannot be subtly wrong. The refusal
-// happens before the second request is issued, so the token never leaves the
-// origin CheckTransport approved.
+// happens before the second request is issued, so the credential never leaves
+// the origin CheckTransport approved.
 func NoRedirectClient(base *http.Client) *http.Client {
 	guarded := *base
 	guarded.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
 		return fmt.Errorf("%w: the ToolHive API redirected this request to %s; "+
-			"a push carrying an identity token is not followed across redirects",
+			"a push carrying a signing credential is not followed across redirects",
 			ErrInsecureTransport, req.URL.Redacted())
 	}
 	return &guarded


### PR DESCRIPTION
## Summary

`POST /api/v1beta/skills/push` accepts `key`, a path to a cosign private key that the `thv serve` process opens and signs with. Without independent authorization, the management API can become a signing oracle: an untrusted caller can ask the server to publish an artifact signed by any readable key.

Checking only the backend peer address is not sufficient. A public reverse proxy can forward an untrusted request over loopback or a UNIX socket, making the caller appear local to the API server.

This change:

- Generates an independent 128-bit key-signing capability at server startup. It is separate from the discovery nonce, which `/health` intentionally exposes.
- Stores the capability only in the owner-protected server discovery file and requires it for every key-bearing push, using a constant-time comparison and failing closed when it is missing or misconfigured.
- Has automatically discovered skill clients attach the capability only to key-bearing pushes. `TOOLHIVE_API_URL` and manually constructed clients do not inherit it.
- Protects the capability as a bearer credential: it is not logged or returned by `/health`, is refused over an unprotected remote transport, and is never followed across redirects.
- Documents the conditional header and 403 response in OpenAPI, CLI help, and the skills architecture guide.

This was found while reviewing #6528, which restores the same `--key` path for plugins. The plugin branch will need to adopt the same capability after rebasing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [x] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [x] Linting (`task lint-fix`)
- [ ] Manual testing (describe below)
- [x] Generated API and CLI documentation (`task docs`)

Regression coverage includes fail-closed capability checks, a real reverse proxy whose backend sees a loopback peer, discovery round trips, health-header non-disclosure, client header scoping, and redirect refusal.

## Changes

| Area | Change |
|------|--------|
| API server and discovery | Generate, persist, and verify the protected key-signing capability |
| Skills API client | Read the capability only from local discovery and attach it only to key pushes |
| Transport security | Refuse insecure delivery and redirects for signing credentials |
| Tests | Cover proxy bypass, missing/wrong capability, non-disclosure, and redirect leakage |
| Docs | Document the capability header, 403 response, CLI constraint, and architecture |

## Does this introduce a user-facing change?

Yes. `thv skill push --key` now requires the automatically discovered local ToolHive server. A key-bearing push through `TOOLHIVE_API_URL`, a manually constructed client, or a caller without the protected discovery capability receives 403. Keyless signing with an OIDC identity token and unsigned pushes are unchanged. The 403 body names the runnable alternatives: drop `--key` (the CLI acquires an identity token itself) or pass `--identity-token`; direct API callers are told to send `identity_token` in place of `key`.

## Special notes for reviewers

- Loopback and IPC are intentionally not authorization boundaries because a reverse proxy can make a remote caller appear local.
- The discovery nonce is intentionally not reused: `/health` returns it publicly for instance verification.
- Existing clients remain compatible for non-key operations. Old clients talking to the new server receive 403 only when they attempt a key-bearing push without the capability.
- The capability header is documented as optional because it is required only when `request.key` is set.
- **Package-level change in `pkg/server/discovery`:** `ServerInfo` gains a `KeySigningCapability` field. Every literal in this repo is keyed, and `go vet`'s `composites` check already rejects unkeyed literals of a struct imported from another package, so any downstream code this could break is code `go vet` refuses today. A separate discovery-file DTO would keep the exported shape byte-identical but would also mean a second `Write`/`Read` signature to thread the capability through; I judged that a worse trade for a field addition. Migration, if anyone does hit it: switch the literal to keyed fields.
- **Review round (2026-09-10):** the 403 remediation originally said "sign keylessly with `identity_token`", the JSON field, while the CLI relays the server body verbatim and only knows `--identity-token`. Reworded in 9d52481 (originally 668364a before the rebase onto current `main`) so a terminal user gets a runnable path first; the test now pins `--identity-token`, `drop --key`, and `identity_token` all appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


