### PR TITLE
Restore the release actor lookup the failure notice references

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -344,9 +344,32 @@ jobs:
 #                                            "$fn"
 #          done <<<"$checksums"
 
+  extract-release-actor:
+    name: Extract Release Actor
+    runs-on: ubuntu-slim
+    permissions: {}
+    outputs:
+      triggered_by: ${{ steps.extract.outputs.triggered_by }}
+    steps:
+      - name: Extract actor from release body
+        id: extract
+        env:
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          # create-release-tag.yml embeds this HTML comment in the release notes; parse it back out here.
+          # head -n 1 keeps only the first match: a second Release-Triggered-By comment
+          # (for example from a merged PR title folded into --generate-notes) must not
+          # turn this into a multi-line GITHUB_OUTPUT write.
+          TRIGGERED_BY=$(echo "$RELEASE_BODY" | grep -oP '(?<=<!-- Release-Triggered-By: )[^[:space:]]+(?= -->)' | head -n 1 || true)
+          if [ -z "$TRIGGERED_BY" ]; then
+            echo "No Release-Triggered-By comment in the release notes; the notice will fall back to github.actor."
+          fi
+          echo "triggered_by=$TRIGGERED_BY" >> "$GITHUB_OUTPUT"
+
   notify-release-failure:
     name: Notify Release Failure
     needs:
+      - extract-release-actor
       - compute-build-flags
       - release-binaries
       - image-build-and-push


### PR DESCRIPTION
## Summary

The release failure Slack notice reads `needs.extract-release-actor.outputs.triggered_by`,
but no job of that name exists in `releaser.yml` any more: #4982 removed
`extract-release-actor` together with the docs-website dispatch it fed, and left the
payload's reference behind. The expression is always undefined, so the notice falls
through to `github.actor`, which on `release: published` is the release GitHub App rather
than the person who started the release. `actionlint` flags it:

```
releaser.yml:364:428: property "extract-release-actor" is not defined in object type
{compute-build-flags: ...; image-build-and-push: ...; publish-helm: ...;
 release-binaries: ...; skills-publish: ...} [expression]
```

The producer side never went away: `create-release-tag.yml` still reads the
`Release-Triggered-By` trailer from the release commit and writes
`<!-- Release-Triggered-By: X -->` into the release notes "parsed by releaser.yml". This
restores the consumer.

- Re-add an `extract-release-actor` job that reads `github.event.release.body` through
  `env:` and extracts the username from the HTML comment (same pattern as the job removed
  in #4982). `permissions: {}`, no token, no checkout, no `${{ }}` inside `run:`.
- Keep only the first match (`head -n 1`): `--generate-notes` copies merged PR titles into
  the body verbatim, so a second `Release-Triggered-By` comment is reachable, and a two-line
  value would make the `GITHUB_OUTPUT` write malformed and fail the job.
- Add it to `notify-release-failure`'s `needs:` so the output is addressable again.

When the comment is absent the output is empty, the step logs one line saying so, and the
payload's existing `|| github.actor` fallback applies, as before.

Fixes #6265

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Dependency update
- [ ] Documentation
- [ ] Other (describe):

## Test plan

- [ ] Unit tests (`task test`)
- [ ] E2E tests (`task test-e2e`)
- [ ] Linting (`task lint-fix`)
- [x] Manual testing (describe below)

The release workflow cannot run from a pull request, so the verification is static plus a
shell test of the extraction:

- `actionlint .github/workflows/releaser.yml`: the `extract-release-actor` property error
  is gone; the remaining output is byte-identical to `main` (two pre-existing shellcheck
  infos at lines 91 and 258, untouched here).
- `zizmor --persona regular .github/workflows/releaser.yml`: same findings as `main`, zero
  new (the new job binds the release body through `env:` and has no expression in `run:`).
- The new step's `run:` body executed locally under `bash -e` against sample release
  bodies: the comment present (yields the name), absent (empty value, the fallback log line,
  exactly one `triggered_by=` line written), an unrelated HTML comment first plus trailing
  whitespace (yields the name), and the comment twice with different names on one line and
  on two lines (yields exactly the first name and exactly one output line). Negative
  control: without `head -n 1` the two-comment bodies write two lines. Also checked under
  `set -o pipefail`: a no-match body exits 1 and a two-match body exits 141 from `head`
  closing the pipe, which is why `|| true` stays.
- Removing the new `needs:` entry brings the actionlint error back; removing the job while
  keeping the `needs:` entry produces the unknown-job error. Both restored.

## Does this introduce a user-facing change?

No.

