### PR TITLE
fix(authserver): import miniredis in the runner test

### DIFF
--- a/pkg/authserver/runner/embeddedauthserver_test.go
+++ b/pkg/authserver/runner/embeddedauthserver_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/ory/fosite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## Summary

`main` is red on Lint and Tests:

```
pkg/authserver/runner/embeddedauthserver_test.go:1689:8: undefined: miniredis (typecheck)
```

`TestCreateStorage_NoAuthRedisConnects` (added in #6551) calls `miniredis.RunT` but the file never imports it. The module is already in `go.mod`, so this is just the missing import line. The package fails typecheck, which takes every test in it down with it, not only the new one.


## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

`go vet ./pkg/authserver/runner/` is clean and `go test ./pkg/authserver/runner/ -run TestCreateStorage_NoAuthRedisConnects` passes. Both fail on `main` at bb4c1854 without this.

## Does this introduce a user-facing change?

No.
