### PR TITLE
docs: point nine stale paths at the code that exists

### DIFF
--- a/docs/arch/03-transport-architecture.md
+++ b/docs/arch/03-transport-architecture.md
@@ -806,7 +806,7 @@ when delivery lands it does not also require rewriting the fan-out primitives.
 
 ### Network Isolation
 
-**Implementation**: `pkg/permissions/profile.go`
+**Implementation**: [`toolhive-core/permissions`](https://github.com/stacklok/toolhive-core/tree/main/permissions)
 
 - MCP servers can run in isolated networks
 - Egress proxy for allowed destinations

--- a/docs/arch/06-registry-system.md
+++ b/docs/arch/06-registry-system.md
@@ -860,8 +860,8 @@ thv run weather-server --image-verification enabled
 ```
 
 **Implementation**:
-- `pkg/registry/types.go` - Provenance type definitions
-- `pkg/container/verifier/` - Sigstore/cosign verification using sigstore-go library
+- [`toolhive-core/registry/types`](https://github.com/stacklok/toolhive-core/tree/main/registry/types) - Provenance type definitions
+- [`toolhive-core/container/verifier`](https://github.com/stacklok/toolhive-core/tree/main/container/verifier) - Sigstore/cosign verification using sigstore-go library
 - `pkg/runner/retriever/retriever.go` - Image verification orchestration
 
 ### Supply Chain Security
@@ -919,7 +919,7 @@ ToolHive uses the `io.modelcontextprotocol.registry/publisher-provided` extensio
 For the complete schema definition, see:
 - **Schemas**: published in [`stacklok/toolhive-core`](https://github.com/stacklok/toolhive-core) under `registry/types/data/`
 - **Documentation**: `docs/registry/schema.md`
-- **Validation**: `pkg/registry/schema_validation.go`
+- **Validation**: [`toolhive-core/registry/types`](https://github.com/stacklok/toolhive-core/tree/main/registry/types)
 
 **Implementation**: `pkg/registry/`
 

--- a/docs/arch/10-virtual-mcp-architecture.md
+++ b/docs/arch/10-virtual-mcp-architecture.md
@@ -77,7 +77,7 @@ graph TB
 | **Composition** | Execute multi-step workflows across multiple backends |
 | **Caching** | Reduce auth overhead by caching exchanged tokens |
 
-**Implementation**: `pkg/vmcp/` (discovery: `pkg/vmcp/discovery/`, routing: `pkg/vmcp/router/`)
+**Implementation**: `pkg/vmcp/` (discovery: `pkg/vmcp/aggregator/`, routing: `pkg/vmcp/router/`)
 
 ## Backend Discovery
 
@@ -1005,7 +1005,7 @@ Middleware is applied by wrapping handlers, so execution order is outer-to-inner
 
 ### Discovery Middleware
 
-The Discovery middleware (`pkg/vmcp/discovery/middleware.go`) is central to vMCP's multi-tenant design:
+Discovery (`pkg/vmcp/aggregator/discoverer.go`) is central to vMCP's multi-tenant design:
 
 - **Initialize requests** (no session ID): Discovers capabilities from all backends in the MCPGroup, stores routing table in session
 - **Subsequent requests** (with session ID): Retrieves cached capabilities from session
@@ -1042,7 +1042,7 @@ The server wires them around discovery/annotation-enrichment so the effective ex
 Audit → Authentication → MCP Parsing → Discovery → Annotation Enrichment → Authorization → Next Handler
 ```
 
-**Implementation**: `pkg/vmcp/server/server.go`, `pkg/vmcp/discovery/middleware.go`, `pkg/vmcp/auth/factory/`
+**Implementation**: `pkg/vmcp/server/server.go`, `pkg/vmcp/aggregator/discoverer.go`, `pkg/vmcp/auth/factory/`
 
 ### Authorization Enforcement (core admission seam + pre-dispatch gate)
 

--- a/docs/arch/vmcp-library.md
+++ b/docs/arch/vmcp-library.md
@@ -55,7 +55,6 @@ The table below maps every sub-package to its stability level per RFC THV-0059. 
 | `pkg/vmcp/composer` | Experimental | Composite tool DAG executor; workflow API not yet stable |
 | `pkg/vmcp/cache` | Internal | Token cache; not intended for external use |
 | `pkg/vmcp/conversion` | Internal | CRD-to-config conversion; K8s-specific, not for local embedding |
-| `pkg/vmcp/discovery` | Internal | Discovery middleware; use via aggregator, not directly |
 | `pkg/vmcp/headerforward` | Internal | Per-backend HTTP header-forwarding round-tripper; the root `headerforward` package only; `pkg/vmcp/headerforward/wirefmt` is a separate wire-format helper used by aggregator/workloads/cli/operator |
 | `pkg/vmcp/k8s` | Internal | Kubernetes-specific discovery; not for local embedding |
 | `pkg/vmcp/workloads` | Internal | Backend workload helpers for K8s mode; not for local embedding |

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -59,7 +59,7 @@ code := httperr.Code(err)  // Returns 500 if no code is found
 ### Error Definitions
 
 Error types with HTTP status codes are defined in:
-- `pkg/errors/errors.go` - Core error utilities (`WithCode`, `Code`, `CodedError`)
+- [`toolhive-core/httperr`](https://github.com/stacklok/toolhive-core/tree/main/httperr) - Core error utilities (`WithCode`, `Code`, `CodedError`)
 - `pkg/groups/errors.go` - Group-related errors
 - `pkg/container/runtime/types.go` - Runtime errors (`ErrWorkloadNotFound`)
 - `pkg/workloads/types/validate.go` - Workload validation errors


### PR DESCRIPTION
Closes the rest of #6387, which is assigned to me. #6388 took the five plain renames; these are the nine that needed a decision about what the replacement should say.

Re-measured against `e532cf0` rather than re-quoted from the issue. Two things changed since I filed it: one line had moved again, and `pkg/skills/feature_gate.go` is already gone from the docs, so it is nine rather than the ten I last counted.

### Four moved to toolhive-core

The replacement is the import path the Go code uses today, not a guess.

| document | was | now |
|---|---|---|
| `docs/arch/03-transport-architecture.md` | `pkg/permissions/profile.go` | `toolhive-core/permissions` |
| `docs/arch/06-registry-system.md` | `pkg/registry/types.go` | `toolhive-core/registry/types` |
| `docs/arch/06-registry-system.md` | `pkg/container/verifier/` | `toolhive-core/container/verifier` |
| `docs/error-handling.md` | `pkg/errors/errors.go` | `toolhive-core/httperr` |

Two of these are self-evidencing. `pkg/runner/retriever/retriever.go` imports `toolhive-core/container/verifier`, and `docs/error-handling.md` already uses `httperr.Code(err)` in the example directly above the list that still named `pkg/errors`.

`pkg/registry/schema_validation.go` is named as the validator for schemas the same document already says are published in toolhive-core, so it points there too.

### Discovery

`pkg/vmcp/discovery/` is not in the tree. Discovery is, in `pkg/vmcp/aggregator/discoverer.go`, so the three references name the aggregator rather than dropping the idea. The `vmcp-library.md` row is removed: it lists a package that no longer exists, and it already told readers to use it via the aggregator.

### One left alone deliberately

`docs/arch/10-virtual-mcp-architecture.md` still has a **Backend Enrichment Middleware** section naming `pkg/vmcp/server/backend_enrichment.go`. That file went in #5622 and nothing in the tree replaces it, so unlike the others this is not a path that moved, it is a section describing something that is gone. Deleting a section is an editorial call rather than a path fix, so I have left it for you. Happy to send it as a one-line follow-up if you would like it removed.

### Verification

All four toolhive-core links resolve, and all five in-tree paths are present at `e532cf0`. Docs only, no code changes.