### PR TITLE
Generalize vMCP session dial-control into a per-workload resolver

### DIFF
--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -154,7 +154,7 @@ type defaultMultiSessionFactory struct {
 	backendInitTimeout     time.Duration
 	revisionLookup         func(workloadID string) (mcpparser.Revision, bool)
 	requestTimeoutResolver func(workloadID string) time.Duration
-	dialControl            func(network, address string, c syscall.RawConn) error
+	dialControlResolver    func(workloadID string) func(network, address string, c syscall.RawConn) error
 }
 
 // MultiSessionFactoryOption configures a defaultMultiSessionFactory.
@@ -223,23 +223,36 @@ func WithRevisionLookup(lookup func(workloadID string) (mcpparser.Revision, bool
 	}
 }
 
-// WithDialControl installs a per-connection Control hook on the dialer used to
-// open the per-backend connections this factory establishes at session init
-// (MakeSessionWithID and RestoreSession). The hook fires after DNS resolution
-// and before the TCP handshake, receiving the resolved peer IP — so it can
-// enforce a dial policy (e.g. refuse dials into private ranges to blunt SSRF /
-// DNS-rebinding) on backend endpoints that may be operator- or
-// attacker-influenceable.
+// WithDialControlResolver supplies a dial-control hook chosen per backend, so an
+// embedder can apply a per-backend dial policy to the connections opened at
+// session init (MakeSessionWithID and RestoreSession). Mirrors WithRevisionLookup
+// / WithRequestTimeoutResolver: the resolver receives a backend workload ID and
+// returns the net.Dialer.Control hook to install for that backend, or nil to
+// leave it on http.DefaultTransport.
+//
+// The returned hook fires after DNS resolution and before the TCP handshake,
+// receiving the resolved peer IP — so it can enforce a per-backend dial policy
+// (e.g. refuse dials into private ranges to blunt SSRF / DNS-rebinding) on
+// backend endpoints that may be operator- or attacker-influenceable. A nil
+// resolver (the default), or a resolver that returns nil for a given workload,
+// leaves that backend's transport on http.DefaultTransport — byte-for-byte
+// unchanged from the no-hook path.
 //
 // It is the session-factory counterpart to pkg/vmcp/client.WithDialControl,
 // which guards the aggregation and tool-call paths; without this option those
-// paths could be guarded while session-init dials were not. The signature
-// matches net.Dialer.Control exactly, and a nil control (the default) leaves
-// the dial path unchanged. See backend.WithDialControl for the full security
-// caveats (per-TCP-dial not per-request, proxy transparency, both IP families).
-func WithDialControl(control func(network, address string, c syscall.RawConn) error) MultiSessionFactoryOption {
+// paths could be guarded while session-init dials were not. The returned hook
+// matches net.Dialer.Control exactly. See backend.WithDialControlResolver for
+// the full security caveats (per-TCP-dial not per-request, proxy transparency,
+// both IP families).
+//
+// Concurrency: the resolver is called from the per-backend init goroutines
+// started by makeBaseSession, up to maxConcurrency at once, so it must be safe
+// for concurrent use.
+func WithDialControlResolver(
+	resolve func(workloadID string) func(network, address string, c syscall.RawConn) error,
+) MultiSessionFactoryOption {
 	return func(f *defaultMultiSessionFactory) {
-		f.dialControl = control
+		f.dialControlResolver = resolve
 	}
 }
 
@@ -250,7 +263,7 @@ func NewSessionFactory(registry vmcpauth.OutgoingAuthRegistry, opts ...MultiSess
 	f.connector = backend.NewHTTPConnector(
 		registry,
 		backend.WithRequestTimeoutResolver(f.requestTimeoutResolver),
-		backend.WithDialControl(f.dialControl),
+		backend.WithDialControlResolver(f.dialControlResolver),
 	)
 	return f
 }

--- a/pkg/vmcp/session/factory.go
+++ b/pkg/vmcp/session/factory.go
@@ -241,18 +241,21 @@ func WithRevisionLookup(lookup func(workloadID string) (mcpparser.Revision, bool
 // It is the session-factory counterpart to pkg/vmcp/client.WithDialControl,
 // which guards the aggregation and tool-call paths; without this option those
 // paths could be guarded while session-init dials were not. The returned hook
-// matches net.Dialer.Control exactly. See backend.WithDialControlResolver for
-// the full security caveats (per-TCP-dial not per-request, proxy transparency,
-// both IP families).
+// matches net.Dialer.Control exactly, but the option shapes differ: this one is
+// a per-backend resolver, whereas client.WithDialControl is not (yet) per-backend.
+// See backend.WithDialControlResolver for the full security caveats — including
+// that the resolver only SELECTS a hook, so the returned hook must itself inspect
+// the resolved address or it gives no SSRF/DNS-rebinding protection (per-TCP-dial
+// not per-request, proxy transparency, both IP families).
 //
 // Concurrency: the resolver is called from the per-backend init goroutines
 // started by makeBaseSession, up to maxConcurrency at once, so it must be safe
 // for concurrent use.
 func WithDialControlResolver(
-	resolve func(workloadID string) func(network, address string, c syscall.RawConn) error,
+	resolver func(workloadID string) func(network, address string, c syscall.RawConn) error,
 ) MultiSessionFactoryOption {
 	return func(f *defaultMultiSessionFactory) {
-		f.dialControlResolver = resolve
+		f.dialControlResolver = resolver
 	}
 }
 

--- a/pkg/vmcp/session/factory_dialcontrol_test.go
+++ b/pkg/vmcp/session/factory_dialcontrol_test.go
@@ -6,8 +6,6 @@ package session
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/url"
 	"syscall"
 	"testing"
 
@@ -18,13 +16,24 @@ import (
 	"github.com/stacklok/toolhive/pkg/vmcp"
 )
 
-// TestSessionFactory_WithDialControl_GuardsSessionInit proves the option is
-// threaded from the public NewSessionFactory API down to the per-backend
-// session-init dial: with a deny-all control the real backend is never reached,
-// so the (partial-failure) session is created but holds no capabilities. The
+// denyAllResolver returns a WithDialControlResolver argument that resolves a
+// deny-all hook for every workload, standing in for an embedder's per-backend
+// SSRF/private-address guard that happens to block all of this test's backends.
+func denyAllResolver() func(workloadID string) func(network, address string, c syscall.RawConn) error {
+	return func(_ string) func(network, address string, c syscall.RawConn) error {
+		return func(_, _ string, _ syscall.RawConn) error {
+			return errors.New("dial blocked by test policy")
+		}
+	}
+}
+
+// TestSessionFactory_WithDialControlResolver_GuardsSessionInit proves the option
+// is threaded from the public NewSessionFactory API down to the per-backend
+// session-init dial: with a deny-all hook the real backend is never reached, so
+// the (partial-failure) session is created but holds no capabilities. The
 // unguarded TestSessionFactory_Integration_CapabilityDiscovery shows the same
 // backend IS reached and discovered without the option.
-func TestSessionFactory_WithDialControl_GuardsSessionInit(t *testing.T) {
+func TestSessionFactory_WithDialControlResolver_GuardsSessionInit(t *testing.T) {
 	t.Parallel()
 
 	baseURL := startInProcessMCPServer(t)
@@ -35,10 +44,7 @@ func TestSessionFactory_WithDialControl_GuardsSessionInit(t *testing.T) {
 		TransportType: "streamable-http",
 	}
 
-	factory := NewSessionFactory(newUnauthenticatedRegistry(t),
-		WithDialControl(func(_, _ string, _ syscall.RawConn) error {
-			return errors.New("dial blocked by test policy")
-		}))
+	factory := NewSessionFactory(newUnauthenticatedRegistry(t), WithDialControlResolver(denyAllResolver()))
 
 	// A blocked backend is a partial failure: the backend is excluded and the
 	// session is still created, just with no held connection or capabilities.
@@ -52,11 +58,11 @@ func TestSessionFactory_WithDialControl_GuardsSessionInit(t *testing.T) {
 	assert.Empty(t, sess.Prompts(), "guarded session-init dial must not discover backend prompts")
 }
 
-// TestSessionFactory_WithDialControl_GuardsRestoreSession proves the option
-// also covers the RestoreSession path (which has its own filtering and
-// identity-binding restore logic), not just MakeSessionWithID. A guarded
-// factory restoring from valid stored metadata must not reach the backend.
-func TestSessionFactory_WithDialControl_GuardsRestoreSession(t *testing.T) {
+// TestSessionFactory_WithDialControlResolver_GuardsRestoreSession proves the
+// option also covers the RestoreSession path (which has its own filtering and
+// identity-binding restore logic), not just MakeSessionWithID. A guarded factory
+// restoring from valid stored metadata must not reach the backend.
+func TestSessionFactory_WithDialControlResolver_GuardsRestoreSession(t *testing.T) {
 	t.Parallel()
 
 	baseURL := startInProcessMCPServer(t)
@@ -77,10 +83,7 @@ func TestSessionFactory_WithDialControl_GuardsRestoreSession(t *testing.T) {
 	require.NoError(t, orig.Close())
 
 	// A guarded factory restoring from that metadata must not reach the backend.
-	guarded := NewSessionFactory(newUnauthenticatedRegistry(t),
-		WithDialControl(func(_, _ string, _ syscall.RawConn) error {
-			return errors.New("dial blocked by test policy")
-		}))
+	guarded := NewSessionFactory(newUnauthenticatedRegistry(t), WithDialControlResolver(denyAllResolver()))
 	restored, err := guarded.RestoreSession(context.Background(), uuid.New().String(), storedMeta, []*vmcp.Backend{backend})
 	require.NoError(t, err)
 	require.NotNil(t, restored)
@@ -90,16 +93,17 @@ func TestSessionFactory_WithDialControl_GuardsRestoreSession(t *testing.T) {
 	assert.Empty(t, restored.BackendSessions(), "guarded restore must hold no backend connection")
 }
 
-// TestSessionFactory_WithDialControl_AppliesPerBackend proves the control is
-// applied per-backend within a single session: with two backends and a control
-// that blocks only one address, the allowed backend connects and the blocked
-// one is excluded. This is the production scenario the feature exists for.
-func TestSessionFactory_WithDialControl_AppliesPerBackend(t *testing.T) {
+// TestSessionFactory_WithDialControlResolver_AppliesPerBackend proves the hook is
+// resolved per-backend within a single session: with two backends and a resolver
+// that returns a deny-all hook for one workload ID and nil for the other, the
+// allowed backend connects and the blocked one is excluded. This is the
+// production scenario the resolver exists for — a per-backend dial policy the
+// single address-blind hook could not express.
+func TestSessionFactory_WithDialControlResolver_AppliesPerBackend(t *testing.T) {
 	t.Parallel()
 
 	allowedURL := startInProcessMCPServer(t)
 	blockedURL := startInProcessMCPServer(t)
-	blockedHost := mustHost(t, blockedURL)
 
 	allowed := &vmcp.Backend{
 		ID: "allowed-backend", Name: "allowed-backend", BaseURL: allowedURL, TransportType: "streamable-http",
@@ -109,11 +113,13 @@ func TestSessionFactory_WithDialControl_AppliesPerBackend(t *testing.T) {
 	}
 
 	factory := NewSessionFactory(newUnauthenticatedRegistry(t),
-		WithDialControl(func(_, address string, _ syscall.RawConn) error {
-			if address == blockedHost {
-				return fmt.Errorf("dial blocked by test policy: %s", address)
+		WithDialControlResolver(func(workloadID string) func(network, address string, c syscall.RawConn) error {
+			if workloadID != blocked.ID {
+				return nil
 			}
-			return nil
+			return func(_, _ string, _ syscall.RawConn) error {
+				return errors.New("dial blocked by test policy")
+			}
 		}))
 
 	sess, err := factory.MakeSessionWithID(
@@ -123,16 +129,7 @@ func TestSessionFactory_WithDialControl_AppliesPerBackend(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, sess.Close()) })
 
 	conns := sess.BackendSessions()
-	assert.Contains(t, conns, "allowed-backend", "the allowed backend must be connected")
-	assert.NotContains(t, conns, "blocked-backend", "the blocked backend must be excluded by the dial control")
+	assert.Contains(t, conns, "allowed-backend", "the workload the resolver returns nil for must be connected")
+	assert.NotContains(t, conns, "blocked-backend", "the workload with a deny-all hook must be excluded")
 	assert.NotEmpty(t, sess.Tools(), "the allowed backend's capabilities must still be discovered")
-}
-
-// mustHost returns the host:port of rawURL for matching against the address a
-// net.Dialer.Control hook receives.
-func mustHost(t *testing.T, rawURL string) string {
-	t.Helper()
-	u, err := url.Parse(rawURL)
-	require.NoError(t, err)
-	return u.Host
 }

--- a/pkg/vmcp/session/factory_dialcontrol_test.go
+++ b/pkg/vmcp/session/factory_dialcontrol_test.go
@@ -6,8 +6,12 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -132,4 +136,153 @@ func TestSessionFactory_WithDialControlResolver_AppliesPerBackend(t *testing.T) 
 	assert.Contains(t, conns, "allowed-backend", "the workload the resolver returns nil for must be connected")
 	assert.NotContains(t, conns, "blocked-backend", "the workload with a deny-all hook must be excluded")
 	assert.NotEmpty(t, sess.Tools(), "the allowed backend's capabilities must still be discovered")
+}
+
+// TestSessionFactory_WithDialControlResolver_AppliesPerBackendOnRestore is the
+// RestoreSession counterpart to _AppliesPerBackend. It proves the resolver is keyed
+// on each backend's own workload ID during restore, not only under a blanket
+// deny-all: a bug threading the wrong workload ID into the resolver on the restore
+// path (e.g. always the first backend's) would still pass GuardsRestoreSession but
+// fail here.
+func TestSessionFactory_WithDialControlResolver_AppliesPerBackendOnRestore(t *testing.T) {
+	t.Parallel()
+
+	allowedURL := startInProcessMCPServer(t)
+	blockedURL := startInProcessMCPServer(t)
+	allowed := &vmcp.Backend{
+		ID: "allowed-backend", Name: "allowed-backend", BaseURL: allowedURL, TransportType: "streamable-http",
+	}
+	blocked := &vmcp.Backend{
+		ID: "blocked-backend", Name: "blocked-backend", BaseURL: blockedURL, TransportType: "streamable-http",
+	}
+	backends := []*vmcp.Backend{allowed, blocked}
+
+	// Seed valid stored metadata (backend IDs + identity binding) from a real
+	// unguarded session over both backends.
+	seed := NewSessionFactory(newUnauthenticatedRegistry(t))
+	orig, err := seed.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, orig.Tools(), "sanity: the unguarded seed session must reach both backends")
+	storedMeta := orig.GetMetadata()
+	require.NoError(t, orig.Close())
+
+	// Restore with a resolver that denies only the blocked workload ID.
+	guarded := NewSessionFactory(newUnauthenticatedRegistry(t),
+		WithDialControlResolver(func(workloadID string) func(network, address string, c syscall.RawConn) error {
+			if workloadID != blocked.ID {
+				return nil
+			}
+			return func(_, _ string, _ syscall.RawConn) error {
+				return errors.New("dial blocked by test policy")
+			}
+		}))
+	restored, err := guarded.RestoreSession(context.Background(), uuid.New().String(), storedMeta, backends)
+	require.NoError(t, err)
+	require.NotNil(t, restored)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+
+	conns := restored.BackendSessions()
+	assert.Contains(t, conns, "allowed-backend", "the workload the resolver returns nil for must survive restore")
+	assert.NotContains(t, conns, "blocked-backend", "the workload the resolver denies must be excluded on restore")
+}
+
+// TestSessionFactory_WithDialControlResolver_IsolatesPanickingResolver proves an
+// embedder resolver that panics for one workload is isolated to that backend: the
+// backend is excluded like any other init failure and the session is still created
+// with the surviving backend, rather than the panic crashing the per-backend init
+// goroutine (and the process).
+func TestSessionFactory_WithDialControlResolver_IsolatesPanickingResolver(t *testing.T) {
+	t.Parallel()
+
+	allowedURL := startInProcessMCPServer(t)
+	panicURL := startInProcessMCPServer(t)
+	allowed := &vmcp.Backend{
+		ID: "allowed-backend", Name: "allowed-backend", BaseURL: allowedURL, TransportType: "streamable-http",
+	}
+	panicky := &vmcp.Backend{
+		ID: "panic-backend", Name: "panic-backend", BaseURL: panicURL, TransportType: "streamable-http",
+	}
+
+	factory := NewSessionFactory(newUnauthenticatedRegistry(t),
+		WithDialControlResolver(func(workloadID string) func(network, address string, c syscall.RawConn) error {
+			if workloadID == panicky.ID {
+				panic("resolver boom for " + workloadID)
+			}
+			return nil
+		}))
+
+	sess, err := factory.MakeSessionWithID(
+		context.Background(), uuid.New().String(), nil, []*vmcp.Backend{allowed, panicky}, nil)
+	require.NoError(t, err, "a resolver panic for one backend must not fail whole-session creation")
+	require.NotNil(t, sess)
+	t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+	conns := sess.BackendSessions()
+	assert.Contains(t, conns, "allowed-backend", "the backend whose resolver did not panic must connect")
+	assert.NotContains(t, conns, "panic-backend", "the backend whose resolver panicked must be excluded")
+}
+
+// TestSessionFactory_WithDialControlResolver_InvokedConcurrently pins the documented
+// contract that the resolver is called from the per-backend init goroutines
+// concurrently (up to maxConcurrency). A barrier proves it deterministically: every
+// invocation announces arrival and then blocks until all backends' resolvers have
+// arrived, which can only complete if the invocations overlap in time — a serial
+// caller would leave the first invocation waiting and the test would hit its timeout.
+// Run under -race, the shared arrival state also exercises the safe-for-concurrent-use
+// claim.
+func TestSessionFactory_WithDialControlResolver_InvokedConcurrently(t *testing.T) {
+	t.Parallel()
+
+	const n = 3
+	backends := make([]*vmcp.Backend, n)
+	for i := range backends {
+		url := startInProcessMCPServer(t)
+		id := fmt.Sprintf("backend-%d", i)
+		backends[i] = &vmcp.Backend{ID: id, Name: id, BaseURL: url, TransportType: "streamable-http"}
+	}
+
+	var arrived sync.WaitGroup
+	arrived.Add(n)
+	release := make(chan struct{})
+	var inFlight, maxObserved atomic.Int32
+
+	factory := NewSessionFactory(newUnauthenticatedRegistry(t),
+		WithDialControlResolver(func(_ string) func(network, address string, c syscall.RawConn) error {
+			cur := inFlight.Add(1)
+			for {
+				old := maxObserved.Load()
+				if cur <= old || maxObserved.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			arrived.Done()
+			// Block until every backend's resolver has also arrived — only reachable
+			// if the invocations run concurrently.
+			select {
+			case <-release:
+			case <-time.After(5 * time.Second):
+			}
+			inFlight.Add(-1)
+			return nil
+		}))
+
+	// Release the barrier once all n resolvers are concurrently in flight.
+	barrierMet := make(chan struct{})
+	go func() {
+		arrived.Wait()
+		close(release)
+		close(barrierMet)
+	}()
+
+	sess, err := factory.MakeSessionWithID(context.Background(), uuid.New().String(), nil, backends, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sess.Close()) })
+
+	select {
+	case <-barrierMet:
+	case <-time.After(10 * time.Second):
+		t.Fatal("resolvers were not invoked concurrently: barrier never reached n arrivals")
+	}
+	assert.GreaterOrEqual(t, int(maxObserved.Load()), 2,
+		"the resolver must be invoked concurrently for multiple backends")
 }

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -138,6 +138,28 @@ func WithDialControlResolver(
 	}
 }
 
+// resolveDialControl invokes the per-workload dial-control resolver, isolating a
+// panicking embedder resolver to this one backend: a panic is recovered and
+// returned as an error, so the backend is excluded from the session like any
+// other init failure rather than crashing the per-backend init goroutine (and
+// with it the process). A nil resolver, or one that returns nil for this
+// workload, yields a nil hook — the transport stays on http.DefaultTransport.
+func resolveDialControl(
+	resolver func(workloadID string) func(network, address string, c syscall.RawConn) error,
+	workloadID string,
+) (hook func(network, address string, c syscall.RawConn) error, err error) {
+	if resolver == nil {
+		return nil, nil
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			hook = nil
+			err = fmt.Errorf("dial-control resolver panicked for backend %s: %v", workloadID, r)
+		}
+	}()
+	return resolver(workloadID), nil
+}
+
 func (c *httpConnectorConfig) requestTimeout(workloadID string) time.Duration {
 	if c.requestTimeoutResolver != nil {
 		if timeout := c.requestTimeoutResolver(workloadID); timeout > 0 {
@@ -505,9 +527,11 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry, opts ...HTTPConnec
 		// Resolve the dial-control hook for this backend. A nil resolver, or a
 		// resolver that returns nil for this workload, leaves dialControl nil so
 		// the transport stays on http.DefaultTransport (see WithDialControlResolver).
-		var dialControl func(network, address string, c syscall.RawConn) error
-		if connectorConfig.dialControlResolver != nil {
-			dialControl = connectorConfig.dialControlResolver(target.WorkloadID)
+		// A panicking resolver is isolated to this backend rather than crashing the
+		// per-backend init goroutine (and the process).
+		dialControl, err := resolveDialControl(connectorConfig.dialControlResolver, target.WorkloadID)
+		if err != nil {
+			return nil, nil, err
 		}
 
 		c, err := createMCPClient(

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -94,11 +94,13 @@ func WithRequestTimeoutResolver(resolver func(workloadID string) time.Duration) 
 // DNS-rebinding attacks that a host-name–based check cannot: a hostname can
 // legitimately resolve to a blocked IP after the name-based check passes.
 //
-// It is the session-init twin of pkg/vmcp/client.WithDialControl (which guards
-// the aggregation and tool-call paths); the returned hook shares that signature
-// and the same standard 30 s dial timeouts. A nil resolver (the default), or a
-// resolver that returns nil for a given workload, leaves that backend's dial path
-// byte-for-byte identical to before this hook existed.
+// The returned hook has the same net.Dialer.Control signature as
+// pkg/vmcp/client.WithDialControl (which guards the aggregation and tool-call
+// paths) and the same standard 30 s dial timeouts. The option shapes differ,
+// though: this one is a per-backend resolver, whereas client.WithDialControl is
+// not (yet) per-backend — it installs one hook for every backend. A nil resolver
+// (the default), or a resolver that returns nil for a given workload, leaves that
+// backend's dial path byte-for-byte identical to before this hook existed.
 //
 // The resolver is called once per backend from the per-backend init goroutines,
 // so it must be safe for concurrent use. The hook it returns matches
@@ -106,6 +108,12 @@ func WithRequestTimeoutResolver(resolver func(workloadID string) time.Duration) 
 //
 // Security limitations embedders must understand:
 //
+//   - The resolver only SELECTS a hook; it is not itself the guard. The SSRF /
+//     DNS-rebinding protection exists only if the RETURNED hook inspects the
+//     resolved address. A resolver that decides allow/deny purely from the
+//     workloadID — never looking at address inside the hook it returns — looks
+//     like a per-backend guard but gives zero protection against that workload's
+//     endpoint resolving into a blocked range. Return an address-checking hook.
 //   - Per-TCP-dial, not per-request: the hook fires once per TCP connection.
 //     A pooled connection is reused without re-invoking the hook until it is
 //     recycled. Because each backend gets its own isolated transport and
@@ -123,10 +131,10 @@ func WithRequestTimeoutResolver(resolver func(workloadID string) time.Duration) 
 //     Cheat Sheet for the full set of ranges to deny (loopback, RFC 1918,
 //     link-local 169.254/16, CGNAT 100.64/10, IPv6 ULA).
 func WithDialControlResolver(
-	resolve func(workloadID string) func(network, address string, c syscall.RawConn) error,
+	resolver func(workloadID string) func(network, address string, c syscall.RawConn) error,
 ) HTTPConnectorOption {
 	return func(cfg *httpConnectorConfig) {
-		cfg.dialControlResolver = resolve
+		cfg.dialControlResolver = resolver
 	}
 }
 

--- a/pkg/vmcp/session/internal/backend/mcp_session.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session.go
@@ -47,7 +47,7 @@ type HTTPConnectorOption func(*httpConnectorConfig)
 
 type httpConnectorConfig struct {
 	requestTimeoutResolver func(workloadID string) time.Duration
-	dialControl            func(network, address string, c syscall.RawConn) error
+	dialControlResolver    func(workloadID string) func(network, address string, c syscall.RawConn) error
 }
 
 // mcpClientParams carries the per-connection options NewHTTPConnector's closure
@@ -59,8 +59,9 @@ type mcpClientParams struct {
 	// sink, when non-nil, enables persistent backend-notification consumption
 	// (see createMCPClient); nil leaves it disabled.
 	sink ListChangedSink
-	// dialControl, when non-nil, installs a net.Dialer.Control hook on the
-	// backend transport (see WithDialControl); nil uses http.DefaultTransport.
+	// dialControl is the hook resolved for this backend's workload ID (see
+	// WithDialControlResolver). When non-nil it installs a net.Dialer.Control hook
+	// on the backend transport; nil uses http.DefaultTransport.
 	dialControl func(network, address string, c syscall.RawConn) error
 	// requestTimeout bounds each backend operation and the transport dial.
 	requestTimeout time.Duration
@@ -82,19 +83,26 @@ func WithRequestTimeoutResolver(resolver func(workloadID string) time.Duration) 
 	}
 }
 
-// WithDialControl installs a per-connection Control hook on the dialer used to
-// open every backend connection at session init (the MCP handshake and
-// capability listing). The hook fires after DNS resolution and before the TCP
-// handshake, receiving the resolved peer IP in address — which is why it
-// defeats DNS-rebinding attacks that a host-name–based check cannot: a hostname
-// can legitimately resolve to a blocked IP after the name-based check passes.
+// WithDialControlResolver supplies a dial-control hook chosen per backend, so an
+// embedder can apply a per-backend dial policy to the connections opened at
+// session init (the MCP handshake and capability listing). The resolver receives
+// a backend workload ID and returns the net.Dialer.Control hook to install for
+// that backend, or nil to leave it on http.DefaultTransport.
+//
+// The returned hook fires after DNS resolution and before the TCP handshake,
+// receiving the resolved peer IP in address — which is why it defeats
+// DNS-rebinding attacks that a host-name–based check cannot: a hostname can
+// legitimately resolve to a blocked IP after the name-based check passes.
 //
 // It is the session-init twin of pkg/vmcp/client.WithDialControl (which guards
-// the aggregation and tool-call paths); the two share the same signature and
-// the same standard 30 s dial timeouts. A nil control (the default) leaves the
-// dial path byte-for-byte identical to before this hook existed.
+// the aggregation and tool-call paths); the returned hook shares that signature
+// and the same standard 30 s dial timeouts. A nil resolver (the default), or a
+// resolver that returns nil for a given workload, leaves that backend's dial path
+// byte-for-byte identical to before this hook existed.
 //
-// The signature matches net.Dialer.Control exactly.
+// The resolver is called once per backend from the per-backend init goroutines,
+// so it must be safe for concurrent use. The hook it returns matches
+// net.Dialer.Control exactly.
 //
 // Security limitations embedders must understand:
 //
@@ -114,9 +122,11 @@ func WithRequestTimeoutResolver(resolver func(workloadID string) time.Duration) 
 //     such as ::ffff:127.0.0.1 — in their check. See the OWASP SSRF Prevention
 //     Cheat Sheet for the full set of ranges to deny (loopback, RFC 1918,
 //     link-local 169.254/16, CGNAT 100.64/10, IPv6 ULA).
-func WithDialControl(control func(network, address string, c syscall.RawConn) error) HTTPConnectorOption {
+func WithDialControlResolver(
+	resolve func(workloadID string) func(network, address string, c syscall.RawConn) error,
+) HTTPConnectorOption {
 	return func(cfg *httpConnectorConfig) {
-		cfg.dialControl = control
+		cfg.dialControlResolver = resolve
 	}
 }
 
@@ -206,7 +216,7 @@ func (f httpRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, erro
 // backendBaseTransport returns the innermost RoundTripper for backend
 // connections. With a nil dialControl it returns http.DefaultTransport
 // unchanged, so the no-hook path is byte-for-byte identical to before
-// WithDialControl existed. With a non-nil hook it delegates to
+// any dial-control hook existed. With a non-nil hook it delegates to
 // networking.CloneDefaultTransportWithDialControl — the single backend
 // transport construction point shared with pkg/vmcp/client — which clones
 // DefaultTransport and installs a net.Dialer whose Control hook fires on the
@@ -484,11 +494,19 @@ func NewHTTPConnector(registry vmcpauth.OutgoingAuthRegistry, opts ...HTTPConnec
 			}
 		}
 
+		// Resolve the dial-control hook for this backend. A nil resolver, or a
+		// resolver that returns nil for this workload, leaves dialControl nil so
+		// the transport stays on http.DefaultTransport (see WithDialControlResolver).
+		var dialControl func(network, address string, c syscall.RawConn) error
+		if connectorConfig.dialControlResolver != nil {
+			dialControl = connectorConfig.dialControlResolver(target.WorkloadID)
+		}
+
 		c, err := createMCPClient(
 			ctx, target, identity, registry, sessionHint, provider,
 			mcpClientParams{
 				sink:           sink,
-				dialControl:    connectorConfig.dialControl,
+				dialControl:    dialControl,
 				requestTimeout: transportTimeout,
 			},
 		)
@@ -573,9 +591,9 @@ func createMCPClient(
 
 	// Build shared transport chain (innermost first → outermost):
 	//   backendBaseTransport → authRoundTripper → identityRoundTripper → headerForwardRoundTripper
-	// The innermost stage is http.DefaultTransport unless a dial-control hook is
-	// configured (see WithDialControl), in which case it is a cloned transport
-	// carrying that hook on its dialer.
+	// The innermost stage is http.DefaultTransport unless a dial-control hook was
+	// resolved for this backend (see WithDialControlResolver), in which case it is
+	// a cloned transport carrying that hook on its dialer.
 	// On an outbound request, the outermost stage runs first: header-forward
 	// injects its headers onto a request that does not yet carry auth/identity
 	// headers, then inner stages run and call Set() unconditionally so any

--- a/pkg/vmcp/session/internal/backend/mcp_session_dialcontrol_test.go
+++ b/pkg/vmcp/session/internal/backend/mcp_session_dialcontrol_test.go
@@ -26,10 +26,10 @@ func denyAllDial(_, _ string, _ syscall.RawConn) error {
 }
 
 // TestHTTPConnector_DialControlGuardsSessionInit proves that a Control hook
-// supplied via WithDialControl fires on the session-init dial for every backend
-// transport: a deny-all hook makes the connect fail before any request reaches
-// the backend. The companion unguarded connector against the same server shows
-// the target IS dialed without the hook, so it is the guard — not an
+// resolved via WithDialControlResolver fires on the session-init dial for every
+// backend transport: a deny-all hook makes the connect fail before any request
+// reaches the backend. The companion unguarded connector against the same server
+// shows the target IS dialed without the hook, so it is the guard — not an
 // unreachable server — that blocks the request.
 func TestHTTPConnector_DialControlGuardsSessionInit(t *testing.T) {
 	t.Parallel()
@@ -65,7 +65,10 @@ func TestHTTPConnector_DialControlGuardsSessionInit(t *testing.T) {
 				fired.Store(true)
 				return errors.New("dial blocked by test policy")
 			}
-			guarded := NewHTTPConnector(newTestRegistry(t), WithDialControl(control))
+			guarded := NewHTTPConnector(newTestRegistry(t),
+				WithDialControlResolver(func(_ string) func(network, address string, c syscall.RawConn) error {
+					return control
+				}))
 			sess, _, err := guarded(ctx, target, nil, "", nil)
 			if sess != nil {
 				_ = sess.Close()
@@ -84,6 +87,73 @@ func TestHTTPConnector_DialControlGuardsSessionInit(t *testing.T) {
 			assert.Positive(t, hits.Load(), "unguarded session-init dial must reach the backend")
 		})
 	}
+}
+
+// TestHTTPConnector_DialControlResolvesPerWorkload proves the resolver is keyed
+// on the backend workload ID: a single connector resolves a deny-all hook for
+// one workload and nil for another, so dialing the denied workload fails before
+// reaching its server while the allowed workload connects and reaches its own.
+func TestHTTPConnector_DialControlResolvesPerWorkload(t *testing.T) {
+	t.Parallel()
+
+	var allowedHits, blockedHits atomic.Int32
+	allowedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		allowedHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(allowedSrv.Close)
+	blockedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		blockedHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(blockedSrv.Close)
+
+	const blockedWorkloadID = "blocked-backend"
+	var fired atomic.Bool
+	connector := NewHTTPConnector(newTestRegistry(t),
+		WithDialControlResolver(func(workloadID string) func(network, address string, c syscall.RawConn) error {
+			if workloadID != blockedWorkloadID {
+				return nil
+			}
+			return func(_, _ string, _ syscall.RawConn) error {
+				fired.Store(true)
+				return errors.New("dial blocked by test policy")
+			}
+		}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	blocked := &vmcp.BackendTarget{
+		WorkloadID:    blockedWorkloadID,
+		WorkloadName:  blockedWorkloadID,
+		BaseURL:       blockedSrv.URL,
+		TransportType: "streamable-http",
+	}
+	sess, _, err := connector(ctx, blocked, nil, "", nil)
+	if sess != nil {
+		_ = sess.Close()
+	}
+	require.Error(t, err, "the deny-all hook resolved for the blocked workload must fail its dial")
+	assert.True(t, fired.Load(), "the resolved hook must have been invoked for the blocked workload")
+	assert.Zero(t, blockedHits.Load(), "the blocked workload's server must not be reached")
+
+	// The workload the resolver returns nil for is left on http.DefaultTransport,
+	// so its dial proceeds and reaches the server. (A bare httptest server is not
+	// a real MCP endpoint, so the handshake still fails afterwards — reaching the
+	// server, not completing init, is what proves the hook was NOT installed for
+	// this workload.)
+	allowed := &vmcp.BackendTarget{
+		WorkloadID:    "allowed-backend",
+		WorkloadName:  "allowed-backend",
+		BaseURL:       allowedSrv.URL,
+		TransportType: "streamable-http",
+	}
+	sess2, _, _ := connector(ctx, allowed, nil, "", nil)
+	if sess2 != nil {
+		_ = sess2.Close()
+	}
+	assert.Positive(t, allowedHits.Load(), "the allowed workload's server must be reached")
 }
 
 // TestBackendBaseTransport_NilHookReturnsDefault pins the no-op guarantee: with


### PR DESCRIPTION
## Summary

PR #6547 added `session.WithDialControl` / `backend.WithDialControl`: a **single, address-blind** `net.Dialer.Control` hook applied to every backend's session-init dials (the MCP handshake plus capability listing). Because that hook receives only `(network, address, RawConn)`, an embedder cannot vary the dial policy **per backend** — every backend gets the same hook. vMCP needs a per-backend dial policy at session initialize (some backends opt into private-IP dialing, most don't), which the single hook cannot express.

Since #6547 is merged but **not yet in any release tag**, this generalizes that option in place rather than adding a second one alongside — we ship one option, not two.

- **Replace `session.WithDialControl` with `session.WithDialControlResolver`**, a `func(workloadID string) func(network, address string, c syscall.RawConn) error`, mirroring the sibling `WithRevisionLookup` / `WithRequestTimeoutResolver` options in the same file. The resolver is called per backend and returns the hook to install for that workload (or `nil`).
- **Replace `backend.WithDialControl` (`HTTPConnectorOption`) likewise.** The connector resolves the per-workload hook in `NewHTTPConnector`'s closure — where the `target` (and thus `target.WorkloadID`) is known — and threads the already-resolved hook through `mcpClientParams`, so `createMCPClient` and the `backendBaseTransport` / `networking.CloneDefaultTransportWithDialControl` primitive are unchanged.
- **Preserve the no-hook invariant exactly**: a nil resolver, or a resolver that returns `nil` for a given workload, leaves that backend's transport on `http.DefaultTransport` — byte-for-byte identical to the no-hook path (no clone).

## Type of change

- [x] Refactoring (no behavior change)

The default (no resolver) path is unchanged; this reshapes an opt-in embedder API that is not yet released.

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Ran the affected packages (`pkg/networking`, `pkg/vmcp/session`, `pkg/vmcp/session/internal/backend`, `pkg/vmcp/client`) with the Taskfile flags — all green; `golangci-lint --fix` reports 0 issues. Coverage kept and extended:

- **Per-backend keying (new):** at the connector level, one connector resolves a deny-all hook for one workload ID and `nil` for another — the denied workload's server is never reached (hook asserted to have fired) while the allowed workload's dial proceeds and reaches its server. At the factory level, a two-backend session whose resolver denies one workload ID proves the allowed backend connects and the denied one is excluded.
- Deny-all resolver yields **zero** backend requests during session `initialize` for both the `streamable-http` and `sse` transports, with the hook asserted to have actually fired.
- The resolver also guards the `RestoreSession` path.
- A nil dial control still returns `http.DefaultTransport` unchanged (`TestBackendBaseTransport_NilHookReturnsDefault`, unchanged).

## Changes

| File | Change |
|------|--------|
| `pkg/vmcp/session/factory.go` | Replace `WithDialControl` with `WithDialControlResolver`; hold the resolver on the factory and thread it into the HTTP connector. |
| `pkg/vmcp/session/factory_dialcontrol_test.go` | Update to the resolver signature; re-key the per-backend test off `workloadID` instead of address. |
| `pkg/vmcp/session/internal/backend/mcp_session.go` | Replace `WithDialControl` with `WithDialControlResolver`; resolve the per-workload hook in the connector closure and thread the resolved hook through `mcpClientParams`. `createMCPClient` and `backendBaseTransport` unchanged. |
| `pkg/vmcp/session/internal/backend/mcp_session_dialcontrol_test.go` | Update the guard test to the resolver; add a per-workload resolution test. |

## Does this introduce a user-facing change?

No end-user behavior changes. This reshapes an opt-in, not-yet-released embedder API from a single address-blind dial-control hook into a per-workload resolver, so a deployment can enforce a per-backend dial policy on the connections opened at vMCP session initialization.

## Special notes for reviewers

- The no-hook path is intentionally byte-for-byte identical to before: `backendBaseTransport(nil)` returns `http.DefaultTransport` directly rather than a clone, and the connector installs no hook when the resolver is nil or returns nil.
- `networking.CloneDefaultTransportWithDialControl` is the right primitive and is untouched — only the option shape above it changes.
- The resolver is called from the per-backend init goroutines (up to `maxConcurrency`), so it is documented as requiring concurrency-safety.
- No production caller wired the previous option (the #6547 `cli/serve.go` follow-up was deferred), so this is an internal-plumbing + test-surface change with no call site to migrate.

Generated with [Claude Code](https://claude.com/claude-code)
