### PR TITLE
fix(sdk): unbreak sdk-verify after the Go 1.27 bump

### DIFF
--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -15,7 +15,12 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version-file: sdk/go/go.mod
+          # Root go.mod, not sdk/go/go.mod: sdk-verify runs generator tooling
+          # from the root module (cmd/help/openapi-normalize, ogen-client-wrapper),
+          # so the toolchain has to satisfy the root's Go version. setup-go pins
+          # GOTOOLCHAIN=local, so a lower version here fails outright rather than
+          # upgrading. The SDK module keeps its own lower floor for consumers.
+          go-version-file: go.mod
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:

--- a/sdk/go/client/oas_schemas_gen.go
+++ b/sdk/go/client/oas_schemas_gen.go
@@ -20142,7 +20142,7 @@ type TemplatesRuntimeConfig struct {
 	BuildWith []string `json:"build_with"`
 	// BuilderImage is the full image reference for the builder stage.
 	// An empty string signals "use the default for this transport type" during config merging.
-	// Examples: "golang:1.26-alpine", "node:24-alpine", "python:3.14-slim".
+	// Examples: "golang:1.27-alpine", "node:24-alpine", "python:3.14-slim".
 	BuilderImage OptString `json:"builder_image"`
 	// RuntimeEnv contains environment variables to inject into the Dockerfile's
 	// final runtime stage. Unlike BuildEnv (pkg/container/templates.TemplateData.BuildEnv),

--- a/sdk/go/openapi.json
+++ b/sdk/go/openapi.json
@@ -4957,7 +4957,7 @@
             "uniqueItems": false
           },
           "builder_image": {
-            "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.26-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
+            "description": "BuilderImage is the full image reference for the builder stage.\nAn empty string signals \"use the default for this transport type\" during config merging.\nExamples: \"golang:1.27-alpine\", \"node:24-alpine\", \"python:3.14-slim\"",
             "type": "string"
           },
           "runtime_env": {

--- a/sdk/go/openapi.yaml
+++ b/sdk/go/openapi.yaml
@@ -4585,7 +4585,7 @@ components:
                     description: |-
                         BuilderImage is the full image reference for the builder stage.
                         An empty string signals "use the default for this transport type" during config merging.
-                        Examples: "golang:1.26-alpine", "node:24-alpine", "python:3.14-slim"
+                        Examples: "golang:1.27-alpine", "node:24-alpine", "python:3.14-slim"
                     type: string
                 runtime_env:
                     additionalProperties:


### PR DESCRIPTION
## Summary

`Go SDK / Verify generated Go SDK` is red on `main` (7e52ab9). Two leftovers from the Go 1.27 bump in #6639.

**1. The job installs the wrong Go.** `setup-go` reads `sdk/go/go.mod` (`go 1.26.0`), but `sdk-verify` runs generator tooling out of the *root* module (`cmd/help/openapi-normalize`, `cmd/help/ogen-client-wrapper`), which is now `go 1.27`. `setup-go` pins `GOTOOLCHAIN=local`, so it fails outright rather than upgrading:

```
go: go.mod requires go >= 1.27 (running go 1.26.0; GOTOOLCHAIN=local)
```

Pointed `setup-go` at the root `go.mod`. Deliberately not bumping `sdk/go/go.mod` - that's the published floor for SDK consumers, and there's no reason to raise it just so CI can run root tooling. Building the 1.26-floor SDK module with a 1.27 toolchain is fine, and `sdk-test`/`sdk-lint` still pass.

**2. The committed SDK artifacts are stale.** The bump also edited a `BuilderImage` doc comment (`"golang:1.26-alpine"` -> `"golang:1.27-alpine"`), which flows through `docs/server/swagger.json` into `sdk/go/openapi.json`, `openapi.yaml` and the generated client. So even on a correct toolchain, verify's diff fails:

```
-  "description": "... Examples: \"golang:1.27-alpine\", ...   (freshly generated)
+  "description": "... Examples: \"golang:1.26-alpine\", ...   (committed)
```

Regenerated with `task sdk-generate`. It's a one-line change in each of the three files.

## Type of change

- [x] Bug fix

## Test plan

- [x] Unit tests (`task test`)
- [x] Linting (`task lint-fix`)

Reproduced both on a clean checkout of main. Under Go 1.26 you get the toolchain error; under 1.27 you get the diff. With this change, on Go 1.27:

```
bash ./sdk/go/verify.sh   → rc=0
task sdk-test             → rc=0
task sdk-lint             → rc=0
```

I can't exercise the workflow's `setup-go` step locally, so that half is reasoned from the error rather than executed - worth a sanity check from someone who can re-run the job.

## Does this introduce a user-facing change?

No. `sdk/go/go.mod` is untouched, so the SDK's minimum Go version for consumers is unchanged.
