### PR TITLE
Document AI plugin support

### DIFF
--- a/cmd/thv/app/ai_plugin.go
+++ b/cmd/thv/app/ai_plugin.go
@@ -10,6 +10,7 @@ import (
 var aiPluginCmd = &cobra.Command{
 	Use:   "ai-plugin",
 	Short: "Manage AI-tool plugins",
-	Long: `The ai-plugin command provides subcommands to manage plugins for AI tools
-(e.g. Claude Code, Codex) — not plugins for ToolHive itself.`,
+	Long: `Manage plugins for AI tools such as Claude Code and Codex, not plugins
+for ToolHive itself. A plugin is a manifest-based bundle that may contain
+commands, agents, skills, hooks, and server declarations.`,
 }

--- a/cmd/thv/app/ai_plugin_install.go
+++ b/cmd/thv/app/ai_plugin_install.go
@@ -24,8 +24,12 @@ var (
 var aiPluginInstallCmd = &cobra.Command{
 	Use:   "install [plugin-name]",
 	Short: "Install an AI-tool plugin",
-	Long: `Install a plugin by name or OCI reference.
-The plugin will be fetched from a remote registry and installed locally.`,
+	Long: `Install a plugin from git, an OCI reference, or an exact registry name.
+
+Project-scoped installs verify signatures and record trust in toolhive.lock.yaml.
+Use --public-key for the first project install of a key-pair-signed OCI artifact;
+the key is then pinned for sync and upgrade. User-scoped installs do not use
+lock-file verification and reject --public-key.`,
 	Args: cobra.ExactArgs(1),
 	PreRunE: chainPreRunE(
 		validateAIPluginScope(&aiPluginInstallScope),

--- a/cmd/thv/app/ai_plugin_push.go
+++ b/cmd/thv/app/ai_plugin_push.go
@@ -18,16 +18,19 @@ var (
 var aiPluginPushCmd = &cobra.Command{
 	Use:   "push [reference]",
 	Short: "Push a built AI-tool plugin to an OCI registry",
-	Long:  `Push a previously built plugin artifact to a remote OCI registry.`,
-	Args:  cobra.ExactArgs(1),
-	RunE:  aiPluginPushCmdFunc,
+	Long: `Push a previously built plugin artifact to a remote OCI registry.
+
+Push signs keylessly by default. Use --no-sign to publish unsigned; plugin push
+does not support key-pair signing and has no --key flag.`,
+	Args: cobra.ExactArgs(1),
+	RunE: aiPluginPushCmdFunc,
 }
 
 func init() {
 	aiPluginCmd.AddCommand(aiPluginPushCmd)
-	// No --key flag: plugin signing is keyless-only until install-time key
-	// verification exists (#6442). Pushing a key-signed plugin would produce
-	// an artifact no project-scoped install can accept.
+	// No --key flag: plugin push supports keyless signing or explicit
+	// --no-sign. Project installs can verify externally key-pair-signed
+	// artifacts with ai-plugin install --public-key.
 	aiPluginPushCmd.Flags().StringVar(&aiPluginPushIdentityToken, "identity-token", "",
 		"OIDC identity token (or a path to a file containing one) for keyless signing. "+
 			"If omitted, one is acquired automatically: from the GitHub Actions OIDC token when "+
@@ -46,8 +49,8 @@ func aiPluginPushCmdFunc(cmd *cobra.Command, args []string) error {
 		FlagValue: aiPluginPushIdentityToken,
 		NoSign:    aiPluginPushNoSign,
 		Confirm:   confirmBrowserSignIn,
-		// No --key: plugin signing is keyless-only (#6442), so the
-		// remediation must not offer a flag this command does not define.
+		// Plugin push has no --key flag, so remediation must not offer
+		// a signing choice this command does not define.
 		Remediation: "Provide --identity-token, run in CI with id-token: write permission, " +
 			"or pass --no-sign to push unsigned",
 	})

--- a/cmd/thv/app/ai_plugin_sync.go
+++ b/cmd/thv/app/ai_plugin_sync.go
@@ -50,7 +50,7 @@ func init() {
 	aiPluginSyncCmd.Flags().StringVar(&aiPluginSyncProjectRoot, "project-root", "",
 		"Project root path (default: auto-detected from the current directory)")
 	aiPluginSyncCmd.Flags().StringVar(&aiPluginSyncClientsRaw, "clients", "",
-		`Comma-separated target client apps (e.g. claude-code,opencode), or "all" for every available client`)
+		`Comma-separated target client apps (e.g. claude-code,codex), or "all" for every available client`)
 	aiPluginSyncCmd.Flags().BoolVar(&aiPluginSyncCheck, "check", false,
 		"Report drift without installing, writing, or removing anything")
 	aiPluginSyncCmd.Flags().BoolVar(&aiPluginSyncAdopt, "adopt", false,

--- a/cmd/thv/app/ai_plugin_upgrade.go
+++ b/cmd/thv/app/ai_plugin_upgrade.go
@@ -54,7 +54,7 @@ func init() {
 	aiPluginUpgradeCmd.Flags().StringVar(&aiPluginUpgradeProjectRoot, "project-root", "",
 		"Project root path (default: auto-detected from the current directory)")
 	aiPluginUpgradeCmd.Flags().StringVar(&aiPluginUpgradeClientsRaw, "clients", "",
-		`Comma-separated target client apps (e.g. claude-code,opencode), or "all" for every available client`)
+		`Comma-separated target client apps (e.g. claude-code,codex), or "all" for every available client`)
 	aiPluginUpgradeCmd.Flags().BoolVar(&aiPluginUpgradePreview, "preview", false,
 		"Report what would change without persisting anything (OCI sources are still fetched to compare digests)")
 	aiPluginUpgradeCmd.Flags().BoolVar(&aiPluginUpgradeFailOnChanges, "fail-on-changes", false,

--- a/docs/arch/00-overview.md
+++ b/docs/arch/00-overview.md
@@ -12,7 +12,7 @@ ToolHive is a **platform** - not just a container runner. It provides the buildi
 - **Proxy and enhance** MCP server communications with middleware
 - **Aggregate and compose** multiple MCP servers into unified interfaces
 - **Manage at scale** using Kubernetes operators or local deployments
-- **Curate and distribute** trusted MCP server registries
+- **Curate and distribute** trusted MCP servers, Agent Skills, and AI-tool plugins
 
 The platform is designed to be extensible, allowing developers to build on top of its proxy and middleware capabilities.
 
@@ -145,7 +145,9 @@ For detailed definitions and relationships, see [Core Concepts](02-core-concepts
 - **RunConfig** - Portable configuration format
 - **Permission Profiles** - Security policies
 - **Groups** - Logical server collections
-- **Registry** - Catalog of trusted MCP servers
+- **Registry** - Catalog of MCP servers, Agent Skills, and AI-tool plugins
+- **Skill** - One `SKILL.md`-based instruction component for AI assistants
+- **AI-tool plugin** - A manifest-based, multi-component bundle materialized for supported AI clients
 - **Virtual MCP Server** - Aggregates multiple backends into unified interface
 
 ## Deployment Modes

--- a/docs/arch/02-core-concepts.md
+++ b/docs/arch/02-core-concepts.md
@@ -472,7 +472,28 @@ A **skill** is an Agent Skill -- a markdown-based instruction set (SKILL.md) tha
 
 **For architecture details**, see [Skills System](12-skills-system.md).
 
-**Related concepts:** Registry, Group, Client
+**Related concepts:** Registry, Group, Client, AI-tool Plugin
+
+### AI-tool Plugin
+
+An **AI-tool plugin** is a versioned bundle for AI clients, described by
+`.claude-plugin/plugin.json`. It can contain commands, agents, skills, hooks,
+and MCP or LSP server declarations. A plugin can therefore contain skills, but
+a skill remains an independently installable single instruction component.
+Neither is a ToolHive extension or an MCP server workload.
+
+ToolHive resolves plugins from git, OCI, or a registry name; materializes the
+complete source tree into supported clients; and manages user- or project-scope
+installations. Client capability lists describe which components a client
+loads, not which files ToolHive extracts. Plugin-declared MCP and LSP servers
+are not managed by ToolHive's workload lifecycle.
+
+**Implementation:** `pkg/plugins/`, with client adapters in
+`pkg/plugins/adapters/` and CLI commands under `cmd/thv/app/ai_plugin*.go`.
+
+**For architecture details**, see [Plugins System](14-plugins-system.md).
+
+**Related concepts:** Skill, Registry, Group, Client, Workload
 
 ## Verbs (Actions)
 
@@ -811,11 +832,12 @@ Registry
 | **Permission Profile** | Security policy (filesystem, network, privileges) |
 | **Group** | Logical collection of related MCP servers |
 | **Virtual MCP Server** | Aggregates multiple MCP servers into unified interface |
-| **Registry** | Catalog of MCP server definitions |
+| **Registry** | Catalog of MCP server, Agent Skill, and AI-tool plugin definitions |
 | **Session** | State tracking for MCP connections |
 | **Runtime** | Abstraction over container systems |
 | **Client** | Application that uses MCP servers |
-| **Skill** | Agent Skill (SKILL.md) extending AI assistant capabilities |
+| **Skill** | One Agent Skill (`SKILL.md`) extending AI assistant capabilities |
+| **AI-tool Plugin** | Manifest-based bundle of multiple AI-client components |
 | **Deploy** | Create and start a workload |
 | **Proxy** (verb) | Forward traffic with middleware |
 | **Attach** | Connect to container stdin/stdout |
@@ -835,3 +857,5 @@ Registry
 - [RunConfig and Permissions](05-runconfig-and-permissions.md) - Configuration schema
 - [Middleware](../middleware.md) - Middleware system
 - [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md) - vMCP aggregation details
+- [Skills System](12-skills-system.md) - Agent Skill architecture
+- [Plugins System](14-plugins-system.md) - AI-tool plugin architecture

--- a/docs/arch/06-registry-system.md
+++ b/docs/arch/06-registry-system.md
@@ -963,6 +963,21 @@ re-sync, modify `configYAML` (or restart the registry API pod).
 
 **Implementation**: `cmd/thv-operator/controllers/mcpregistry_controller.go`
 
+## Skill and Plugin Catalog Integration
+
+The configured registry can expose Agent Skills and AI-tool plugins alongside
+MCP servers. These entries provide discovery metadata and OCI package
+references; their installation and trust lifecycles remain owned by the skills
+and plugins services.
+
+For plugin name resolution, ToolHive searches the registry and then requires an
+exact, case-insensitive name match (and namespace match when one was supplied).
+Zero matches are not found and multiple exact matches are rejected as
+ambiguous; a fuzzy search result is never selected merely because it appeared
+first. The selected entry must provide an OCI package. See
+[Plugins System](14-plugins-system.md#1-discovery) for the complete resolution
+chain and [Skills System](12-skills-system.md) for skill discovery.
+
 ## Related Documentation
 
 ### Internal Documentation

--- a/docs/arch/07-groups.md
+++ b/docs/arch/07-groups.md
@@ -1,10 +1,10 @@
 # Groups
 
-Groups are a logical abstraction for organizing related MCP servers. They provide organizational structure and serve as a foundation for future features.
+Groups are a logical abstraction for organizing related MCP servers, Agent Skills, and AI-tool plugins. They provide a shared organizational model without merging the distinct workload, skill, and plugin lifecycles.
 
 ## Concept
 
-A **group** is a named collection of MCP servers that share a common purpose or use case.
+A **group** is a named collection of MCP servers and may also record Agent Skill and AI-tool plugin membership for the same purpose or use case.
 
 **Examples:**
 - `data-pipeline` - Data ingestion, transformation, storage tools
@@ -58,6 +58,20 @@ Groups support standard lifecycle operations: create, list, and remove. Workload
 - CLI commands: `cmd/thv/app/group.go`
 - Group manager: `pkg/groups/`
 - Workload integration: `pkg/workloads/manager.go`
+
+### Skill and Plugin Membership
+
+The shared group record has `Skills []string` and `Plugins []string` fields in
+addition to workload membership. A skill or plugin install can add its name to
+a group; list operations can filter on that membership; uninstall removes the
+name from all groups. These updates participate in each service's rollback so a
+failed install or uninstall does not leave stale membership.
+
+Groups organize these resources only. A grouped plugin is still materialized by
+the plugin service, and plugin-declared MCP or LSP servers do not become
+ToolHive workloads. See [Skills System](12-skills-system.md#group-integration)
+and [Plugins System](14-plugins-system.md#group-integration) for lifecycle
+details.
 
 ## Registry Groups
 
@@ -141,4 +155,5 @@ Groups may serve as the foundation for additional features:
 - [Workloads Lifecycle](08-workloads-lifecycle.md) - Group operations
 - [Virtual MCP Server Architecture](10-virtual-mcp-architecture.md) - Group-based aggregation
 - [Skills System](12-skills-system.md) - Skills organized in groups
+- [Plugins System](14-plugins-system.md) - AI-tool plugins organized in groups
 - [Deployment Modes](01-deployment-modes.md) - How groups apply per deployment mode

--- a/docs/arch/12-skills-system.md
+++ b/docs/arch/12-skills-system.md
@@ -444,7 +444,7 @@ Once an entry is pinned, the key does its job on the lock-driven operations too,
 - **`upgrade`** applies the pinned key to the candidate. Verifying against it *is* the evidence the signer has not changed, since there is no certificate identity to compare. A candidate that moved to keyless signing or lost its signature is a signer change and blocks like one — `--allow-signer-change` genuinely resolves those, by dropping the recorded key and re-verifying keylessly. A candidate signed by a *different* key is reported as a failure instead: re-anchoring in place is not supported, so it needs an uninstall and a reinstall, and printing the `--allow-signer-change` remedy would send the caller into a refusal one step later.
 - **`sync --adopt`** refuses a key-signed install. Adoption back-fills trust from what the stored bundle reveals, and a key-pair bundle reveals no identity and does not carry the key; recording the install as unsigned instead would file a false trust decision about an artifact that is signed.
 
-Scope for v1 (issue [#6442](https://github.com/stacklok/toolhive/issues/6442)): `--public-key` is accepted on `install` only — `upgrade` and `sync` use the anchor the lock already records and take no key of their own, and in-place re-anchoring to a different key is deliberately not offered. The plugins surface does not accept a key at all yet.
+`--public-key` is accepted on `install` only — `upgrade` and `sync` use the anchor the lock already records and take no key of their own, and in-place re-anchoring to a different key is deliberately not offered. Plugins use the same install-side public-key model for project-scoped OCI installs; plugin push remains keyless-by-default or explicit `--no-sign` and has no `--key` flag.
 
 Plugins carry the same trust model over the same lock file: project-scoped plugin installs are recorded under the file's `plugins:` key, verified on the same TOFU/`allow_unsigned`/`allow_signer_change` terms, and published signed-by-default through `thv ai-plugin push`. See [Trust Model](14-plugins-system.md#trust-model) in the plugins document for what differs.
 
@@ -469,7 +469,7 @@ Entries are sorted by name for stable diffs. `source` is never rewritten by `syn
 
 ### Install and Uninstall Hooks
 
-For project-scope installs (with the feature enabled), `skillsvc.Install`'s single existing choke point (`installAndRegister` — every dispatch path, OCI or git, direct or registry-resolved, converges there) additionally:
+For project-scope installs, `skillsvc.Install`'s single existing choke point (`installAndRegister` — every dispatch path, OCI or git, direct or registry-resolved, converges there) additionally:
 
 1. Computes `contentDigest` from the extracted files.
 2. Materializes `toolhive.requires` dependencies recursively — reading `SKILL.md` back from disk (not from the resolver's own parse, so this works uniformly across OCI and git sources), with a `Visited` set guarding cycles and `skills.MaxDependencies` bounding the whole tree.
@@ -505,7 +505,7 @@ Reinstalling *at the pinned reference* (never re-resolving `source`) uses `build
 
 ### CLI Confirmation and Exit Codes
 
-Because skill content is a set of AI-followed instructions, `sync` and `upgrade` gate real installs behind a confirmation prompt (skipped by `--check`/`--preview`/`--fail-on-changes`, which never write to the lock file or extracted skill directories — an OCI `--preview` still pulls the artifact to compare digests, but persists nothing). The prompt is printed to stderr together with a summary of the lock entries being acted on (name, source, short digest) so the human gate has something concrete to judge, and everything echoed into it is stripped of non-graphic characters so a hostile directory or entry name cannot repaint the prompt with terminal escapes. On a non-interactive terminal without `--yes`, the command refuses outright rather than silently proceeding. Until Sigstore verification lands, this prompt is a speed bump, not a security boundary — see the trust-model note above.
+Because skill content is a set of AI-followed instructions, `sync` and `upgrade` gate real installs behind a confirmation prompt (skipped by `--check`/`--preview`/`--fail-on-changes`, which never write to the lock file or extracted skill directories — an OCI `--preview` still pulls the artifact to compare digests, but persists nothing). The prompt is printed to stderr together with a summary of the lock entries being acted on (name, source, short digest) so the human gate has something concrete to judge, and everything echoed into it is stripped of non-graphic characters so a hostile directory or entry name cannot repaint the prompt with terminal escapes. On a non-interactive terminal without `--yes`, the command refuses outright rather than silently proceeding. This confirmation is an intentional review point in addition to the signature and lock-file trust controls above.
 
 Exit codes follow a CI-oriented contract distinct from the generic `1` used elsewhere in the CLI:
 
@@ -660,7 +660,6 @@ ToolHive owns the installation lifecycle, scoping model, CLI/API interfaces, and
 | CLI commands | `cmd/thv/app/skill*.go` |
 | Group integration | `pkg/groups/skills.go` |
 | Lock file schema | `pkg/skills/lockfile/` |
-| Lock file rollout gate | `pkg/skills/feature_gate.go` |
 | Install/uninstall lock hooks | `pkg/skills/skillsvc/lock.go` |
 | Sync | `pkg/skills/skillsvc/sync.go`, `pkg/skills/skillsvc/pin.go` |
 | Upgrade | `pkg/skills/skillsvc/upgrade.go` |

--- a/docs/arch/14-plugins-system.md
+++ b/docs/arch/14-plugins-system.md
@@ -2,334 +2,296 @@
 
 ## Why This Exists
 
-Plugins are the Claude Plugin manifest format — an OCI artifact containing a
-`.claude-plugin/plugin.json` manifest plus component directories (`commands/`,
-`agents/`, `skills/`, `hooks/`). A plugin bundles multiple component types into
-a single installable unit, where a skill is a single component.
+An **AI-tool plugin** is a multi-component bundle described by
+`.claude-plugin/plugin.json`. It may contain commands, agents, skills, hooks,
+MCP server declarations, and LSP server declarations. A plugin is installed as
+one versioned unit; a [skill](12-skills-system.md) is one `SKILL.md`-based
+instruction component with its own lifecycle. Neither is a ToolHive plugin or
+an MCP server workload.
 
-The plugins system mirrors `pkg/skills` structurally — the scoping model
-(user vs. project), install-status lifecycle, storage shape, and OCI artifact
-layout are identical — but diverges at the materialization seam: a skill
-installs into a single directory, while a plugin must be materialized into
-each target client's directory layout (Claude Code's plugins dir + settings.json
-marketplace, Codex's `.agents/plugins` marketplace), and different clients load
-different component subsets.
+ToolHive discovers, packages, distributes, verifies, records, and materializes
+AI-tool plugins for supported clients. The plugin source tree is distributed as
+an OCI artifact, or resolved directly from git. Client adapters place that tree
+and the required marketplace metadata into each client's layout.
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    pluginsvc.service                         │
-│  Install (dispatch: git → OCI → registry name)              │
-│  Uninstall · List · Info                                     │
-│  per-(scope,name,projectRoot) pluginLock                     │
-└───────────────┬─────────────────────────────────────────────┘
-                │  MaterializationAdapter interface
-                │  (Materialize / Dematerialize / EnsureRegistered /
-                │   Health / SupportedComponents / ScopeSupport)
-       ┌────────┴────────┐
-       ▼                 ▼
-┌─────────────┐   ┌──────────────┐
-│ ClaudeCode  │   │    Codex     │
-│ Adapter     │   │   Adapter    │
-│ FS + JSON   │   │ FS + JSON    │
-│ ~/.claude/  │   │ ~/.agents/   │
-│ plugins/    │   │ plugins/     │
-│ +settings   │   │ marketplace  │
-│ .json       │   │ .json        │
-└─────────────┘   └──────────────┘
+```mermaid
+flowchart LR
+    CLI[thv ai-plugin CLI] --> HTTP[Plugin HTTP client]
+    HTTP --> API[REST API /api/v1beta/plugins]
+    API --> Service[pkg/plugins/pluginsvc]
+    Service --> Git[Git resolver]
+    Service --> OCI[OCI store and registry]
+    Service --> Catalog[Registry plugin lookup]
+    Service --> Store[SQLite PluginStore]
+    Service --> Lock[toolhive.lock.yaml]
+    Service --> Groups[Group manager]
+    Service --> Adapters[MaterializationAdapter]
+    Adapters --> Claude[Claude Code files and settings]
+    Adapters --> Codex[Codex files and marketplace.json]
 ```
 
-### Phasing
+The CLI is an HTTP client even for local operation. `pkg/api/v1/plugins.go`
+translates REST requests to `PluginService` and `PluginLockService` calls;
+`pkg/plugins/pluginsvc` owns resolution, verification, locking, persistence,
+rollback, and lifecycle behavior. `MaterializationAdapter` isolates the
+client-specific filesystem and registration rules.
 
-- **Phase 2** (shipped): build/validate/push/list-builds/delete-build/get-content
-  + SQLite storage + migration 002.
-- **Phase 3** (this doc): install/list/info/uninstall + MaterializationAdapter
-  (Claude Code + Codex) + groups integration.
-- **Phase 4** (shipped, #5528): REST API + `thv ai-plugin` CLI + app wiring.
-- **Phase 5b** (shipped, #5529): registry-name install wired via `lazyPluginLookup`;
-  plain-name resolution through the registry lookup chain.
+The API exposes install, uninstall, list, info, validate, build, push, local
+build listing/removal, content inspection, sync, and upgrade. `/sync` and
+`/upgrade` return `501 Not Implemented` only when an injected service does not
+implement `PluginLockService`; the normal `pluginsvc.New` service does.
 
 ## Core Concepts
 
 ### Plugin Manifest
 
-`.claude-plugin/plugin.json` — kebab-case name, version, description, author,
-license, keywords. Parsed by `plugins.ParsePluginManifest` (`pkg/plugins/parser.go`).
+`.claude-plugin/plugin.json` supplies the plugin's name, version, description,
+author, license, and keywords. Names are validated as kebab-case. Build and git
+installation parse this manifest before packaging or materialization.
 
 ### Component Inventory
 
-A plugin declares component directories. The OCI config carries a
-`ComponentInventory` (map of component-type → count): `commands`, `agents`,
-`skills`, `hooks`, `mcpServers`, `lspServers`. Not all clients load all types.
+The OCI config records counts for `commands`, `agents`, `skills`, `hooks`,
+`mcpServers`, and `lspServers`. Adapters expose a client capability list so
+`info` can report plugin-declared components that the client does not load.
+
+That capability report is not a file filter: adapters extract the complete
+plugin tree, including component directories outside their capability list.
+ToolHive does not start, configure, or lifecycle-manage plugin-declared MCP or
+LSP servers as ToolHive workloads. Whether a client interprets any declared
+component is client behavior.
 
 ### Installation Scopes
 
-Identical to skills: `user` (user-wide) or `project` (project-local, must be a
-git repository). Storage keys on `(scope, project_root)`.
+- **User scope** is the default and installs for the current user.
+- **Project scope** requires a git project root, writes a `plugins:` entry to
+  the project's `toolhive.lock.yaml`, and applies signature verification.
+
+Installed records are keyed by plugin name, scope, and project root. An empty
+client selection, or `all`, targets every detected plugin-supporting client;
+explicit client names are validated against configured materializers.
 
 ### Multi-Client Materialization
 
-Unlike skills (single directory per client), plugins materialize differently
-per client:
+| Client | Materialized layout | Registration and loading |
+|---|---|---|
+| Claude Code | `~/.claude/plugins/<name>/` or `<project>/.claude/plugins/<name>/` | ToolHive maintains the shared `.claude-plugin/marketplace.json` and the `enabledPlugins` and `extraKnownMarketplaces.toolhive` entries in the scope's `settings.json`. |
+| Codex | `~/.agents/plugins/toolhive/<name>/` or `<project>/.agents/plugins/toolhive/<name>/` | ToolHive maintains the scope's `.agents/plugins/marketplace.json`. It does not edit `config.toml` or invoke Codex; the user must run `codex plugin install <name>@toolhive`. |
 
-| Client | Layout | Config mutation | Components loaded | Scope degradation |
-|---|---|---|---|---|
-| Claude Code | `~/.claude/plugins/<name>/` | `~/.claude/settings.json`: `enabledPlugins["<name>@toolhive"]` + `extraKnownMarketplaces.toolhive` (`directory` source pointing at the plugins root); shared `~/.claude/plugins/.claude-plugin/marketplace.json` (top-level `name`/`owner`/`plugins[]`, each `source: "./<name>"`) | commands, agents, skills, hooks | none |
-| Codex | `~/.agents/plugins/toolhive/<name>/` (user) or `<root>/.agents/plugins/toolhive/<name>/` (project) | shared `.agents/plugins/marketplace.json` (top-level `name` + `plugins[]`, each with a `local` `source.path` = `./toolhive/<name>` relative to the marketplace root, plus `policy`/`category`). No `config.toml` mutation — see "Codex load step" below. | skills, mcpServers, hooks | none |
-
-The `MaterializationAdapter` interface (`pkg/plugins/adapter.go`) owns this:
-each adapter extracts the plugin tree and (optionally) mutates client config,
-reporting which component types it deliberately dropped.
+`Materialize`, `Dematerialize`, `EnsureRegistered`, and `Health` make adapter
+changes reversible and check both the source tree and required registration.
+Shared JSON files are updated under a file lock and written atomically.
 
 ## Plugin Lifecycle
 
 ### 1. Discovery
 
-OCI reference (`ghcr.io/org/plugin:v1`), git reference
-(`git://host/owner/repo[@ref][#subdir]`), or plain name (registry lookup —
-wired via `lazyPluginLookup`; `thv ai-plugin install <plain-name>`
-resolves through the registry's `SearchPlugins` → first hit's OCI package).
+`thv ai-plugin install` resolves input in this order:
+
+1. a `git://...` reference;
+2. an OCI reference;
+3. a validated plain or namespace-qualified name.
+
+A name checks the local OCI store first, then searches the configured ToolHive
+registry. Search results are post-filtered for an exact, case-insensitive name
+(and namespace, when supplied), plus the requested version when present. One
+exact match is required: zero matches return not found and multiple matches are
+rejected as ambiguous. ToolHive does not install the first fuzzy search result.
+The resolved catalog entry must contain a usable OCI package.
+
+Git and OCI installs also require the manifest name to match the repository's
+last path component (or the git subdirectory name). This prevents accidental
+name clobbering; it is not proof of publisher identity.
 
 ### 2. Building
 
-`pluginsvc.Build` packages a local plugin directory into an OCI artifact via
-`ociplugins.PluginPackager`. The layer is a single tar.gz of the whole plugin
-tree.
+`thv ai-plugin validate <path>` validates a local plugin tree. `thv ai-plugin
+build <path>` parses the manifest, packages the complete tree as one tar.gz OCI
+layer, records the component inventory in the OCI config, and writes the
+artifact to the local plugin OCI store. Local-build metadata distinguishes
+builds from artifacts cached by pull or content inspection.
 
-### 3. Installation
+### 3. Publishing
 
-`pluginsvc.Install` dispatches by reference type:
+`thv ai-plugin push <reference>` publishes a local build. Push is signed
+keylessly by default: an OIDC identity token can be supplied with
+`--identity-token`, acquired from GitHub Actions OIDC, or acquired through an
+interactive browser sign-in. `--no-sign` is the explicit unsigned alternative.
+There is no plugin push `--key` option.
 
-1. **Git** (`gitresolver.IsGitReference`): clone via `pkg/git.Client`, read
-   `.claude-plugin/plugin.json`, collect all files, build an in-memory tar.gz,
-   then materialize.
-2. **OCI**: pull via registry client, extract config + layer. **Name/repo
-   consistency check**: the declared plugin name must match the OCI reference's
-   last path component (422 on mismatch — prevents accidental clobbering; not
-   publisher authenticity).
-3. **Plain name**: local store → registry lookup → 404 with install hint.
+A signed push stages content at its immutable digest, attaches the signature,
+and only then promotes the requested tag. A signing failure therefore does not
+leave the requested tag resolving to unsigned content. Identity tokens are not
+sent over non-loopback HTTP and token-bearing requests do not follow redirects.
 
-After resolving the artifact, `installWithExtraction` resolves target clients,
-acquires the per-plugin lock, calls each client's `MaterializationAdapter`,
-builds the `InstalledPlugin` record, persists it (Create/Update with
-upgrade-digest/same-digest-new-clients branches), and registers the plugin in
-its group. When a `ClientManager` is configured, target trees are snapshotted
-(files plus registration state via `Health`) before materialization; any later
-failure — extraction, DB persist, group registration, or lock write — restores
-the snapshot exactly (files, and `EnsureRegistered` only when the tree was
-registered before) and joins every compensation error with the trigger.
-Without a `ClientManager` (embedded/test services), compensation degrades to
-dematerializing what this call wrote.
+### 4. Installation
 
-### 4. Uninstallation
+After resolution, the service verifies project-scoped content, acquires a
+per-plugin lock, materializes each target client, persists the installed record,
+updates group membership, and writes the project lock entry. Existing trees and
+registration state are snapshotted when the client manager is available. A
+later extraction, database, group, or lock-file failure restores prior files,
+registration, storage, and group state; compensation errors are returned with
+the original failure.
 
-`pluginsvc.Uninstall` is scope-dependent:
+A same-digest install can add newly requested clients without replacing the
+other clients. Upgrades and sync repairs force rematerialization when required
+to keep the recorded content digest and trust material aligned with the files
+on disk.
 
-- **Unmanaged / user scope**: `Dematerialize` per client (best-effort,
-  `errors.Join`), remove group memberships, then delete the store record.
-  Group removal snapshots memberships first and restores them if an update
-  midway or the DB delete fails, keeping the operation retryable. Idempotent.
-- **Lock-managed project scope**: fails closed. Every stored client must have
-  a materializer, the lock entry is removed after snapshotting client trees,
-  and a later dematerialize/group/DB failure restores the pin, the trees, and
-  adapter registration so the plugin is never left half-removed or
-  installed-but-untracked.
+### 5. Uninstallation
 
-### 5. Info
+User-scope and otherwise unmanaged installs are dematerialized from each client,
+removed from groups, and deleted from storage. Lock-managed project uninstall
+fails closed: it snapshots the lock and client trees, removes the lock entry,
+and restores the pin and materialization if a later step fails. Both paths make
+repeated removal safe and join partial-cleanup errors rather than hiding them.
 
-`pluginsvc.Info` returns metadata + the install record + two computed fields:
-- `UnmaterializedComponents` — per client, component types the plugin declares
-  that the adapter does NOT load (static diff of `Components` vs
-  `SupportedComponents`).
-- `ProjectScopeDegradedClients` — clients for which a project-scope install
-  degraded (recomputed from scope + `DegradesOnProjectScope`).
+### 6. Info
 
-## Git-Based Plugin Resolution
+`thv ai-plugin info` combines manifest metadata, the installed record, group
+membership, and project trust state. `UnmaterializedComponents` is the static
+difference between the plugin inventory and each adapter's capability list; it
+does not assert those files were omitted. `ProjectScopeDegradedClients` reports
+scope degradation declared by adapters (neither current adapter degrades).
 
-The git resolver reuses `pkg/skills/gitresolver`'s skill-agnostic helpers
-(`ParseGitReference`, `IsGitReference`, `ResolveAuth`, `WriteFiles`,
-`CloneConfigForRef`, `ClientForURL`) but does NOT call `Resolver.Resolve` —
-that method is skill-specific (reads `SKILL.md`). Instead,
-`pluginsvc.installFromGit` clones directly, reads the plugin manifest, and
-collects the whole subtree (a plugin is multi-component, not a single file).
+## Lock, Sync, and Upgrade
 
-A **name/repo consistency check** (mirroring the OCI check) enforces that the
-declared manifest name matches the name implied by the git reference — the
-subdir's last segment when `#subdir` is present, else the repo's last segment
-(422 on mismatch). When collecting files, the executable bit committed in the
-repo is **preserved** (rather than forcing 0644) so hook scripts keep `+x`.
+Project installs share `toolhive.lock.yaml` with skills but use the `plugins:`
+key. Each entry pins the original source, resolved reference, artifact digest,
+on-disk content digest, and trust decision. Target clients remain part of the
+installed-plugin record. The schema and common
+atomic lock-file mechanics are documented in [Project Lock File](12-skills-system.md#project-lock-file).
+
+`thv ai-plugin sync` restores the pinned state without re-resolving the source:
+
+- missing or drifted installs are reinstalled at the pinned digest;
+- `--check` reports drift without writing;
+- `--adopt` records eligible unmanaged project installs;
+- `--prune` removes managed installs absent from the lock file;
+- real changes require confirmation, or `--yes` in non-interactive use.
+
+Sync checks artifact and content digests, expected clients, adapter health, and
+stored OCI signature material. Git signatures live on commits, so unchanged git
+entries have no stored bundle to re-verify offline; the recorded identity is
+rechecked when git content is resolved again.
+
+`thv ai-plugin upgrade [name...]` re-resolves each mutable lock source and
+installs changed content. Immutable OCI digests and full git commit pins are
+reported as not upgradable. `--preview` and `--fail-on-changes` plan without
+installing (OCI candidates are still fetched to compare digests).
+`--allow-ref-change` permits a repository move, while
+`--allow-signer-change` permits supported trust transitions. Neither option
+silently replaces a pinned cosign public key with an arbitrary different key.
 
 ## Storage
 
-`pkg/storage/sqlite/plugin_store.go` — `installed_plugins` +
-`plugin_dependencies` tables (migration 002). Reuses the `entries` table's
-`UNIQUE(entry_type, name)` with `entry_type = "plugin"`. The
-`PluginStore` interface has Create/Get/List/Update/Delete + dependency methods.
+`pkg/storage/sqlite/plugin_store.go` persists installed plugins and dependency
+metadata in `installed_plugins` and `plugin_dependencies` (migration 002),
+sharing the `entries` namespace with other managed objects. The local OCI store
+holds builds and pulled artifacts separately from installation records.
+
+Plugin dependencies are parsed and stored, but ToolHive does not currently
+materialize plugin-declared dependencies. Every project plugin lock entry is
+therefore explicit; `requiredBy` is reserved for future use.
 
 ## Group Integration
 
-`groups.Group` carries a `Plugins []string` field (mirrors `Skills`).
-`groups.AddPluginToGroup` / `groups.RemovePluginFromAllGroups` are line-for-line
-ports of the skills analogues.
+`groups.Group.Plugins` stores plugin names alongside workload and skill
+membership. Installation can add a plugin with `--group`; listing can filter by
+group; uninstall removes the plugin from all groups. Group updates participate
+in install/uninstall rollback. Groups organize resources but do not merge the
+plugin lifecycle with MCP workload lifecycle.
 
 ## Security Model
 
 ### Trust Model
 
-Project-scoped plugin installs are verified against Sigstore signatures, and the project's `toolhive.lock.yaml` — the same file skills use, under its own `plugins:` key — records the trust decisions those verifications produce. A plugin contributes hooks, agents, commands, and MCP server declarations to whichever client loads it, so this is a strictly larger blast radius than a skill: the trust decision is never implicit.
+Project-scoped installs verify signatures and record a trust decision in the
+lock file. User-scoped installs deliberately bypass lock-backed verification;
+they also reject `--public-key` rather than accepting a key that would not be
+used.
 
-On first install of a signed plugin the observed signer identity is recorded (trust on first use) as the entry's `provenance:` block and **displayed to the user** — by `thv ai-plugin install` when it completes, and by `thv ai-plugin info` on every later read. Each subsequent install, sync, and upgrade enforces that identity *inside* the Sigstore verification policy: OCI artifacts through their attached signature bundles, git commits through gitsign signature-and-chain verification (recorded `provisional: true` — the transparency-log proof of signing time is not yet validated, so the replay window is unbounded until that lands, and the marker is rendered wherever the identity is). `thv ai-plugin sync` additionally re-verifies each **OCI** entry's stored signature bundle offline — embedded trust root, no network — before counting it current, so a tampered-with stored bundle is caught in CI rather than at the next install. Git entries are not re-verified this way: a git install stores no bundle by design, because its signature lives on the commit rather than beside an artifact, so sync has nothing to re-check offline and an unchanged git plugin passes as current on its digest and content hash alone. A git entry's recorded identity is enforced when its content is next re-resolved — on drift, upgrade, or reinstall — not on every sync. `thv ai-plugin upgrade` refuses to move to an artifact signed by a different identity, or to an unsigned one, without an explicit `--allow-signer-change`.
+For keyless OCI signatures and gitsign commits, first project install records
+the observed certificate identity (TOFU) and displays it. Subsequent install,
+sync, and upgrade enforce the recorded signer and available certificate fields.
+Git trust is marked provisional because signing-time transparency proof is not
+yet validated. Plugins do not currently consume catalog-declared provenance,
+so registry-name installation does not replace first-use TOFU.
 
-Publishing is signed by default, and **keyless only**. `thv ai-plugin push` requires either an OIDC identity token (`--identity-token`, or acquired automatically from a GitHub Actions OIDC token — the only ambient provider implemented — or an interactive browser sign-in) or an explicit `--no-sign`. Signing attaches the signature manifest next to the pushed artifact, where install-time verification finds it.
+For a key-pair-signed OCI artifact, the first project install requires
+`--public-key <cosign.pub>`. ToolHive verifies against that key and pins its DER
+SPKI representation in the lock entry. Sync and upgrade reuse the pinned key;
+they do not take another key flag. A different key cannot be auto-adopted or
+substituted with `--allow-signer-change`: changing to an arbitrary key requires
+removing the existing lock anchor and reinstalling explicitly.
 
-A signed push is **staged and then promoted**: the content is published under its immutable digest, the signature is attached to that digest, and only then is the requested tag pushed. The ordering carries the guarantee. Publishing the tag first and signing afterwards would mean that any Fulcio, Rekor, or attachment failure leaves the tag already live and resolving to unsigned content — consumable by user-scoped installs with no verification at all — and returning an error does not retract it. Staged-then-promoted leaves the blobs uploaded but nothing tagged, so a consumer resolving the tag finds nothing. The staged manifest is untagged and garbage-collectable by the registry; ToolHive does not attempt to delete it, since the registry client exposes no delete and registries commonly forbid manifest deletion. An unsigned (`--no-sign`) push has no ordering constraint and publishes the requested reference directly.
+`--allow-unsigned` applies only when content has no signature and records
+`unsigned: true` as an explicit project policy exception. It does not permit an
+invalid, damaged, wrong-key, or otherwise unverifiable signature, and it does
+not turn a signed artifact into an unsigned one. Lock-driven restore honors an
+existing unsigned decision. A legacy entry with neither provenance nor
+`unsigned: true` is drift and fails closed until sync can verify it or the user
+explicitly runs `sync --allow-unsigned` for genuinely unsigned content.
 
-The identity token itself is withheld from unprotected transports: the CLI refuses to send it to a `http://` ToolHive API on a non-loopback host, because it is a bearer credential redeemable at Fulcio for a certificate in the caller's name. HTTPS, loopback HTTP, and the Unix socket / named pipe transports are all accepted. A token-bearing push additionally **refuses to follow redirects** — clearing the base URL says nothing about where a 307 or 308 from that URL would replay the body, and those status codes preserve both method and body, so following one would hand the credential to whatever `Location` names. The ToolHive API does not redirect its own endpoints, so there is no legitimate case being given up.
+Plugin publishing remains keyless-by-default or explicit `--no-sign`; plugin
+push has no `--key`, even though project installation can verify externally
+key-pair-signed artifacts with `--public-key`.
 
-There is deliberately **no `--key` flag**, and key signing is unrepresentable rather than rejected: `plugins.PushOptions` does not alias `skills.PushOptions` precisely so that it carries no `Key` field, the push DTO has none, and the push endpoint rejects unknown JSON fields so a `key` from an older client is a 400 naming the field instead of a silent unsigned publish. Making the request impossible to construct is the point — while the field existed, the in-process service answered a key with a 400 while the HTTP client dropped it and published unsigned, so the same `PluginService.Push` call meant different things depending on which implementation was wired in.
-
-The reason is that install-time verification is keyless-only (`verifier.VerifyOCI` checks a Fulcio certificate chain), and neither the lock schema nor the install API carries a public key, so a key-signed artifact fails verification as `verifier.ErrKeySigned` — a verdict distinct from both `ErrUnsigned` and `ErrSignatureInvalid`, which means `--allow-unsigned` cannot override it and a project-scoped install is refused outright. Offering key signing would only let publishers produce plugins nobody can install. `thv skill push --key` still accepts one — carrying a caveat on the flag and in the [skills lock-file model](12-skills-system.md#project-lock-file) — and produces exactly this outcome. The flag returns here once install, sync, and the lock can carry a public key, tracked in [#6442](https://github.com/stacklok/toolhive/issues/6442).
-
-**Migrating entries written before verification.** A lock entry recording neither a `provenance:` block nor `unsigned: true` predates trust recording — it was written while verification was gated off, or hand-edited. The lock schema permits that shape (validation enforces only that the two are mutually exclusive, not that one is present), so `pluginsvc.verifyStoredSignature` is the layer that rejects it: such an entry is reported as **drift**, never as current. `thv ai-plugin sync --check` surfaces it as drifted, `thv ai-plugin info` renders it as `(trust unrecorded)` rather than leaving it indistinguishable from an untracked install, and `thv ai-plugin sync` repairs it by reinstalling from the pinned reference, which runs install-time verification.
-
-The repair completes on its own **only when a signature actually verifies**. Unsigned content fails closed and needs `thv ai-plugin sync --allow-unsigned` to proceed. This is the whole point of the migration rather than an inconvenience in it: repairing an unsigned legacy entry automatically would rewrite "no trust decision" into `unsigned: true` with nobody having chosen it, converting an entry that is visibly ambiguous into a standing exception that looks deliberate. Recording an unsigned exception is a trust decision, and nothing makes it on the user's behalf — so a lock-driven restore gets no implicit allowance (`isAllowedUnsigned` grants only the explicit flag), and the failure names `sync --allow-unsigned` as the remedy because `install --allow-unsigned` is not the operation that owns the lock entry.
-
-An entry that already records `unsigned: true` is a different case and is honored without re-asking: restoring a decision the lock file states is not the same as inventing one.
-
-Reinstalling is the intended migration, not `--adopt`: adoption records whatever the machine already has, whereas a reinstall re-fetches and verifies against the registry. A same-digest reinstall is also the repair path for a stored bundle that has gone stale or corrupt — the freshly verified bundle replaces it rather than being discarded.
-
-**A lock entry only ever describes content the install that wrote it materialized.** An entry asserts a `contentDigest` hashed from the source just fetched, never read back from disk, so `dispatchExtraction` rematerializes whenever an install is the one bringing a record under lock tracking for the first time — even at an unchanged digest with every client already present, where it would otherwise short-circuit. Without that, a legacy tree modified since it was installed would stay active behind a brand-new entry naming a real signer and a pristine digest, and only a later `sync --check` would notice. The condition is the unmanaged-to-managed transition rather than "a bundle was freshly verified", which would miss two shapes that need it just as much: a git install produces no bundle at all (`VerifyGit` returns none — its signature lives on the commit, as above), and an `--allow-unsigned` reinstall produces no provenance, yet both write a `contentDigest`.
-
-What is still trusted on faith, deliberately and visibly:
-
-- **Unsigned plugins** install only with an explicit `--allow-unsigned`, recorded as `unsigned: true` in the lock entry. That entry is a standing exception: lock-driven operations (sync restores, upgrade re-pins) honor it without re-asking, and `thv ai-plugin info` renders it as `(unsigned — explicit exception)`.
-- **The lock file itself** remains a repository-editable policy document. A diff converting a `provenance:` block to `unsigned: true` is a trust downgrade that sync will honor — it cannot happen without a lock file edit, which is exactly what lock-file review must catch. Reviewing `provenance`, `unsigned`, `digest`, and `resolvedReference` changes carries the same weight as reviewing the plugin content itself.
-- **First use** anchors trust to whatever identity signed the artifact at that moment; verify the printed identity is the publisher you expect.
-- **Declared-but-unmanaged components** (`mcpServers`, `lspServers`) are recorded in the inventory and shown by `info`, but ToolHive neither materializes nor lifecycle-manages them — their content is not covered by anything above beyond the artifact digest.
-
-Plugins do not yet consume catalog-declared provenance the way skills do (`registry.Skill.Provenance`), so a plugin's first project-scoped install is always ordinary trust on first use.
-
-See [Project Lock File](12-skills-system.md#project-lock-file) in the skills document for the lock file's schema and the shared verification internals.
+The lock file is repository-editable policy. Review changes to `provenance`,
+`publicKey`, `unsigned`, `digest`, and `resolvedReference` as carefully as the
+plugin content. In particular, changing a signed entry to `unsigned: true` is a
+trust downgrade that sync will honor.
 
 ### Archive Extraction Safety
 
-Both adapters delegate to `skills.Installer.Extract`, which enforces:
-decompression bomb limits, per-file size/count caps, symlink/hardlink rejection,
-pre-extraction `ValidatePathNoSymlinks`, post-extraction `CheckFilesystem`, and
-prefix-containment on every written file.
+Adapters use the shared skills installer, which bounds decompressed size and
+file count, rejects symlinks and hardlinks, validates containment and parent
+symlinks before writing, and checks the resulting filesystem. Git clone storage
+is bounded to 100 MB and 10,000 files. Plugin names are validated before path
+construction so they cannot escape the selected user or project root.
 
-### Path Construction
+### Codex Marketplace Registration
 
-`ClientManager.GetPluginPath` validates the plugin name (kebab-case, no `..`)
-before `filepath.Join` — neither `clientType` nor `pluginName` can escape the
-home/project dir.
-
-### Marketplace registration (Codex)
-
-The Codex adapter follows Codex's marketplace model. Codex discovers
-marketplaces at a fixed set of paths, including the personal
-`~/.agents/plugins/marketplace.json` and the per-repo
-`$REPO_ROOT/.agents/plugins/marketplace.json`. The adapter extracts each
-plugin's source under that marketplace root, namespaced by the marketplace name
-(`<root>/toolhive/<name>`), and maintains the `marketplace.json` so Codex can
-discover it. The manifest has a top-level `name` and a `plugins` array; each
-entry has a `local` `source.path` that is **relative to the marketplace root**
-and starts with `./` (`./toolhive/<name>`), plus the required `policy` and
-`category` fields. Writes use `fileutils.WithFileLock` + `AtomicWriteFile`, and
-the plugin name is validated (no traversal) by `GetPluginPath` before use.
-`Dematerialize` removes the plugin's source directory and its `plugins` array
-entry, deleting the manifest when no plugins remain.
-
-#### Codex load step (manual, by design)
-
-Unlike Claude Code, ToolHive does **not** fully automate Codex plugin loading,
-and this is deliberate:
-
-- **No `config.toml` mutation.** Codex's `[plugins."<name>@<marketplace>"]`
-  `enabled` key is only an on/off toggle for an *already-installed* plugin;
-  setting `enabled = true` for a plugin that was never installed does not load
-  it, and writing to the user's shared `config.toml` has blast radius for no
-  benefit. The adapter leaves `config.toml` untouched.
-- **No shelling out.** Loading a Codex plugin requires an explicit install
-  (`codex plugin install <name>@toolhive`), which is a CLI action. ToolHive
-  never invokes client binaries to mutate their state (every other client
-  integration is file-based config editing), so the adapter does not shell out
-  to `codex`.
-
-Instead, ToolHive lays down the plugin source and a discoverable
-`marketplace.json`, and the user completes loading with a one-time:
+ToolHive extracts the full source under the Codex marketplace root and maintains
+`marketplace.json` with a relative `./toolhive/<name>` local source plus required
+policy and category fields. It neither edits `~/.codex/config.toml` nor invokes
+the `codex` executable. Marketplace discovery alone does not install the plugin
+into Codex; complete the client-side step manually:
 
 ```bash
-# The personal marketplace at ~/.agents/plugins is auto-discovered; if needed:
-codex plugin marketplace add ~/.agents/plugins
 codex plugin install <name>@toolhive
 ```
 
-Automating this (e.g. a dedicated integration that drives the Codex install flow
-without shelling out) is tracked as a follow-up.
+### Claude Code Registration
 
-### settings.json Mutation (Claude Code)
-
-The Claude Code adapter mutates `~/.claude/settings.json` (or the project
-`<root>/.claude/settings.json`) under `fileutils.WithFileLock`. It adds
-`enabledPlugins["<name>@toolhive"]` and an `extraKnownMarketplaces.toolhive`
-entry whose `source` is a `directory` source pointing at the **plugins root**
-(the directory containing all installed plugins), not the per-plugin directory.
-A single shared `marketplace.json` lives at `<root>/.claude-plugin/marketplace.json`
-with the required top-level `name`/`owner` fields and a `plugins` array; each
-plugin is one entry with a `source: "./<name>"` path resolved against the
-marketplace root. `upsert`/`remove` keep that array in sync as plugins are
-installed and uninstalled, so a non-LIFO uninstall cannot invalidate the shared
-marketplace path. `Dematerialize` removes the plugin from the `plugins` array
-(deleting the manifest and its `.claude-plugin` dir when empty), reverts its own
-`enabledPlugins` additions, and drops `extraKnownMarketplaces.toolhive` only when
-no remaining `@toolhive` plugins are enabled.
-
-### Name/Repo Consistency
-
-The OCI install path rejects artifacts whose declared name doesn't match the
-reference's repository last segment. This is a consistency check, not publisher
-authenticity — `pluginConfig.Name` is self-declared. Publisher authenticity is
-established separately, by signature verification (see [Trust Model](#trust-model)).
-
-### Git Clone Bounds
-
-The git client wraps both worktree and storer in `LimitedFs` (100MB total,
-10k files), bounding the in-memory clone.
-
-## Dependency on toolhive-core
-
-The OCI plugin layer (`ociplugins.Store`, `PluginPackager`, `RegistryClient`,
-`PluginConfig`, `ComponentInventory`) comes from
-`github.com/stacklok/toolhive-core/oci/plugins`, mirroring how skills uses
-`toolhive-core/oci/skills`.
+ToolHive maintains one shared marketplace under the scope's plugins root and
+adds `<name>@toolhive` to `enabledPlugins`. It removes only its own entries on
+uninstall and removes the shared ToolHive marketplace registration only when no
+ToolHive plugins remain.
 
 ## Key Files
 
 | File | Purpose |
 |---|---|
-| `pkg/plugins/adapter.go` | `MaterializationAdapter` interface |
-| `pkg/plugins/types.go` | `InstalledPlugin`, `PluginMetadata`, `ComponentInventory` |
-| `pkg/plugins/options.go` | `InstallOptions`/`InstallResult`/`PluginInfo` etc. |
-| `pkg/plugins/service.go` | `PluginService` interface |
-| `pkg/plugins/pluginsvc/service.go` | concrete `service` + `With*` options + `pluginLock` |
-| `pkg/plugins/pluginsvc/install.go` | Install dispatch |
-| `pkg/plugins/pluginsvc/install_oci.go` | OCI pull + name/repo check |
-| `pkg/plugins/pluginsvc/install_git.go` | git clone + manifest read |
-| `pkg/plugins/pluginsvc/install_extraction.go` | shared materialize + persist core |
-| `pkg/plugins/pluginsvc/list.go` / `info.go` / `uninstall.go` | lifecycle methods |
-| `pkg/plugins/adapters/claudecode.go` | Claude Code adapter (FS + settings.json mutation) |
-| `pkg/plugins/adapters/codex.go` | Codex adapter (FS + TOML) |
-| `pkg/registry/api/plugins_client.go` | MCP v0.1 registry plugin search client |
-| `pkg/api/v1/registry_v01_plugins.go` | HTTP handler for plugin search endpoint |
-| `pkg/storage/sqlite/plugin_store.go` | SQLite store |
-| `pkg/groups/plugins.go` | group membership |
-| `pkg/client/plugins.go` | client metadata + path resolution |
+| `cmd/thv/app/ai_plugin*.go` | CLI commands and help |
+| `pkg/api/v1/plugins.go` | REST routes |
+| `pkg/plugins/service.go` | Service interfaces |
+| `pkg/plugins/pluginsvc/` | Resolution, lifecycle, trust, lock, sync, and upgrade |
+| `pkg/plugins/adapter.go` | Client materialization contract |
+| `pkg/plugins/adapters/claudecode.go` | Claude Code materializer |
+| `pkg/plugins/adapters/codex.go` | Codex filesystem and marketplace materializer |
+| `pkg/plugins/client/` | HTTP client |
+| `pkg/storage/sqlite/plugin_store.go` | Installed-plugin persistence |
+| `pkg/registry/api/plugins_client.go` | Registry plugin search client |
+| `pkg/groups/plugins.go` | Group membership integration |
+| `pkg/skills/lockfile/` | Shared lock schema and atomic updates |
 
 ## Related Documentation
 
-- [Skills System](12-skills-system.md) - Sibling distribution system (OCI artifacts, multi-client install, build/publish/install lifecycle)
-- [Registry System](06-registry-system.md) - Registry-name resolution in the install dispatch chain
-- [Groups](07-groups.md) - Plugin group membership (`pkg/groups/plugins.go`)
-- [Core Concepts](02-core-concepts.md) - Platform terminology
+- [Core Concepts](02-core-concepts.md) - Skill, plugin, workload, registry, and group terminology
+- [Skills System](12-skills-system.md) - Skill lifecycle and shared project lock mechanics
+- [Registry System](06-registry-system.md) - Plugin catalog discovery integration
+- [Groups](07-groups.md) - Shared organizational model

--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -26,7 +26,7 @@ Welcome to the ToolHive architecture documentation. This directory contains comp
 ### Detailed Component Documentation
 
 1. **[Core Concepts](02-core-concepts.md)**
-   - Nouns: Workloads, Transports, Proxy, Middleware, RunConfig, Permissions, Groups, Registry, Sessions
+   - Nouns: Workloads, Transports, Proxy, Middleware, RunConfig, Permissions, Groups, Registry, Sessions, Skills, AI-tool Plugins
    - Verbs: Deploy, Proxy, Attach, Parse, Filter, Authorize, Audit, Export, Import, Monitor
    - Terminology quick reference
 
@@ -114,11 +114,10 @@ Welcome to the ToolHive architecture documentation. This directory contains comp
     - Guidance for downstream embedders on pinning and upgrading
 
 14. **[Plugins System](14-plugins-system.md)**
-    - Plugin manifest format (`.claude-plugin/plugin.json`) and OCI artifact layout
-    - Install dispatch (git → OCI → registry name) and the per-plugin lock
-    - `MaterializationAdapter` seam: Claude Code (pure FS) vs Codex (FS + TOML)
-    - Component inventory and per-client dropped-component warnings
-    - Name/repo consistency check, extraction safety, TOML mutation under file lock
+    - AI-tool plugin lifecycle (discover, build, push, install, sync, upgrade)
+    - Client materialization: Claude Code settings and Codex marketplace files
+    - Project lock-file trust, including keyless and pinned public-key verification
+    - Complete component inventory and boundaries with MCP workloads
 
 15. **[Envoy Network Proxy](15-envoy-network-proxy.md)**
     - Experimental Envoy backend (`TOOLHIVE_NETWORK_PROXY=envoy`) replacing two Squid containers with one
@@ -192,9 +191,9 @@ graph TB
         AuthStorage[11: Auth Server Storage<br/>Memory & Redis backends]
     end
 
-    subgraph "Agent Skills"
-        Skills[12: Skills System<br/>Build, publish, install]
-        Plugins[14: Plugins System<br/>MaterializationAdapter]
+    subgraph "AI Extensions"
+        Skills[12: Skills System<br/>Single instruction components]
+        Plugins[14: Plugins System<br/>Multi-component AI-tool bundles]
     end
 
     %% Navigation paths
@@ -243,6 +242,7 @@ graph TB
     style vMCP fill:#e0f2f1,stroke:#004d40,stroke-width:2px
     style AuthStorage fill:#e0f2f1,stroke:#004d40,stroke-width:2px
     style Skills fill:#e8eaf6,stroke:#283593,stroke-width:2px
+    style Plugins fill:#e8eaf6,stroke:#283593,stroke-width:2px
 ```
 
 **Color Legend:**
@@ -252,7 +252,7 @@ graph TB
 - 🟠 **Orange (Configuration & Security)**: Security model and configuration management
 - 🔴 **Pink (Distribution & Organization)**: How servers are cataloged and organized
 - 🟦 **Teal (Runtime Management)**: Lifecycle and cluster management
-- 🔷 **Indigo (Agent Skills)**: Skills lifecycle and distribution system
+- 🔷 **Indigo (AI Extensions)**: Skill and AI-tool plugin lifecycle and distribution
 
 **Navigation Paths:**
 - **For first-time readers**: Follow the arrows from Overview → Concepts → your area of interest

--- a/docs/cli/thv_ai-plugin.md
+++ b/docs/cli/thv_ai-plugin.md
@@ -15,8 +15,9 @@ Manage AI-tool plugins
 
 ### Synopsis
 
-The ai-plugin command provides subcommands to manage plugins for AI tools
-(e.g. Claude Code, Codex) — not plugins for ToolHive itself.
+Manage plugins for AI tools such as Claude Code and Codex, not plugins
+for ToolHive itself. A plugin is a manifest-based bundle that may contain
+commands, agents, skills, hooks, and server declarations.
 
 ### Options
 

--- a/docs/cli/thv_ai-plugin_install.md
+++ b/docs/cli/thv_ai-plugin_install.md
@@ -15,8 +15,12 @@ Install an AI-tool plugin
 
 ### Synopsis
 
-Install a plugin by name or OCI reference.
-The plugin will be fetched from a remote registry and installed locally.
+Install a plugin from git, an OCI reference, or an exact registry name.
+
+Project-scoped installs verify signatures and record trust in toolhive.lock.yaml.
+Use --public-key for the first project install of a key-pair-signed OCI artifact;
+the key is then pinned for sync and upgrade. User-scoped installs do not use
+lock-file verification and reject --public-key.
 
 ```
 thv ai-plugin install [plugin-name] [flags]

--- a/docs/cli/thv_ai-plugin_push.md
+++ b/docs/cli/thv_ai-plugin_push.md
@@ -17,6 +17,9 @@ Push a built AI-tool plugin to an OCI registry
 
 Push a previously built plugin artifact to a remote OCI registry.
 
+Push signs keylessly by default. Use --no-sign to publish unsigned; plugin push
+does not support key-pair signing and has no --key flag.
+
 ```
 thv ai-plugin push [reference] [flags]
 ```

--- a/docs/cli/thv_ai-plugin_sync.md
+++ b/docs/cli/thv_ai-plugin_sync.md
@@ -36,7 +36,7 @@ thv ai-plugin sync [flags]
       --adopt                 Write lock entries for existing unmanaged project-scope installs
       --allow-unsigned        Record plugins as unsigned in the lock file: when adopting installs whose signature state cannot be established (--adopt), and when repairing an entry that records no trust decision and whose content is unsigned
       --check                 Report drift without installing, writing, or removing anything
-      --clients string        Comma-separated target client apps (e.g. claude-code,opencode), or "all" for every available client
+      --clients string        Comma-separated target client apps (e.g. claude-code,codex), or "all" for every available client
       --format string         Output format (json, text) (default "text")
   -h, --help                  help for sync
       --project-root string   Project root path (default: auto-detected from the current directory)

--- a/docs/cli/thv_ai-plugin_upgrade.md
+++ b/docs/cli/thv_ai-plugin_upgrade.md
@@ -40,7 +40,7 @@ thv ai-plugin upgrade [plugin-name...] [flags]
 ```
       --allow-ref-change      Permit the artifact to move to a different repository during upgrade
       --allow-signer-change   Permit upgrading to an artifact signed by a different identity; the new identity replaces the recorded one
-      --clients string        Comma-separated target client apps (e.g. claude-code,opencode), or "all" for every available client
+      --clients string        Comma-separated target client apps (e.g. claude-code,codex), or "all" for every available client
       --fail-on-changes       Report what would change without installing anything; a CI freshness gate
       --format string         Output format (json, text) (default "text")
   -h, --help                  help for upgrade

--- a/pkg/plugins/adapter.go
+++ b/pkg/plugins/adapter.go
@@ -38,9 +38,9 @@ type MaterializeRequest struct {
 	// ProjectRoot is the project root path for project-scoped installs.
 	// Empty for user-scoped.
 	ProjectRoot string
-	// Components is the plugin's component inventory, used to warn on
-	// component types the adapter does not materialize (e.g. Codex drops
-	// commands/agents).
+	// Components is the plugin's component inventory, used to report
+	// component types the target client does not load. Adapters still extract
+	// the complete plugin tree.
 	Components ComponentInventory
 }
 
@@ -58,12 +58,14 @@ type DematerializeRequest struct {
 	ProjectRoot string
 }
 
-// MaterializeResult reports what was written and what was deliberately dropped.
+// MaterializeResult reports what was written and which declared components
+// are outside the target client's loading capabilities. The latter are not
+// omitted from the extracted plugin tree.
 type MaterializeResult struct {
-	// InstalledComponents lists the component types the adapter materialized.
+	// InstalledComponents lists the component types the target client loads.
 	InstalledComponents []ComponentType
 	// DroppedComponents lists component types the plugin declares that this
-	// adapter does NOT materialize.
+	// client does not load. The complete plugin tree is still extracted.
 	DroppedComponents []ComponentType
 	// InstallPath is the root directory the adapter wrote (informational).
 	InstallPath string
@@ -91,8 +93,8 @@ type ScopeSupport struct {
 // and reverts its own mutations. It generalizes skills.PathResolver: instead
 // of resolving a single skill path, it owns extraction + (optional) config
 // mutation for a multi-component plugin tree, because the materialization
-// strategy differs per client (Claude Code = pure filesystem; Codex = FS
-// cache + TOML mutation).
+// strategy differs per client (Claude Code = filesystem + settings and
+// marketplace JSON; Codex = filesystem + marketplace JSON).
 type MaterializationAdapter interface {
 	// Materialize extracts the plugin into the client's directory layout and,
 	// for config-based clients, mutates the client config. Must be idempotent

--- a/pkg/plugins/pluginsvc/build.go
+++ b/pkg/plugins/pluginsvc/build.go
@@ -191,8 +191,8 @@ func (s *service) pushSigned(ctx context.Context, opts plugins.PushOptions, d di
 	// reads the artifact back to decide whether this identity already signed
 	// it, so a not-yet-created tag would fail the attach.
 	//
-	// No key is forwarded — plugin pushes are keyless-only until install-time
-	// key verification exists (#6442), and PushOptions carries no key field.
+	// Plugin push intentionally forwards only the identity token: key-pair
+	// signing is not part of the plugin push contract.
 	if _, err := s.artifactSigner().SignOCI(ctx, staged, d.String(), signer.Options{
 		IdentityToken: opts.IdentityToken,
 		FulcioURL:     os.Getenv(envFulcioURL),
@@ -321,13 +321,11 @@ func (s *service) DeleteBuild(ctx context.Context, tag string) error {
 // Ambiguous or absent input is rejected here, before the artifact is pushed,
 // rather than surfacing as a signing failure afterward.
 //
-// Diverges from skillsvc.validateSigningInputs on purpose: there is no key
-// branch to validate. Install-time verification is keyless-only, and a
-// key-signed artifact fails it as verifier.ErrKeySigned — a verdict distinct
-// from ErrUnsigned, so --allow-unsigned cannot override it and the plugin is
-// uninstallable project-scoped. Rather than accept a key and reject it here,
-// plugins.PushOptions omits the field entirely (#6442), so the unsupported
-// request cannot be constructed by any caller, in-process or over HTTP.
+// Diverges from skillsvc.validateSigningInputs on purpose: plugin push has no
+// key branch. Key-pair signing is not part of this push contract, so
+// plugins.PushOptions omits the field and the unsupported request cannot be
+// constructed by an in-process or HTTP caller. Project installs can still
+// verify an externally key-pair-signed OCI artifact with --public-key.
 func validateSigningInputs(opts plugins.PushOptions) error {
 	switch {
 	case opts.NoSign && opts.IdentityToken != "":

--- a/skills/toolhive-cli-user/SKILL.md
+++ b/skills/toolhive-cli-user/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: toolhive-cli-user
 description: >-
-  Guide for using ToolHive CLI (thv) to run and manage MCP servers and skills.
-  Use when running, listing, stopping, building, or configuring MCP servers locally.
-  Covers server lifecycle, registry browsing, secrets management, client registration,
-  groups, container builds, exports, permissions, network isolation, authentication,
-  and skill management (install, uninstall, list, info, build, push, validate).
-  NOT for Kubernetes operator usage or ToolHive development/contributing.
-version: 0.3.0
+  Guide for using ToolHive CLI (thv) to run and manage MCP servers, skills, and
+  AI-client plugins. Use when managing `thv ai-plugin` installs, project sync or
+  upgrades, or plugin publishing for Claude Code or Codex; also use for MCP
+  server and skill lifecycle commands. Covers server lifecycle, registries,
+  secrets, client registration, builds, permissions, skills, and AI plugins.
+  NOT for Kubernetes operator usage, ToolHive development/contributing, or
+  general AI-client configuration unrelated to ToolHive.
+version: 0.4.0
 license: Apache-2.0
 ---
 
@@ -213,6 +214,31 @@ thv skill push ghcr.io/org/skill:v1.0                   # Push to registry
 
 For all flags and detailed examples, see [COMMANDS.md](references/COMMANDS.md#skill-commands) and [EXAMPLES.md](references/EXAMPLES.md#skills-management-examples).
 
+## AI Plugin Management
+
+Use `thv ai-plugin` for manifest-based bundles for AI clients, not ToolHive itself. Plugins may contain commands, agents, skills, hooks, and declared MCP/LSP entries; they are distinct from standalone ToolHive skills and MCP workloads. Plugin-declared MCP/LSP entries are not ToolHive-managed workloads.
+
+These commands use the ToolHive API; start `thv serve` first. The supported plugin clients are `claude-code` and `codex`; target either, or `all` available clients, with `--clients`. Install an exact registry name, OCI reference, or `git://host/org/repo[@ref][#subdir]` source, then use `list`/`info` to inspect what ToolHive installed. Verification and lock-file trust are project-only: user-scoped installs do not use lock-file verification.
+
+```bash
+thv ai-plugin install example-plugin --clients claude-code
+thv ai-plugin install ghcr.io/example-org/example-plugin:v1.0 --scope project --project-root .
+thv ai-plugin install git://github.com/example-org/example-plugin@v1.0#plugin --scope project --project-root .
+thv ai-plugin list --scope project --project-root .
+thv ai-plugin sync --check --project-root .
+thv ai-plugin upgrade --preview --project-root .
+```
+
+ToolHive extracts, registers, and enables Claude Code plugins. For Codex, ToolHive only materializes the ToolHive marketplace; complete activation yourself:
+
+```bash
+codex plugin install example-plugin@toolhive
+```
+
+ToolHive does not edit Codex `config.toml` or invoke Codex. Installed-component metadata only describes the extracted/materialized tree; it does not prove client activation. A client can leave unsupported components in that tree without loading them.
+
+For command details, trust boundaries, and publishing, see [COMMANDS.md](references/COMMANDS.md#ai-plugin-commands) and [EXAMPLES.md](references/EXAMPLES.md#ai-plugin-management-examples).
+
 ## Debugging
 
 ```bash
@@ -232,6 +258,9 @@ For tool invocation patterns (file args, stdin, JSON output, error handling), se
 - NEVER pass secrets as `-e SECRET=value` -- use `--secret` with managed secrets instead.
 - Confirm destructive operations (`thv rm --all`, `thv stop --all`, `thv group rm --with-workloads`) with the user before running.
 - Skill commands require `thv serve` to be running. If a skill command fails with a connection error, suggest starting `thv serve` first.
+- AI plugin commands also require `thv serve`. Treat plugin content as AI-followed instructions: inspect the source and use project-scoped installs only in the intended project.
+- For an externally key-pair-signed OCI plugin, give `--public-key` only on its first project install; ToolHive pins the key in `toolhive.lock.yaml` for sync and upgrade. Do not replace that pin without explicit review.
+- Never add `--allow-unsigned`, `--allow-signer-change`, `--allow-ref-change`, `--force`, `--prune`, or `--yes` silently. Unsigned consent is explicit and does not bypass invalid signature verification. Confirm before `sync`/`upgrade` applies content or `builds remove` deletes a local artifact.
 - If the user asks about Kubernetes deployment, this skill does not cover the operator -- direct them accordingly.
 
 ## Error Handling
@@ -248,6 +277,10 @@ For tool invocation patterns (file args, stdin, JSON output, error handling), se
 | Sensitive files exposed in mount | No `.thvignore` configured | Add `.thvignore` in mounted directory or globally at `~/.config/toolhive/thvignore` |
 | Skill command fails with connection error | `thv serve` not running | Start `thv serve` before using skill commands |
 | Skill validation fails | Invalid SKILL.md or directory structure | Run `thv skill validate ./path` and fix reported errors |
+| AI plugin API unreachable | `thv serve` is not running | Start `thv serve`; increase `TOOLHIVE_API_TIMEOUT` only for a server that is still working |
+| Plugin sync check fails | Missing or drifted project plugin | Review the result, then run `thv ai-plugin sync` and confirm; do not add trust-bypass flags automatically |
+| Plugin activation unclear | Client did not load a declared component | Inspect client support and client output; materialized component metadata is not activation proof |
+| Plugin signature rejected | Untrusted, invalid, or changed signer | Inspect the artifact and lock pin; `--allow-unsigned` cannot bypass invalid verification |
 
 ## Global Options
 

--- a/skills/toolhive-cli-user/references/COMMANDS.md
+++ b/skills/toolhive-cli-user/references/COMMANDS.md
@@ -526,6 +526,121 @@ thv skill validate [flags] PATH
 
 Shell completion available for directory paths.
 
+## AI Plugin Commands
+
+All AI plugin commands use the ToolHive API; ensure `thv serve` is running. Plugins are AI-client bundles, not ToolHive workloads. Do not infer that a declared or materialized component is activated by the client.
+
+### thv ai-plugin validate
+
+Validate a local plugin directory before building. Invalid results exit non-zero; `--format json` prints the validation result.
+
+```
+thv ai-plugin validate [flags] PATH
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format` | Output format: `text` or `json` |
+
+### thv ai-plugin build and builds
+
+Build a local directory into the local OCI store; successful `build` prints its reference. List local artifacts with `builds` (`--format text` or `json`). `builds remove` deletes the named local artifact and its blobs; it is separate from uninstalling an installed plugin and has no confirmation flag.
+
+```
+thv ai-plugin build [flags] PATH
+thv ai-plugin builds [--format text|json]
+thv ai-plugin builds remove TAG
+```
+
+| Command | Flag | Description |
+|---------|------|-------------|
+| `build` | `-t, --tag` | OCI tag for the built artifact |
+
+### thv ai-plugin push
+
+Push a previously built local artifact. Signing is keyless by default: use `--identity-token TOKEN_OR_PATH`, GitHub Actions OIDC with `id-token: write`, or interactive browser sign-in. Use `--no-sign` only when intentionally publishing unsigned content; project consumers must explicitly consent to an unsigned install. No `--key` option exists.
+
+```
+thv ai-plugin push [flags] REFERENCE
+```
+
+| Flag | Description |
+|------|-------------|
+| `--identity-token` | OIDC identity token or path to a token file |
+| `--no-sign` | Publish unsigned instead of keyless signing |
+
+### thv ai-plugin install
+
+Install one exact registry name, OCI reference, or Git source (`git://host/org/repo[@ref][#subdir]`). The supported plugin clients are `claude-code` and `codex`; `--clients all` selects available clients. `--scope` defaults to `user`; verification and lock-file trust are project-only, so project scope requires `--project-root` and records trust in `toolhive.lock.yaml`. For the first project install of an externally key-pair-signed OCI artifact, use `--public-key PATH`; ToolHive pins and reuses that key for sync and upgrade. User scope rejects `--public-key`.
+
+```
+thv ai-plugin install [flags] PLUGIN_NAME
+```
+
+| Flag | Description |
+|------|-------------|
+| `--clients` | Comma-separated client IDs, or `all` |
+| `--scope` | `user` (default) or `project` |
+| `--project-root` | Required for project scope |
+| `--group` | Add the plugin to a group after installation |
+| `--public-key` | First-project-install cosign public key for an externally key-signed OCI artifact |
+| `--allow-unsigned` | Explicitly record a project-scope unsigned exception; never use to work around invalid verification |
+| `--force` | Overwrite an existing plugin directory; use only after confirmation |
+
+### thv ai-plugin list, info, and uninstall
+
+`list` has alias `ls`. `info` includes trust and component information; declared MCP/LSP servers are not ToolHive-managed workloads. `uninstall` removes an installed plugin at the selected scope; it does not remove a local build.
+
+```
+thv ai-plugin list|ls [flags]
+thv ai-plugin info [flags] PLUGIN_NAME
+thv ai-plugin uninstall [flags] PLUGIN_NAME
+```
+
+| Command | Flags |
+|---------|-------|
+| `list` / `ls` | `--scope`, `--client`, `--group`, `--project-root`, `--format text|json` |
+| `info` | `--scope`, `--project-root`, `--format text|json` |
+| `uninstall` | `--scope` (default `user`), `--project-root` (required for project scope) |
+
+### thv ai-plugin sync
+
+Compare project installs with `toolhive.lock.yaml`. `--check` makes no changes and exits non-zero for missing/drifted plugins, making it suitable for CI. Without `--check`, sync prompts before it installs; `--yes` skips that prompt and must be chosen explicitly for non-interactive use.
+
+```
+thv ai-plugin sync [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--project-root` | Project root; auto-detected by default |
+| `--clients` | Comma-separated client IDs, or `all` |
+| `--check` | Report only; no install, write, or removal |
+| `--adopt` | Write lock entries for existing unmanaged project installs |
+| `--prune` | Remove installed plugins absent from the lock; confirm explicitly |
+| `--yes` | Skip the normal confirmation prompt |
+| `--allow-unsigned` | Explicitly record unsigned state while adopting/repairing; not a verification bypass |
+| `--format` | Output format: `text` or `json` |
+
+### thv ai-plugin upgrade
+
+Re-resolve mutable project lock entries. Immutable OCI-digest and full Git-commit sources are not upgradable. `--preview` and `--fail-on-changes` make no persistent change; the latter exits non-zero when upgrades are available. A normal upgrade prompts before installing; use `--yes` only with explicit approval. Do not add `--allow-ref-change` or `--allow-signer-change` without reviewing the candidate repository or signer.
+
+```
+thv ai-plugin upgrade [flags] [PLUGIN_NAME...]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--project-root` | Project root; auto-detected by default |
+| `--clients` | Comma-separated client IDs, or `all` |
+| `--preview` | Report planned changes without persisting (OCI content may still be fetched) |
+| `--fail-on-changes` | CI freshness check; report only and exit non-zero if changes exist |
+| `--allow-ref-change` | Permit a move to a different repository after explicit review |
+| `--allow-signer-change` | Permit replacing the recorded signer after explicit review |
+| `--yes` | Skip the normal confirmation prompt |
+| `--format` | Output format: `text` or `json` |
+
 ## Utility Commands
 
 ### thv inspector

--- a/skills/toolhive-cli-user/references/EXAMPLES.md
+++ b/skills/toolhive-cli-user/references/EXAMPLES.md
@@ -608,3 +608,88 @@ thv run myserver -e SERVICE_URL=http://host.containers.internal:8080
 thv run myserver -e SERVICE_URL=http://172.17.0.1:8080
 ```
 
+## AI Plugin Management Examples
+
+> **Placeholders:** Replace `example-plugin`, `example-org`, paths, and versions below with reviewed values. Start `thv serve` before any `thv ai-plugin` command.
+
+### Inspect and Install
+
+```bash
+# Inspect installed project plugins before changing them.
+thv ai-plugin list --scope project --project-root .
+thv ai-plugin info example-plugin --scope project --project-root .
+
+# Install a reviewed OCI plugin into this project and target Claude Code.
+thv ai-plugin install ghcr.io/example-org/example-plugin:v1.0 \
+  --scope project --project-root . --clients claude-code
+
+# A Git source can select a ref and plugin subdirectory.
+thv ai-plugin install git://github.com/example-org/plugin-repo@v1.0#plugins/example-plugin \
+  --scope project --project-root . --clients codex
+```
+
+For Codex, then complete the explicit client hand-off; ToolHive does not invoke Codex or edit `config.toml`:
+
+```bash
+codex plugin install example-plugin@toolhive
+```
+
+### First Install of an Externally Key-Signed OCI Plugin
+
+```bash
+# Supply the reviewed public key only for the first project install.
+# ToolHive pins it in toolhive.lock.yaml and reuses it for sync and upgrade.
+thv ai-plugin install ghcr.io/example-org/example-plugin:v1.0 \
+  --scope project --project-root . --public-key ./keys/example-plugin.cosign.pub
+```
+
+### Check and Restore Project Drift
+
+```bash
+# CI-safe inspection: no install, lock-file write, or deletion.
+thv ai-plugin sync --check --project-root .
+
+# After reviewing the lock entries and prompt, restore missing/drifted plugins.
+thv ai-plugin sync --project-root .
+```
+
+Do not use `--allow-unsigned` for a failed signature: it only records an explicit unsigned exception and cannot validate invalid content. Do not use `--prune` or `--yes` unless explicitly approved.
+
+### Preview and Apply an Upgrade
+
+```bash
+# Show mutable-reference changes without persisting them.
+thv ai-plugin upgrade --preview --project-root .
+
+# After reviewing repositories and signer identities, confirm at the prompt.
+thv ai-plugin upgrade example-plugin --project-root .
+```
+
+`--fail-on-changes` is the non-mutating CI freshness check. Do not add `--allow-ref-change`, `--allow-signer-change`, or `--yes` without explicit approval.
+
+### Validate, Build, and Publish
+
+```bash
+# Validate before building; an invalid plugin exits non-zero.
+thv ai-plugin validate ./example-plugin
+
+# Build into the local OCI store, then inspect the local build.
+thv ai-plugin build ./example-plugin --tag ghcr.io/example-org/example-plugin:v1.0
+thv ai-plugin builds
+
+# Push signed by default (keyless signing acquires an OIDC token when needed).
+thv ai-plugin push ghcr.io/example-org/example-plugin:v1.0
+```
+
+Use `thv ai-plugin push --no-sign ...` only when intentionally publishing unsigned content under an approved policy; do not recommend it as an installation workaround.
+
+### Uninstall Versus Removing a Local Build
+
+```bash
+# Remove the project installation; this does not delete the local OCI artifact.
+thv ai-plugin uninstall example-plugin --scope project --project-root .
+
+# Separately remove a reviewed local build by its tag.
+thv ai-plugin builds remove ghcr.io/example-org/example-plugin:v1.0
+```
+


### PR DESCRIPTION
## Summary

AI plugins have reached feature parity in several areas that the architecture docs and the `toolhive-cli-user` skill did not describe, while several claims had become stale. This change makes the documented lifecycle and operational guidance match the shipped CLI and plugin service behavior.

- Document AI plugin concepts, materialization, resolution, project locking, trust anchors, sync/upgrade behavior, registry/group integration, and client-specific boundaries.
- Correct stale claims around public-key verification, Codex registration, keyless plugin publishing, and supported plugin-client examples.
- Extend the CLI user skill with safe AI-plugin workflows, complete command reference material, and practical examples.
- Regenerate CLI references for updated help text.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [x] Documentation
- [ ] Other (describe):

## Test plan

- [x] Linting (`task lint-fix`)
- [x] Manual testing (regenerated `thv ai-plugin` command references and checked the resulting diff with `git diff --check`)

## Changes

| File area | Change |
|------|--------|
| `docs/arch/` | Make AI-plugin architecture, lifecycle, trust, registry, and group documentation current and navigable. |
| `cmd/thv/app/ai_plugin*.go` | Clarify CLI help and correct supported-client examples. |
| `docs/cli/thv_ai-plugin*.md` | Regenerate affected command references. |
| `pkg/plugins/` | Correct stale comments describing plugin integration and signing behavior. |
| `skills/toolhive-cli-user/` | Add safe AI-plugin workflows, commands, and examples. |

## Does this introduce a user-facing change?

Yes. `thv ai-plugin --help`, generated CLI documentation, and the ToolHive CLI user skill now explain the current plugin lifecycle and safety controls. The sync/upgrade client examples now correctly use `codex` rather than unsupported `opencode`.

## Implementation plan

<details>
<summary>Approved implementation plan</summary>

1. Retain `docs/arch/14-plugins-system.md` as the canonical plugin architecture document and update its lifecycle, materialization, trust, locking, and safety coverage.
2. Correct stale sibling documentation and add concise Plugin terminology/navigation in the architecture overview, core concepts, registry, groups, and architecture index without duplicating the shared Skills lock-schema material.
3. Correct plugin CLI help at the Cobra source, then regenerate its affected CLI reference pages.
4. Extend the existing `toolhive-cli-user` skill rather than creating a new skill. Keep its core workflow concise and move detailed syntax/examples into existing one-level-deep references.
5. Explicitly document client boundaries, project-only verification, public-key pinning, keyless publishing, unsigned consent, sync/upgrade confirmations, and the Codex handoff.

</details>

## Special notes for reviewers

`task docs` regenerated the affected CLI pages, then exceeded the harness time limit while running the final Swagger generation step; no unrelated generated-file changes remain. `task test` and `task build` also exceeded the 120-second harness limit before producing test/build results. The code changes are help text and comments only; `task lint` and `git diff --check` passed.

Generated with [Claude Code](https://claude.com/claude-code)